### PR TITLE
chore(format): prettier --write agent-resource-loader.ts

### DIFF
--- a/packages/server/src/agent-resource-loader.ts
+++ b/packages/server/src/agent-resource-loader.ts
@@ -85,9 +85,7 @@ export async function buildWorkbenchResourceLoader(
   agentDir: string,
   settingsManager: SettingsManager,
 ): Promise<ResourceLoader> {
-  const appendSystemPrompt = config.agentSecretHygieneRule
-    ? [WORKBENCH_SECRET_HYGIENE_RULE]
-    : [];
+  const appendSystemPrompt = config.agentSecretHygieneRule ? [WORKBENCH_SECRET_HYGIENE_RULE] : [];
   const loader = new DefaultResourceLoader({
     cwd,
     agentDir,


### PR DESCRIPTION
## Summary

Fixes the CI \`format:check\` failure on \`main\` after PR #3 merged. Prettier collapses the \`config.agentSecretHygieneRule ? [...] : []\` ternary onto one line; the merged file had it split across three.

One-line change, no behavior change.

## Test plan

- [x] \`npm run format:check\` passes locally.
- [x] \`npm run check\` (typecheck + lint + format) passes.
- [ ] CI \`format:check\` step goes green on this PR.