### PR TITLE
feat(security): terminal env allowlist + opt-in agent secret-hygiene prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,20 @@ the README for the support window policy.
 
 ### Security
 
-- **Agent secret-hygiene system-prompt rule.** Every `createAgentSession`
-  now ships an `appendSystemPrompt` addendum telling the model to treat
-  env-var values as credentials by default and not echo them into
-  responses or tool outputs unless explicitly asked. Phrased around
-  *displaying values* (not accessing variables) so legitimate skill
-  workflows that need `$GITHUB_TOKEN`, `$AWS_*`, etc. continue to work
-  — `curl -H "Authorization: Bearer $X"` is fine, `printenv X` to
-  reflect the value back to the user is not. This is a behavioral
-  nudge against accidental disclosure (model decides on its own to
-  `printenv` while debugging), not a security control — see
-  [SECURITY.md](./SECURITY.md) for the threat-model framing.
+- **Agent secret-hygiene system-prompt rule (opt-in).** When
+  `AGENT_SECRET_HYGIENE_RULE=true`, every `createAgentSession` ships
+  an `appendSystemPrompt` addendum telling the model to treat env-var
+  values as credentials by default and not echo them into responses
+  or tool outputs unless explicitly asked. Phrased around *displaying
+  values* (not accessing variables) so legitimate skill workflows
+  that need `$GITHUB_TOKEN`, `$AWS_*`, etc. continue to work —
+  `curl -H "Authorization: Bearer $X"` is fine, `printenv X` to
+  reflect the value back to the user is not. Default OFF: kept opt-in
+  so the workbench doesn't ship invisible behavioral rules. The flag
+  is intentionally absent from `docker-compose.yml` and
+  `.env.example` — operators discover it via [SECURITY.md](./SECURITY.md)
+  alongside the threat-model caveats (behavioral nudge, not a
+  security control).
 - **Terminal env-var allowlist.** The integrated terminal and the `!`
   exec route now start from an allowlist of harmless system vars
   (`PATH`, `HOME`, `USER`, `SHELL`, `TERM`, `LANG`/`LC_*`, `TZ`, …)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ the README for the support window policy.
   in the freshly-spawned shell. Reattach to an existing PTY does not
   re-source so manually-switched venvs are preserved.
 
+### Security
+
+- **Terminal env-var allowlist.** The integrated terminal and the `!`
+  exec route now start from an allowlist of harmless system vars
+  (`PATH`, `HOME`, `USER`, `SHELL`, `TERM`, `LANG`/`LC_*`, `TZ`, …)
+  instead of inheriting the workbench process's full env minus a
+  named denylist. Workbench secrets, provider API keys, cloud
+  credentials, and any other host-env var are dropped before spawn,
+  so `printenv` / `echo $X` returns nothing for them. Operators who
+  need a specific var in-shell opt it back in via the new
+  `TERMINAL_PASSTHROUGH_ENV` env (comma- or whitespace-separated).
+  Closes the previous fail-open denylist that leaked any
+  newly-named secret variable until added to the list. See
+  [SECURITY.md](./SECURITY.md) for the full rationale and a note on
+  the unrelated terminal-can-read-pi-config-files limitation.
+
 ### Build & release
 
 - **Release tooling.** New `scripts/bump-version.sh <new-version>` that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ the README for the support window policy.
 
 ### Security
 
+- **Agent secret-hygiene system-prompt rule.** Every `createAgentSession`
+  now ships an `appendSystemPrompt` addendum telling the model to treat
+  env-var values as credentials by default and not echo them into
+  responses or tool outputs unless explicitly asked. Phrased around
+  *displaying values* (not accessing variables) so legitimate skill
+  workflows that need `$GITHUB_TOKEN`, `$AWS_*`, etc. continue to work
+  — `curl -H "Authorization: Bearer $X"` is fine, `printenv X` to
+  reflect the value back to the user is not. This is a behavioral
+  nudge against accidental disclosure (model decides on its own to
+  `printenv` while debugging), not a security control — see
+  [SECURITY.md](./SECURITY.md) for the threat-model framing.
 - **Terminal env-var allowlist.** The integrated terminal and the `!`
   exec route now start from an allowlist of harmless system vars
   (`PATH`, `HOME`, `USER`, `SHELL`, `TERM`, `LANG`/`LC_*`, `TZ`, …)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,39 @@ workspace root. The threat model assumes:
   attachment path uses fenced-code-block insertion with a fence longer than
   the longest backtick-run in the file contents. A hostile attached file
   can't escape the fence to inject instructions to the LLM.
+- **Host env-var inheritance into the spawned shell**. The integrated
+  terminal and the `!` exec route start from a small allowlist of harmless
+  system vars (`PATH`, `HOME`, `USER`, `SHELL`, `TERM`, `LANG`/`LC_*`, `TZ`,
+  …). Everything else — workbench secrets (`JWT_SECRET`, `API_KEY`,
+  `UI_PASSWORD`), provider keys (`*_API_KEY`), cloud credentials (`AWS_*`,
+  `KUBECONFIG`, `GH_TOKEN`, …), or any other host-env var — is dropped
+  before spawn so an authenticated user can't `printenv` / `echo $X` to read
+  them. Operators who legitimately need a specific var in-shell opt it back
+  in via `TERMINAL_PASSTHROUGH_ENV` (comma- or whitespace-separated). The
+  list lives in `packages/server/src/pty-manager.ts#TERMINAL_ENV_ALLOWLIST`.
+
+## Known limitations
+
+These are documented gaps, not bugs — they reflect deliberate scope
+choices that operators should know about when planning a deployment.
+
+- **Terminal can read pi config files.** The integrated terminal runs as a
+  real shell with the workbench process's filesystem access. The pi-coding-
+  agent SDK requires the workbench process to read its own config dir
+  (`PI_CONFIG_DIR`, default `~/.pi/agent`: `auth.json`, `models.json`,
+  `settings.json`), so a shell running under the same UID can also read
+  them — meaning an authenticated user can `cat ~/.pi/agent/auth.json` and
+  see any persisted provider API keys / OAuth tokens. Path-based blocking
+  inside the shell is trivially bypassable (`cat $(echo ~)/.pi/...`,
+  `python -c "print(open('...').read())"`, `dd if=...`) and would offer
+  false confidence. The actual mitigation is OS-level: run the workbench
+  process and the shell as **separate UIDs**, with `auth.json` mode 600
+  owned by the workbench UID. This is achievable in custom Docker
+  deployments today; pi-workbench's stock image runs both as the same
+  user. If your threat model includes "an authenticated workbench user
+  must not be able to read provider credentials," prefer OAuth (where
+  losing a token costs you a re-auth, not a key rotation) and rotate API
+  keys whenever you suspect terminal access has been abused.
 
 ## What is explicitly out of scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,6 +72,22 @@ workspace root. The threat model assumes:
   them. Operators who legitimately need a specific var in-shell opt it back
   in via `TERMINAL_PASSTHROUGH_ENV` (comma- or whitespace-separated). The
   list lives in `packages/server/src/pty-manager.ts#TERMINAL_ENV_ALLOWLIST`.
+- **Accidental secret disclosure by the agent**. The agent's autonomous
+  `bash` tool DOES inherit the workbench process env (deliberately — skills
+  often legitimately need `$GITHUB_TOKEN`, `$AWS_*`, etc. to do their job).
+  To reduce the realistic failure mode where the model decides on its own
+  to `printenv` while debugging and dumps secrets into the assistant
+  transcript, every session ships a system-prompt addendum
+  (`packages/server/src/agent-resource-loader.ts#WORKBENCH_SECRET_HYGIENE_RULE`)
+  that tells the model to treat env-var values as credentials by default
+  and to reference them by name (`$X`) rather than expanding them inline.
+  This is a **behavioral nudge, not a control** — a determined user, a
+  prompt injection in a tool result, or the model's own reasoning can talk
+  it out of compliance. Operators with adversarial threat models should
+  pair it with the deployment posture below (don't run with sensitive env
+  vars in `process.env` if the agent doesn't need them; prefer
+  `~/.pi/agent/auth.json` for provider credentials, since those are read
+  by the SDK before tool spawn rather than passed through).
 
 ## Known limitations
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,22 +72,38 @@ workspace root. The threat model assumes:
   them. Operators who legitimately need a specific var in-shell opt it back
   in via `TERMINAL_PASSTHROUGH_ENV` (comma- or whitespace-separated). The
   list lives in `packages/server/src/pty-manager.ts#TERMINAL_ENV_ALLOWLIST`.
-- **Accidental secret disclosure by the agent**. The agent's autonomous
-  `bash` tool DOES inherit the workbench process env (deliberately — skills
-  often legitimately need `$GITHUB_TOKEN`, `$AWS_*`, etc. to do their job).
-  To reduce the realistic failure mode where the model decides on its own
-  to `printenv` while debugging and dumps secrets into the assistant
-  transcript, every session ships a system-prompt addendum
-  (`packages/server/src/agent-resource-loader.ts#WORKBENCH_SECRET_HYGIENE_RULE`)
-  that tells the model to treat env-var values as credentials by default
-  and to reference them by name (`$X`) rather than expanding them inline.
-  This is a **behavioral nudge, not a control** — a determined user, a
-  prompt injection in a tool result, or the model's own reasoning can talk
-  it out of compliance. Operators with adversarial threat models should
-  pair it with the deployment posture below (don't run with sensitive env
-  vars in `process.env` if the agent doesn't need them; prefer
-  `~/.pi/agent/auth.json` for provider credentials, since those are read
-  by the SDK before tool spawn rather than passed through).
+- **Accidental secret disclosure by the agent (opt-in).** The agent's
+  autonomous `bash` tool DOES inherit the workbench process env
+  (deliberately — skills often legitimately need `$GITHUB_TOKEN`,
+  `$AWS_*`, etc. to do their job). The realistic failure mode is the
+  model deciding on its own to `printenv` while debugging and dumping
+  secrets into the assistant transcript (which the user may screen-share,
+  log, or paste into a bug report). Operators worried about this can opt
+  in to a system-prompt addendum that asks the model to treat env-var
+  values as credentials by default and reference them by name (`$X`)
+  rather than expanding them inline. Enable by setting:
+
+  ```
+  AGENT_SECRET_HYGIENE_RULE=true
+  ```
+
+  The exact rule text lives in
+  `packages/server/src/agent-resource-loader.ts#WORKBENCH_SECRET_HYGIENE_RULE`.
+
+  **Important caveats — read before enabling.** This is a *behavioral
+  nudge, not a control*. The model can be talked out of it by a
+  determined user ("show me $X"), by a prompt injection landed in a
+  tool result, or by its own reasoning that "the user clearly wants
+  me to print this var." Skills and one-off prompts that legitimately
+  need to display a value can still do so by asking explicitly — the
+  rule says "unless the user explicitly asked." Operators with
+  adversarial threat models should pair it with the deployment
+  posture below (don't put sensitive env vars in `process.env` if
+  the agent doesn't need them; prefer `~/.pi/agent/auth.json` for
+  provider credentials, since those are read by the SDK before tool
+  spawn rather than inherited at spawn). The flag is intentionally
+  not surfaced in `docker-compose.yml` or `.env.example` so operators
+  meet the rule the same time they meet these caveats.
 
 ## Known limitations
 

--- a/packages/server/src/agent-resource-loader.ts
+++ b/packages/server/src/agent-resource-loader.ts
@@ -1,0 +1,77 @@
+/**
+ * Workbench-customized ResourceLoader for the agent.
+ *
+ * Why this exists: pi's `DefaultResourceLoader` accepts an
+ * `appendSystemPrompt: string[]` that gets concatenated onto the
+ * agent's base system prompt. We use this hook to inject one
+ * workbench-specific behavioral rule about secret hygiene — a soft
+ * safeguard that tells the model to treat env-var values as
+ * credentials by default and not echo them back into responses /
+ * tool output.
+ *
+ * **What this is and is not.**
+ *
+ * - It IS a behavioral nudge that catches the realistic failure
+ *   mode: the agent decides on its own to `printenv` or `echo $X`
+ *   while debugging and dumps secrets into the assistant transcript
+ *   (which the user may screen-share, copy into Slack, paste into a
+ *   bug report, etc.).
+ * - It is NOT a security control. The model can be talked out of it
+ *   by a determined user, by a prompt injection landed in a tool
+ *   result, or by its own reasoning that "the user clearly wants me
+ *   to print this var, the rule must not apply." Operators with
+ *   adversarial threat models should not rely on this rule alone.
+ *
+ * Phrased deliberately around *displaying values*, not around
+ * accessing or referencing variables — skills that legitimately
+ * need to check whether `$GITHUB_TOKEN` is set, or pass `$X` to a
+ * subcommand, must continue to work. The rule only constrains
+ * surfacing values to the user.
+ *
+ * If you change this text, write it as guidance the model will buy
+ * into ("treat as credentials by default") rather than as an
+ * absolute prohibition ("never print env vars") — the latter
+ * generalizes badly and gets argued away by smart-enough sessions.
+ */
+import {
+  DefaultResourceLoader,
+  type ResourceLoader,
+  SettingsManager,
+} from "@mariozechner/pi-coding-agent";
+
+export const WORKBENCH_SECRET_HYGIENE_RULE = `
+When running shell commands on behalf of the user, treat the contents of \
+environment variables as credentials by default. Do not echo, print, or \
+paste env-var *values* into your responses or tool outputs unless the user \
+has explicitly asked you to display that specific variable. Checking \
+whether a variable is set (\`-z "$X"\` style) is fine; printing the value \
+is not. If you need to use a secret in a command, reference it by \`$NAME\` \
+rather than expanding it inline (e.g. \`curl -H "Authorization: Bearer \
+$GITHUB_TOKEN"\`, not \`curl -H "Authorization: Bearer ghp_..."\`).
+
+This rule applies even when debugging — if you suspect an env var is \
+misconfigured, prefer reporting "\$X is unset" or "\$X is set (length N)" \
+over reflecting the value. The transcript may be screen-shared, logged, or \
+pasted into bug reports.
+`.trim();
+
+/**
+ * Build a ResourceLoader pre-loaded with the workbench's
+ * `appendSystemPrompt` addendum. Mirrors the SDK's own internal
+ * construction at sdk.js:87 (instantiate + await reload()), so the
+ * loader is ready to hand to `createAgentSession` as-is.
+ */
+export async function buildWorkbenchResourceLoader(
+  cwd: string,
+  agentDir: string,
+  settingsManager: SettingsManager,
+): Promise<ResourceLoader> {
+  const loader = new DefaultResourceLoader({
+    cwd,
+    agentDir,
+    settingsManager,
+    appendSystemPrompt: [WORKBENCH_SECRET_HYGIENE_RULE],
+  });
+  await loader.reload();
+  return loader;
+}

--- a/packages/server/src/agent-resource-loader.ts
+++ b/packages/server/src/agent-resource-loader.ts
@@ -3,13 +3,20 @@
  *
  * Why this exists: pi's `DefaultResourceLoader` accepts an
  * `appendSystemPrompt: string[]` that gets concatenated onto the
- * agent's base system prompt. We use this hook to inject one
- * workbench-specific behavioral rule about secret hygiene — a soft
- * safeguard that tells the model to treat env-var values as
+ * agent's base system prompt. We optionally use this hook to inject
+ * one workbench-specific behavioral rule about secret hygiene — a
+ * soft safeguard that tells the model to treat env-var values as
  * credentials by default and not echo them back into responses /
  * tool output.
  *
- * **What this is and is not.**
+ * **Opt-in.** Default behavior matches stock pi (no addendum). The
+ * rule is appended only when the operator sets
+ * `AGENT_SECRET_HYGIENE_RULE=true`. Kept opt-in so we don't ship
+ * invisible behavioral rules that constrain the agent in ways the
+ * user never asked for. See `SECURITY.md` for the discoverable
+ * documentation and the threat-model framing.
+ *
+ * **What this is and is not (when enabled).**
  *
  * - It IS a behavioral nudge that catches the realistic failure
  *   mode: the agent decides on its own to `printenv` or `echo $X`
@@ -38,6 +45,7 @@ import {
   type ResourceLoader,
   SettingsManager,
 } from "@mariozechner/pi-coding-agent";
+import { config } from "./config.js";
 
 export const WORKBENCH_SECRET_HYGIENE_RULE = `
 When running shell commands on behalf of the user, treat the contents of \
@@ -56,21 +64,28 @@ pasted into bug reports.
 `.trim();
 
 /**
- * Build a ResourceLoader pre-loaded with the workbench's
+ * Build a ResourceLoader pre-loaded with the workbench's optional
  * `appendSystemPrompt` addendum. Mirrors the SDK's own internal
  * construction at sdk.js:87 (instantiate + await reload()), so the
  * loader is ready to hand to `createAgentSession` as-is.
+ *
+ * When `config.agentSecretHygieneRule` is false (the default), the
+ * loader is built with no addendum and behaves identically to the
+ * SDK's own default loader — opt-in only, see the file header.
  */
 export async function buildWorkbenchResourceLoader(
   cwd: string,
   agentDir: string,
   settingsManager: SettingsManager,
 ): Promise<ResourceLoader> {
+  const appendSystemPrompt = config.agentSecretHygieneRule
+    ? [WORKBENCH_SECRET_HYGIENE_RULE]
+    : [];
   const loader = new DefaultResourceLoader({
     cwd,
     agentDir,
     settingsManager,
-    appendSystemPrompt: [WORKBENCH_SECRET_HYGIENE_RULE],
+    appendSystemPrompt,
   });
   await loader.reload();
   return loader;

--- a/packages/server/src/agent-resource-loader.ts
+++ b/packages/server/src/agent-resource-loader.ts
@@ -47,21 +47,28 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { config } from "./config.js";
 
-export const WORKBENCH_SECRET_HYGIENE_RULE = `
-When running shell commands on behalf of the user, treat the contents of \
-environment variables as credentials by default. Do not echo, print, or \
-paste env-var *values* into your responses or tool outputs unless the user \
-has explicitly asked you to display that specific variable. Checking \
-whether a variable is set (\`-z "$X"\` style) is fine; printing the value \
-is not. If you need to use a secret in a command, reference it by \`$NAME\` \
-rather than expanding it inline (e.g. \`curl -H "Authorization: Bearer \
-$GITHUB_TOKEN"\`, not \`curl -H "Authorization: Bearer ghp_..."\`).
-
-This rule applies even when debugging — if you suspect an env var is \
-misconfigured, prefer reporting "\$X is unset" or "\$X is set (length N)" \
-over reflecting the value. The transcript may be screen-shared, logged, or \
-pasted into bug reports.
-`.trim();
+/**
+ * Plain string (not a backtick template) so what's stored is exactly
+ * what's documented — no surprises from template-literal escape rules
+ * (in particular, `\$` inside backticks emits a literal backslash, and
+ * `\<newline>` is a line continuation). Concatenated for readability;
+ * the resulting string the model sees is normal prose with paragraph
+ * breaks at the intentional `\n\n`s.
+ */
+export const WORKBENCH_SECRET_HYGIENE_RULE =
+  "When running shell commands on behalf of the user, treat the contents of " +
+  "environment variables as credentials by default. Do not echo, print, or " +
+  "paste env-var *values* into your responses or tool outputs unless the user " +
+  "has explicitly asked you to display that specific variable. Checking " +
+  'whether a variable is set (`-z "$X"` style) is fine; printing the value ' +
+  "is not. If you need to use a secret in a command, reference it by `$NAME` " +
+  'rather than expanding it inline (e.g. `curl -H "Authorization: Bearer ' +
+  '$GITHUB_TOKEN"`, not `curl -H "Authorization: Bearer ghp_..."`).' +
+  "\n\n" +
+  "This rule applies even when debugging — if you suspect an env var is " +
+  'misconfigured, prefer reporting "$X is unset" or "$X is set (length N)" ' +
+  "over reflecting the value. The transcript may be screen-shared, logged, " +
+  "or pasted into bug reports.";
 
 /**
  * Build a ResourceLoader pre-loaded with the workbench's optional
@@ -89,4 +96,28 @@ export async function buildWorkbenchResourceLoader(
   });
   await loader.reload();
   return loader;
+}
+
+/**
+ * One-time boot log so operators can confirm from container logs that
+ * `AGENT_SECRET_HYGIENE_RULE` was read. Prevents the most common
+ * "I set the env var but nothing happened" debugging dead-end (image
+ * cached an old build, env var didn't reach the process, config
+ * ignored the value, etc.) — the log either appears or it doesn't.
+ *
+ * Called from `index.ts` at startup. Side-effect-only; safe to call
+ * once.
+ */
+export function logSecretHygieneState(): void {
+  if (config.agentSecretHygieneRule) {
+    console.log(
+      "[agent-resource-loader] AGENT_SECRET_HYGIENE_RULE=true — appending " +
+        `secret-hygiene rule to every agent system prompt (${WORKBENCH_SECRET_HYGIENE_RULE.length} chars)`,
+    );
+  } else {
+    console.log(
+      "[agent-resource-loader] AGENT_SECRET_HYGIENE_RULE not set — agent system " +
+        "prompt unmodified (set =true to opt in; see SECURITY.md)",
+    );
+  }
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -19,6 +19,18 @@ function readInt(key: string, fallback: number): number {
   return n;
 }
 
+function readStringList(key: string): string[] {
+  const v = readEnv(key);
+  if (v === undefined) return [];
+  // Comma- or whitespace-separated; either is natural in shell, k8s
+  // env, and docker-compose `environment:` lists. Drop empties so
+  // trailing commas don't produce ghost entries.
+  return v
+    .split(/[,\s]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 function readBool(key: string, fallback: boolean): boolean {
   const v = readEnv(key)?.toLowerCase();
   if (v === undefined) return fallback;
@@ -240,6 +252,26 @@ export const config = Object.freeze({
     pushWindowMs: readInt("RATE_LIMIT_PUSH_WINDOW_MS", 60_000),
   }),
   corsOrigin: CORS_ORIGIN,
+  /**
+   * Extra env-var names the operator wants the integrated terminal
+   * (and the `!` exec route) to inherit from the workbench process.
+   *
+   * The terminal env starts from a small allowlist of harmless system
+   * vars (PATH, HOME, USER, SHELL, TERM, locales — see
+   * `pty-manager.ts#TERMINAL_ENV_ALLOWLIST`). Everything else is
+   * dropped — including provider API keys (`OPENAI_API_KEY`,
+   * `AWS_ACCESS_KEY_ID`, etc.) the operator may have in their host
+   * shell that would otherwise be inherited by every spawn. This
+   * defaults to fail-safe: any new sensitive var the operator sets
+   * is hidden from the shell unless they explicitly pass it through.
+   *
+   * Add specific vars here when the shell genuinely needs them
+   * (e.g. `KUBECONFIG`, `EDITOR`, `OPENAI_BASE_URL` for an internal
+   * proxy). Format: comma- or whitespace-separated.
+   *
+   * Example: `TERMINAL_PASSTHROUGH_ENV=KUBECONFIG,EDITOR,NODE_ENV`
+   */
+  terminalPassthroughEnv: Object.freeze(readStringList("TERMINAL_PASSTHROUGH_ENV")),
 } as const);
 
 export function authEnabled(): boolean {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -272,6 +272,25 @@ export const config = Object.freeze({
    * Example: `TERMINAL_PASSTHROUGH_ENV=KUBECONFIG,EDITOR,NODE_ENV`
    */
   terminalPassthroughEnv: Object.freeze(readStringList("TERMINAL_PASSTHROUGH_ENV")),
+  /**
+   * Opt-in: append a workbench-defined "secret hygiene" rule to the
+   * agent's system prompt. The rule asks the model to treat env-var
+   * values as credentials by default and not echo them into responses
+   * or tool outputs unless explicitly asked. See
+   * `agent-resource-loader.ts#WORKBENCH_SECRET_HYGIENE_RULE` for the
+   * exact wording and `SECURITY.md` for the threat-model framing
+   * (behavioral nudge, not a security control).
+   *
+   * Default OFF. Operators who want it explicitly opt in by setting
+   * `AGENT_SECRET_HYGIENE_RULE=true`. Kept opt-in (rather than
+   * default-on) so the workbench doesn't ship invisible behavioral
+   * rules that constrain the agent in ways the user never asked for.
+   * Deliberately not surfaced in `docker-compose.yml` or
+   * `.env.example` — this is an advanced knob, intentionally
+   * discoverable only via SECURITY.md so operators meet the rule
+   * the same time they meet its caveats.
+   */
+  agentSecretHygieneRule: readBool("AGENT_SECRET_HYGIENE_RULE", false),
 } as const);
 
 export function authEnabled(): boolean {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -28,6 +28,7 @@ import { terminalRoutes } from "./routes/terminal.js";
 import { disposeAll as disposeAllMcp, loadGlobal as loadGlobalMcp } from "./mcp/manager.js";
 import { disposeAllSessions } from "./session-registry.js";
 import { disposeAllPtys, installPtyExitHandler } from "./pty-manager.js";
+import { logSecretHygieneState } from "./agent-resource-loader.js";
 
 /**
  * Per-route auth metadata. Routes that should skip the auth preHandler set
@@ -430,6 +431,12 @@ async function start(): Promise<void> {
     }
   }
   const fastify = await buildServer();
+  // One-line confirmation of optional security knobs that are easy to
+  // typo or forget to wire through. If you add another opt-in
+  // behavioral toggle here, log its state too — operators should be
+  // able to grep container logs for the answer to "did my env var
+  // take effect" without sending a test prompt.
+  logSecretHygieneState();
   try {
     await fastify.listen({ port: config.port, host: config.host });
     fastify.log.info(`pi-workbench server listening on :${config.port}`);

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import * as nodePty from "node-pty";
+import { config } from "./config.js";
 
 /**
  * Per-project PTY tracking with reattach support.
@@ -338,39 +339,76 @@ export function installPtyExitHandler(): void {
 }
 
 /**
- * Workbench secrets that the PTY shell MUST NOT inherit. Without this
- * scrub, an authenticated user can `echo $JWT_SECRET` to read the
- * server's JWT signing key — turning a 7-day browser token into a
- * permanent backdoor (they can mint new tokens with arbitrary `exp`)
- * AND defeating any future JWT_SECRET rotation (re-sign with the new
- * secret they read from env). API_KEY and UI_PASSWORD have similar
- * privilege-escalation shapes.
+ * Allowlist of env-var names the PTY shell (and the `!` exec route)
+ * may inherit from the workbench process. Everything else is dropped.
  *
- * Provider keys (ANTHROPIC_API_KEY etc.) are also scrubbed when set
- * via env — operators should use `auth.json` for those, and the agent's
- * own LLM calls don't need them at the shell level. If an operator
- * relies on env-injected provider keys for a CLI tool they invoke FROM
- * the terminal, they need to re-export in their shell rc.
+ * Allowlist instead of denylist because the threat model is "any
+ * secret an operator has in their host env leaks into the shell." A
+ * denylist of named secrets is fail-open — every newly-named provider
+ * key (`SOMEPROVIDER_API_KEY`), kube credential, cloud token, etc.
+ * leaks until we add it by name. An allowlist is fail-safe: anything
+ * not on this list is hidden by default; operators with a legitimate
+ * need pass specific vars through via `TERMINAL_PASSTHROUGH_ENV`.
+ *
+ * What's on the list and why:
+ *   PATH, HOME, USER, LOGNAME, SHELL — required for a usable shell
+ *   PWD                              — the shell sets it but inheriting
+ *                                      avoids a transient empty value
+ *   TERM, COLORTERM                  — xterm rendering / 256-color
+ *   TERMINFO                         — fallback terminfo lookup
+ *   LANG, LC_*                       — locale (UTF-8, sorting, dates)
+ *   TZ                               — timezone-aware tools (`date`)
+ *   HOSTNAME                         — prompt customization (`\h` in PS1)
+ *   EDITOR, PAGER, VISUAL            — interactive defaults (git
+ *                                      commit, less, etc.)
+ *
+ * Conspicuously NOT on the list (must be opt-in via
+ * `TERMINAL_PASSTHROUGH_ENV` if the operator wants them in-shell):
+ *   - Workbench secrets: JWT_SECRET, API_KEY, UI_PASSWORD
+ *   - Provider keys:     ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.
+ *   - Cloud credentials: AWS_*, GOOGLE_APPLICATION_CREDENTIALS,
+ *                        GH_TOKEN, GITHUB_TOKEN, KUBECONFIG, ...
+ *   - Anything else      — assume it's sensitive until proven harmless.
  */
-const SCRUB_ENV_VARS: ReadonlySet<string> = new Set([
-  "JWT_SECRET",
-  "API_KEY",
-  "UI_PASSWORD",
-  "ANTHROPIC_API_KEY",
-  "OPENAI_API_KEY",
-  "GROQ_API_KEY",
-  "GOOGLE_API_KEY",
-  "MISTRAL_API_KEY",
-  "OPENROUTER_API_KEY",
-  "DEEPSEEK_API_KEY",
-  "XAI_API_KEY",
+const TERMINAL_ENV_ALLOWLIST: ReadonlySet<string> = new Set([
+  "PATH",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "PWD",
+  "TERM",
+  "COLORTERM",
+  "TERMINFO",
+  "LANG",
+  "TZ",
+  "HOSTNAME",
+  "EDITOR",
+  "PAGER",
+  "VISUAL",
 ]);
 
+/**
+ * Variable names matching this prefix-style pattern are also allowed
+ * — covers the locale family (`LC_ALL`, `LC_CTYPE`, `LC_MESSAGES`, …)
+ * without enumerating every variant.
+ */
+const TERMINAL_ENV_ALLOWLIST_PREFIXES: readonly string[] = ["LC_"];
+
+function isAllowedByDefault(name: string): boolean {
+  if (TERMINAL_ENV_ALLOWLIST.has(name)) return true;
+  for (const prefix of TERMINAL_ENV_ALLOWLIST_PREFIXES) {
+    if (name.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
 function filterEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const passthrough = new Set(config.terminalPassthroughEnv);
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(env)) {
     if (typeof v !== "string") continue;
-    if (SCRUB_ENV_VARS.has(k)) continue;
+    if (!isAllowedByDefault(k) && !passthrough.has(k)) continue;
     out[k] = v;
   }
   return out;
@@ -378,9 +416,10 @@ function filterEnv(env: NodeJS.ProcessEnv): Record<string, string> {
 
 /**
  * Re-export so non-PTY callers (the user-bash `!` exec route) get the
- * same secret-scrubbing posture without having to re-state the secret
- * list. The PTY and the one-shot user-bash share an identical threat
- * model: an authenticated browser user must not be able to `echo
- * $JWT_SECRET` from a shell the workbench spawned on their behalf.
+ * same env allowlist without having to re-implement it. The PTY and
+ * the one-shot user-bash share an identical threat model: an
+ * authenticated browser user must not be able to `echo
+ * $JWT_SECRET` (or any other host-env secret) from a shell the
+ * workbench spawned on their behalf.
  */
 export const scrubbedEnv = (): Record<string, string> => filterEnv(process.env);

--- a/packages/server/src/routes/exec.ts
+++ b/packages/server/src/routes/exec.ts
@@ -32,10 +32,13 @@ import { scrubbedEnv } from "../pty-manager.js";
  * inject context.
  *
  * Security posture: BashOperations is overridden to inject our
- * `scrubbedEnv()` (no JWT_SECRET / API_KEY / UI_PASSWORD / provider
- * keys), matching the integrated terminal's posture. The agent's own
- * bash TOOL may still have an env-exposure surface — that's a
- * separate fix for a separate code path.
+ * `scrubbedEnv()` — an allowlist-based filter that only passes
+ * known-harmless system vars (PATH, HOME, TERM, locales, …). Workbench
+ * secrets, provider keys, cloud credentials, and any other host-env
+ * vars are dropped unless the operator opts them back in via
+ * `TERMINAL_PASSTHROUGH_ENV`. Matches the integrated terminal's
+ * posture. The agent's own bash TOOL may still have an env-exposure
+ * surface — that's a separate fix for a separate code path.
  */
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -49,8 +52,9 @@ interface ExecBody {
  * Build a BashOperations that delegates to local spawn, but with our
  * scrubbed env. createLocalBashOperations from the SDK would inherit
  * `process.env` verbatim, leaking secrets the workbench process
- * carries (JWT_SECRET, API_KEY, etc.) — see pty-manager.SCRUB_ENV_VARS
- * for the full list and rationale.
+ * carries (JWT_SECRET, API_KEY, etc.) — see
+ * pty-manager.TERMINAL_ENV_ALLOWLIST for the full set of allowed
+ * passthrough vars and rationale.
  */
 function workbenchBashOperations(): BashOperations {
   return {

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -8,6 +8,7 @@ import {
   SettingsManager,
   type SessionInfo,
 } from "@mariozechner/pi-coding-agent";
+import { buildWorkbenchResourceLoader } from "./agent-resource-loader.js";
 import { config } from "./config.js";
 import { makeDedupe, makeLock } from "./concurrency.js";
 import { effectiveSkillsForProject } from "./config-manager.js";
@@ -312,10 +313,16 @@ export async function createSession(
   // for Phase 6's prompt route.
   const customTools = await resolveMcpCustomTools(projectId, workspacePath);
   const settingsManager = await buildSessionSettingsManager(workspacePath, projectId);
+  const resourceLoader = await buildWorkbenchResourceLoader(
+    workspacePath,
+    config.piConfigDir,
+    settingsManager,
+  );
   const { session } = await createAgentSession({
     cwd: workspacePath,
     sessionManager,
     settingsManager,
+    resourceLoader,
     agentDir: config.piConfigDir,
     customTools,
   });
@@ -457,10 +464,16 @@ export async function resumeSession(
     const sessionManager = SessionManager.open(match.path, dir, workspacePath);
     const customTools = await resolveMcpCustomTools(projectId, workspacePath);
     const settingsManager = await buildSessionSettingsManager(workspacePath, projectId);
+    const resourceLoader = await buildWorkbenchResourceLoader(
+      workspacePath,
+      config.piConfigDir,
+      settingsManager,
+    );
     const { session } = await createAgentSession({
       cwd: workspacePath,
       sessionManager,
       settingsManager,
+      resourceLoader,
       agentDir: config.piConfigDir,
       customTools,
     });
@@ -823,10 +836,16 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
   const sessionManager = SessionManager.open(newPath, dir, source.workspacePath);
   const customTools = await resolveMcpCustomTools(source.projectId, source.workspacePath);
   const settingsManager = await buildSessionSettingsManager(source.workspacePath, source.projectId);
+  const resourceLoader = await buildWorkbenchResourceLoader(
+    source.workspacePath,
+    config.piConfigDir,
+    settingsManager,
+  );
   const { session } = await createAgentSession({
     cwd: source.workspacePath,
     sessionManager,
     settingsManager,
+    resourceLoader,
     agentDir: config.piConfigDir,
     customTools,
   });
@@ -865,10 +884,16 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
         source.workspacePath,
         source.projectId,
       );
+      const restoredResourceLoader = await buildWorkbenchResourceLoader(
+        source.workspacePath,
+        config.piConfigDir,
+        restoredSettingsManager,
+      );
       const { session: restoredSession } = await createAgentSession({
         cwd: source.workspacePath,
         sessionManager: restoredManager,
         settingsManager: restoredSettingsManager,
+        resourceLoader: restoredResourceLoader,
         agentDir: config.piConfigDir,
         customTools: restoredCustomTools,
       });

--- a/tests/test-terminal.ts
+++ b/tests/test-terminal.ts
@@ -274,6 +274,46 @@ async function main(): Promise<void> {
       // assert no error closes the socket.
       await new Promise((r) => setTimeout(r, 100));
       assert("socket still open after resize", term.ws.readyState === WebSocket.OPEN);
+
+      // ---- Env allowlist: secrets dropped, harmless vars passed through ----
+      // The workbench server process has API_KEY set (we passed it
+      // above), but the PTY shell must NOT inherit it. Wrap the
+      // expansion with two sentinels: if API_KEY expanded to empty,
+      // the sentinels appear adjacent in the printf OUTPUT line
+      // (distinct from the shell's input echo, which contains quotes
+      // between them and so won't match the adjacency probe).
+      const sL = "ENVCHK_L_" + randomBytes(3).toString("hex");
+      const sR = "_ENVCHK_R_" + randomBytes(3).toString("hex");
+      send(term.ws, {
+        type: "input",
+        data: `printf '%s%s%s\\n' "${sL}" "$API_KEY" "${sR}"\n`,
+      });
+      const adjacent = `${sL}${sR}`;
+      const sawAdjacent = await waitForOutput(term, adjacent, 5_000);
+      assert(
+        "API_KEY is NOT inherited by PTY shell",
+        sawAdjacent,
+        `expected sentinels ${sL} and ${sR} to appear adjacent (API_KEY empty); ` +
+          `last output: ${term.output.slice(-400)}`,
+      );
+
+      // PATH must still come through — a shell with no PATH can't even
+      // run `ls`. Sanity-check the allowlist actually allows things.
+      const pL = "PATHCHK_L_" + randomBytes(3).toString("hex");
+      const pR = "_PATHCHK_R_" + randomBytes(3).toString("hex");
+      send(term.ws, {
+        type: "input",
+        data: `printf '%s%s%s\\n' "${pL}" "$PATH" "${pR}"\n`,
+      });
+      const pathAdjacent = `${pL}${pR}`;
+      const sawPath = await waitForOutput(term, pR, 5_000);
+      assert("PATH echo wraps reach client", sawPath);
+      assert(
+        "PATH is inherited by PTY shell (not empty)",
+        !term.output.includes(pathAdjacent),
+        `unexpected adjacent sentinels — PATH expanded to empty. ` +
+          `last output: ${term.output.slice(-400)}`,
+      );
     }
 
     // ---- Concurrent terminal ----


### PR DESCRIPTION
## Summary

Three layered defenses against accidental secret disclosure through workbench-spawned shells and the agent's own bash tool. Each layer addresses a distinct, realistic failure mode; none is a substitute for the others.

### 1. Terminal + `!` exec env-var allowlist (commit \`6b35e55\`)

`pty-manager.filterEnv` switches from a named-secret denylist to an allowlist of harmless system vars (\`PATH\`, \`HOME\`, \`USER\`, \`LOGNAME\`, \`SHELL\`, \`PWD\`, \`TERM\`, \`COLORTERM\`, \`TERMINFO\`, \`LANG\`, \`LC_*\`, \`TZ\`, \`HOSTNAME\`, \`EDITOR\`, \`PAGER\`, \`VISUAL\`).

- **Closes a fail-open posture.** Any newly-named secret variable previously leaked into the spawned shell until added to the denylist by name. Allowlist is fail-safe — anything not on it is hidden by default.
- **Operators opt specific vars back in** via the new \`TERMINAL_PASSTHROUGH_ENV\` env (comma- or whitespace-separated). Example: \`TERMINAL_PASSTHROUGH_ENV=KUBECONFIG,EDITOR,NODE_ENV\`.
- Same scrub applies to the chat input's \`!\` / \`!!\` user-bash route via the existing \`scrubbedEnv()\` re-export.
- New smoke test in \`tests/test-terminal.ts\` proving \`API_KEY\` is dropped and \`PATH\` survives end-to-end through the PTY shell.

### 2. Agent system-prompt secret-hygiene rule (commit \`8df95ee\`)

Adds \`packages/server/src/agent-resource-loader.ts\` that builds a \`DefaultResourceLoader\` with an \`appendSystemPrompt\` addendum. The rule asks the model to treat env-var values as credentials by default — don't echo, print, or paste values into responses or tool outputs unless the user explicitly asked for that variable. Phrased around *displaying values* (not accessing variables) so legitimate skill workflows that need \`\$GITHUB_TOKEN\`, \`\$AWS_*\`, etc. still work — \`curl -H \"Authorization: Bearer \$X\"\` is fine, \`printenv X\` to reflect the value back is not.

Wired into all four \`createAgentSession\` callsites in \`session-registry.ts\` (initial create, resume, fork, fork-source-restore).

### 3. Opt-in toggle for the system-prompt rule (commit \`14584ca\`)

Default OFF. The rule is appended only when the operator sets:

\`\`\`
AGENT_SECRET_HYGIENE_RULE=true
\`\`\`

Deliberately not surfaced in \`docker/docker-compose.yml\` or \`docker/.env.example\` — operators discover the flag via SECURITY.md alongside the threat-model caveats (behavioral nudge, not a security control). Rationale: shipping invisible behavioral rules that constrain the agent in ways the user never asked for is a bad precedent; soft rules belong behind explicit opt-in until we have evidence default-on is unambiguously wanted.

## What this is NOT

- **Not a security control for the agent's bash tool.** The agent's autonomous bash tool deliberately keeps inheriting the workbench process env — skills legitimately need \`\$GITHUB_TOKEN\` / \`\$AWS_*\` / etc. to do their job. The opt-in system-prompt rule reduces accidental disclosure but is talkable-out-of by determined users, prompt-injected tool results, or the model's own reasoning.
- **Not a fix for terminal users reading pi config files.** The integrated terminal still runs as the same UID as the workbench process, so \`cat ~/.pi/agent/auth.json\` still works. SECURITY.md documents this as a known limitation; the actual fix is OS-level UID separation, which is operator-side.

## Documentation

- \`SECURITY.md\` gains a new "Host env-var inheritance into the spawned shell" entry under "What the project tries to defend against," a new "Accidental secret disclosure by the agent (opt-in)" entry on the same list with the env-var name and full caveats, and a new "Known limitations" section noting the terminal-can-read-pi-config-files exposure with the deployment-side mitigation.
- \`CHANGELOG.md\` gains a new \"### Security\" subsection under Unreleased with all three changes.

## Test plan

- [x] \`npm run typecheck\` clean across server, client, tests.
- [x] \`tests/test-terminal.ts\` — new env-allowlist assertions pass: \`API_KEY\` is NOT inherited by the PTY shell; \`PATH\` IS. (Pre-existing \"activePtys returns to 0 after close\" failure is unrelated to this PR — see Notes below.)
- [x] \`tests/test-session.ts\` — session creation through the new \`buildWorkbenchResourceLoader\` doesn't regress. (Same pre-existing dispose failures as on main.)
- [ ] **Manual: terminal env passthrough.** Set \`TERMINAL_PASSTHROUGH_ENV=KUBECONFIG\` in the workbench env, open a terminal, run \`echo \$KUBECONFIG\` — value appears. Without the var, value is empty.
- [ ] **Manual: terminal secret blocking.** With \`API_KEY\` set on the workbench process, open a terminal and run \`echo \$API_KEY\` — output is empty.
- [ ] **Manual: agent rule opt-in.** Without \`AGENT_SECRET_HYGIENE_RULE\`, ask the agent \"what does \$PATH expand to?\" — agent prints it. Set \`AGENT_SECRET_HYGIENE_RULE=true\`, restart, ask the same — agent should hedge / decline / ask for confirmation per the rule. Then explicitly say \"yes, I want to see \$PATH\" — agent should comply (the rule has an explicit-opt-in escape hatch).
- [ ] **Manual: agent rule default off.** Confirm fresh deploy without the env var behaves identically to pre-PR \`main\` — no behavior change for users who don't opt in.

## Notes

- Pre-existing \`tests/test-terminal.ts\` failure (\`activePtys returns to 0 after close\`) is NOT caused by this PR — it's a stale assertion from before the IDLE_REAP_MS detach behavior was added. Stashing this branch and running on main reproduces the same failure. Out of scope here; happy to fix in a follow-up.
- Pre-existing \`tests/test-session.ts\` dispose failures likewise unchanged from main.