### PR TITLE
feat(chat): collapse tool calls into one entry per call + header preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+### Changed
+
+- **Tool calls render as one collapsed entry per call.** Previously
+  the assistant-side `toolCall` block and its matching `toolResult`
+  message rendered as two separate boxes in the chat — one showing
+  `→ <tool>` plus a JSON dump of arguments, the other showing the
+  tool's output. Now each tool invocation is paired by `toolCallId`
+  and rendered as a single entry with three rows: header
+  (`→ <tool>` + an error / running badge), collapsible **Input**
+  (closed by default), and collapsible **Output** (closed by
+  default). The `edit` tool keeps its specialized diff renderer
+  inside the Output row so file diffs still display as +/- lines
+  once expanded. Mid-stream calls without a result yet show a
+  "running…" badge in the header.
+
 ### Added
 
 - **Config export / import as `.tar.gz`.** New `Settings → Backup`

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -163,9 +163,39 @@ export function ChatView({ sessionId }: Props) {
             </p>
           )}
           <div className="mx-auto max-w-3xl space-y-4">
-            {messages.map((m, i) => (
-              <Message key={i} message={m} />
-            ))}
+            {(() => {
+              // Pair toolCall blocks (in assistant messages) with their
+              // matching toolResult messages (by toolCallId) so each
+              // tool invocation renders as one collapsed entry instead
+              // of two separate boxes. Loose toolResults — orphans
+              // from older sessions, or results whose call we never
+              // saw — still render via the standalone path.
+              const toolResultsById = new Map<string, AgentMessageLike>();
+              const pairedIds = new Set<string>();
+              for (const m of messages) {
+                if (m.role === "toolResult" && typeof m.toolCallId === "string") {
+                  toolResultsById.set(m.toolCallId, m);
+                }
+              }
+              for (const m of messages) {
+                if (m.role !== "assistant" || !Array.isArray(m.content)) continue;
+                for (const block of m.content as Record<string, unknown>[]) {
+                  if (block.type === "toolCall" && typeof block.id === "string") {
+                    pairedIds.add(block.id);
+                  }
+                }
+              }
+              return messages.map((m, i) => {
+                if (
+                  m.role === "toolResult" &&
+                  typeof m.toolCallId === "string" &&
+                  pairedIds.has(m.toolCallId)
+                ) {
+                  return null; // rendered inline next to its toolCall
+                }
+                return <Message key={i} message={m} toolResultsById={toolResultsById} />;
+              });
+            })()}
             {streamingText.length > 0 && (
               <div className="rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3">
                 <div className="mb-1 text-[10px] uppercase tracking-wider text-neutral-500">
@@ -426,7 +456,13 @@ function FileRefBadge({ ref: r }: { ref: FileRef }) {
   );
 }
 
-function Message({ message }: { message: AgentMessageLike }) {
+function Message({
+  message,
+  toolResultsById,
+}: {
+  message: AgentMessageLike;
+  toolResultsById?: Map<string, AgentMessageLike>;
+}) {
   // User text messages — may include image + file attachments per
   // Phase 14. Optimistic shape uses a blob URL on the image block;
   // canonical refetched shape uses raw base64 with a mimeType, which
@@ -515,9 +551,14 @@ function Message({ message }: { message: AgentMessageLike }) {
       <div className="rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3">
         <div className="mb-1 text-[10px] uppercase tracking-wider text-neutral-500">assistant</div>
         <div className="space-y-2 text-sm text-neutral-100">
-          {content.map((block, i) => (
-            <AssistantBlock key={i} block={block as Record<string, unknown>} />
-          ))}
+          {content.map((block, i) => {
+            const blockProps: {
+              block: Record<string, unknown>;
+              toolResultsById?: Map<string, AgentMessageLike>;
+            } = { block: block as Record<string, unknown> };
+            if (toolResultsById !== undefined) blockProps.toolResultsById = toolResultsById;
+            return <AssistantBlock key={i} {...blockProps} />;
+          })}
         </div>
       </div>
     );
@@ -553,7 +594,13 @@ function Message({ message }: { message: AgentMessageLike }) {
   );
 }
 
-function AssistantBlock({ block }: { block: Record<string, unknown> }) {
+function AssistantBlock({
+  block,
+  toolResultsById,
+}: {
+  block: Record<string, unknown>;
+  toolResultsById?: Map<string, AgentMessageLike>;
+}) {
   const type = block.type;
 
   if (type === "text" && typeof block.text === "string") {
@@ -572,19 +619,9 @@ function AssistantBlock({ block }: { block: Record<string, unknown> }) {
   }
 
   if (type === "toolCall") {
-    const name = String(block.name ?? "tool");
-    const args = block.input ?? block.arguments ?? {};
-    return (
-      <div className="rounded border border-neutral-700 bg-neutral-950 px-3 py-2 text-xs">
-        <div className="mb-1 text-neutral-300">
-          <span className="text-neutral-500">→ </span>
-          <span className="font-mono">{name}</span>
-        </div>
-        <pre className="overflow-auto text-[11px] text-neutral-400">
-          {typeof args === "string" ? args : JSON.stringify(args, null, 2)}
-        </pre>
-      </div>
-    );
+    const id = typeof block.id === "string" ? block.id : undefined;
+    const result = id !== undefined ? toolResultsById?.get(id) : undefined;
+    return <ToolCallEntry block={block} result={result} />;
   }
 
   return (
@@ -594,6 +631,132 @@ function AssistantBlock({ block }: { block: Record<string, unknown> }) {
         {JSON.stringify(block, null, 2)}
       </pre>
     </details>
+  );
+}
+
+/**
+ * One tool invocation rendered as a single entry: header (always
+ * visible) + collapsible Input row + collapsible Output row.
+ *
+ * Replaces the prior layout where the assistant-side toolCall block
+ * and its matching toolResult message rendered as two separate boxes.
+ * Pairing happens in the parent render loop via toolCallId; if no
+ * result has arrived yet (mid-streaming) the Output row shows
+ * "running…" and is not collapsible.
+ *
+ * `edit` keeps its specialized diff renderer inside the Output row —
+ * the diff is the most informative content for that tool, and
+ * showing it inside the same collapsed entry keeps the visual
+ * grouping while preserving the per-file +/- gutter the user is
+ * used to.
+ */
+function ToolCallEntry({
+  block,
+  result,
+}: {
+  block: Record<string, unknown>;
+  result: AgentMessageLike | undefined;
+}) {
+  const name = String(block.name ?? "tool");
+  const args = block.input ?? block.arguments ?? {};
+  const argsText = typeof args === "string" ? args : JSON.stringify(args, null, 2);
+
+  const isError = result?.isError === true;
+  const resultContent = Array.isArray(result?.content) ? result?.content : [];
+  const outputText = resultContent
+    .filter((c): c is { type: "text"; text: string } => {
+      const o = c as { type?: unknown; text?: unknown };
+      return o.type === "text" && typeof o.text === "string";
+    })
+    .map((c) => c.text)
+    .join("\n");
+
+  // For `edit`, prefer the unified diff string the SDK puts on
+  // result.details over the joined text body — same logic the prior
+  // standalone ToolResult used; keeping it here means edit results
+  // still render as a real diff once expanded.
+  const editDiff =
+    name === "edit" && result !== undefined
+      ? (() => {
+          const d = (result.details as { diff?: unknown } | undefined)?.diff;
+          return typeof d === "string" ? d : outputText;
+        })()
+      : undefined;
+  const editFn = name === "edit" && result !== undefined ? extractFilename(result) : undefined;
+  const editStats = editDiff !== undefined ? countDiffLines(editDiff) : undefined;
+
+  // Border tint reflects success/error/pending so the user can scan
+  // a long thread without expanding every entry.
+  const borderClass =
+    result === undefined
+      ? "border-neutral-700"
+      : isError
+        ? "border-red-700/50"
+        : "border-neutral-800";
+
+  return (
+    <div className={`rounded border ${borderClass} bg-neutral-950 text-xs`}>
+      <div className="flex items-center justify-between px-3 py-2 text-neutral-300">
+        <div className="min-w-0 truncate">
+          <span className="text-neutral-500">→ </span>
+          <span className="font-mono">{name}</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {result === undefined && (
+            <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400">
+              running…
+            </span>
+          )}
+          {isError && (
+            <span className="rounded bg-red-900/30 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-red-300">
+              error
+            </span>
+          )}
+        </div>
+      </div>
+
+      {argsText.length > 0 && (
+        <details className="border-t border-neutral-800/60">
+          <summary className="cursor-pointer px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
+            Input
+          </summary>
+          <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">
+            {argsText}
+          </pre>
+        </details>
+      )}
+
+      {result !== undefined && (
+        <details className="border-t border-neutral-800/60">
+          <summary className="cursor-pointer px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
+            Output
+            {editStats !== undefined && (
+              <span className="ml-2 font-mono text-[10px]">
+                <span className="text-emerald-400">+{editStats.adds}</span>{" "}
+                <span className="text-red-400">-{editStats.dels}</span>
+              </span>
+            )}
+            {editFn !== undefined && (
+              <span className="ml-2 font-mono text-[10px] text-neutral-500">{editFn}</span>
+            )}
+          </summary>
+          {editDiff !== undefined && editStats !== undefined ? (
+            <div className="px-3 pb-2">
+              <ChatEditDiff
+                diff={editDiff}
+                filename={editFn}
+                adds={editStats.adds}
+                dels={editStats.dels}
+              />
+            </div>
+          ) : (
+            <pre className="max-h-96 overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-300">
+              {outputText.length > 0 ? outputText : "(empty)"}
+            </pre>
+          )}
+        </details>
+      )}
+    </div>
   );
 }
 

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -663,6 +663,23 @@ function ToolCallEntry({
 
   const isError = result?.isError === true;
   const resultContent = Array.isArray(result?.content) ? result?.content : [];
+
+  // One-line header preview so the entry is scannable without
+  // expanding it. Pulled from the tool's args by name:
+  //   bash         → command (most informative single line)
+  //   read/write   → file path / filename
+  //   edit         → file path (the +/- counts live on the Output row)
+  //   anything else → no preview (the Input row carries it)
+  // Long values are truncated visually via CSS; the full text lives
+  // in the Input row anyway.
+  const argsObj = isObjectShape(args) ? args : undefined;
+  const preview =
+    name === "bash" && typeof argsObj?.command === "string"
+      ? argsObj.command
+      : (name === "read" || name === "write" || name === "edit") &&
+          typeof argsObj?.path === "string"
+        ? argsObj.path
+        : undefined;
   const outputText = resultContent
     .filter((c): c is { type: "text"; text: string } => {
       const o = c as { type?: unknown; text?: unknown };
@@ -697,9 +714,14 @@ function ToolCallEntry({
   return (
     <div className={`rounded border ${borderClass} bg-neutral-950 text-xs`}>
       <div className="flex items-center justify-between px-3 py-2 text-neutral-300">
-        <div className="min-w-0 truncate">
+        <div className="min-w-0 flex-1 truncate">
           <span className="text-neutral-500">→ </span>
           <span className="font-mono">{name}</span>
+          {preview !== undefined && (
+            <span className="ml-2 truncate font-mono text-neutral-400" title={preview}>
+              {preview}
+            </span>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-1">
           {result === undefined && (
@@ -891,6 +913,10 @@ function BashExecution({ message }: { message: AgentMessageLike }) {
       )}
     </div>
   );
+}
+
+function isObjectShape(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
 function extractText(message: AgentMessageLike): string {


### PR DESCRIPTION
## Summary

Tool invocations in the chat now render as a single collapsed entry per call instead of two separate boxes (the assistant-side \`toolCall\` block and the matching \`toolResult\` message).

### Before

For one bash call the user saw two boxes:

\`\`\`
[ → bash                  ]
[ { "command": "ls -la" } ]

[ bash → ls -la ]
[ <output…>     ]
\`\`\`

### After

\`\`\`
[ → bash    ls -la                  ]   ← header (always visible)
[ ▶ Input                           ]   ← collapsed by default
[ ▶ Output                          ]   ← collapsed by default
\`\`\`

## How it works

- The render loop pre-builds a \`Map<toolCallId, toolResultMessage>\` from the messages array, plus a \`Set<toolCallId>\` of ids appearing in any assistant message's \`toolCall\` blocks.
- A \`toolResult\` whose id is in that set is **skipped** in the outer message loop — it gets rendered inline next to its call.
- The \`toolCall\` block itself renders via a new \`ToolCallEntry\` component: header (\`→ <tool>\`) + collapsible Input + collapsible Output.
- Loose \`toolResult\` messages (no matching call we ever saw — orphans from older sessions, partial restores) still fall through to the standalone path.

## Header preview

Right-aligned to the tool name, populated from args by tool name:

| Tool | Preview source |
|---|---|
| \`bash\` | \`args.command\` |
| \`read\` / \`write\` / \`edit\` | \`args.path\` |
| anything else | none (the Input row carries it) |

Long previews truncate with CSS; the full value is reachable on hover via the \`title\` attribute. Generic tools with opaque-shape args don't get a preview — keeps the header honest.

## State badges

- **Mid-stream**: \`running…\` badge in the header while the call is in flight.
- **Error**: red \`error\` badge + red border tint when \`isError\` is true.
- **Edit-specific**: the Output row's summary shows \`+adds -dels filename\` so a long thread is still scannable without expanding every diff. The diff itself stays the existing \`ChatEditDiff\` renderer (real +/- gutter) inside the collapsed body.

## What was deliberately dropped

- The standalone bash / read / write specialized layouts (with their own headers like \`bash → ls -la\` and visible-by-default output) are gone in favor of the uniform collapsed entry. The information they carried is now inside Input / Output rows of the same entry.

## Test plan

- [x] \`npm run check\` clean (typecheck + lint + format).
- [x] \`npm run test:ci\` — all 17 tests PASS.
- [x] **Manual**: send a prompt that triggers a \`bash\` call → expect one entry with \`→ bash    <command>\` header + Input + Output rows; no second box.
- [x] **Manual**: trigger an \`edit\` → expect \`→ edit    <path>\` header; Output row summary shows \`+N -M filename\`; expanding it shows the +/- diff via the existing diff renderer.
- [x] **Manual**: while a tool is mid-execution → header shows \`running…\` badge.
- [x] **Manual**: trigger a tool that errors → header shows red \`error\` badge + the entry's border is red-tinted.
- [x] **Manual**: load a session that has tool messages without paired calls (e.g. via JSONL replay) → orphans still render via the legacy ToolResult path, no regression.