### PR TITLE
fix(tests): repair pre-existing test-session and test-terminal failures

### DIFF
--- a/packages/server/src/agent-resource-loader.ts
+++ b/packages/server/src/agent-resource-loader.ts
@@ -85,9 +85,7 @@ export async function buildWorkbenchResourceLoader(
   agentDir: string,
   settingsManager: SettingsManager,
 ): Promise<ResourceLoader> {
-  const appendSystemPrompt = config.agentSecretHygieneRule
-    ? [WORKBENCH_SECRET_HYGIENE_RULE]
-    : [];
+  const appendSystemPrompt = config.agentSecretHygieneRule ? [WORKBENCH_SECRET_HYGIENE_RULE] : [];
   const loader = new DefaultResourceLoader({
     cwd,
     agentDir,

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -291,6 +291,23 @@ export const config = Object.freeze({
    * the same time they meet its caveats.
    */
   agentSecretHygieneRule: readBool("AGENT_SECRET_HYGIENE_RULE", false),
+  /**
+   * How long a detached PTY (its WebSocket closed but no replacement
+   * attached yet) is held alive before being reaped. The 10-minute
+   * default protects the common reattach use case: page refresh,
+   * transient network blip, laptop sleep — none of those should kill
+   * the user's shell.
+   *
+   * Operators in resource-constrained envs (kiosks, low-RAM
+   * containers) can shrink this. The integration test pins it to
+   * ~200 ms so the reap-on-close assertion completes within a normal
+   * test budget instead of waiting 10 minutes.
+   *
+   * Read by `pty-manager.ts#IDLE_REAP_MS` at module load. Setting
+   * this to 0 effectively disables reattach-after-WS-drop (every WS
+   * close becomes a hard kill); use that deliberately or not at all.
+   */
+  terminalIdleReapMs: readInt("PTY_IDLE_REAP_MS", 10 * 60 * 1000),
 } as const);
 
 export function authEnabled(): boolean {

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -57,8 +57,14 @@ export interface ManagedPty {
 
 /** Rolling output buffer cap per PTY (in bytes). 256 KB ≈ ~3000 lines of typical shell output. */
 const OUTPUT_BUFFER_BYTES = 256 * 1024;
-/** Time a detached PTY (no WS attached) is held alive before being reaped. */
-const IDLE_REAP_MS = 10 * 60 * 1000;
+/**
+ * Time a detached PTY (no WS attached) is held alive before being reaped.
+ * Sourced from `config.terminalIdleReapMs` so operators in resource-
+ * constrained deployments can shorten the window, AND so the integration
+ * test can pin it down to ~200 ms to actually exercise the reap path
+ * within a test budget.
+ */
+const IDLE_REAP_MS = config.terminalIdleReapMs;
 
 interface Entry {
   managed: ManagedPty;

--- a/tests/test-session.ts
+++ b/tests/test-session.ts
@@ -91,12 +91,19 @@ async function main(): Promise<void> {
     createSession: (projectId: string, workspacePath: string) => Promise<TestLive>;
     getSession: (id: string) => TestLive | undefined;
     listSessions: (projectId?: string) => TestLive[];
-    disposeSession: (id: string) => boolean;
+    // Async because dispose now awaits an in-flight LLM-call abort
+    // before tearing down (session-registry.ts: ABORT_TIMEOUT_MS).
+    disposeSession: (id: string) => Promise<boolean>;
     resumeSession: (id: string, projectId: string, workspacePath: string) => Promise<TestLive>;
     discoverSessionsOnDisk: (projectId: string, workspacePath: string) => Promise<TestDiscovered[]>;
     sessionCount: () => number;
     disposeAllSessions: () => void;
   }
+  // The dispose path lays down a 1500 ms "tombstone" on the
+  // sessionId so a polling SSE client can't re-resume the session
+  // before the disk delete completes. Tests that dispose then
+  // immediately resume the same id need to wait this out.
+  const TOMBSTONE_MS = 1500;
   const registry = (await import(
     resolve(repoRoot, "packages/server/dist/session-registry.js")
   )) as unknown as TestRegistry;
@@ -210,7 +217,7 @@ async function main(): Promise<void> {
     );
 
     // 5. dispose removes from registry, leaves JSONL on disk
-    assert("disposeSession returns true", registry.disposeSession(live.sessionId) === true);
+    assert("disposeSession returns true", (await registry.disposeSession(live.sessionId)) === true);
     assert("registry.sessionCount() === 0 after dispose", registry.sessionCount() === 0);
     assert(
       "getSession returns undefined after dispose",
@@ -223,10 +230,14 @@ async function main(): Promise<void> {
     );
     assert(
       "disposeSession on unknown id returns false",
-      registry.disposeSession("does-not-exist") === false,
+      (await registry.disposeSession("does-not-exist")) === false,
     );
 
-    // 6. resume — same id comes back, name persists
+    // 6. resume — same id comes back, name persists.
+    // Wait out the tombstone first; dispose-then-immediate-resume
+    // would otherwise hit SessionTombstonedError (the design exists
+    // to defeat polling SSE clients during a hard-delete race).
+    await new Promise((r) => setTimeout(r, TOMBSTONE_MS + 100));
     const resumed = await registry.resumeSession(live.sessionId, projectId, workspacePath);
     assert("resumeSession returns same sessionId", resumed.sessionId === live.sessionId);
     assert("registry.sessionCount() === 1 after resume", registry.sessionCount() === 1);
@@ -237,7 +248,7 @@ async function main(): Promise<void> {
       rediscovered[0]?.name === "phase-4-test",
       `got ${rediscovered[0]?.name}`,
     );
-    registry.disposeSession(resumed.sessionId);
+    await registry.disposeSession(resumed.sessionId);
 
     // 6b. Multi-client fan-out: in a fresh session (so it doesn't disturb
     // the resume-name assertion above), inject two stub SSEClients and
@@ -294,7 +305,7 @@ async function main(): Promise<void> {
       assert("misbehaving client was removed from the set", !fanSession.clients.has(stubBad));
       assert("healthy client kept receiving events", fanGood.length > 0);
     } finally {
-      registry.disposeSession(fanSession.sessionId);
+      await registry.disposeSession(fanSession.sessionId);
     }
 
     // 7. resumeSession on an unknown id throws SessionNotFoundError
@@ -333,7 +344,7 @@ async function main(): Promise<void> {
         `got ${body.activeSessions}`,
       );
       assert("health.activePtys is still 0 (Phase 11)", body.activePtys === 0);
-      registry.disposeSession(probe.sessionId);
+      await registry.disposeSession(probe.sessionId);
       const res2 = await fetch(`${listenAddr}/api/v1/health`);
       const body2 = (await res2.json()) as { activeSessions: number };
       assert("health updates after dispose to 0", body2.activeSessions === 0);
@@ -362,7 +373,7 @@ async function main(): Promise<void> {
         );
       } finally {
         unsubPrompt();
-        registry.disposeSession(liveForPrompt.sessionId);
+        await registry.disposeSession(liveForPrompt.sessionId);
       }
     } else {
       console.log("\n[test-session] (skipped live-prompt — set PI_TEST_LIVE_PROMPT=1 to run)");

--- a/tests/test-terminal.ts
+++ b/tests/test-terminal.ts
@@ -34,6 +34,17 @@ const __dirname = dirname(__filename);
 const repoRoot = resolve(__dirname, "..");
 const serverEntry = resolve(repoRoot, "packages/server/dist/index.js");
 
+/**
+ * Detached-PTY reap window for both spawned servers in this test.
+ * Production default is 10 minutes (production code wants reattach
+ * across a page-refresh / VPN blip / laptop-sleep to Just Work);
+ * we override to 200 ms here so the post-close assertions actually
+ * complete within the test budget. The wait constant below adds a
+ * generous timer-jitter buffer on top.
+ */
+const REAP_MS = 200;
+const REAP_WAIT_MS = REAP_MS + 800;
+
 let failures = 0;
 function assert(label: string, ok: boolean, detail?: string): void {
   if (ok) console.log(`  PASS  ${label}`);
@@ -187,6 +198,11 @@ async function main(): Promise<void> {
       UI_PASSWORD: undefined,
       JWT_SECRET: undefined,
       SERVE_CLIENT: "false",
+      // Shrink the detached-PTY reap window so the "activePtys returns
+      // to 0 after close" assertion exercises the real reap path within
+      // the test budget instead of waiting the 10-minute production
+      // default. 200 ms is comfortably above any timer-scheduling jitter.
+      PTY_IDLE_REAP_MS: String(REAP_MS),
       // Predictable PS1 so the prompt doesn't drown the test output.
       PS1: "$ ",
     },
@@ -341,7 +357,16 @@ async function main(): Promise<void> {
         t.ws.close(1000, "test_done");
         await closed;
       }
-      assert("activePtys returns to 0 after close", (await waitForPtyCount(base, 0)) === 0);
+      // PTYs are kept alive on WS close so a reattach can pick them
+      // back up; cleanup happens via the idle reaper (PTY_IDLE_REAP_MS,
+      // pinned to REAP_MS for this test). Wait the reap window plus a
+      // buffer, then assert the count drains. waitForPtyCount polls so
+      // we don't actually have to wait the full window unless the
+      // reaper is genuinely slow.
+      assert(
+        "activePtys returns to 0 after idle reap",
+        (await waitForPtyCount(base, 0, REAP_WAIT_MS)) === 0,
+      );
     }
   } finally {
     for (const t of opened) {


### PR DESCRIPTION
## Summary

Two integration tests have been failing on \`main\` since at least PR #1 (likely earlier). They went unnoticed because \`npm run check\` doesn't actually run them — it's just typecheck + lint + format. This PR fixes the assertions; a follow-up PR should add a CI step that runs the test scripts so this can't happen again.

### \`tests/test-session.ts\` — disposeSession became async

\`disposeSession\` now \`await\`s an in-flight LLM-call abort with a 5 s ceiling before tearing down (\`session-registry.ts\` ABORT_TIMEOUT_MS). The test interface still typed it as sync and most callers didn't await — \`disposeSession(...) === true\` compared a Promise to true (false), and downstream \`sessionCount\` checks raced the dispose. Cascading failures plus a \`SessionTombstonedError\` on the next \`resumeSession\`.

Fix: type as async, \`await\` all six callsites, and sleep through TOMBSTONE_MS (1.5 s + buffer) between dispose and the dispose-then-resume scenario. **No production code change.**

### \`tests/test-terminal.ts\` — IDLE_REAP_MS detach behavior

The \"activePtys returns to 0 after close\" assertion was written before \`pty-manager\` grew the IDLE_REAP_MS detach-then-reap behavior. On WS close the PTY is now intentionally kept alive for 10 minutes so a page refresh / VPN blip / laptop sleep can reattach without losing the user's shell. So activePtys does NOT drop to 0 immediately, and the assertion fails.

Fix: surface the reap window as \`config.terminalIdleReapMs\` (env: \`PTY_IDLE_REAP_MS\`, default 10 min). \`pty-manager\` reads it at module load. Operators in resource-constrained envs can shrink it; the test pins it to 200 ms so the assertion exercises the real reap path within the test budget.

The new assertion (\"activePtys returns to 0 after idle reap\") is strictly stronger than the original — it actually proves the reap fires, where the original silently passed before the detach behavior was added at all.

### \`packages/server/src/agent-resource-loader.ts\` — formatting

Same one-line prettier fix as PR #4. Included here so this PR's CI passes regardless of merge order; if PR #4 lands first this commit becomes a no-op merge.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run check\` clean (typecheck + lint + format)
- [x] \`npx tsx tests/test-session.ts\` — full PASS
- [x] \`npx tsx tests/test-terminal.ts\` — full PASS, including the new "returns to 0 after idle reap" assertion that exercises the real reap path
- [ ] CI build/check passes on this PR (note: the existing CI workflow doesn't run the integration tests — that's the gap that let these failures sit on main; out of scope for this PR but worth a follow-up)

## Notes

- I dug into git history before making changes — both failures reproduce at \`fd70215\` (commit immediately *before* PR #1 venv-autoactivate). They've been broken on main for at least 3 merges. Not caused by any work in this session.
- Adding an \`npm run test\` loop + CI step to prevent this class of "broken test sat on main" recurrence is a separate one-PR follow-up.