### PR TITLE
feat(chat): markdown rendering with syntax highlighting + raw toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ the README for the support window policy.
 
 ### Changed
 
+- **Markdown + syntax-highlighted code in chat messages.** User
+  text bubbles, assistant text blocks, and the streaming preview
+  now render through `react-markdown` + `remark-gfm` — headings,
+  bold / italic, lists, tables, blockquotes, links, and fenced
+  code blocks. Fenced code blocks get prism-react-renderer syntax
+  highlighting (same library DiffBlock and ContextInspectorPanel
+  already use, so the dark surfaces stay visually consistent).
+  Inline `` `code` `` gets a styled monospace span. Raw HTML in
+  message content is ignored (no `rehype-raw`); links open in a
+  new tab with `noopener noreferrer`. Tool calls, file-reference
+  badges, bash exec messages, and image attachments still use
+  their dedicated renderers — markdown is for prose only.
 - **Tool calls render as one collapsed entry per call.** Previously
   the assistant-side `toolCall` block and its matching `toolResult`
   message rendered as two separate boxes in the chat — one showing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,22 @@ the README for the support window policy.
 
 - **Markdown + syntax-highlighted code in chat messages.** User
   text bubbles, assistant text blocks, and the streaming preview
-  now render through `react-markdown` + `remark-gfm` — headings,
-  bold / italic, lists, tables, blockquotes, links, and fenced
-  code blocks. Fenced code blocks get prism-react-renderer syntax
+  now render through `react-markdown` + `remark-gfm` +
+  `remark-breaks` — headings, bold / italic, lists, tables,
+  blockquotes, links, fenced code blocks, and chat-style single-
+  newline preservation (so the line breaks the user typed survive
+  the round-trip; CommonMark default would have folded them into
+  whitespace). Fenced code blocks get prism-react-renderer syntax
   highlighting (same library DiffBlock and ContextInspectorPanel
   already use, so the dark surfaces stay visually consistent).
   Inline `` `code` `` gets a styled monospace span. Raw HTML in
   message content is ignored (no `rehype-raw`); links open in a
-  new tab with `noopener noreferrer`. Tool calls, file-reference
-  badges, bash exec messages, and image attachments still use
-  their dedicated renderers — markdown is for prose only.
+  new tab with `noopener noreferrer`. Each user / assistant message
+  has a small `raw` / `rendered` toggle in the corner so the
+  underlying text (literal `**`, backticks, exact whitespace)
+  stays one click away. Tool calls, file-reference badges, bash
+  exec messages, and image attachments still use their dedicated
+  renderers — markdown is for prose only.
 - **Tool calls render as one collapsed entry per call.** Previously
   the assistant-side `toolCall` block and its matching `toolResult`
   message rendered as two separate boxes in the chat — one showing

--- a/package-lock.json
+++ b/package-lock.json
@@ -11943,6 +11943,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -13879,6 +13893,21 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {
@@ -17239,6 +17268,7 @@
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
         "refractor": "^5.0.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "zustand": "^5.0.3"
       },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "refractor": "^5.0.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "zustand": "^5.0.3"
   },

--- a/packages/client/src/components/ChatMarkdown.tsx
+++ b/packages/client/src/components/ChatMarkdown.tsx
@@ -1,0 +1,184 @@
+/**
+ * Markdown renderer for chat messages — assistant text blocks, user
+ * text bubbles, and the streaming preview.
+ *
+ * Uses `react-markdown` + `remark-gfm` (already in package.json from
+ * the v1 install but never wired) for the markdown / GFM dialect, and
+ * `prism-react-renderer` for syntax-highlighted fenced code blocks
+ * (same library DiffBlock and ContextInspectorPanel use, so themes
+ * stay consistent across the dark surfaces).
+ *
+ * Design choices that aren't obvious from the diff:
+ *
+ * - **No raw HTML.** react-markdown ignores HTML tags by default,
+ *   which is the right posture for assistant output that may
+ *   round-trip user-controlled content; we don't add the
+ *   `rehype-raw` plugin.
+ * - **Heading scale is dampened.** Default `<h1>`/`<h2>` are
+ *   document-sized (1.5rem+); inside a chat bubble they drown the
+ *   prose. Mapped to text-base / text-sm.
+ * - **Links open in a new tab.** `target="_blank"` + `rel="noopener
+ *   noreferrer"` so a click doesn't navigate away from the
+ *   conversation, and `noopener` defeats `window.opener` reach-back.
+ * - **Code blocks unwrap from their `<pre>`.** react-markdown nests
+ *   `<code>` inside `<pre>` for fenced blocks; we replace `<pre>`
+ *   with a fragment and let the code-renderer below own the
+ *   `<pre>` layout — otherwise the prism-themed `<pre>` ends up
+ *   inside the markdown library's bare `<pre>`, doubling the
+ *   background and padding.
+ * - **Inline code keeps the same monospace look across the app.**
+ *   We mirror the badge style used in SettingsPanel
+ *   (`code.font-mono`) so a `like-this` token reads the same
+ *   whether it appears in chat, in a settings hint, or in a tool
+ *   preview header.
+ * - **Streaming-friendly.** react-markdown handles unfinished input
+ *   gracefully — an open code fence renders as a code block until
+ *   it's closed by the next token. The streaming preview is the
+ *   primary user of that behavior; no special-case handling needed
+ *   here.
+ */
+import { Highlight, themes as prismThemes } from "prism-react-renderer";
+import type { HTMLAttributes, ReactNode } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+interface Props {
+  text: string;
+  /**
+   * Smaller text variant used by inline contexts (assistant
+   * (streaming) preview, anywhere bubble whitespace is tight). The
+   * default matches the assistant text block (text-sm).
+   */
+  size?: "sm" | "xs";
+}
+
+/**
+ * react-markdown 10 dropped the `inline` prop on the code component.
+ * The convention now: fenced blocks come through with a
+ * `className="language-foo"` from the fence's lang hint; inline
+ * code (single backticks) has no className. We branch on that to
+ * pick the inline-styled span vs the prism-highlighted block.
+ */
+const CodeRenderer = ({ className, children, ...rest }: HTMLAttributes<HTMLElement>): ReactNode => {
+  const langMatch = /language-([\w-]+)/.exec(className ?? "");
+  if (langMatch === null) {
+    return (
+      <code
+        className="rounded bg-neutral-800 px-1 py-0.5 font-mono text-[0.9em] text-neutral-100"
+        {...rest}
+      >
+        {children}
+      </code>
+    );
+  }
+  const language = langMatch[1] ?? "text";
+  // children is the code text. Coerce to string and strip a single
+  // trailing newline that `react-markdown` reliably adds — leaving
+  // it produces an awkward blank last line in the highlight.
+  const code = String(children ?? "").replace(/\n$/, "");
+
+  return (
+    <Highlight code={code} language={language} theme={prismThemes.vsDark}>
+      {({ style, tokens, getLineProps, getTokenProps }) => (
+        <pre
+          className="overflow-x-auto rounded border border-neutral-800 p-2 font-mono text-[12px]"
+          style={{ ...style, background: "#0d0d0d" }}
+        >
+          {tokens.map((line, i) => {
+            const lineProps = getLineProps({ line });
+            return (
+              <div key={i} {...lineProps}>
+                {line.map((token, key) => {
+                  const tokenProps = getTokenProps({ token });
+                  return <span key={key} {...tokenProps} />;
+                })}
+              </div>
+            );
+          })}
+        </pre>
+      )}
+    </Highlight>
+  );
+};
+
+const components: Components = {
+  // Heading scale — see header comment for why we shrink.
+  h1: ({ children }) => (
+    <h1 className="mb-1 mt-3 text-base font-semibold first:mt-0">{children}</h1>
+  ),
+  h2: ({ children }) => <h2 className="mb-1 mt-3 text-sm font-semibold first:mt-0">{children}</h2>,
+  h3: ({ children }) => <h3 className="mb-1 mt-2 text-sm font-semibold first:mt-0">{children}</h3>,
+  h4: ({ children }) => <h4 className="mb-1 mt-2 text-xs font-semibold first:mt-0">{children}</h4>,
+  h5: ({ children }) => <h5 className="mb-1 mt-2 text-xs font-semibold first:mt-0">{children}</h5>,
+  h6: ({ children }) => <h6 className="mb-1 mt-2 text-xs font-semibold first:mt-0">{children}</h6>,
+
+  // Paragraph + lists — tight spacing inside a bubble; the bubble
+  // already provides outer padding.
+  p: ({ children }) => <p className="my-2 first:mt-0 last:mb-0">{children}</p>,
+  ul: ({ children }) => <ul className="my-2 ml-5 list-disc space-y-1 first:mt-0">{children}</ul>,
+  ol: ({ children }) => <ol className="my-2 ml-5 list-decimal space-y-1 first:mt-0">{children}</ol>,
+  li: ({ children }) => <li className="leading-snug">{children}</li>,
+
+  // Blockquote: subtle left border, dimmer text.
+  blockquote: ({ children }) => (
+    <blockquote className="my-2 border-l-2 border-neutral-700 pl-3 text-neutral-400">
+      {children}
+    </blockquote>
+  ),
+
+  // Tables (GFM): scrollable wrapper to handle wide columns inside
+  // a fixed-width bubble.
+  table: ({ children }) => (
+    <div className="my-2 overflow-x-auto">
+      <table className="min-w-full border-collapse text-xs">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border border-neutral-800 px-2 py-1 text-left font-semibold">{children}</th>
+  ),
+  td: ({ children }) => (
+    <td className="border border-neutral-800 px-2 py-1 align-top">{children}</td>
+  ),
+
+  // Links → new tab + safe rel. Keep the text unchanged.
+  a: ({ children, href }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-400 underline hover:text-blue-300"
+    >
+      {children}
+    </a>
+  ),
+
+  // Horizontal rule — match neutral border palette.
+  hr: () => <hr className="my-3 border-neutral-800" />,
+
+  // Strong / em — defaults are fine; explicit so we own the look.
+  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+
+  // Code — see CodeRenderer header for the inline / fenced split.
+  code: CodeRenderer,
+  // Unwrap react-markdown's bare <pre> — CodeRenderer owns the
+  // <pre>, so the parent fragment keeps the layout single-bubble.
+  pre: ({ children }) => <>{children}</>,
+};
+
+export function ChatMarkdown({ text, size = "sm" }: Props) {
+  // The outer container holds the typography scale + breaks long
+  // unbroken tokens (URLs, identifiers, base64 dumps) so a single
+  // gigantic word can't blow out the bubble width. Tailwind's
+  // `break-words` covers the common case; `[overflow-wrap:anywhere]`
+  // catches the rare hostile-input case (very long unbroken hex
+  // strings, etc.).
+  const sizeClass = size === "xs" ? "text-xs" : "text-sm";
+  return (
+    <div className={`${sizeClass} break-words [overflow-wrap:anywhere]`}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {text}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/packages/client/src/components/ChatMarkdown.tsx
+++ b/packages/client/src/components/ChatMarkdown.tsx
@@ -40,6 +40,7 @@
 import { Highlight, themes as prismThemes } from "prism-react-renderer";
 import type { HTMLAttributes, ReactNode } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
 interface Props {
@@ -173,10 +174,20 @@ export function ChatMarkdown({ text, size = "sm" }: Props) {
   // `break-words` covers the common case; `[overflow-wrap:anywhere]`
   // catches the rare hostile-input case (very long unbroken hex
   // strings, etc.).
+  //
+  // remark-breaks: standard CommonMark folds a single `\n` into
+  // whitespace, so "line one\nline two" would join on one line.
+  // That defies what users expect from a chat surface (Slack,
+  // Discord, GitHub comments all preserve single newlines).
+  // remark-breaks rewrites the AST so each lone newline becomes a
+  // hard break — without changing the dialect for the rest
+  // (paragraph breaks at blank lines, fenced blocks unaffected,
+  // etc.). Applied alongside remark-gfm so tables / strikethrough
+  // / autolinks still work.
   const sizeClass = size === "xs" ? "text-xs" : "text-sm";
   return (
     <div className={`${sizeClass} break-words [overflow-wrap:anywhere]`}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={components}>
         {text}
       </ReactMarkdown>
     </div>

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -16,6 +16,7 @@ import {
   type AgentMessageLike,
 } from "../store/session-store";
 import { useActiveProject } from "../store/project-store";
+import { ChatMarkdown } from "./ChatMarkdown";
 import { DiffBlock } from "./DiffBlock";
 import { SessionTreePanel } from "./SessionTreePanel";
 
@@ -59,9 +60,12 @@ interface Props {
  * detection lives at the renderer boundary rather than in the store so we
  * don't couple the bundle to SDK type internals.
  *
- * Markdown rendering is deliberately rough (paragraphs only). `react-markdown`
- * + `remark-gfm` are installed; wiring full markdown is a polish step that
- * can land alongside the diff viewer (Phase 12).
+ * Markdown rendering for user text, assistant text blocks, and the
+ * streaming preview goes through `ChatMarkdown` — `react-markdown` +
+ * `remark-gfm` with prism-highlighted fenced code blocks. Tool calls,
+ * file-reference badges, bash exec messages, and image attachments
+ * still render as their dedicated components (markdown is for prose
+ * only).
  */
 export function ChatView({ sessionId }: Props) {
   // EMPTY_* fallbacks are stable module-level constants — using `?? []` here
@@ -201,10 +205,10 @@ export function ChatView({ sessionId }: Props) {
                 <div className="mb-1 text-[10px] uppercase tracking-wider text-neutral-500">
                   assistant (streaming)
                 </div>
-                <pre className="whitespace-pre-wrap break-words font-sans text-sm text-neutral-100">
-                  {streamingText}
-                  <span className="ml-1 inline-block h-3 w-1.5 animate-pulse bg-neutral-300" />
-                </pre>
+                <div className="text-neutral-100">
+                  <ChatMarkdown text={streamingText} />
+                  <span className="ml-1 inline-block h-3 w-1.5 animate-pulse bg-neutral-300 align-text-bottom" />
+                </div>
               </div>
             )}
             {isStreaming && streamingText.length === 0 && (
@@ -495,9 +499,9 @@ function Message({
       <div className="rounded-lg bg-neutral-800 px-4 py-3">
         <div className="mb-1 text-[10px] uppercase tracking-wider text-neutral-400">you</div>
         {text.length > 0 && (
-          <pre className="whitespace-pre-wrap break-words font-sans text-sm text-neutral-100">
-            {text}
-          </pre>
+          <div className="text-neutral-100">
+            <ChatMarkdown text={text} />
+          </div>
         )}
         {fileRefs.length > 0 && (
           <div className="mt-2 flex flex-col gap-1">
@@ -604,7 +608,7 @@ function AssistantBlock({
   const type = block.type;
 
   if (type === "text" && typeof block.text === "string") {
-    return <pre className="whitespace-pre-wrap break-words font-sans">{block.text}</pre>;
+    return <ChatMarkdown text={block.text} />;
   }
 
   if (type === "thinking" && typeof block.thinking === "string") {

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -467,6 +467,13 @@ function Message({
   message: AgentMessageLike;
   toolResultsById?: Map<string, AgentMessageLike>;
 }) {
+  // Per-message toggle: rendered markdown (default) ↔ raw plaintext.
+  // Useful when the user wants to copy a literal `**bold**` or see
+  // exactly what whitespace the assistant emitted. State lives at
+  // the message level so all text blocks within an assistant message
+  // flip together (one click, not one per block).
+  const [showRaw, setShowRaw] = useState(false);
+
   // User text messages — may include image + file attachments per
   // Phase 14. Optimistic shape uses a blob URL on the image block;
   // canonical refetched shape uses raw base64 with a mimeType, which
@@ -497,10 +504,13 @@ function Message({
     }
     return (
       <div className="rounded-lg bg-neutral-800 px-4 py-3">
-        <div className="mb-1 text-[10px] uppercase tracking-wider text-neutral-400">you</div>
+        <div className="mb-1 flex items-center justify-between">
+          <span className="text-[10px] uppercase tracking-wider text-neutral-400">you</span>
+          {text.length > 0 && <RawToggle showRaw={showRaw} onToggle={setShowRaw} />}
+        </div>
         {text.length > 0 && (
           <div className="text-neutral-100">
-            <ChatMarkdown text={text} />
+            {showRaw ? <RawText text={text} /> : <ChatMarkdown text={text} />}
           </div>
         )}
         {fileRefs.length > 0 && (
@@ -551,15 +561,23 @@ function Message({
   // Assistant messages — content is an array of TextContent / ThinkingContent / ToolCall.
   if (message.role === "assistant") {
     const content = Array.isArray(message.content) ? message.content : [];
+    // Show the raw toggle only when the message has at least one
+    // text block — toolCall and thinking blocks aren't markdown and
+    // the toggle would do nothing useful for them.
+    const hasTextBlock = content.some((b) => (b as Record<string, unknown>).type === "text");
     return (
       <div className="rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3">
-        <div className="mb-1 text-[10px] uppercase tracking-wider text-neutral-500">assistant</div>
+        <div className="mb-1 flex items-center justify-between">
+          <span className="text-[10px] uppercase tracking-wider text-neutral-500">assistant</span>
+          {hasTextBlock && <RawToggle showRaw={showRaw} onToggle={setShowRaw} />}
+        </div>
         <div className="space-y-2 text-sm text-neutral-100">
           {content.map((block, i) => {
             const blockProps: {
               block: Record<string, unknown>;
               toolResultsById?: Map<string, AgentMessageLike>;
-            } = { block: block as Record<string, unknown> };
+              showRaw?: boolean;
+            } = { block: block as Record<string, unknown>, showRaw };
             if (toolResultsById !== undefined) blockProps.toolResultsById = toolResultsById;
             return <AssistantBlock key={i} {...blockProps} />;
           })}
@@ -601,14 +619,17 @@ function Message({
 function AssistantBlock({
   block,
   toolResultsById,
+  showRaw = false,
 }: {
   block: Record<string, unknown>;
   toolResultsById?: Map<string, AgentMessageLike>;
+  /** When true, render text blocks as plain `<pre>` instead of markdown. */
+  showRaw?: boolean;
 }) {
   const type = block.type;
 
   if (type === "text" && typeof block.text === "string") {
-    return <ChatMarkdown text={block.text} />;
+    return showRaw ? <RawText text={block.text} /> : <ChatMarkdown text={block.text} />;
   }
 
   if (type === "thinking" && typeof block.thinking === "string") {
@@ -916,6 +937,43 @@ function BashExecution({ message }: { message: AgentMessageLike }) {
         </pre>
       )}
     </div>
+  );
+}
+
+/**
+ * Tiny header-corner button to flip a message between rendered
+ * markdown and raw plaintext. Owned by the parent `Message`
+ * component (state lives there so all text blocks within one
+ * assistant message flip together).
+ *
+ * Sits in the same row as the role label (`you` / `assistant`).
+ * Defaults to "rendered" — click flips to raw, click again flips
+ * back. Per-session, per-message; not persisted.
+ */
+function RawToggle({ showRaw, onToggle }: { showRaw: boolean; onToggle: (next: boolean) => void }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(!showRaw)}
+      className="rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-500 hover:bg-neutral-700/40 hover:text-neutral-300"
+      title={showRaw ? "Show rendered markdown" : "Show raw text"}
+    >
+      {showRaw ? "rendered" : "raw"}
+    </button>
+  );
+}
+
+/**
+ * Plain-text counterpart to ChatMarkdown — used when the user has
+ * flipped a message to raw view. Preserves whitespace verbatim
+ * (including the literal `**` and backticks the user typed) and
+ * keeps long-token wrapping consistent with the rendered view.
+ */
+function RawText({ text }: { text: string }) {
+  return (
+    <pre className="whitespace-pre-wrap break-words font-sans text-sm text-neutral-100 [overflow-wrap:anywhere]">
+      {text}
+    </pre>
   );
 }
 


### PR DESCRIPTION
## Summary

Wires the \`react-markdown\` + \`remark-gfm\` + \`prism-react-renderer\` deps that have been in \`package.json\` since v1 but never imported. User text bubbles, assistant text blocks, and the streaming preview now render through a chat-tuned \`ChatMarkdown\` component — headings, bold / italic, lists, tables, blockquotes, links, and prism-highlighted fenced code blocks.

## What's now rendered

| Markdown | Result |
|---|---|
| \`**bold**\` / \`*italic*\` | bold / italic |
| \`# Heading\` … \`###### h6\` | dampened heading scale (text-base → text-xs) |
| \`\` \`inline code\` \`\` | monospace badge with subtle background |
| ` \`\`\`ts ... \`\`\` ` | prism-highlighted block (vsDark, matches DiffBlock) |
| \`- item\` / \`1. item\` | bulleted / numbered list |
| \`> quoted\` | left-bordered, dimmed blockquote |
| GFM tables | scrollable when wider than the bubble |
| \`[label](url)\` | new-tab link with \`noopener noreferrer\` |
| \`~~strike~~\` | strikethrough (via GFM) |
| \`- [x] task\` | task list (via GFM) |
| Single newline | preserved (via remark-breaks — chat-style, not CommonMark default) |

## Two follow-ups baked in (commit \`9ba3ed9\`)

1. **\`remark-breaks\`** — CommonMark folds a single \`\\n\` into whitespace, but chat surfaces (Slack / Discord / GitHub comments) preserve them. Adds the plugin so the line breaks the user typed survive the round-trip without changing parsing for anything else.
2. **\`raw\` / \`rendered\` toggle** — small button in each bubble's header (right of the role label). Click to flip the message between rendered markdown and the literal source text. State lives at the message level, so all text blocks within an assistant message flip together. Per-session, per-message; not persisted. Hidden on messages with no text content.

## Design choices that aren't obvious from the diff

- **No raw HTML.** \`react-markdown\` ignores HTML by default — keeping it that way is the right posture for assistant output that may round-trip user-controlled content. We don't add \`rehype-raw\`.
- **Heading scale dampened.** Default \`<h1>\`/\`<h2>\` are document-sized; mapped to text-base / text-sm so they don't drown the prose inside a bubble.
- **react-markdown 10 dropped \`inline\` from the code prop.** \`CodeRenderer\` now branches on className: \`language-foo\` → prism Highlight, no className → styled inline span.
- **\`<pre>\` override unwraps to a fragment.** prism's themed \`<pre>\` would otherwise nest inside react-markdown's bare \`<pre>\`, doubling the background and padding.
- **Streaming-friendly.** react-markdown handles unfinished input gracefully — open code fence renders as a code block until the closing fence arrives; no special handling needed.

## What's unchanged

Tool calls, file-reference badges, bash exec messages, image attachments — all keep their dedicated renderers. Markdown is for prose only.

## Test plan

- [x] \`npm run check\` clean (typecheck + lint + format).
- [x] \`npm run test:ci\` — all 17 tests PASS.
- [ ] **Manual**: send a message containing \`**bold**\`, \`\` \`inline\` \`\`, ` \`\`\`ts ... \`\`\` `, a list, and a table → expect each rendered correctly with syntax highlighting in the code block.
- [ ] **Manual**: type a multi-line message with single newlines → newlines are preserved (no longer joined into one paragraph).
- [ ] **Manual**: click the \`raw\` button on a bubble → switches to plain \`<pre>\` view; click \`rendered\` to flip back. State is per-message.
- [ ] **Manual**: streaming response → renders incrementally; open code fence shows as a block while still streaming, closes cleanly when the fence arrives.
- [ ] **Manual**: links open in a new tab.

## Notes

Two new deps in \`packages/client\`:
- \`remark-breaks@^4.0.0\` (chat-style hard breaks)

(\`react-markdown\`, \`remark-gfm\`, \`prism-react-renderer\` were already installed.)