### PR TITLE
feat(site): GitHub Pages site (landing + 7 doc pages)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy GitHub Pages
+
+# Pages site source: docs/site/. The static HTML there is generated
+# by `npm run build:site` (scripts/build-site.mjs) — generated output
+# is committed alongside the script so the deploy job is a pure copy
+# (no Node install, no marked dependency, no version surprises in CI).
+#
+# Re-runs whenever docs/site/** changes on main, OR on manual
+# dispatch (handy when only the workflow itself changes).
+
+on:
+  push:
+    branches: [main]
+    paths: [docs/site/**]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# A single in-flight Pages deploy at a time — no parallel runs.
+# `cancel-in-progress: false` so a PR-merge-and-immediately-push
+# scenario lands both deploys in order rather than one cancelling
+# the other.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,10 @@ node_modules
 package-lock.json
 *.md
 
+# Generated GitHub Pages output — emitted by `npm run build:site`
+# (scripts/build-site.mjs). Hand-edit the script, not the output.
+docs/site/
+
 # User data — written at runtime, not source.
 workspace
 workbench

--- a/docs/site/docs/api.html
+++ b/docs/site/docs/api.html
@@ -1,0 +1,587 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>API Examples — pi-workbench</title>
+  <meta name="description" content="End-to-end scripting recipes against the REST + SSE surface.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-workbench
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="api.html" class="active">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-workbench">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>API Examples</h1>
+      <p class="docs-subtitle">End-to-end scripting recipes against the REST + SSE surface.</p>
+<p>End-to-end recipes for the most common things you&#39;ll do programmatically:
+list projects, create a session, send a prompt, stream the response, abort,
+fetch the turn diff, run git commands, upload files. Examples in curl,
+Python, and Node — all three follow the same shape.</p>
+<p>For the full route reference, open <code>/api/docs</code> in your deploy (Swagger UI
+auto-generated from the route schemas). For the SSE side, see
+<a href="./sse-events.md"><code>docs/sse-events.md</code></a>.</p>
+<h2>Setup</h2>
+<pre><code class="language-bash">BASE=http://localhost:3000
+KEY=&lt;your API_KEY&gt;
+</code></pre>
+<p>All requests use <code>Authorization: Bearer &lt;key&gt;</code>. If your deploy uses
+<code>UI_PASSWORD</code> instead, get a JWT first:</p>
+<pre><code class="language-bash">TOKEN=$(curl -s -X POST $BASE/api/v1/auth/login \
+  -H &quot;Content-Type: application/json&quot; \
+  -d &#39;{&quot;password&quot;:&quot;your-ui-password&quot;}&#39; | jq -r &#39;.token&#39;)
+KEY=$TOKEN
+</code></pre>
+<p>JWTs expire (default 7 days, configurable via <code>JWT_EXPIRES_IN_SECONDS</code>);
+API keys don&#39;t.</p>
+<h2>Health probe (no auth)</h2>
+<pre><code class="language-bash">curl -s $BASE/api/v1/health
+# {&quot;status&quot;:&quot;ok&quot;,&quot;activeSessions&quot;:0,&quot;activePtys&quot;:0}
+</code></pre>
+<pre><code class="language-python">import httpx
+print(httpx.get(f&quot;{BASE}/api/v1/health&quot;).json())
+</code></pre>
+<pre><code class="language-javascript">const res = await fetch(`${BASE}/api/v1/health`);
+console.log(await res.json());
+</code></pre>
+<h2>End-to-end: create session, send prompt, stream response</h2>
+<h3>curl</h3>
+<pre><code class="language-bash"># 1. List projects
+curl -s -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/projects
+
+# 2. Create a session
+SESSION=$(curl -s -X POST $BASE/api/v1/sessions \
+  -H &quot;Authorization: Bearer $KEY&quot; \
+  -H &quot;Content-Type: application/json&quot; \
+  -d &#39;{&quot;projectId&quot;:&quot;&lt;projectId&gt;&quot;}&#39; | jq -r &#39;.sessionId&#39;)
+echo &quot;Session: $SESSION&quot;
+
+# 3. Send a prompt (fire-and-forget — response comes via SSE)
+curl -s -X POST $BASE/api/v1/sessions/$SESSION/prompt \
+  -H &quot;Authorization: Bearer $KEY&quot; \
+  -H &quot;Content-Type: application/json&quot; \
+  -d &#39;{&quot;text&quot;:&quot;Refactor packages/server/src/auth.ts to extract the JWT verifier into its own function&quot;}&#39;
+# {&quot;accepted&quot;:true}
+
+# 4. Stream the response (Ctrl+C to stop)
+curl -N -H &quot;Authorization: Bearer $KEY&quot; \
+  $BASE/api/v1/sessions/$SESSION/stream
+
+# 5. Abort if needed
+curl -X POST -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/sessions/$SESSION/abort
+</code></pre>
+<h3>Python</h3>
+<pre><code class="language-python">import json
+import httpx
+
+BASE = &quot;http://localhost:3000&quot;
+KEY = &quot;&lt;your API_KEY&gt;&quot;
+H = {&quot;Authorization&quot;: f&quot;Bearer {KEY}&quot;}
+
+# 1. List projects
+projects = httpx.get(f&quot;{BASE}/api/v1/projects&quot;, headers=H).json()[&quot;projects&quot;]
+print(f&quot;Found {len(projects)} projects&quot;)
+
+# 2. Create a session
+session = httpx.post(
+    f&quot;{BASE}/api/v1/sessions&quot;,
+    headers=H,
+    json={&quot;projectId&quot;: projects[0][&quot;id&quot;]},
+).json()
+session_id = session[&quot;sessionId&quot;]
+print(f&quot;Created session {session_id}&quot;)
+
+# 3. Send a prompt
+httpx.post(
+    f&quot;{BASE}/api/v1/sessions/{session_id}/prompt&quot;,
+    headers=H,
+    json={&quot;text&quot;: &quot;Run the test suite and fix any failures.&quot;},
+)
+
+# 4. Stream the response
+streaming_text = &quot;&quot;
+with httpx.stream(
+    &quot;GET&quot;,
+    f&quot;{BASE}/api/v1/sessions/{session_id}/stream&quot;,
+    headers={**H, &quot;Accept&quot;: &quot;text/event-stream&quot;},
+    timeout=None,
+) as r:
+    buffer = &quot;&quot;
+    for chunk in r.iter_text():
+        buffer += chunk
+        while &quot;\n\n&quot; in buffer:
+            event, buffer = buffer.split(&quot;\n\n&quot;, 1)
+            for line in event.splitlines():
+                if not line.startswith(&quot;data: &quot;):
+                    continue
+                payload = json.loads(line[6:])
+                if payload[&quot;type&quot;] == &quot;message_update&quot;:
+                    e = payload.get(&quot;assistantMessageEvent&quot;) or {}
+                    if e.get(&quot;type&quot;) == &quot;text_delta&quot;:
+                        streaming_text += e[&quot;delta&quot;]
+                        print(e[&quot;delta&quot;], end=&quot;&quot;, flush=True)
+                elif payload[&quot;type&quot;] == &quot;agent_end&quot;:
+                    print(&quot;\n\n[turn complete]&quot;)
+                    raise SystemExit(0)
+</code></pre>
+<h3>Node</h3>
+<pre><code class="language-javascript">const BASE = &quot;http://localhost:3000&quot;;
+const KEY = &quot;&lt;your API_KEY&gt;&quot;;
+const H = { Authorization: `Bearer ${KEY}` };
+
+// 1. List projects
+const projects = (await (await fetch(`${BASE}/api/v1/projects`, { headers: H })).json())
+  .projects;
+console.log(`Found ${projects.length} projects`);
+
+// 2. Create a session
+const session = await (
+  await fetch(`${BASE}/api/v1/sessions`, {
+    method: &quot;POST&quot;,
+    headers: { ...H, &quot;Content-Type&quot;: &quot;application/json&quot; },
+    body: JSON.stringify({ projectId: projects[0].id }),
+  })
+).json();
+const sessionId = session.sessionId;
+console.log(`Created session ${sessionId}`);
+
+// 3. Send a prompt
+await fetch(`${BASE}/api/v1/sessions/${sessionId}/prompt`, {
+  method: &quot;POST&quot;,
+  headers: { ...H, &quot;Content-Type&quot;: &quot;application/json&quot; },
+  body: JSON.stringify({ text: &quot;Run npm test and fix the failures.&quot; }),
+});
+
+// 4. Stream the response
+const streamRes = await fetch(`${BASE}/api/v1/sessions/${sessionId}/stream`, {
+  headers: { ...H, Accept: &quot;text/event-stream&quot; },
+});
+const reader = streamRes.body.pipeThrough(new TextDecoderStream()).getReader();
+let buffer = &quot;&quot;;
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  buffer += value;
+  let idx;
+  while ((idx = buffer.indexOf(&quot;\n\n&quot;)) !== -1) {
+    const event = buffer.slice(0, idx);
+    buffer = buffer.slice(idx + 2);
+    for (const line of event.split(&quot;\n&quot;)) {
+      if (!line.startsWith(&quot;data: &quot;)) continue;
+      const payload = JSON.parse(line.slice(6));
+      if (payload.type === &quot;message_update&quot;) {
+        const e = payload.assistantMessageEvent ?? {};
+        if (e.type === &quot;text_delta&quot;) process.stdout.write(e.delta);
+      } else if (payload.type === &quot;agent_end&quot;) {
+        console.log(&quot;\n\n[turn complete]&quot;);
+        process.exit(0);
+      }
+    }
+  }
+}
+</code></pre>
+<h2>Project CRUD</h2>
+<h3>List</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/projects
+# { &quot;projects&quot;: [{ &quot;id&quot;: &quot;...&quot;, &quot;name&quot;: &quot;...&quot;, &quot;path&quot;: &quot;...&quot;, &quot;createdAt&quot;: &quot;...&quot; }] }
+</code></pre>
+<h3>Create</h3>
+<pre><code class="language-bash">curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/projects \
+  -d &#39;{&quot;name&quot;:&quot;my-app&quot;,&quot;path&quot;:&quot;/workspace/my-app&quot;}&#39;
+</code></pre>
+<p>The path must be an existing directory inside <code>WORKSPACE_PATH</code>. Server
+returns 403 if outside, 409 if a project with that path already exists.</p>
+<h3>Browse for a folder (folder picker)</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/projects/browse?path=/workspace&quot;
+# { &quot;path&quot;:&quot;/workspace&quot;, &quot;parentPath&quot;:null, &quot;entries&quot;:[{ &quot;name&quot;,&quot;path&quot;,&quot;isGitRepo&quot; }] }
+</code></pre>
+<p>Omit <code>path</code> to start at <code>WORKSPACE_PATH</code>.</p>
+<h3>Rename / delete</h3>
+<pre><code class="language-bash">curl -s -X PATCH -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/projects/$PROJECT_ID \
+  -d &#39;{&quot;name&quot;:&quot;new-name&quot;}&#39;
+
+# Plain delete: removes the workbench&#39;s record, leaves session JSONLs orphaned
+curl -s -X DELETE -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/projects/$PROJECT_ID
+
+# Cascade delete: also rm -rf the project&#39;s session directory
+curl -s -X DELETE -H &quot;Authorization: Bearer $KEY&quot; &quot;$BASE/api/v1/projects/$PROJECT_ID?cascade=1&quot;
+</code></pre>
+<h2>Session lifecycle</h2>
+<blockquote>
+<p><strong>Cold sessions and lazy resume.</strong> A session created earlier and not currently
+active in the registry is &quot;cold&quot; — it lives only as a <code>.jsonl</code> on disk.
+<code>/sessions/:id/tree</code> and <code>/sessions/:id/context</code> will lazy-resume a cold
+session into memory automatically. <code>/sessions/:id/messages</code>,
+<code>/sessions/:id/turn-diff</code>, and <code>/sessions/:id/name</code> do <strong>not</strong> auto-resume
+and return <code>404 session_not_found</code> on a cold id. The reliable workaround
+is to open the SSE stream first (<code>GET /sessions/:id/stream</code>), which always
+auto-resumes; subsequent calls then succeed.</p>
+</blockquote>
+<h3>List sessions for a project</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/sessions?projectId=$PROJECT_ID&quot;
+# { &quot;sessions&quot;: [{ sessionId, projectId, workspacePath, isLive, name?, createdAt, lastActivityAt, messageCount, firstMessage }] }
+</code></pre>
+<h3>Get full message history</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  $BASE/api/v1/sessions/$SESSION/messages
+# { &quot;messages&quot;: [...] }
+</code></pre>
+<h3>Get token + cost telemetry</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  $BASE/api/v1/sessions/$SESSION/context
+# { messages, totalInputTokens, totalOutputTokens, totalCacheReadTokens, totalCacheWriteTokens, totalTokens, totalCost, turns[], contextUsage }
+</code></pre>
+<p><code>turns[]</code> is the per-turn breakdown derived from each
+<code>AssistantMessage.usage</code>. <code>contextUsage.tokens</code> may be omitted when the
+SDK doesn&#39;t have a fresh count (right after compaction). The <code>messages</code>
+array mirrors the SSE <code>snapshot.messages</code> payload — it can be large
+(tens of KB) for a long session, so consider polling sparingly.</p>
+<h3>Get session tree (branching history)</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  $BASE/api/v1/sessions/$SESSION/tree
+# { leafId, branchIds[], entries: [{ id, parentId, type, timestamp, role?, preview?, label? }] }
+</code></pre>
+<p><code>leafId</code> is the current branch tip; <code>branchIds</code> is the full path from
+root to leaf (= the active branch). Off-path entries are alternate
+branches.</p>
+<h3>Navigate to a different leaf</h3>
+<pre><code class="language-bash">curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/sessions/$SESSION/navigate \
+  -d &#39;{&quot;entryId&quot;:&quot;&lt;some-entry-id&gt;&quot;}&#39;
+# Optional: { entryId, summarize: true, customInstructions: &quot;...&quot;, label: &quot;...&quot; }
+</code></pre>
+<p><code>summarize: true</code> writes a <code>branch_summary</code> entry capturing what the
+abandoned branch did. <code>label</code> bookmarks the abandoned tip.</p>
+<h3>Fork from an entry into a new session</h3>
+<pre><code class="language-bash">curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/sessions/$SESSION/fork \
+  -d &#39;{&quot;entryId&quot;:&quot;&lt;some-entry-id&gt;&quot;}&#39;
+# Returns the new session&#39;s summary
+</code></pre>
+<p>The new session&#39;s path-to-leaf includes everything from the root through
+<code>entryId</code>. The source session is preserved (in-memory restoration of the
+source session manager happens server-side after the SDK&#39;s destructive
+fork operation).</p>
+<h3>Set the model for THIS session only</h3>
+<pre><code class="language-bash">curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/sessions/$SESSION/model \
+  -d &#39;{&quot;provider&quot;:&quot;anthropic&quot;,&quot;modelId&quot;:&quot;claude-sonnet-4-5-20250929&quot;}&#39;
+</code></pre>
+<p>The route snapshots <code>settings.json</code> before calling the SDK and restores
+it after, so per-session model picks don&#39;t mutate the global default.</p>
+<h3>Steer or follow up</h3>
+<pre><code class="language-bash"># Steer (interrupt at next tool boundary)
+curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/sessions/$SESSION/steer \
+  -d &#39;{&quot;text&quot;:&quot;Actually, use TypeScript not JavaScript&quot;,&quot;mode&quot;:&quot;steer&quot;}&#39;
+
+# Follow up (queue for after the current run)
+curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/sessions/$SESSION/steer \
+  -d &#39;{&quot;text&quot;:&quot;And then run the tests&quot;,&quot;mode&quot;:&quot;followUp&quot;}&#39;
+</code></pre>
+<h3>Abort the current run</h3>
+<pre><code class="language-bash">curl -X POST -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/sessions/$SESSION/abort
+</code></pre>
+<h3>Dispose / hard-delete</h3>
+<pre><code class="language-bash"># Dispose only — kills the live session, preserves the JSONL
+curl -X DELETE -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/sessions/$SESSION
+
+# Hard delete — disposes AND removes the JSONL
+curl -X DELETE -H &quot;Authorization: Bearer $KEY&quot; &quot;$BASE/api/v1/sessions/$SESSION?hard=1&quot;
+</code></pre>
+<h2>Multipart prompt with attachments</h2>
+<pre><code class="language-bash">curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; \
+  $BASE/api/v1/sessions/$SESSION/prompt \
+  -F &quot;text=Look at this screenshot and tell me what&#39;s wrong&quot; \
+  -F &quot;attachments=@./screenshot.png&quot; \
+  -F &quot;attachments=@./logs.txt&quot;
+</code></pre>
+<p>Image attachments are base64-encoded and forwarded as <code>images</code> to the
+SDK. Text attachments are decoded as UTF-8 and prepended to the prompt
+as fenced code blocks (with backtick-fence-break-safe fence selection).
+Caps: 10 MB / file, 8 files, 4 images max.</p>
+<h2>File operations</h2>
+<h3>List the project tree</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/files/tree?projectId=$PROJECT_ID&amp;maxDepth=4&quot;
+</code></pre>
+<h3>Read a file</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/files/read?projectId=$PROJECT_ID&amp;path=/workspace/my-app/src/index.ts&quot;
+# { path, content, size, language, binary }
+</code></pre>
+<h3>Write / create a file (atomic tmp + rename)</h3>
+<pre><code class="language-bash">curl -s -X PUT -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/files/write \
+  -d &#39;{&quot;projectId&quot;:&quot;...&quot;,&quot;path&quot;:&quot;/workspace/my-app/notes.md&quot;,&quot;content&quot;:&quot;# Notes\n\n...&quot;}&#39;
+</code></pre>
+<h3>Search</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/files/search?projectId=$PROJECT_ID&amp;q=TODO&amp;caseSensitive=1&quot;
+# { engine: &quot;ripgrep&quot; | &quot;node&quot;, matches: [...], truncated: bool }
+</code></pre>
+<h3>Upload (multipart, with SHA-256 verification)</h3>
+<pre><code class="language-bash"># Compute SHA-256 yourself, send as `sha256:&lt;filename&gt;` field BEFORE the file part
+SHA=$(sha256sum ./report.pdf | cut -d&#39; &#39; -f1)
+curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; \
+  $BASE/api/v1/files/upload \
+  -F &quot;projectId=$PROJECT_ID&quot; \
+  -F &quot;parentPath=/workspace/my-app/uploads&quot; \
+  -F &quot;sha256:report.pdf=$SHA&quot; \
+  -F &quot;files=@./report.pdf&quot;
+# { files: [{ path, size, sha256 }] }
+</code></pre>
+<p>Server hashes the received bytes and rejects with 422
+<code>checksum_mismatch</code> if your hash doesn&#39;t match. Per-file cap 500 MB,
+aggregate 2 GB, max 16 files.</p>
+<h3>Download (file or folder-as-tar.gz)</h3>
+<pre><code class="language-bash"># File: streams the bytes
+curl -s -OJ -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/files/download?projectId=$PROJECT_ID&amp;path=/workspace/my-app/src/index.ts&quot;
+
+# Folder: gzipped tar (Content-Disposition includes the .tar.gz filename)
+curl -s -OJ -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/files/download?projectId=$PROJECT_ID&amp;path=/workspace/my-app/src&quot;
+
+# Whole project (omit path)
+curl -s -OJ -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/files/download?projectId=$PROJECT_ID&quot;
+</code></pre>
+<p>The folder/project tar.gz omits the same noise dirs as the file tree
+(<code>node_modules</code>, <code>.git</code>, <code>dist</code>, <code>build</code>, etc.).</p>
+<h2>Git operations</h2>
+<pre><code class="language-bash"># Status
+curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/git/status?projectId=$PROJECT_ID&quot;
+
+# Diff (unstaged)
+curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/git/diff?projectId=$PROJECT_ID&quot;
+
+# Diff a single file
+curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/git/diff/file?projectId=$PROJECT_ID&amp;path=/workspace/my-app/src/index.ts&amp;staged=1&quot;
+
+# Log
+curl -s -H &quot;Authorization: Bearer $KEY&quot; \
+  &quot;$BASE/api/v1/git/log?projectId=$PROJECT_ID&amp;limit=50&quot;
+
+# Stage / unstage / revert
+curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/git/stage \
+  -d &#39;{&quot;projectId&quot;:&quot;...&quot;,&quot;paths&quot;:[&quot;/workspace/my-app/src/index.ts&quot;]}&#39;
+
+# Commit
+curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/git/commit \
+  -d &#39;{&quot;projectId&quot;:&quot;...&quot;,&quot;message&quot;:&quot;feat: ship the thing&quot;}&#39;
+
+# Branch management
+curl -s -H &quot;Authorization: Bearer $KEY&quot; &quot;$BASE/api/v1/git/branches?projectId=$PROJECT_ID&quot;
+curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/git/branch/create \
+  -d &#39;{&quot;projectId&quot;:&quot;...&quot;,&quot;name&quot;:&quot;feat/x&quot;,&quot;checkout&quot;:true}&#39;
+
+# Remotes
+curl -s -H &quot;Authorization: Bearer $KEY&quot; &quot;$BASE/api/v1/git/remotes?projectId=$PROJECT_ID&quot;
+curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/git/remote/add \
+  -d &#39;{&quot;projectId&quot;:&quot;...&quot;,&quot;name&quot;:&quot;origin&quot;,&quot;url&quot;:&quot;git@github.com:you/repo.git&quot;}&#39;
+
+# Push / pull / fetch
+curl -s -X POST -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/git/push \
+  -d &#39;{&quot;projectId&quot;:&quot;...&quot;,&quot;remote&quot;:&quot;origin&quot;,&quot;branch&quot;:&quot;main&quot;,&quot;setUpstream&quot;:true}&#39;
+</code></pre>
+<h2>Configuration</h2>
+<h3>List providers (presence-only auth)</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/config/providers
+curl -s -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/config/auth
+# Returns presence: { providers: { anthropic: { configured: true, source: &quot;auth.json&quot; }, ... } }
+# Key VALUES are never returned.
+</code></pre>
+<h3>Set / remove an API key</h3>
+<pre><code class="language-bash">curl -s -X PUT -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/config/auth/anthropic \
+  -d &#39;{&quot;apiKey&quot;:&quot;sk-ant-...&quot;}&#39;
+
+curl -s -X DELETE -H &quot;Authorization: Bearer $KEY&quot; \
+  $BASE/api/v1/config/auth/anthropic
+</code></pre>
+<h3>Read / write agent settings</h3>
+<pre><code class="language-bash">curl -s -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/config/settings
+
+curl -s -X PUT -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/config/settings \
+  -d &#39;{&quot;defaultThinkingLevel&quot;:&quot;high&quot;}&#39;
+# Patch is shallow-merged; pass null to delete a key.
+</code></pre>
+<h3>Read / write models.json (custom providers)</h3>
+<pre><code class="language-bash"># GET returns the file with `apiKey` / `apiKeyCommand` REPLACED by
+# &quot;***REDACTED***&quot; so the raw secret never leaves the server. The
+# persisted file is unchanged; PUT takes the actual values.
+curl -s -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/config/models
+
+curl -s -X PUT -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/config/models \
+  -d &#39;{&quot;providers&quot;:{&quot;vllm-local&quot;:{&quot;api&quot;:&quot;openai-completions&quot;,&quot;url&quot;:&quot;http://localhost:8000/v1&quot;,&quot;models&quot;:[...]}}}&#39;
+</code></pre>
+<h3>List / toggle skills</h3>
+<pre><code class="language-bash"># List the merged skills (global from ~/.pi/agent/skills/ + project-local
+# from &lt;project&gt;/.pi/skills/) with per-skill enabled state for the
+# given workspace.
+curl -s -G -H &quot;Authorization: Bearer $KEY&quot; \
+  --data-urlencode &quot;workspacePath=/workspace/my-project&quot; \
+  $BASE/api/v1/config/skills
+# { skills: [{ name, description, source: &quot;global&quot;|&quot;project&quot;, filePath, enabled, disableModelInvocation }] }
+
+# Enable / disable a skill for the current workspace. Toggles persist in
+# settings.json (skills array) — disabling a skill doesn&#39;t touch the
+# skill .md file itself.
+curl -s -X PUT -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
+  &quot;$BASE/api/v1/config/skills/&lt;skill-name&gt;/enabled&quot; \
+  -d &#39;{&quot;enabled&quot;:true,&quot;workspacePath&quot;:&quot;/workspace/my-project&quot;}&#39;
+</code></pre>
+<h2>UI config (public, no auth)</h2>
+<pre><code class="language-bash">curl -s $BASE/api/v1/ui-config
+# { minimal: false, workspaceRoot: &quot;/workspace&quot; }
+</code></pre>
+<p>Used by the React client at boot to know which surfaces to render.</p>
+<h2>Auth</h2>
+<pre><code class="language-bash"># Whether auth is enabled at all
+curl -s $BASE/api/v1/auth/status
+# { authEnabled: true | false }
+
+# Login (when UI_PASSWORD is set)
+curl -s -X POST -H &quot;Content-Type: application/json&quot; \
+  $BASE/api/v1/auth/login \
+  -d &#39;{&quot;password&quot;:&quot;your-ui-password&quot;}&#39;
+# { token, expiresAt }
+
+# Logout (client-side; server stateless — just discard the token)
+</code></pre>
+<p>JWT tokens default to 7-day expiry; the response&#39;s <code>expiresAt</code> is an ISO
+timestamp. Refresh by logging in again before expiry.</p>
+<h2>Putting it together: a script that opens a session, runs a prompt, and exits when done</h2>
+<pre><code class="language-python">#!/usr/bin/env python3
+&quot;&quot;&quot;Send a one-shot prompt to a pi-workbench session and print the response.&quot;&quot;&quot;
+import json
+import sys
+import httpx
+
+BASE = &quot;http://localhost:3000&quot;
+KEY = &quot;&lt;your API_KEY&gt;&quot;
+H = {&quot;Authorization&quot;: f&quot;Bearer {KEY}&quot;}
+
+if len(sys.argv) != 3:
+    print(&quot;usage: send.py &lt;projectId&gt; &#39;&lt;prompt&gt;&#39;&quot;)
+    sys.exit(1)
+
+project_id, prompt = sys.argv[1], sys.argv[2]
+
+# Create a session
+session = httpx.post(f&quot;{BASE}/api/v1/sessions&quot;, headers=H, json={&quot;projectId&quot;: project_id}).json()
+sid = session[&quot;sessionId&quot;]
+
+# Send the prompt
+httpx.post(f&quot;{BASE}/api/v1/sessions/{sid}/prompt&quot;, headers=H, json={&quot;text&quot;: prompt})
+
+# Stream until agent_end
+with httpx.stream(
+    &quot;GET&quot;,
+    f&quot;{BASE}/api/v1/sessions/{sid}/stream&quot;,
+    headers={**H, &quot;Accept&quot;: &quot;text/event-stream&quot;},
+    timeout=None,
+) as r:
+    buffer = &quot;&quot;
+    for chunk in r.iter_text():
+        buffer += chunk
+        while &quot;\n\n&quot; in buffer:
+            event, buffer = buffer.split(&quot;\n\n&quot;, 1)
+            for line in event.splitlines():
+                if not line.startswith(&quot;data: &quot;):
+                    continue
+                p = json.loads(line[6:])
+                if p[&quot;type&quot;] == &quot;message_update&quot;:
+                    e = p.get(&quot;assistantMessageEvent&quot;) or {}
+                    if e.get(&quot;type&quot;) == &quot;text_delta&quot;:
+                        print(e[&quot;delta&quot;], end=&quot;&quot;, flush=True)
+                elif p[&quot;type&quot;] == &quot;agent_end&quot;:
+                    print(&quot;\n&quot;)
+                    sys.exit(0)
+</code></pre>
+<p>Save as <code>send.py</code>, make executable, and use as <code>./send.py &lt;projectId&gt; &quot;add a docstring to the auth module&quot;</code>.</p>
+<h2>See also</h2>
+<ul>
+<li><a href="http://localhost:3000/api/docs" target="_blank" rel="noopener noreferrer"><code>/api/docs</code></a> (live in your deploy) —
+Swagger UI with every route&#39;s full schema, try-it-out included</li>
+<li><a href="./sse-events.md"><code>docs/sse-events.md</code></a> — full SSE event catalogue +
+reconnect patterns</li>
+<li><a href="./architecture.md"><code>docs/architecture.md</code></a> — request lifecycles +
+module map</li>
+<li><a href="../packages/client/src/lib/api-client.ts"><code>packages/client/src/lib/api-client.ts</code></a> —
+reference TypeScript client (the React UI uses it; same API surface)</li>
+</ul>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/architecture.html
+++ b/docs/site/docs/architecture.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Architecture — pi-workbench</title>
+  <meta name="description" content="How requests flow through the workbench, from the browser to the pi SDK.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-workbench
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html" class="active">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-workbench">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Architecture</h1>
+      <p class="docs-subtitle">How requests flow through the workbench, from the browser to the pi SDK.</p>
+<p>This document is the deeper dive that the <a href="../README.md"><code>README.md</code></a> ASCII
+diagram refers out to. For contributor-focused architecture rules
+(conventions, &quot;where does X live&quot;, code-organization invariants), see
+<a href="../CLAUDE.md"><code>CLAUDE.md</code></a> at the repo root.</p>
+<h2>What pi-workbench is</h2>
+<p>A self-hosted HTTP server + browser UI that wraps the
+<a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener noreferrer"><code>pi-coding-agent</code></a> SDK. It is <strong>not</strong>
+a reimplementation of the agent loop — all of that is the SDK. The
+workbench is the bridge:</p>
+<ul>
+<li>Fastify HTTP server hosts the SDK as an in-process embedding</li>
+<li>REST routes for project / session / file / git / config / terminal /
+upload-download CRUD</li>
+<li>Server-Sent Events for streaming agent output</li>
+<li>WebSocket for the integrated terminal</li>
+<li>React + Vite frontend that consumes the same REST + SSE surface a
+programmatic client would</li>
+</ul>
+<h2>Component map</h2>
+<pre><code>┌──────────────────────────────────────────────────────────────────────┐
+│                              Browser                                 │
+│                                                                      │
+│  React + Vite UI (packages/client/)                                  │
+│    ├─ ChatView    — renders SDK message stream                       │
+│    ├─ ChatInput   — sends prompts + attachments                      │
+│    ├─ ProjectSidebar / SessionList — project + session navigation    │
+│    ├─ FileBrowserPanel + EditorPanel — workspace files               │
+│    ├─ SearchPanel + TurnDiffPanel + GitPanel + ContextInspectorPanel │
+│    ├─ TerminalPanel — xterm.js + WebSocket to PTY                    │
+│    └─ SessionTreePanel — session branching navigator                 │
+│                                                                      │
+│  Zustand stores: auth, project, session, file, terminal, ui-config   │
+│  Single api-client.ts entry point for ALL HTTP calls                 │
+│  Single sse-client.ts entry point for ALL streaming                  │
+└──────────────────────────────────────────────────────────────────────┘
+         │ HTTP (REST + SSE) + WebSocket (terminal only)
+         │ All under /api/v1/
+         ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                       Fastify (packages/server/)                     │
+│                                                                      │
+│  index.ts               — plugin registration, auth pre-handler      │
+│  config.ts              — single source of truth for env vars        │
+│  auth.ts                — JWT sign / verify + API-key check          │
+│                                                                      │
+│  session-registry.ts    — IN-MEMORY Map&lt;sessionId, LiveSession&gt;.     │
+│                           Single source of truth for live SDK state. │
+│                           ALL session interactions route through.    │
+│  sse-bridge.ts          — AgentSessionEvent → SSE serialization      │
+│  pty-manager.ts         — node-pty lifecycle, attach/detach for      │
+│                           reconnect-survives-page-refresh            │
+│  file-manager.ts        — every fs.* call. Path validation, atomic   │
+│                           writes, upload checksum, download streaming│
+│  file-searcher.ts       — ripgrep + Node fallback, project-scoped    │
+│  git-runner.ts          — git CLI wrapper                            │
+│  config-manager.ts      — pi config files (auth/models/settings)     │
+│  project-manager.ts     — projects.json CRUD + cascade-delete        │
+│  turn-diff-builder.ts   — aggregate diffs from a session turn        │
+│                                                                      │
+│  routes/{auth,projects,sessions,stream,prompt,control,config,        │
+│          files,git,terminal,health}.ts                               │
+│                                                                      │
+│         ┌────────────────────────────────────────────────────────┐   │
+│         │ embedded:                                              │   │
+│         │   @mariozechner/pi-coding-agent (AgentSession,         │   │
+│         │   SessionManager, AuthStorage, ModelRegistry)          │   │
+│         │   @mariozechner/pi-agent-core (Agent, AgentMessage)    │   │
+│         │   @mariozechner/pi-ai (provider abstraction)           │   │
+│         └────────────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────────────┘
+         │ filesystem
+         ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                            On-disk state                             │
+│                                                                      │
+│  ${WORKSPACE_PATH}/&lt;project&gt;/         — user code                    │
+│  ${SESSION_DIR}/&lt;projectId&gt;/*.jsonl   — session transcripts          │
+│  ${WORKBENCH_DATA_DIR}/projects.json  — project registry             │
+│  ${PI_CONFIG_DIR}/auth.json           — provider API keys            │
+│  ${PI_CONFIG_DIR}/models.json         — custom provider definitions  │
+│  ${PI_CONFIG_DIR}/settings.json       — agent defaults               │
+└──────────────────────────────────────────────────────────────────────┘
+         │ HTTPS
+         ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                   LLM providers + MCP servers                        │
+│                                                                      │
+│  Anthropic / OpenAI / Google / OpenRouter / vLLM / Ollama / ...      │
+│  (whatever you&#39;ve configured in models.json + auth.json)             │
+└──────────────────────────────────────────────────────────────────────┘
+</code></pre>
+<h2>Request lifecycles</h2>
+<h3>Browser sends a prompt</h3>
+<pre><code>Browser                Server                          SDK / Provider
+   │                     │                                   │
+   ├── POST /api/v1/sessions/:id/prompt ──▶                  │
+   │   { text: &quot;...&quot; } or multipart/form-data                │
+   │                     │                                   │
+   │                     ├── session-registry.getSession()   │
+   │                     │   returns LiveSession             │
+   │                     │                                   │
+   │                     ├── live.session.prompt(text) ─────▶│ async
+   │                     │   (fire-and-forget; returns       │
+   │                     │   only when the WHOLE agent run   │
+   │                     │   finishes including retries +    │
+   │                     │   compaction)                     │
+   │                     │                                   │
+   ◀── 202 Accepted ─────┤                                   │
+   │   { accepted: true }│                                   │
+   │                     │                                   │
+   │                     ├── via sse-bridge.ts ──────────────│
+   │   (already-open SSE │   AgentSessionEvent flowing       │
+   │   connection)       │   into LiveSession.clients Set    │
+   ◀── data: {type:&quot;agent_start&quot;, ...}                       │
+   ◀── data: {type:&quot;message_update&quot;, delta:&quot;Hello&quot;}          │
+   ◀── data: {type:&quot;tool_execution_start&quot;, ...}              │
+   ◀── data: {type:&quot;tool_execution_end&quot;,   ...}              │
+   ◀── data: {type:&quot;message_update&quot;, delta:&quot; world&quot;}         │
+   ◀── data: {type:&quot;agent_end&quot;,     ...}                     │
+</code></pre>
+<p>The HTTP <code>POST /prompt</code> returns 202 immediately — the request is
+fire-and-forget. The actual response streams over the already-open SSE
+connection (<code>GET /api/v1/sessions/:id/stream</code>).</p>
+<h3>SSE stream connect (cold session resume)</h3>
+<pre><code>Browser                Server                         Disk
+   │                     │                              │
+   ├── GET /api/v1/sessions/:id/stream ──▶              │
+   │                     │                              │
+   │                     ├── getSession(id)             │
+   │                     │   returns undefined          │
+   │                     │   (not in in-memory          │
+   │                     │   registry — server          │
+   │                     │   restarted, or never        │
+   │                     │   touched this session)      │
+   │                     │                              │
+   │                     ├── findSessionLocation(id) ──▶│ scans
+   │                     │                              │ ${SESSION_DIR}
+   │                     │                              │
+   │                     ◀── { projectId, workspacePath }
+   │                     │                              │
+   │                     ├── resumeSession(id, ...) ────│ reads
+   │                     │   creates LiveSession from    │ JSONL
+   │                     │   existing JSONL              │
+   │                     │                              │
+   │                     ├── snapshot event ────────────│
+   ◀── data: {type:&quot;snapshot&quot;, messages:[...], isStreaming:false}
+   │                     │                              │
+   │   (subsequent events flow as they arrive)          │
+</code></pre>
+<h3>Server restart preserves sessions</h3>
+<p>The <code>LiveSession</code> registry is <strong>in-memory</strong>. On server restart it&#39;s
+empty. Sessions survive because their JSONL files persist on disk; the
+registry is rebuilt <strong>lazily</strong> as clients reconnect their SSE streams
+(see &quot;SSE stream connect&quot; above).</p>
+<p><code>discoverSessionsOnDisk()</code> scans <code>${SESSION_DIR}</code> and parses <strong>only the
+first line</strong> of each <code>.jsonl</code> (the session header) to populate the
+sidebar&#39;s session list — no full sessions land in memory eagerly.</p>
+<h2>Persistence model</h2>
+<p>The workbench is stateless on the server side <strong>except for</strong>:</p>
+<table>
+<thead>
+<tr>
+<th>State</th>
+<th>Storage</th>
+<th>Survives restart?</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Project registry</td>
+<td><code>${WORKBENCH_DATA_DIR}/projects.json</code></td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>Session transcripts</td>
+<td><code>${SESSION_DIR}/&lt;projectId&gt;/*.jsonl</code></td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>Pi auth + models + settings</td>
+<td><code>${PI_CONFIG_DIR}/*.json</code> (SDK-owned)</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>Live AgentSession instances</td>
+<td>In-memory <code>session-registry.ts</code> Map</td>
+<td><strong>No</strong> — lazy-rebuilt on next SSE connect</td>
+</tr>
+<tr>
+<td>PTY processes</td>
+<td>In-memory <code>pty-manager.ts</code> Map</td>
+<td><strong>No</strong> — killed on shutdown; client tab list survives via localStorage</td>
+</tr>
+<tr>
+<td>SSE client connections</td>
+<td>In-memory <code>LiveSession.clients</code> Set</td>
+<td><strong>No</strong> — clients reconnect with backoff</td>
+</tr>
+<tr>
+<td>Browser-side state</td>
+<td>localStorage</td>
+<td>Yes per-browser</td>
+</tr>
+</tbody></table>
+<p>Atomic write pattern (<code>tmp + rename</code>) is used for every config write —
+<code>config-manager.ts</code>, <code>project-manager.ts</code>, <code>file-manager.ts.writeFile</code>,
+<code>writeFileBytes</code>. Half-written files never appear at the target path
+even on a crash mid-write.</p>
+<h2>Threading + concurrency</h2>
+<p>Node.js single-threaded event loop. The SDK&#39;s agent loop runs on the
+same loop. Heavy CPU is rare; most work is I/O (HTTP to the LLM,
+filesystem ops). For the few cases where it matters:</p>
+<ul>
+<li><strong>Multipart upload</strong> streams part bodies straight into <code>writeFileBytes</code>
+without buffering the full file in memory</li>
+<li><strong>File search</strong> (<code>file-searcher.ts</code>) uses <code>child_process.spawn(rg)</code>
+for ripgrep so the heavy work happens in a subprocess; the Node
+fallback walks with bounded concurrency (16-wide)</li>
+<li><strong>PTY data</strong> flows from <code>node-pty</code> → callback → WebSocket frame, no
+buffering beyond what xterm needs</li>
+</ul>
+<h2>Key invariants</h2>
+<ol>
+<li><p><strong>All filesystem ops go through <code>file-manager.ts</code>.</strong> Routes never
+import <code>node:fs</code> directly. Every call validates the resolved path is
+inside the project root via <code>verifyPathSafe()</code> (lexical + realpath
+walk). Violations return 403, never 500.</p>
+</li>
+<li><p><strong>All session interactions go through <code>session-registry.ts</code>.</strong> Routes
+never call <code>createAgentSession</code> or import <code>AgentSession</code> directly.
+The registry is the single source of truth for live SDK state.</p>
+</li>
+<li><p><strong>All config-file writes are atomic.</strong> <code>tmp + rename</code> pattern in
+<code>config-manager.ts</code> and <code>project-manager.ts</code> (and the extension via
+<code>file-manager.writeFile</code>).</p>
+</li>
+<li><p><strong>Auth check is global</strong> with explicit opt-out. <code>index.ts</code>&#39;s
+<code>onRequest</code> hook checks every request unless the route declares
+<code>config: { public: true }</code>. New public routes must explicitly opt in.</p>
+</li>
+<li><p><strong>OpenAPI spec is auto-generated.</strong> <code>@fastify/swagger</code> collects
+<code>schema.description</code> + <code>schema.body</code> + <code>schema.response</code> from each
+route registration. There is no separate spec file; Swagger UI at
+<code>/api/docs</code> reads from the live route definitions.</p>
+</li>
+<li><p><strong>Client routing through <code>api-client.ts</code>.</strong> Components never call
+<code>fetch()</code>. The api-client handles auth-token attachment, JSON
+parsing, validator boundary, and 401 → logout flow.</p>
+</li>
+</ol>
+<h2>File-by-file reference</h2>
+<p>For the canonical &quot;where does X live&quot; answer, read <a href="../CLAUDE.md"><code>CLAUDE.md</code></a>&#39;s
+&quot;Repository Layout&quot; + &quot;Critical Conventions&quot; sections. They&#39;re the
+contributor-side reference and stay in sync with the code.</p>
+<p>This document covers the <em>what</em> and the <em>why</em>; CLAUDE.md covers the
+<em>how</em> and the <em>do-not</em>.</p>
+<h2>See also</h2>
+<ul>
+<li><a href="./CONTAINERS.md"><code>docs/CONTAINERS.md</code></a> — Docker image, volumes,
+resource tuning</li>
+<li><a href="./deployment.md"><code>docs/deployment.md</code></a> — production deploy recipes
+(TLS, reverse proxy, auth)</li>
+<li><a href="./configuration.md"><code>docs/configuration.md</code></a> — pi config files, custom
+providers, MCP setup</li>
+<li><a href="./sse-events.md"><code>docs/sse-events.md</code></a> — full SSE event catalogue</li>
+<li><a href="./api-examples.md"><code>docs/api-examples.md</code></a> — REST + SSE programmatic
+examples in curl / Python / Node</li>
+<li><a href="../kubernetes/DEPLOY.md"><code>kubernetes/DEPLOY.md</code></a> — Kubernetes / OpenShift
+manifests + walkthroughs</li>
+<li><a href="../SECURITY.md"><code>SECURITY.md</code></a> — threat model + vulnerability reporting</li>
+</ul>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/configuration.html
+++ b/docs/site/docs/configuration.html
@@ -1,0 +1,465 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Configuration — pi-workbench</title>
+  <meta name="description" content="Every environment variable the workbench reads, with defaults and intent.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-workbench
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html" class="active">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-workbench">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Configuration</h1>
+      <p class="docs-subtitle">Every environment variable the workbench reads, with defaults and intent.</p>
+<p>pi-workbench&#39;s runtime behavior is shaped by <strong>two</strong> layers of configuration:</p>
+<ol>
+<li><strong>Workbench env vars</strong> — read by <code>packages/server/src/config.ts</code> at
+startup. Controls ports, paths, auth, and the <code>MINIMAL_UI</code> frontend
+gate. Documented in <a href="#environment-variables">Environment variables</a> below.</li>
+<li><strong>Pi SDK config files</strong> — JSON files under <code>${PI_CONFIG_DIR}</code> (default
+<code>~/.pi/agent</code>, container <code>/home/pi/.pi/agent</code>). Owned by the pi SDK,
+surfaced by the workbench&#39;s Settings panel and the
+<code>/api/v1/config/*</code> routes. See <a href="#pi-sdk-config-files">Pi SDK config files</a>
+below.</li>
+</ol>
+<h2>Environment variables</h2>
+<table>
+<thead>
+<tr>
+<th>Variable</th>
+<th>Default</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>PORT</code></td>
+<td><code>3000</code></td>
+<td>Fastify listen port.</td>
+</tr>
+<tr>
+<td><code>HOST</code></td>
+<td><code>0.0.0.0</code></td>
+<td>Bind address.</td>
+</tr>
+<tr>
+<td><code>LOG_LEVEL</code></td>
+<td><code>info</code></td>
+<td>Pino log level.</td>
+</tr>
+<tr>
+<td><code>WORKSPACE_PATH</code></td>
+<td><code>~/.pi-workbench/workspace</code></td>
+<td>Where project code lives. Docker image overrides to <code>/workspace</code> (mounted from host). Point at an existing dir (e.g. <code>~/Code</code>) to reuse code you already have on disk.</td>
+</tr>
+<tr>
+<td><code>PI_CONFIG_DIR</code></td>
+<td><code>~/.pi/agent</code></td>
+<td>Pi SDK config dir (auth.json, models.json, settings.json — owned by the SDK). The Docker image overrides this to <code>/home/pi/.pi/agent</code> (mounted from the host&#39;s <code>~/.pi/agent</code>).</td>
+</tr>
+<tr>
+<td><code>WORKBENCH_DATA_DIR</code></td>
+<td><code>~/.pi-workbench</code></td>
+<td>Workbench-owned state (projects.json). Defaults to the same dotdir as the workspace (<code>projects.json</code> sits alongside <code>workspace/</code>). Kept separate from <code>PI_CONFIG_DIR</code> so we don&#39;t mix our state into the pi SDK&#39;s directory. Docker image points this at <code>/home/pi/.pi-workbench</code> (mounted from the host&#39;s <code>~/.pi-workbench-docker</code> by default — container has its own project list).</td>
+</tr>
+<tr>
+<td><code>CLIENT_DIST_PATH</code></td>
+<td><code>&lt;server-dist&gt;/../../client/dist</code></td>
+<td>Built Vite output served by Fastify in production.</td>
+</tr>
+<tr>
+<td><code>SERVE_CLIENT</code></td>
+<td><code>true</code></td>
+<td>Set to <code>false</code> to skip static-serving (useful when running the dev Vite server in front of the API).</td>
+</tr>
+<tr>
+<td><code>SESSION_DIR</code></td>
+<td><code>${WORKSPACE_PATH}/.pi/sessions</code></td>
+<td>JSONL session storage.</td>
+</tr>
+<tr>
+<td><code>UI_PASSWORD</code></td>
+<td>(unset)</td>
+<td>If set, enables browser JWT auth. <code>JWT_SECRET</code> is auto-generated on first boot if not supplied. After the user changes it via the UI, a scrypt hash is persisted to <code>${WORKBENCH_DATA_DIR}/password-hash</code> and this env var is ignored on subsequent logins.</td>
+</tr>
+<tr>
+<td><code>REQUIRE_PASSWORD_CHANGE</code></td>
+<td><code>true</code></td>
+<td>When the user logs in with the env-supplied <code>UI_PASSWORD</code> and no on-disk hash exists yet, the issued token is scoped to <code>POST /auth/change-password</code> and the UI forces the user to pick a new password before continuing. Set to <code>false</code> to keep the env-supplied password as-is (useful when <code>UI_PASSWORD</code> is itself sourced from a sealed secret you rotate out-of-band).</td>
+</tr>
+<tr>
+<td><code>JWT_SECRET</code></td>
+<td>(unset, auto-generated)</td>
+<td>HS256 signing key. <strong>Optional</strong> — when <code>UI_PASSWORD</code> is set and <code>JWT_SECRET</code> is not, the server generates one and persists it to <code>${WORKBENCH_DATA_DIR}/jwt-secret</code> (mode 0600). The data dir is already a PVC / bind-mount in K8s and Docker, so tokens survive restarts with no extra wiring. Set this env var to override (e.g. <code>openssl rand -hex 32</code>). Delete the file to rotate.</td>
+</tr>
+<tr>
+<td><code>API_KEY</code></td>
+<td>(unset)</td>
+<td>Static bearer token for programmatic access.</td>
+</tr>
+<tr>
+<td><code>JWT_EXPIRES_IN_SECONDS</code></td>
+<td><code>604800</code></td>
+<td>JWT lifetime (default 7 d).</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_LOGIN_MAX</code></td>
+<td><code>10</code></td>
+<td>Max <code>/auth/login</code> attempts per window.</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_LOGIN_WINDOW_MS</code></td>
+<td><code>60000</code></td>
+<td>Login rate-limit window (ms).</td>
+</tr>
+<tr>
+<td><code>CORS_ORIGIN</code></td>
+<td>(reflect request origin)</td>
+<td>Pin to a specific origin in production.</td>
+</tr>
+<tr>
+<td><code>TRUST_PROXY</code></td>
+<td><code>false</code></td>
+<td>Set to <code>true</code> when running behind a reverse proxy (nginx, Caddy, Traefik) so <code>req.ip</code> reflects the real client IP — required for the login rate limit to work per-user.</td>
+</tr>
+<tr>
+<td><code>MINIMAL_UI</code></td>
+<td><code>false</code></td>
+<td>Hide terminal / git / last-turn / providers / agent settings. Frontend gate; doesn&#39;t disable server routes.</td>
+</tr>
+</tbody></table>
+<p>Production-relevant env tuning (rate limits, JWT lifetime, TLS / proxy
+posture) lives in <a href="./deployment.md"><code>deployment.md</code></a>.</p>
+<h2>Pi SDK config files</h2>
+<p>This section covers layer 2 — what each pi config file does, how the
+workbench reads/writes it, and how to wire up a custom provider.</p>
+<h2>File layout</h2>
+<pre><code>${PI_CONFIG_DIR}/
+├── auth.json          — provider API keys + OAuth tokens
+├── models.json        — custom provider definitions
+└── settings.json      — agent defaults (model, thinking level, modes)
+</code></pre>
+<p>Skills (per-project Markdown files) live elsewhere — under <code>.pi/skills/</code>
+inside each project directory and inside <code>~/.pi/agent/skills/</code> for global
+skills. The workbench surfaces them but doesn&#39;t own their storage.</p>
+<h2>auth.json — provider API keys</h2>
+<p>The pi SDK stores provider credentials here. Format is owned by the SDK;
+schematically:</p>
+<pre><code class="language-json">{
+  &quot;anthropic&quot;: { &quot;apiKey&quot;: &quot;sk-ant-...&quot; },
+  &quot;openai&quot;:    { &quot;apiKey&quot;: &quot;sk-...&quot; },
+  &quot;google&quot;:    { &quot;apiKey&quot;: &quot;...&quot; },
+  &quot;openrouter&quot;:{ &quot;apiKey&quot;: &quot;sk-or-...&quot; }
+}
+</code></pre>
+<p>Some providers use OAuth and store tokens here instead of bare API keys.
+Pi handles the format; the workbench doesn&#39;t parse it.</p>
+<h3>How the workbench surfaces it</h3>
+<p>The Settings → Providers tab shows every provider that has a key
+configured (a green dot) or doesn&#39;t (an &quot;Add key&quot; button). It uses
+<strong>presence-only</strong> information from <code>GET /api/v1/config/auth</code> — the
+actual key values <strong>never</strong> leave the server. The route is enforced in
+<code>config-manager.ts</code>&#39;s <code>readAuthSummary()</code>; if you find a code path that
+returns key values, that&#39;s a security bug — file a private advisory.</p>
+<p>Adding a key uses <code>PUT /api/v1/config/auth/:provider</code> with <code>{ apiKey }</code>.
+Removing uses <code>DELETE /api/v1/config/auth/:provider</code>. Both write
+atomically (<code>tmp + rename</code>) so you can&#39;t end up with a corrupted file
+on a crash mid-write.</p>
+<p>In <code>MINIMAL_UI</code> mode the Providers tab is hidden; manage credentials
+out-of-band (edit <code>auth.json</code> directly, then <code>kubectl rollout restart</code>
+or <code>docker compose restart</code>).</p>
+<h2>models.json — custom provider definitions</h2>
+<p>Built-in providers (Anthropic, OpenAI, Google, OpenRouter, Bedrock,
+Vertex, etc.) are baked into pi-ai and don&#39;t need entries here. Use
+<code>models.json</code> only for <strong>custom</strong> OpenAI-compatible endpoints — vLLM,
+LiteLLM, Ollama, llama.cpp&#39;s <code>--api</code>, your company&#39;s internal proxy.</p>
+<pre><code class="language-json">{
+  &quot;providers&quot;: {
+    &quot;vllm-local&quot;: {
+      &quot;api&quot;: &quot;openai-completions&quot;,
+      &quot;url&quot;: &quot;http://localhost:8000/v1&quot;,
+      &quot;models&quot;: [
+        {
+          &quot;id&quot;: &quot;Qwen/Qwen2.5-Coder-32B-Instruct&quot;,
+          &quot;name&quot;: &quot;Qwen 2.5 Coder 32B (vLLM)&quot;,
+          &quot;contextWindow&quot;: 32000,
+          &quot;maxTokens&quot;: 8000,
+          &quot;input&quot;: [&quot;text&quot;],
+          &quot;reasoning&quot;: false,
+          &quot;cost&quot;: { &quot;input&quot;: 0, &quot;output&quot;: 0, &quot;cacheRead&quot;: 0, &quot;cacheWrite&quot;: 0 }
+        }
+      ]
+    },
+    &quot;ollama&quot;: {
+      &quot;api&quot;: &quot;openai-completions&quot;,
+      &quot;url&quot;: &quot;http://localhost:11434/v1&quot;,
+      &quot;models&quot;: [
+        {
+          &quot;id&quot;: &quot;llama3.1:70b&quot;,
+          &quot;name&quot;: &quot;Llama 3.1 70B (Ollama)&quot;,
+          &quot;contextWindow&quot;: 128000,
+          &quot;maxTokens&quot;: 4000,
+          &quot;input&quot;: [&quot;text&quot;],
+          &quot;reasoning&quot;: false,
+          &quot;cost&quot;: { &quot;input&quot;: 0, &quot;output&quot;: 0, &quot;cacheRead&quot;: 0, &quot;cacheWrite&quot;: 0 }
+        }
+      ]
+    }
+  }
+}
+</code></pre>
+<h3>Field reference (per model entry)</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>id</code></td>
+<td>string</td>
+<td>The exact <code>model</code> value the provider expects in API requests</td>
+</tr>
+<tr>
+<td><code>name</code></td>
+<td>string</td>
+<td>Display name in the model picker</td>
+</tr>
+<tr>
+<td><code>contextWindow</code></td>
+<td>number</td>
+<td>Tokens the model accepts as input. The Context Inspector uses this for the &quot;context window&quot; bar.</td>
+</tr>
+<tr>
+<td><code>maxTokens</code></td>
+<td>number</td>
+<td>Max output tokens per response. Pi clamps <code>max_tokens</code> in API calls to this.</td>
+</tr>
+<tr>
+<td><code>input</code></td>
+<td><code>(&quot;text&quot; | &quot;image&quot;)[]</code></td>
+<td>What content types the model accepts. Image-capable models can receive multipart attachments.</td>
+</tr>
+<tr>
+<td><code>reasoning</code></td>
+<td>boolean</td>
+<td>True if the model supports thinking / extended-reasoning blocks (OpenAI o1, Claude Sonnet 4.5 with thinking, etc.). Surfaces the thinking-level selector in Settings → Agent.</td>
+</tr>
+<tr>
+<td><code>cost</code></td>
+<td><code>{ input, output, cacheRead, cacheWrite }</code> (numbers, USD per 1M tokens)</td>
+<td>Required by the SDK type. Surfaces in the Context Inspector&#39;s per-turn cost telemetry. Set every field to <code>0</code> for self-hosted endpoints (vLLM, Ollama, llama.cpp) where you don&#39;t pay per token; for OpenAI-compatible commercial endpoints, copy the upstream provider&#39;s published rates. Without a <code>cost</code> block the model entry is rejected on next session creation.</td>
+</tr>
+</tbody></table>
+<h3>Provider <code>api</code> field</h3>
+<p>Each provider entry&#39;s <code>api</code> field tells pi-ai which protocol adapter to use:</p>
+<ul>
+<li><code>openai-completions</code> — <code>/v1/chat/completions</code> shape (OpenAI, vLLM,
+LiteLLM, Ollama, llama.cpp)</li>
+<li><code>openai-responses</code> — OpenAI&#39;s newer Responses API</li>
+<li><code>anthropic-messages</code> — Anthropic&#39;s Messages API</li>
+<li><code>google-generative-ai</code> — Google&#39;s Generative Language API</li>
+<li><code>bedrock-converse-stream</code> — AWS Bedrock Converse API (streaming)</li>
+</ul>
+<p>For most third-party endpoints you&#39;ll use <code>openai-completions</code>. Check the
+endpoint&#39;s docs to confirm wire-format compatibility.</p>
+<h3>How the workbench surfaces it</h3>
+<p>Settings → Providers shows a collapsible &quot;Custom providers (models.json)&quot;
+section with a raw-JSON editor. The editor is gated behind a <code>&lt;details&gt;</code>
+to keep casual users from accidentally clobbering it; a typed form per
+provider type is deferred to Phase 18 polish.</p>
+<p>Reads via <code>GET /api/v1/config/models</code>, writes via
+<code>PUT /api/v1/config/models</code> (full-document replace; the route validates
+<code>{ providers: {...} }</code> shape but doesn&#39;t validate per-provider schemas
+— pi-ai validates on next session creation).</p>
+<p>In <code>MINIMAL_UI</code> mode this surface is hidden. Edit <code>models.json</code> directly
+and restart.</p>
+<h2>settings.json — agent defaults</h2>
+<p>Pi-side defaults that apply to new sessions:</p>
+<pre><code class="language-json">{
+  &quot;defaultProvider&quot;: &quot;anthropic&quot;,
+  &quot;defaultModel&quot;: &quot;claude-sonnet-4-5-20250929&quot;,
+  &quot;defaultThinkingLevel&quot;: &quot;medium&quot;,
+  &quot;steeringMode&quot;: &quot;all&quot;,
+  &quot;followUpMode&quot;: &quot;all&quot;
+}
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Values</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>defaultProvider</code></td>
+<td>A provider key (<code>anthropic</code>, <code>openai</code>, <code>google</code>, custom from <code>models.json</code>, etc.)</td>
+<td>Picked by new sessions when no per-session model is set.</td>
+</tr>
+<tr>
+<td><code>defaultModel</code></td>
+<td>A model id from the chosen provider</td>
+<td>Same.</td>
+</tr>
+<tr>
+<td><code>defaultThinkingLevel</code></td>
+<td><code>minimal</code> / <code>low</code> / <code>medium</code> / <code>high</code> / <code>xhigh</code></td>
+<td>For reasoning-capable models. Lower = faster + cheaper; higher = better at hard problems.</td>
+</tr>
+<tr>
+<td><code>steeringMode</code></td>
+<td><code>all</code> / <code>one-at-a-time</code></td>
+<td>How the SDK delivers queued steering messages. <code>all</code> flushes the entire queue in one delivery to the agent at the next opportunity; <code>one-at-a-time</code> waits for the agent&#39;s response between queued messages. The per-call <code>mode</code> body field on <code>POST /sessions/:id/steer</code> is independent (<code>steer</code> vs <code>followUp</code> — that&#39;s the WHEN of delivery, not the BATCHING).</td>
+</tr>
+<tr>
+<td><code>followUpMode</code></td>
+<td><code>all</code> / <code>one-at-a-time</code></td>
+<td>Same shape as <code>steeringMode</code> but for follow-up messages (delivered after the agent goes fully idle rather than at the next tool-call boundary).</td>
+</tr>
+</tbody></table>
+<p>Other SDK keys (less commonly tuned) are accepted by the
+<code>PUT /api/v1/config/settings</code> route and persist in this file.</p>
+<h3>How the workbench surfaces it</h3>
+<p>Settings → Agent is a typed form for the common fields plus an
+&quot;Edit as JSON&quot; toggle for the long tail of SDK keys. Form changes
+fire <code>PUT /api/v1/config/settings</code> with a partial patch (Fastify
+shallow-merges into the existing file).</p>
+<p>The route preserves unknown fields the SDK might add in future
+versions — you won&#39;t lose data by editing through the form.</p>
+<h3>Per-session model override</h3>
+<p>The Settings → Agent default is the <strong>fallback</strong>. The chat input has a
+model picker that overrides per-session. The override persists in
+browser localStorage (<code>pi-workbench/model/&lt;sessionId&gt;</code>) and re-applies
+on session switch. It does NOT modify <code>settings.json</code>.</p>
+<p>(See the commit history around <code>routes/control.ts:setModel</code> for the
+gory details — the SDK&#39;s <code>setModel</code> writes the global default as a
+side effect, which the workbench undoes by snapshot-and-restore around
+the call so per-session selection doesn&#39;t mutate the global default.)</p>
+<h2>Per-project skills</h2>
+<p>Pi supports project-scoped skill files (Markdown files with YAML
+frontmatter the agent loads as additional instructions). They live
+under:</p>
+<ul>
+<li><strong>Project-local:</strong> <code>&lt;project-path&gt;/.pi/skills/*.md</code></li>
+<li><strong>Global:</strong> <code>~/.pi/agent/skills/*.md</code> — available across all projects</li>
+</ul>
+<p>The workbench&#39;s Settings → Skills tab shows the merged list (global +
+project-local) for the active project, with a toggle per skill to
+enable/disable for THIS project. Disable state writes to the project&#39;s
+<code>settings.json</code>; the skill files themselves are untouched.</p>
+<h2>Container ergonomics</h2>
+<p>Inside Docker, the bind mounts are:</p>
+<table>
+<thead>
+<tr>
+<th>Container path</th>
+<th>Default host path</th>
+<th>What lives here</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>/home/pi/.pi/agent</code></td>
+<td><code>~/.pi/agent</code></td>
+<td><code>auth.json</code>, <code>models.json</code>, <code>settings.json</code> (shared with host pi CLI by default)</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi-workbench</code></td>
+<td><code>~/.pi-workbench-docker</code></td>
+<td><code>projects.json</code> (separate from host&#39;s <code>~/.pi-workbench</code>)</td>
+</tr>
+<tr>
+<td><code>/workspace</code></td>
+<td><code>../workspace</code> (relative to compose file)</td>
+<td>User code; sessions under <code>.pi/sessions/</code> here</td>
+</tr>
+</tbody></table>
+<p>Sharing <code>~/.pi/agent</code> with the host means the host CLI and the container
+see the same provider keys + custom providers + agent defaults. Set
+<code>PI_CONFIG_HOST_PATH</code> to a different host directory if you want
+container-isolated config.</p>
+<p><code>projects.json</code> defaults to a SEPARATE host directory because mixing the
+host CLI&#39;s project list with the container&#39;s would mean the container
+can see projects whose paths point inside the host&#39;s home directory —
+they&#39;d resolve to invalid paths inside the container&#39;s filesystem.
+Setting both to the same host path requires also using the same
+workspace path semantics.</p>
+<h2>MCP servers</h2>
+<p>MCP server definitions live in <code>${WORKBENCH_DATA_DIR}/mcp.json</code> (global)
+and <code>&lt;projectPath&gt;/.mcp.json</code> (project-scoped). Manage them from the
+<strong>Settings → MCP</strong> tab in the browser, or edit the files directly. See
+<a href="./mcp.md"><code>mcp.md</code></a> for the field reference, transport options,
+auth model, and troubleshooting.</p>
+<h2>See also</h2>
+<ul>
+<li><a href="../README.md"><code>README.md</code></a> — workbench env vars + Docker quickstart</li>
+<li><a href="./deployment.md"><code>docs/deployment.md</code></a> — production deploy with TLS +
+reverse proxy + auth</li>
+<li><a href="./CONTAINERS.md"><code>docs/CONTAINERS.md</code></a> — container internals + bind
+mounts + UID/GID handling</li>
+<li><a href="./architecture.md"><code>docs/architecture.md</code></a> — what config-manager.ts
+does + how the routes wire it</li>
+<li><a href="../SECURITY.md"><code>SECURITY.md</code></a> — auth.json key safety + threat model</li>
+</ul>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/containers.html
+++ b/docs/site/docs/containers.html
@@ -1,0 +1,390 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Containers — pi-workbench</title>
+  <meta name="description" content="What's inside the Docker image, how it's structured, and why.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-workbench
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html" class="active">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-workbench">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Containers</h1>
+      <p class="docs-subtitle">What's inside the Docker image, how it's structured, and why.</p>
+<p>This document covers everything you need to know about running pi-workbench
+in a container — the shipped Docker image, the compose recipe, the volume
+layout, the security model, and how to tune resources for your workload.</p>
+<p>For Kubernetes / OpenShift deployments, see <a href="../kubernetes/DEPLOY.md"><code>kubernetes/DEPLOY.md</code></a>.
+For non-container reverse-proxy + TLS recipes, see
+<a href="./deployment.md"><code>docs/deployment.md</code></a>.</p>
+<h2>Why containers</h2>
+<p>pi-workbench is <strong>single-tenant by design</strong> and the container is the unit of
+isolation. The agent&#39;s <code>bash</code> tool is a real shell, the <code>write</code> and <code>edit</code>
+tools touch the workspace filesystem, and the integrated terminal spawns
+a PTY with the workbench process&#39;s permissions. Running in a container:</p>
+<ul>
+<li>Bounds what the agent can damage (only the bind-mounted workspace + the
+container&#39;s filesystem, which is rebuilt on rebuild)</li>
+<li>Pins the runtime (Node major, native bindings) so terminals don&#39;t break
+when you upgrade the host&#39;s Node version</li>
+<li>Makes deploys reproducible across hosts</li>
+<li>Gives you a clean reset — <code>docker compose down &amp;&amp; docker compose up -d</code> =
+fresh container, persisted workspace + config</li>
+</ul>
+<h2>Image overview</h2>
+<p>The Dockerfile (<code>docker/Dockerfile</code>) is multi-stage:</p>
+<table>
+<thead>
+<tr>
+<th>Stage</th>
+<th>Base</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>builder</code></td>
+<td><code>node:22-bookworm-slim</code></td>
+<td>Installs all deps (incl. devDeps), compiles native bindings (<code>node-pty</code>) against the runtime Node, runs <code>npm run build</code> for both packages</td>
+</tr>
+<tr>
+<td><code>runtime</code></td>
+<td><code>node:22-bookworm-slim</code></td>
+<td>Copies only the production deps + built artifacts. Adds <code>git</code>, <code>ripgrep</code>, <code>bash</code>, <code>curl</code>, <code>less</code>, <code>procps</code> for the agent&#39;s tools and the integrated terminal. Switches to a non-root <code>pi</code> user; sets <code>SHELL=/bin/bash</code> so xterm sessions land in bash rather than dash.</td>
+</tr>
+</tbody></table>
+<p>Final image is ~330 MB (Debian slim + Node runtime + production deps + interactive
+shell tools). The base was switched from <code>node:22-alpine</code> to <code>node:22-bookworm-slim</code>
+because the Node native-module ecosystem (node-pty, bcrypt, sharp, …) ships
+prebuilt binaries against glibc; on musl/alpine, those packages fall back to
+source builds, which is both slower and a frequent install-failure mode. No build
+toolchain or devDeps in the runtime image.</p>
+<h3>What&#39;s installed at runtime</h3>
+<ul>
+<li><strong>Node.js 22</strong> (Alpine package)</li>
+<li><strong><code>tini</code></strong> — minimal init for proper signal handling and zombie reaping</li>
+<li><strong><code>git</code></strong> — required by the agent&#39;s bash tool, the file-manager git diffs,
+and the GitPanel routes</li>
+<li><strong><code>ripgrep</code></strong> — pi&#39;s <code>grep</code> tool delegates to <code>rg</code> when present; without
+it, code search inside the agent silently degrades</li>
+</ul>
+<h3>User and permissions</h3>
+<p>The image creates a <code>pi</code> user (uid/gid configurable via <code>PUID</code> / <code>PGID</code>
+build args; default <code>1000:1000</code>) and runs the workbench as that user.</p>
+<p>For bind mounts to be writable, the <code>pi</code> user inside the container must
+match the host user that owns the mounted directory. On Linux:</p>
+<pre><code class="language-bash">PUID=$(id -u) PGID=$(id -g) docker compose -f docker/docker-compose.yml up -d --build
+</code></pre>
+<p>On Docker Desktop for macOS, UID translation is automatic — defaults
+usually work.</p>
+<h2>Volumes</h2>
+<p>The container expects three bind-mounted volumes:</p>
+<table>
+<thead>
+<tr>
+<th>Container path</th>
+<th>Compose env var</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>/workspace</code></td>
+<td><code>WORKSPACE_HOST_PATH</code> (default <code>../workspace</code>)</td>
+<td>User&#39;s project source code. Projects live as subfolders.</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi/agent</code></td>
+<td><code>PI_CONFIG_HOST_PATH</code> (default <code>~/.pi/agent</code>)</td>
+<td>Pi SDK config — <code>auth.json</code>, <code>models.json</code>, <code>settings.json</code>. Bind-mounting from the host means the container inherits provider auth without copying secrets into the image.</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi-workbench</code></td>
+<td><code>WORKBENCH_DATA_HOST_PATH</code> (default <code>~/.pi-workbench-docker</code>)</td>
+<td>Workbench-owned state — <code>projects.json</code>. <strong>Different default</strong> than <code>PI_CONFIG_HOST_PATH</code> so the container has its own project list independent of host CLI use.</td>
+</tr>
+</tbody></table>
+<h3>Why three volumes</h3>
+<ul>
+<li><strong>Workspace</strong> is your code; you back it up.</li>
+<li><strong><code>pi</code> config</strong> is your provider credentials; sharing with the host means
+you don&#39;t have to re-enter API keys after rebuild.</li>
+<li><strong>Workbench data</strong> is the project registry — sharing host vs container
+means coordinating two project lists. Defaulting to a separate host path
+(<code>~/.pi-workbench-docker</code>) keeps them isolated. Set both to the same
+path if you want a shared registry.</li>
+</ul>
+<h3>Sessions live inside the workspace</h3>
+<p>Session JSONLs default to <code>${WORKSPACE_PATH}/.pi/sessions/&lt;projectId&gt;/*.jsonl</code>
+inside the container, which means they live on the workspace bind mount.
+Backing up the workspace = backing up your conversation history. Override
+with the <code>SESSION_DIR</code> env var if you want them elsewhere.</p>
+<h2>Environment variables</h2>
+<p>The compose file forwards every env var pi-workbench reads. See the full
+reference in <a href="./configuration.md#environment-variables"><code>configuration.md</code></a>; the
+container-relevant ones:</p>
+<table>
+<thead>
+<tr>
+<th>Variable</th>
+<th>Container default</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>PORT</code></td>
+<td><code>3000</code></td>
+<td>Internal port; map to host via <code>HOST_PORT</code>.</td>
+</tr>
+<tr>
+<td><code>WORKSPACE_PATH</code></td>
+<td><code>/workspace</code></td>
+<td>Fixed inside the container.</td>
+</tr>
+<tr>
+<td><code>PI_CONFIG_DIR</code></td>
+<td><code>/home/pi/.pi/agent</code></td>
+<td>Fixed inside the container.</td>
+</tr>
+<tr>
+<td><code>WORKBENCH_DATA_DIR</code></td>
+<td><code>/home/pi/.pi-workbench</code></td>
+<td>Fixed inside the container.</td>
+</tr>
+<tr>
+<td><code>UI_PASSWORD</code></td>
+<td>(unset)</td>
+<td>Browser login password. <code>JWT_SECRET</code> auto-generates if not set.</td>
+</tr>
+<tr>
+<td><code>JWT_SECRET</code></td>
+<td>(unset, auto-generated)</td>
+<td>HS256 signing key. When <code>UI_PASSWORD</code> is set and this is empty, persisted to <code>${WORKBENCH_DATA_DIR}/jwt-secret</code> on first boot. Override by setting this env (<code>openssl rand -hex 32</code>).</td>
+</tr>
+<tr>
+<td><code>API_KEY</code></td>
+<td>(unset)</td>
+<td>Static bearer token for programmatic clients.</td>
+</tr>
+<tr>
+<td><code>LOG_LEVEL</code></td>
+<td><code>info</code></td>
+<td>Pino level: <code>trace</code> / <code>debug</code> / <code>info</code> / <code>warn</code> / <code>error</code>.</td>
+</tr>
+<tr>
+<td><code>TRUST_PROXY</code></td>
+<td><code>false</code></td>
+<td>Set to <code>true</code> when behind a reverse proxy so login rate-limit applies per real client IP.</td>
+</tr>
+<tr>
+<td><code>CORS_ORIGIN</code></td>
+<td>(reflect)</td>
+<td>Pin in production, e.g. <code>https://pi.example.com</code>.</td>
+</tr>
+<tr>
+<td><code>MINIMAL_UI</code></td>
+<td><code>false</code></td>
+<td>Hide terminal / git / last-turn / providers / agent settings. See <a href="../README.md"><code>README.md</code></a>.</td>
+</tr>
+</tbody></table>
+<p><strong>Auth is opt-in.</strong> With both <code>UI_PASSWORD</code> and <code>API_KEY</code> unset, the API is
+unauthenticated. That&#39;s fine for <code>127.0.0.1</code>-only deploys; it is <strong>never</strong>
+fine when the container is reachable on a routable interface.</p>
+<h2>Compose recipe</h2>
+<p>The shipped compose file (<code>docker/docker-compose.yml</code>) covers a typical
+single-host deploy. Quickstart:</p>
+<pre><code class="language-bash">cp docker/.env.example docker/.env
+# edit docker/.env — at minimum set HOST_PORT and (for any non-loopback
+# deploy) UI_PASSWORD (JWT_SECRET auto-generates), or API_KEY
+cd docker &amp;&amp; docker compose up -d --build
+</code></pre>
+<h3>Operations</h3>
+<pre><code class="language-bash"># Logs (follow)
+docker compose -f docker/docker-compose.yml logs -f
+
+# Restart after editing .env
+docker compose -f docker/docker-compose.yml restart
+
+# Rebuild on code change
+docker compose -f docker/docker-compose.yml up -d --build
+
+# Tear down (preserves volumes)
+docker compose -f docker/docker-compose.yml down
+
+# Tear down + delete the named volumes (workspace stays — that&#39;s a bind mount)
+docker compose -f docker/docker-compose.yml down -v
+</code></pre>
+<h3>Health check</h3>
+<p>The container has a baked-in health check that <code>fetch</code>s
+<code>http://127.0.0.1:3000/api/v1/health</code> every 30 s. After the start period,
+three failures in a row mark it unhealthy. <code>docker compose ps</code> reports the
+health state.</p>
+<h2>Resource recommendations</h2>
+<p>Default <code>docker-compose.yml</code> doesn&#39;t pin CPU / memory limits — pi-workbench
+is lightweight at idle and the agent&#39;s resource use depends entirely on
+what your prompts ask for. Reasonable starting points:</p>
+<pre><code class="language-yaml">services:
+  pi-workbench:
+    deploy:
+      resources:
+        limits:
+          memory: 2G    # base + room for buffered SSE / one PTY
+        reservations:
+          memory: 512M
+</code></pre>
+<p>Bump if you:</p>
+<ul>
+<li><strong>Run heavy build commands inside the integrated terminal</strong> (npm builds,
+cargo, etc.) — terminal output is buffered in the agent&#39;s session
+history, which lives in memory until the SSE clients drain it</li>
+<li><strong>Open many terminals</strong> — each PTY is a separate node-pty + child shell,
+~5-15 MB per shell at rest, more if you <code>tail -f</code> something</li>
+<li><strong>Have very long running sessions</strong> — pi accumulates message history in
+memory; compaction trims it but cycles in and out</li>
+</ul>
+<p>CPU is rarely the bottleneck — most workbench CPU is forwarding bytes
+between the LLM provider and the browser.</p>
+<h2>Networking</h2>
+<p>The container exposes port 3000 internally. The compose file maps it to
+<code>${HOST_PORT}</code> on the host (default 3000). Bind to a specific host
+interface to limit exposure:</p>
+<pre><code class="language-yaml">ports:
+  - &quot;127.0.0.1:${HOST_PORT}:3000&quot;   # loopback only
+</code></pre>
+<p>For production behind a reverse proxy on the same host, this is the
+recommended posture: only the proxy can reach the workbench, and the
+proxy terminates TLS + handles auth headers.</p>
+<p>For multi-host deployments, put the workbench on a private network the
+proxy can reach. Avoid <code>0.0.0.0:3000:3000</code> on a host whose port 3000 is
+internet-routable.</p>
+<h3>SSE through proxies</h3>
+<p>Server-Sent Events are long-lived HTTP responses. Most proxies need
+explicit configuration to not buffer them:</p>
+<ul>
+<li><strong>nginx:</strong> <code>proxy_buffering off; proxy_read_timeout 3600s;</code></li>
+<li><strong>Caddy:</strong> <code>flush_interval -1</code> + <code>read_timeout 30m</code> (full snippet in
+<a href="../README.md"><code>README.md</code></a>)</li>
+<li><strong>Traefik:</strong> SSE-friendly out of the box (no buffering by default), but
+set <code>transport.respondingTimeouts.readTimeout = 3600s</code> for long agent
+runs</li>
+</ul>
+<p>WebSocket support (terminal route) requires the same upgrade-handling on
+the proxy side; both nginx and Caddy do this transparently in their
+default reverse-proxy directives.</p>
+<h2>Security inside the container</h2>
+<ul>
+<li><strong>Non-root user.</strong> The workbench runs as <code>pi:pi</code>, never as root. The
+<code>tini</code> init handles signal forwarding so the container shuts down
+cleanly on <code>docker stop</code>.</li>
+<li><strong>No new privileges.</strong> The image has no capabilities beyond what the
+base Alpine install provides. The container does not need privileged
+mode, host PID, or <code>--cap-add</code>. If you find yourself adding any of
+these, you&#39;re working around the threat model — open an issue first.</li>
+<li><strong>Read-only root filesystem (optional).</strong> You can add
+<code>read_only: true</code> to the compose file with appropriate <code>tmpfs</code> mounts
+for <code>/tmp</code> and <code>/home/pi/.npm</code> if you want a hardened deploy. Native
+modules and node_modules live in the image (read-only at runtime by
+default), so this works.</li>
+</ul>
+<h2>Updating</h2>
+<p>The image is <strong>not</strong> auto-updating. To pull a new release:</p>
+<pre><code class="language-bash">git pull origin main
+cd docker &amp;&amp; docker compose up -d --build
+</code></pre>
+<p>The build is incremental — npm dep resolution caches; only changed source
+files trigger a rebuild. Cold builds are ~3-5 minutes; warm rebuilds are
+~30 seconds.</p>
+<p>If you&#39;ve forked the project, pin to your fork&#39;s image tag in the compose
+file and update the tag explicitly.</p>
+<h2>Troubleshooting</h2>
+<h3>Container starts but can&#39;t write to <code>/workspace</code></h3>
+<p>UID mismatch. Check the host owner (<code>ls -ln &lt;host-workspace-path&gt;</code>) and
+either:</p>
+<ul>
+<li>Rebuild with matching <code>PUID</code> / <code>PGID</code> build args, OR</li>
+<li><code>chown -R $(id -u):$(id -g) &lt;host-workspace-path&gt;</code> to match the
+container&#39;s defaults</li>
+</ul>
+<h3>Terminal fails to spawn (<code>posix_spawnp failed</code>)</h3>
+<p>The native <code>node-pty</code> binding doesn&#39;t match the runtime Node version.
+This is a host-only issue (the Docker image rebuilds the binding during
+its build stage). If you somehow hit it inside the container, your
+local image is stale — <code>docker compose up -d --build</code> (note <code>--build</code>).</p>
+<h3>Health check failing on first start</h3>
+<p>The first request lazy-loads the project registry from disk, which on a
+slow filesystem (NFS, network bind mount) can take a few seconds. The
+health check has a 10 s start period; tune <code>start_period</code> in the compose
+file&#39;s <code>healthcheck</code> block if needed.</p>
+<h3>Container can&#39;t reach LLM provider</h3>
+<p>The container needs egress to whatever provider domain you&#39;ve configured
+(<code>api.anthropic.com</code>, <code>api.openai.com</code>, etc.). On corporate networks behind
+an HTTP proxy, set <code>HTTPS_PROXY</code> in the environment block.</p>
+<h3><code>git</code> commands fail with &quot;fatal: detected dubious ownership&quot;</h3>
+<p>Recent git versions reject working trees owned by a different UID than
+the running process. Either match UIDs (per the bind-mount section
+above) or run inside the container:</p>
+<pre><code class="language-bash">docker compose exec pi-workbench git config --global --add safe.directory /workspace/&lt;project&gt;
+</code></pre>
+<p>The setting persists across container restarts because it lives in the
+<code>pi</code> user&#39;s git config inside <code>/home/pi/.gitconfig</code>, which is on the
+container filesystem — not on a bind mount. To persist across rebuilds,
+add it to the Dockerfile (or use a config-only bind mount).</p>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/deployment.html
+++ b/docs/site/docs/deployment.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deployment — pi-workbench</title>
+  <meta name="description" content="Getting the workbench running in production: TLS, auth, reverse proxies.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-workbench
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html" class="active">Deployment</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-workbench">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Deployment</h1>
+      <p class="docs-subtitle">Getting the workbench running in production: TLS, auth, reverse proxies.</p>
+<p>This document covers production deployment of pi-workbench: TLS termination,
+reverse-proxy configuration, auth setup, and the per-environment-variable
+guidance for going from &quot;works on localhost&quot; to &quot;works on a public domain
+with no surprises.&quot;</p>
+<p>For the container itself (image, volumes, resources, troubleshooting) see
+<a href="./CONTAINERS.md"><code>docs/CONTAINERS.md</code></a>. For Kubernetes and OpenShift, see
+<a href="../kubernetes/DEPLOY.md"><code>kubernetes/DEPLOY.md</code></a>.</p>
+<h2>Before you deploy</h2>
+<p>A short checklist that catches the common foot-guns:</p>
+<ul>
+<li><input disabled="" type="checkbox"> <code>UI_PASSWORD</code> set, OR <code>API_KEY</code> set, OR both — never run a
+network-exposed deploy with both unset. <code>JWT_SECRET</code> is
+auto-generated and persisted to <code>${WORKBENCH_DATA_DIR}/jwt-secret</code>
+on first boot (override by setting <code>JWT_SECRET</code> env explicitly).</li>
+<li><input disabled="" type="checkbox"> <code>JWT_SECRET</code> either auto-generated (recommended; the persisted
+file is mode 0600 inside your already-mounted data dir) or, if
+overriding, from <code>openssl rand -hex 32</code> — not a memorable string.
+Rotating (delete the file or change the env) invalidates all
+sessions immediately, which is what you want after a key leak.</li>
+<li><input disabled="" type="checkbox"> Reverse proxy (Caddy / nginx / Traefik) terminates TLS in front of
+the workbench. Plain HTTP is fine on <code>127.0.0.1</code>; never on a routable
+interface.</li>
+<li><input disabled="" type="checkbox"> <code>TRUST_PROXY=true</code> so the login rate-limit applies per real client
+IP rather than per proxy hop.</li>
+<li><input disabled="" type="checkbox"> <code>CORS_ORIGIN</code> pinned to your actual domain (e.g.
+<code>https://pi.example.com</code>) — do not leave it reflecting whatever
+the request claims.</li>
+<li><input disabled="" type="checkbox"> Workspace + pi config + workbench data on backed-up storage. The
+container is replaceable; your sessions and provider keys are not.</li>
+<li><input disabled="" type="checkbox"> LLM provider account has a spending limit set. The workbench
+surfaces token + cost telemetry in the Context Inspector but does
+not enforce caps.</li>
+</ul>
+<h2>Recommended topology</h2>
+<pre><code>┌──────────────┐       HTTPS        ┌──────────────┐
+│   Browser    │  ─────────────────▶│   Caddy /    │
+│              │                    │  nginx /     │
+└──────────────┘                    │  Traefik     │
+                                    │  (TLS, auth  │
+                                    │   header     │
+                                    │   forwarding) │
+                                    └──────┬───────┘
+                                           │ HTTP, loopback
+                                           │ or private network
+                                           ▼
+                                    ┌──────────────┐
+                                    │ pi-workbench │
+                                    │  container   │
+                                    │   :3000      │
+                                    └──────────────┘
+                                           │
+                                           ▼
+                                    Bind-mounted volumes
+                                    (workspace, config)
+</code></pre>
+<p>The proxy handles TLS, HSTS, and (optionally) request logging. The
+workbench handles app-level auth. Bind the container&#39;s port 3000 to
+<code>127.0.0.1</code> only on the host so nothing besides the proxy can reach it.</p>
+<h2>Reverse-proxy snippets</h2>
+<h3>Caddy (recommended for simplicity)</h3>
+<pre><code class="language-caddy">pi.example.com {
+    # SSE needs flush-passthrough + a generous read timeout for long
+    # agent runs. The transport block lifts read_timeout from the default
+    # 30s to 30 minutes; flush_interval -1 disables Caddy&#39;s response
+    # buffering so each SSE event reaches the browser immediately.
+    reverse_proxy localhost:3000 {
+        flush_interval -1
+        transport http {
+            read_timeout 30m
+        }
+    }
+
+    # Optional: stricter HSTS than Caddy&#39;s default
+    header {
+        Strict-Transport-Security &quot;max-age=31536000; includeSubDomains&quot;
+        # Tighten if you control all the assets — pi-workbench has no
+        # external script deps post-build, so a strict CSP is feasible
+        # Content-Security-Policy &quot;default-src &#39;self&#39;; img-src &#39;self&#39; data:; ...&quot;
+    }
+
+    # Optional: log to file
+    log {
+        output file /var/log/caddy/pi-workbench.log
+    }
+}
+</code></pre>
+<p>Then: <code>caddy reload --config /etc/caddy/Caddyfile</code>. Caddy auto-provisions
+TLS certificates from Let&#39;s Encrypt — no manual cert handling.</p>
+<h3>nginx</h3>
+<pre><code class="language-nginx">server {
+    listen 443 ssl http2;
+    server_name pi.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/pi.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/pi.example.com/privkey.pem;
+
+    # SSE: disable buffering, allow long-lived connections
+    location / {
+        proxy_pass         http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+
+        # Forwarded headers — TRUST_PROXY=true on the workbench reads these
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket upgrade (terminal route)
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $http_connection;
+
+        # SSE + long agent runs
+        proxy_buffering    off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+
+        # File upload cap matches the workbench&#39;s 50 MB per-file
+        client_max_body_size 100M;
+    }
+}
+
+map $http_upgrade $http_connection {
+    default upgrade;
+    &quot;&quot;      &quot;&quot;;
+}
+
+# HTTP → HTTPS redirect
+server {
+    listen 80;
+    server_name pi.example.com;
+    return 301 https://$host$request_uri;
+}
+</code></pre>
+<p>Reload: <code>nginx -t &amp;&amp; nginx -s reload</code>. Use <code>certbot --nginx</code> for cert
+auto-provisioning.</p>
+<h3>Traefik (Docker labels)</h3>
+<pre><code class="language-yaml"># docker/docker-compose.yml additions for Traefik
+services:
+  pi-workbench:
+    labels:
+      - &quot;traefik.enable=true&quot;
+      - &quot;traefik.http.routers.pi-workbench.rule=Host(`pi.example.com`)&quot;
+      - &quot;traefik.http.routers.pi-workbench.entrypoints=websecure&quot;
+      - &quot;traefik.http.routers.pi-workbench.tls.certresolver=letsencrypt&quot;
+      - &quot;traefik.http.services.pi-workbench.loadbalancer.server.port=3000&quot;
+
+      # SSE / long-running response support
+      - &quot;traefik.http.middlewares.long-timeout.forwardauth.responseheaders=Cache-Control,X-Accel-Buffering&quot;
+</code></pre>
+<p>In your Traefik static config, set
+<code>entryPoints.websecure.transport.respondingTimeouts.readTimeout = 3600s</code>
+so SSE streams don&#39;t terminate after the default 60 s. Traefik handles
+WebSocket upgrades transparently.</p>
+<h2>Production environment variables</h2>
+<p>The full reference is in <a href="./configuration.md#environment-variables"><code>configuration.md</code></a>.
+Production-relevant guidance:</p>
+<table>
+<thead>
+<tr>
+<th>Variable</th>
+<th>Production value</th>
+<th>Why</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>UI_PASSWORD</code></td>
+<td>A strong shared secret if multiple humans share the deploy, OR a personal password for solo use</td>
+<td>Required for browser login.</td>
+</tr>
+<tr>
+<td><code>JWT_SECRET</code></td>
+<td>(leave empty for auto-generation) or <code>$(openssl rand -hex 32)</code> to override</td>
+<td>Signing key for browser session JWTs. When <code>UI_PASSWORD</code> is set and <code>JWT_SECRET</code> is empty, the server generates one and persists it to <code>${WORKBENCH_DATA_DIR}/jwt-secret</code> (mode 0600); the data dir is already a PVC / bind-mount so tokens survive restarts. Rotate by deleting the file (or rotating the env value).</td>
+</tr>
+<tr>
+<td><code>API_KEY</code></td>
+<td><code>$(openssl rand -hex 32)</code></td>
+<td>Static bearer token for scripts / CI. Different secret than the browser login.</td>
+</tr>
+<tr>
+<td><code>JWT_EXPIRES_IN_SECONDS</code></td>
+<td><code>86400</code> (24 h) for higher-trust environments, or leave at default <code>604800</code> (7 d)</td>
+<td>Shorter = re-login more often = smaller blast radius if a token leaks.</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_LOGIN_MAX</code></td>
+<td><code>5</code> if you&#39;re paranoid; default <code>10</code> is fine for most</td>
+<td>Per-IP login attempts per minute.</td>
+</tr>
+<tr>
+<td><code>RATE_LIMIT_LOGIN_WINDOW_MS</code></td>
+<td>Default <code>60000</code></td>
+<td>Rate-limit window.</td>
+</tr>
+<tr>
+<td><code>TRUST_PROXY</code></td>
+<td><code>true</code></td>
+<td>Required when behind any reverse proxy so the rate-limit sees real client IPs.</td>
+</tr>
+<tr>
+<td><code>CORS_ORIGIN</code></td>
+<td>Your exact domain, e.g. <code>https://pi.example.com</code></td>
+<td>Pinning prevents same-network attackers from making cross-origin requests using the user&#39;s credentials.</td>
+</tr>
+<tr>
+<td><code>LOG_LEVEL</code></td>
+<td><code>info</code> (default) or <code>warn</code> if logs are noisy</td>
+<td><code>debug</code> / <code>trace</code> are useful during incidents but produce a lot.</td>
+</tr>
+<tr>
+<td><code>MINIMAL_UI</code></td>
+<td><code>true</code> if your users shouldn&#39;t have terminal / git / settings access</td>
+<td>Frontend-only gate; doesn&#39;t change server route exposure.</td>
+</tr>
+</tbody></table>
+<h3>Setting auth correctly</h3>
+<p>Either browser auth, API key, or both. Never neither for a network-
+exposed deploy.</p>
+<pre><code class="language-bash"># .env example for browser-only auth
+UI_PASSWORD=your-strong-password-here
+JWT_SECRET=                          # blank — auto-generated and persisted
+API_KEY=                             # blank — disabled
+
+# .env example for API-only auth (e.g., headless deploys)
+UI_PASSWORD=
+JWT_SECRET=
+API_KEY=&lt;openssl rand -hex 32 output&gt;
+
+# .env example for both — most common for &quot;humans + scripts share the deploy&quot;
+UI_PASSWORD=your-strong-password-here
+JWT_SECRET=                          # blank — auto-generated and persisted
+API_KEY=&lt;openssl rand -hex 32 output&gt;
+</code></pre>
+<p>When <code>UI_PASSWORD</code> is set and <code>JWT_SECRET</code> is empty, the server
+generates a 48-byte random secret on first boot and persists it to
+<code>${WORKBENCH_DATA_DIR}/jwt-secret</code> (mode 0600). Because <code>WORKBENCH_DATA_DIR</code>
+is already a PVC / bind-mount in K8s and Docker, the secret survives
+restarts and tokens issued before a restart keep working. Set
+<code>JWT_SECRET</code> explicitly only if you want to manage rotation out-of-band
+(e.g. centrally rotated K8s <code>Secret</code>). Delete the file to rotate
+in-place.</p>
+<h2>Backup recommendations</h2>
+<p>Three things worth backing up:</p>
+<ol>
+<li><strong><code>${WORKSPACE_HOST_PATH}</code></strong> — your code. The agent&#39;s writes live here.
+Use whatever you&#39;d use for any code repo: rsync, restic, borg, S3 sync,
+etc. Snapshot via filesystem (ZFS / Btrfs) or storage layer (EBS
+snapshots) if available.</li>
+<li><strong><code>${WORKSPACE_HOST_PATH}/.pi/sessions/</code></strong> — session JSONLs (default
+<code>${SESSION_DIR}</code> lives inside the workspace mount). These are the
+complete record of every prompt / response / tool call. Treat as
+sensitive — they contain everything the agent saw.</li>
+<li><strong><code>${PI_CONFIG_HOST_PATH}</code></strong> — provider API keys + custom provider
+definitions. Encrypted at rest if your backup tooling supports it
+(most do).</li>
+</ol>
+<p><code>projects.json</code> (under <code>${WORKBENCH_DATA_HOST_PATH}</code>) is recoverable
+from disk by re-adding projects manually, so it&#39;s lower priority — but
+also tiny, so back it up anyway.</p>
+<h2>Update / rollback</h2>
+<pre><code class="language-bash"># Update
+git pull origin main
+cd docker &amp;&amp; docker compose up -d --build
+
+# Rollback (assumes you tagged the deployed version locally)
+git checkout v0.X.Y
+cd docker &amp;&amp; docker compose up -d --build
+</code></pre>
+<p>Workspace, sessions, and pi config are on bind mounts — they survive
+container rebuilds. The only state lost during update is in-memory
+(active SSE connections, live PTY processes). SSE clients reconnect
+automatically with backoff; PTYs from before the restart are reaped
+(see <code>pty-manager.ts</code> IDLE_REAP_MS) and replaced with fresh shells on
+reconnect.</p>
+<h2>Multi-deploy patterns</h2>
+<p>pi-workbench is single-tenant. To support multiple users, run multiple
+deploys:</p>
+<pre><code class="language-yaml"># docker-compose.yml — one service per user
+services:
+  pi-workbench-alice:
+    container_name: pi-workbench-alice
+    image: pi-workbench:latest
+    ports: [&quot;127.0.0.1:3001:3000&quot;]
+    volumes:
+      - /srv/alice/workspace:/workspace
+      - /srv/alice/.pi/agent:/home/pi/.pi/agent
+      - /srv/alice/.pi-workbench:/home/pi/.pi-workbench
+    environment:
+      - UI_PASSWORD=${ALICE_PASSWORD}
+      - JWT_SECRET=${ALICE_JWT_SECRET}
+      - TRUST_PROXY=true
+
+  pi-workbench-bob:
+    container_name: pi-workbench-bob
+    image: pi-workbench:latest
+    ports: [&quot;127.0.0.1:3002:3000&quot;]
+    volumes:
+      - /srv/bob/workspace:/workspace
+      - /srv/bob/.pi/agent:/home/pi/.pi/agent
+      - /srv/bob/.pi-workbench:/home/pi/.pi-workbench
+    environment:
+      - UI_PASSWORD=${BOB_PASSWORD}
+      - JWT_SECRET=${BOB_JWT_SECRET}
+      - TRUST_PROXY=true
+</code></pre>
+<p>Then route each via the proxy:</p>
+<pre><code class="language-caddy">alice.pi.example.com {
+    reverse_proxy localhost:3001 { flush_interval -1; transport http { read_timeout 30m } }
+}
+bob.pi.example.com {
+    reverse_proxy localhost:3002 { flush_interval -1; transport http { read_timeout 30m } }
+}
+</code></pre>
+<p>Each deploy has its own JWT secret, its own provider keys, its own
+projects, its own session history. Zero shared state.</p>
+<h2>Monitoring</h2>
+<p>The shipped health endpoint is enough for liveness probes:</p>
+<pre><code class="language-bash">curl -s http://localhost:3000/api/v1/health
+# { &quot;status&quot;: &quot;ok&quot;, &quot;activeSessions&quot;: 0, &quot;activePtys&quot;: 0 }
+</code></pre>
+<p>The container&#39;s <code>HEALTHCHECK</code> directive uses this (see
+<a href="./CONTAINERS.md#health-check"><code>docs/CONTAINERS.md</code></a>).</p>
+<p>For deeper observability, the workbench logs to stdout in pino&#39;s JSON
+format. Pipe through your log aggregator of choice:</p>
+<pre><code class="language-bash"># Promtail / Loki
+docker compose logs -f pi-workbench | promtail-pipe
+
+# Vector
+docker logs -f pi-workbench | vector-pipe
+
+# Just file rotation
+docker compose logs -f pi-workbench &gt;&gt; /var/log/pi-workbench.log
+</code></pre>
+<p>Useful log fields to alert on:</p>
+<ul>
+<li>Repeated <code>terminal exited</code> with non-zero <code>exitCode</code> — agent&#39;s bash
+failing or shell crashing</li>
+<li><code>pty spawn failed</code> — node-pty native binding broken (rare in container,
+common on host installs)</li>
+<li><code>set model failed</code> — provider API rejecting requests (auth, quota)</li>
+<li><code>unmapped file-manager error</code> — defensive log; investigate as a
+potential undocumented error path</li>
+</ul>
+<p>There is no built-in metrics endpoint (no Prometheus exporter). The
+session count and active PTY count from <code>/api/v1/health</code> are the only
+exported numbers; scrape them with a 30 s job and alert on stuck values
+if you care.</p>
+<h2>See also</h2>
+<ul>
+<li><a href="./CONTAINERS.md"><code>docs/CONTAINERS.md</code></a> — Docker image internals,
+resources, troubleshooting</li>
+<li><a href="./configuration.md"><code>docs/configuration.md</code></a> — pi config files
+(auth, models, settings) + custom providers</li>
+<li><a href="./architecture.md"><code>docs/architecture.md</code></a> — component map, request
+lifecycles</li>
+<li><a href="../SECURITY.md"><code>SECURITY.md</code></a> — full threat model + vulnerability
+reporting</li>
+<li><a href="../kubernetes/DEPLOY.md"><code>kubernetes/DEPLOY.md</code></a> — Kubernetes /
+OpenShift recipes</li>
+</ul>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/mcp.html
+++ b/docs/site/docs/mcp.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MCP Servers — pi-workbench</title>
+  <meta name="description" content="Connecting external Model Context Protocol servers to the workbench.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-workbench
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html" class="active">MCP Servers</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-workbench">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>MCP Servers</h1>
+      <p class="docs-subtitle">Connecting external Model Context Protocol servers to the workbench.</p>
+<p>pi-workbench can connect to MCP servers and surface their tools to the
+agent. Configure servers from <strong>Settings → MCP</strong> in the browser, or by
+editing config files directly.</p>
+<blockquote>
+<p>Pi itself has no native MCP support. The integration is workbench-
+internal — see <a href="../packages/server/src/mcp/manager.ts"><code>packages/server/src/mcp/manager.ts</code></a>
+for the contract.</p>
+</blockquote>
+<h2>Scope of v1</h2>
+<ul>
+<li><strong>Remote servers only.</strong> Transports: <code>streamable-http</code> (newer MCP
+spec) and <code>sse</code> (legacy). The default <code>auto</code> transport tries
+<code>streamable-http</code> first and falls back to <code>sse</code> — covers
+<a href="https://github.com/jlowin/fastmcp" target="_blank" rel="noopener noreferrer">fastmcp</a> servers regardless of
+which transport you exposed.</li>
+<li><strong>stdio is not supported.</strong> The workbench is container-native and
+arbitrary subprocess spawning has different security trade-offs.
+Run stdio MCP servers as a separate process and expose them over
+HTTP/SSE if you need them in the workbench.</li>
+<li><strong>Static-header auth only.</strong> Bearer tokens, custom auth headers —
+whatever your MCP server expects. OAuth (per-server consent flow,
+callback handling) is deferred.</li>
+</ul>
+<h2>Where servers live</h2>
+<p>Two layers, merged at session create time:</p>
+<table>
+<thead>
+<tr>
+<th>Scope</th>
+<th>File</th>
+<th>Editable from UI?</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Global</td>
+<td><code>${WORKBENCH_DATA_DIR}/mcp.json</code></td>
+<td>Yes (Settings → MCP)</td>
+</tr>
+<tr>
+<td>Project</td>
+<td><code>&lt;projectPath&gt;/.mcp.json</code></td>
+<td>No — edit in your repo</td>
+</tr>
+</tbody></table>
+<p>Project entries <strong>override</strong> global entries when the server names
+collide. The override is per-server (not per-tool); add a project
+entry with the same <code>name</code> to swap a global server for a project-
+specific one inside that project&#39;s sessions.</p>
+<h2>File format</h2>
+<p><code>mcp.json</code> (workbench-native shape, written by the UI):</p>
+<pre><code class="language-json">{
+  &quot;disabled&quot;: false,
+  &quot;servers&quot;: {
+    &quot;my-server&quot;: {
+      &quot;url&quot;: &quot;https://mcp.example.com/sse&quot;,
+      &quot;transport&quot;: &quot;auto&quot;,
+      &quot;enabled&quot;: true,
+      &quot;headers&quot;: {
+        &quot;Authorization&quot;: &quot;Bearer sk-...&quot;
+      }
+    }
+  }
+}
+</code></pre>
+<p>Project <code>.mcp.json</code> accepts both shapes — workbench-native and the
+Claude Desktop / pi-mcp-adapter standard:</p>
+<pre><code class="language-json">{
+  &quot;mcpServers&quot;: {
+    &quot;chrome-devtools&quot;: {
+      &quot;url&quot;: &quot;https://mcp.example.com/sse&quot;
+    }
+  }
+}
+</code></pre>
+<p>This way an existing project that already had a <code>.mcp.json</code> for other
+MCP clients works without rewriting.</p>
+<h3>Field reference</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Default</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>url</code></td>
+<td>string</td>
+<td>(required)</td>
+<td>The MCP endpoint URL.</td>
+</tr>
+<tr>
+<td><code>transport</code></td>
+<td><code>&quot;auto&quot;</code> | <code>&quot;streamable-http&quot;</code> | <code>&quot;sse&quot;</code></td>
+<td><code>&quot;auto&quot;</code></td>
+<td>Connection probe order. <code>auto</code> tries StreamableHTTP first.</td>
+</tr>
+<tr>
+<td><code>enabled</code></td>
+<td>boolean</td>
+<td><code>true</code></td>
+<td>Disabled servers don&#39;t connect or contribute tools.</td>
+</tr>
+<tr>
+<td><code>headers</code></td>
+<td><code>Record&lt;string, string&gt;</code></td>
+<td>(none)</td>
+<td>Forwarded on every MCP RPC. Treated as secret on read — <code>GET /mcp/servers</code> returns <code>***REDACTED***</code> for every value.</td>
+</tr>
+<tr>
+<td><code>disabled</code></td>
+<td>boolean (top-level)</td>
+<td><code>false</code></td>
+<td>Master kill-switch. When <code>true</code>, NO MCP tools reach the agent regardless of per-server <code>enabled</code>. Surfaced as the toggle at the top of Settings → MCP.</td>
+</tr>
+</tbody></table>
+<h2>How the agent sees the tools</h2>
+<p>Each MCP tool advertised by a connected, enabled server becomes a pi
+<code>ToolDefinition</code> namespaced as <strong><code>&lt;server&gt;__&lt;tool&gt;</code></strong>. The prefix
+guarantees uniqueness so two servers can both advertise <code>search</code>
+without colliding.</p>
+<p>The agent calls them like any other tool. <code>client.callTool()</code> forwards
+the call; the MCP <code>CallToolResult.content</code> array is mapped into pi&#39;s
+content shape:</p>
+<ul>
+<li><code>text</code> → text content</li>
+<li><code>image</code> (with <code>mimeType</code>) → image content (data is base64)</li>
+<li><code>resource_link</code> / <code>resource</code> / unknown blocks → JSON-stringified
+into a text block (so the agent at least sees them rather than
+silently dropping)</li>
+</ul>
+<p><code>isError: true</code> on the MCP response prefixes the first text block with
+<code>[error]</code> so the agent has something actionable in its tool result.</p>
+<h2>Lifecycle</h2>
+<ul>
+<li><strong>Boot.</strong> The server eagerly loads <code>${WORKBENCH_DATA_DIR}/mcp.json</code>
+and connects every enabled global server. Connection failures are
+non-fatal — the server stays in <code>error</code> state and the workbench
+comes up regardless.</li>
+<li><strong>Project sessions.</strong> <code>&lt;projectPath&gt;/.mcp.json</code> is read lazily on
+the first <code>createAgentSession</code> for that project, then cached. A
+config change to that file requires either restarting the workbench
+or hitting the project&#39;s &quot;Probe&quot; button to pick up changes.</li>
+<li><strong>Save.</strong> A <code>PUT</code> from the Settings UI rewrites <code>mcp.json</code>
+atomically (<code>.tmp</code> + <code>rename</code>, mode 0600), then re-syncs the pool
+(disconnect + reconnect entries whose URL / transport / headers
+changed).</li>
+<li><strong>Master toggle.</strong> Flipping the toggle off in Settings doesn&#39;t
+disconnect anything — it just causes future <code>createAgentSession</code>
+calls to skip the <code>customTools</code> injection. Existing live sessions
+keep the tools they booted with.</li>
+</ul>
+<h2>Header status badge</h2>
+<p>The header next to <strong>Settings</strong> shows a colored dot + <code>MCP X/Y</code>:</p>
+<ul>
+<li><strong>emerald</strong> — every configured global server is connected</li>
+<li><strong>amber</strong> — some connected, some not (check Settings → MCP for the
+per-server <code>lastError</code>)</li>
+<li><strong>red</strong> — none connected (and at least one configured)</li>
+<li><strong>neutral</strong> — master toggle off</li>
+</ul>
+<p>Hidden when no servers are configured (keeps the header clean on
+deployments that don&#39;t use MCP) and in <code>MINIMAL_UI</code> mode.</p>
+<h2>Troubleshooting</h2>
+<p><strong>Status stuck in <code>error</code></strong> — open Settings → MCP, expand the server&#39;s
+row, and read <code>lastError</code>. Common causes: wrong URL, missing
+<code>Authorization</code> header, server returning 4xx on <code>tools/list</code>. The
+<strong>Probe</strong> button forces a reconnect + tool re-list; the result lands
+in the same row.</p>
+<p><strong>Both transports fail</strong> — pin <code>transport</code> explicitly. <code>auto</code> tries
+<code>streamable-http</code> and falls back to <code>sse</code>; if the server is misconfigured
+to advertise both but only one works, the auto-probe round-trip wastes
+a few hundred milliseconds on every reconnect. Pinning skips that.</p>
+<p><strong>Headers reset to <code>***REDACTED***</code></strong> — that&#39;s the read-path sentinel,
+not real data. The persisted file still has the real value. When you
+edit the form and save, leaving a sentinel value blank keeps the prior
+on-disk secret; supplying a new value overwrites it (same
+write-merge pattern as <code>models.json</code>).</p>
+<p><strong>Tools don&#39;t show up after editing project <code>.mcp.json</code></strong> — the file
+is read once per project per server lifetime. Hit Probe on the row,
+or restart the workbench, to pick up edits.</p>
+<h2>API surface</h2>
+<p>For automation. All routes are under <code>/api/v1/mcp/</code>:</p>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Path</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>GET</code></td>
+<td><code>/mcp/settings</code></td>
+<td>Master enable + connected/total count (header badge)</td>
+</tr>
+<tr>
+<td><code>PUT</code></td>
+<td><code>/mcp/settings</code></td>
+<td>Toggle the master flag</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/mcp/servers[?projectId=…]</code></td>
+<td>Global config (redacted) + status (global ∪ project)</td>
+</tr>
+<tr>
+<td><code>PUT</code></td>
+<td><code>/mcp/servers/:name</code></td>
+<td>Upsert a global server</td>
+</tr>
+<tr>
+<td><code>DELETE</code></td>
+<td><code>/mcp/servers/:name</code></td>
+<td>Remove a global server</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/mcp/servers/:name/probe[?projectId=…]</code></td>
+<td>Force reconnect + re-list, returns new status</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/mcp/tools?projectId=…</code></td>
+<td>Flat tool list available to sessions in the project</td>
+</tr>
+</tbody></table>
+<p>The Swagger UI at <code>/api/docs</code> has the request/response schemas.</p>
+<h2>See also</h2>
+<ul>
+<li><a href="./configuration.md"><code>docs/configuration.md</code></a> — workbench env vars
+including <code>WORKBENCH_DATA_DIR</code></li>
+<li><a href="./architecture.md"><code>docs/architecture.md</code></a> — where the manager
+sits in the request flow</li>
+<li><a href="../packages/server/src/mcp/manager.ts"><code>packages/server/src/mcp/manager.ts</code></a>
+— integration contract</li>
+</ul>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/sse-events.html
+++ b/docs/site/docs/sse-events.html
@@ -1,0 +1,515 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SSE Events — pi-workbench</title>
+  <meta name="description" content="The agent event stream: every event type, payload, and UI affordance.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-workbench
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="sse-events.html" class="active">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-workbench">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>SSE Events</h1>
+      <p class="docs-subtitle">The agent event stream: every event type, payload, and UI affordance.</p>
+<p>Server-Sent Events stream from <code>GET /api/v1/sessions/:id/stream</code>. Every
+client (the React UI, your scripts, your dashboards) consumes the same
+stream. This document catalogues every event type, full example payloads,
+ordering guarantees, and how to consume the stream from Python and Node.</p>
+<h2>Wire format</h2>
+<p>Standard SSE: each event is one <code>data:</code> line with a JSON-serialized
+payload, followed by a blank line.</p>
+<pre><code>data: {&quot;type&quot;:&quot;agent_start&quot;,&quot;sessionId&quot;:&quot;...&quot;}
+
+data: {&quot;type&quot;:&quot;message_update&quot;,&quot;assistantMessageEvent&quot;:{&quot;type&quot;:&quot;text_delta&quot;,&quot;delta&quot;:&quot;Hello&quot;}}
+
+data: {&quot;type&quot;:&quot;agent_end&quot;,&quot;sessionId&quot;:&quot;...&quot;}
+</code></pre>
+<p>The endpoint sets <code>Content-Type: text/event-stream</code> and <code>Cache-Control: no-cache, no-transform</code>. Reverse proxies must NOT buffer (<code>X-Accel-Buffering: no</code> is set by the server, plus Caddy&#39;s <code>flush_interval -1</code>, plus nginx&#39;s
+<code>proxy_buffering off</code> — see <a href="./deployment.md"><code>docs/deployment.md</code></a>).</p>
+<h2>Connection lifecycle</h2>
+<pre><code>Client                                                    Server
+  │                                                          │
+  ├── GET /api/v1/sessions/:id/stream ─────────────────────▶ │
+  │   Authorization: Bearer &lt;token&gt;                          │
+  │                                                          │
+  │                                              getSession(id)
+  │                                              or lazy resumeSession
+  │                                                          │
+  ◀── data: {&quot;type&quot;:&quot;snapshot&quot;,...} ──────────────────────── │
+  │   (always first; hydrates client state)                  │
+  │                                                          │
+  │   (live events as they arrive)                           │
+  ◀── data: {&quot;type&quot;:&quot;agent_start&quot;,...} ─────────────────────│
+  ◀── data: {&quot;type&quot;:&quot;message_update&quot;,...} ─────────────────│
+  ◀── data: {&quot;type&quot;:&quot;agent_end&quot;,...} ──────────────────────│
+  │                                                          │
+  │   (idle — connection stays open; next agent activity     │
+  │    flows straight through)                               │
+</code></pre>
+<p>The server holds the connection open indefinitely. The client closes by
+disconnecting; the server cleans up the <code>LiveSession.clients</code> Set entry
+on <code>req.raw.on(&quot;close&quot;)</code>. There is no server-side keepalive/heartbeat
+event today — long idle periods on aggressive proxies may need a
+keepalive comment line; track that as a polish item if it bites.</p>
+<h2>Always-first event: <code>snapshot</code></h2>
+<p>Every new SSE connection receives a <code>snapshot</code> as its first event. This
+hydrates a freshly-connected client&#39;s view without requiring a separate
+HTTP call.</p>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;snapshot&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;projectId&quot;: &quot;proj_abc...&quot;,
+  &quot;messages&quot;: [
+    { &quot;role&quot;: &quot;user&quot;, &quot;content&quot;: &quot;Refactor utils.ts&quot;, &quot;timestamp&quot;: 1714398000000 },
+    { &quot;role&quot;: &quot;assistant&quot;, &quot;content&quot;: [{ &quot;type&quot;: &quot;text&quot;, &quot;text&quot;: &quot;Reading the file...&quot; }], &quot;usage&quot;: { ... }, ... }
+  ],
+  &quot;isStreaming&quot;: false
+}
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>sessionId</code></td>
+<td>string</td>
+<td>Echoes the session id from the URL</td>
+</tr>
+<tr>
+<td><code>projectId</code></td>
+<td>string</td>
+<td>The project this session belongs to</td>
+</tr>
+<tr>
+<td><code>messages</code></td>
+<td><code>AgentMessage[]</code></td>
+<td>Full message history as the LLM sees it (post-compaction). Same shape as <code>GET /sessions/:id/messages</code>.</td>
+</tr>
+<tr>
+<td><code>isStreaming</code></td>
+<td>boolean</td>
+<td>True if the agent is mid-run when you connect</td>
+</tr>
+</tbody></table>
+<p>If <code>isStreaming: true</code>, expect <code>agent_end</code> (and possibly more
+<code>message_update</code> deltas + tool events) shortly. Otherwise the next
+events will arrive only when something happens (a <code>POST /prompt</code> or
+<code>POST /steer</code> call).</p>
+<h2>Agent lifecycle events</h2>
+<h3><code>agent_start</code></h3>
+<p>The agent has begun processing a turn. Fired before any
+<code>message_start</code> / <code>message_update</code> / tool events for that turn.</p>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;agent_start&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;timestamp&quot;: 1714398100000
+}
+</code></pre>
+<p>UI action: show &quot;thinking&quot; indicator, disable input or change Send to
+&quot;Steer.&quot; <code>lastAgentStartIndex</code> is captured server-side at this moment to
+bound &quot;the latest turn&quot; for the turn-diff route.</p>
+<h3><code>agent_end</code></h3>
+<p>The agent has finished. Use this to refresh derived state (turn diff,
+git status, context inspector, session tree).</p>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;agent_end&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;timestamp&quot;: 1714398150000
+}
+</code></pre>
+<p>UI action: hide thinking indicator, re-enable input, re-fetch
+<code>/turn-diff</code>, refresh file tree, increment <code>agentEndCountBySession[id]</code>.</p>
+<p>The session-store&#39;s <code>agentEndCount</code> is the canonical &quot;the agent just
+finished&quot; trigger — components that need to react to agent completion
+subscribe to this counter rather than the raw event.</p>
+<h2>Message events</h2>
+<p>The agent&#39;s response streams as a sequence of <code>message_start</code> →
+<code>message_update</code> → <code>message_end</code>. Multiple messages can flow per turn
+(e.g., assistant text → tool call → tool result → assistant text again).</p>
+<h3><code>message_start</code></h3>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;message_start&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;messageRole&quot;: &quot;assistant&quot;
+}
+</code></pre>
+<h3><code>message_update</code></h3>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;message_update&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;assistantMessageEvent&quot;: {
+    &quot;type&quot;: &quot;text_delta&quot;,
+    &quot;delta&quot;: &quot;Hello&quot;
+  }
+}
+</code></pre>
+<p>The <code>assistantMessageEvent</code> shape is from pi-ai&#39;s
+<code>AssistantMessageEventStream</code>. Common variants:</p>
+<table>
+<thead>
+<tr>
+<th><code>assistantMessageEvent.type</code></th>
+<th>Payload</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>text_delta</code></td>
+<td><code>{ type: &quot;text_delta&quot;, delta: &quot;...&quot; }</code> — append to streaming text</td>
+</tr>
+<tr>
+<td><code>thinking_delta</code></td>
+<td><code>{ type: &quot;thinking_delta&quot;, delta: &quot;...&quot; }</code> — thinking-block token</td>
+</tr>
+<tr>
+<td><code>tool_use_start</code></td>
+<td><code>{ type: &quot;tool_use_start&quot;, toolCallId, name, input: {} }</code> — tool call begins</td>
+</tr>
+<tr>
+<td><code>tool_use_input_delta</code></td>
+<td><code>{ type: &quot;tool_use_input_delta&quot;, toolCallId, partialInput: &quot;...&quot; }</code> — JSON args streaming</td>
+</tr>
+<tr>
+<td><code>usage</code></td>
+<td><code>{ type: &quot;usage&quot;, usage: { input, output, cacheRead, cacheWrite, ... } }</code> — token + cost update</td>
+</tr>
+</tbody></table>
+<p>The UI renders streaming text by accumulating <code>text_delta</code> deltas into
+<code>streamingTextBySession[id]</code> (see <code>session-store.ts</code>).</p>
+<h3><code>message_end</code></h3>
+<pre><code class="language-json">{ &quot;type&quot;: &quot;message_end&quot;, &quot;sessionId&quot;: &quot;01J7...&quot; }
+</code></pre>
+<h3><code>tool_call</code></h3>
+<p>Pre-execution event. The agent has decided to invoke a tool.</p>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;tool_call&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;toolCallId&quot;: &quot;call_abc...&quot;,
+  &quot;toolName&quot;: &quot;read&quot;,
+  &quot;input&quot;: { &quot;path&quot;: &quot;src/utils.ts&quot; }
+}
+</code></pre>
+<p>Useful for permission-style UIs (not implemented in v1 — pi runs all
+tool calls without per-call confirmation).</p>
+<h3><code>tool_execution_start</code> / <code>tool_execution_update</code> / <code>tool_execution_end</code></h3>
+<p>Tool runner lifecycle. <code>*_update</code> carries streaming output (e.g. bash
+stdout).</p>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;tool_execution_start&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;toolCallId&quot;: &quot;call_abc...&quot;,
+  &quot;toolName&quot;: &quot;bash&quot;
+}
+</code></pre>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;tool_execution_update&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;toolCallId&quot;: &quot;call_abc...&quot;,
+  &quot;outputDelta&quot;: &quot;Compiling utils.ts...\n&quot;
+}
+</code></pre>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;tool_execution_end&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;toolCallId&quot;: &quot;call_abc...&quot;,
+  &quot;exitCode&quot;: 0
+}
+</code></pre>
+<h3><code>tool_result</code></h3>
+<p>The tool&#39;s result message has been added to the session.</p>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;tool_result&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;message&quot;: {
+    &quot;role&quot;: &quot;toolResult&quot;,
+    &quot;toolCallId&quot;: &quot;call_abc...&quot;,
+    &quot;toolName&quot;: &quot;read&quot;,
+    &quot;content&quot;: [{ &quot;type&quot;: &quot;text&quot;, &quot;text&quot;: &quot;&lt;file contents&gt;&quot; }],
+    &quot;details&quot;: { &quot;path&quot;: &quot;src/utils.ts&quot; },
+    &quot;isError&quot;: false
+  }
+}
+</code></pre>
+<p><code>details</code> is tool-specific. For <code>edit</code> tools it includes a unified diff
+string under a tool-specific field — the workbench&#39;s
+<code>turn-diff-builder.ts</code> extracts these for the Last Turn pane.</p>
+<h2>Steering / queue events</h2>
+<h3><code>queue_update</code></h3>
+<p>The pending steer / followUp queue changed. Pi clears delivered queue
+items by emitting a smaller <code>queue_update</code>; the client doesn&#39;t pop locally.</p>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;queue_update&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;queued&quot;: {
+    &quot;steering&quot;: [&quot;Try a different approach&quot;],
+    &quot;followUp&quot;: [&quot;Run the tests when done&quot;]
+  }
+}
+</code></pre>
+<p>UI action: render the queued-messages badge in <code>ChatView</code>.</p>
+<h2>Compaction events</h2>
+<p>When the agent runs <code>compact</code> to free context-window space:</p>
+<h3><code>compaction_start</code></h3>
+<pre><code class="language-json">{ &quot;type&quot;: &quot;compaction_start&quot;, &quot;sessionId&quot;: &quot;01J7...&quot; }
+</code></pre>
+<p>UI action: show &quot;Compacting context…&quot; banner.</p>
+<h3><code>compaction_end</code></h3>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;compaction_end&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;summary&quot;: &quot;...&quot;,
+  &quot;tokensBefore&quot;: 95000
+}
+</code></pre>
+<p>The session&#39;s <code>messages</code> array now contains a <code>compactionSummary</code>-role
+message at the position of the compaction; UI should refresh.</p>
+<h2>Auto-retry events</h2>
+<p>Provider-side rate-limit / transient-error backoff:</p>
+<h3><code>auto_retry_start</code></h3>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;auto_retry_start&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;attempt&quot;: 2,
+  &quot;delayMs&quot;: 4000,
+  &quot;reason&quot;: &quot;rate_limit&quot;
+}
+</code></pre>
+<p>UI action: show &quot;Retrying in 4s...&quot; banner with a countdown.</p>
+<h3><code>auto_retry_end</code></h3>
+<pre><code class="language-json">{ &quot;type&quot;: &quot;auto_retry_end&quot;, &quot;sessionId&quot;: &quot;01J7...&quot; }
+</code></pre>
+<p>UI action: hide retry banner.</p>
+<h2>Ordering guarantees</h2>
+<p>Within a single SSE connection:</p>
+<ol>
+<li><code>snapshot</code> is <strong>always first</strong>.</li>
+<li>For a single agent turn:<ul>
+<li><code>agent_start</code> precedes everything in that turn.</li>
+<li>For each message in the turn: <code>message_start</code> → 1+ <code>message_update</code>
+→ <code>message_end</code>.</li>
+<li>For each tool call: <code>tool_call</code> → <code>tool_execution_start</code> → 0+
+<code>tool_execution_update</code> → <code>tool_execution_end</code> → <code>tool_result</code>.</li>
+<li><code>agent_end</code> is <strong>last</strong> for that turn.</li>
+</ul>
+</li>
+<li><code>queue_update</code>, <code>compaction_start</code> / <code>_end</code>, and <code>auto_retry_*</code> may
+appear at any point.</li>
+</ol>
+<p>Across multiple concurrent SSE clients on the same session: every client
+sees the same event stream in the same order. Reconnects start with a
+fresh <code>snapshot</code>; events that fired during the disconnect window are
+<strong>not replayed</strong> — the snapshot is authoritative.</p>
+<h2>Forwards-compatibility</h2>
+<p>The server filters events through <code>sse-bridge.ts</code> before forwarding —
+unknown event types from the SDK are not currently passed through.
+Clients should still <strong>silently ignore unknown event types</strong> to be
+forwards-compatible with future SDK additions.</p>
+<p>The <code>assistantMessageEvent.type</code> enum may grow as pi-ai adds streaming
+shapes (e.g., new content-block types). Use a switch with a default
+that no-ops, not a typed exhaustiveness check that throws.</p>
+<h2>Reconnection</h2>
+<p>The shipped client (<code>packages/client/src/lib/sse-client.ts</code>) reconnects
+on disconnect with exponential backoff: 1 → 2 → 4 → 8 → 16 → 30 s,
+capped at 30 s. On reconnect it gets a fresh <code>snapshot</code> and resumes.</p>
+<p>For a programmatic client, mirror this pattern:</p>
+<ul>
+<li>Track <code>reconnectAttempt</code>. Reset to 0 on successful open.</li>
+<li>On socket close (any code), schedule reconnect with
+<code>reconnectDelayMs(attempt++)</code>.</li>
+<li>On 401, drop the connection and prompt re-login (don&#39;t retry — the
+token is dead).</li>
+</ul>
+<h2>Auth on the SSE route</h2>
+<p>The <code>/stream</code> route goes through the same JWT/API-key check as every
+other authenticated route. Pass the token via <code>Authorization: Bearer &lt;token&gt;</code> header. Browsers can&#39;t do this with the built-in <code>EventSource</code>
+API (it doesn&#39;t support custom headers), so the browser client uses a
+<code>fetch</code> + <code>ReadableStream</code> reader instead. Programmatic clients should
+do the same (Python <code>httpx</code>, Node <code>fetch</code>).</p>
+<h2>Consuming SSE programmatically</h2>
+<h3>Python (httpx)</h3>
+<pre><code class="language-python">import json
+import time
+import httpx
+
+API_BASE = &quot;http://localhost:3000&quot;
+TOKEN = &quot;&lt;your bearer token&gt;&quot;
+
+def stream_session(session_id: str):
+    &quot;&quot;&quot;Connect to a session&#39;s SSE stream and yield each event.&quot;&quot;&quot;
+    headers = {&quot;Authorization&quot;: f&quot;Bearer {TOKEN}&quot;, &quot;Accept&quot;: &quot;text/event-stream&quot;}
+    url = f&quot;{API_BASE}/api/v1/sessions/{session_id}/stream&quot;
+
+    with httpx.stream(&quot;GET&quot;, url, headers=headers, timeout=None) as r:
+        r.raise_for_status()
+        buffer = &quot;&quot;
+        for chunk in r.iter_text():
+            buffer += chunk
+            while &quot;\n\n&quot; in buffer:
+                event, buffer = buffer.split(&quot;\n\n&quot;, 1)
+                for line in event.splitlines():
+                    if line.startswith(&quot;data: &quot;):
+                        payload = json.loads(line[6:])
+                        yield payload
+
+# Usage with backoff
+def stream_with_reconnect(session_id: str):
+    delays = [1, 2, 4, 8, 16, 30]
+    attempt = 0
+    while True:
+        try:
+            for event in stream_session(session_id):
+                attempt = 0  # reset on first successful event
+                yield event
+        except httpx.HTTPError as e:
+            if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 401:
+                raise  # auth dead, don&#39;t retry
+            delay = delays[min(attempt, len(delays) - 1)]
+            print(f&quot;[reconnect in {delay}s] {e}&quot;)
+            time.sleep(delay)
+            attempt += 1
+
+# Run
+for event in stream_with_reconnect(&quot;01J7...&quot;):
+    if event[&quot;type&quot;] == &quot;agent_end&quot;:
+        print(&quot;Turn complete&quot;)
+        break
+</code></pre>
+<h3>Node (fetch + ReadableStream)</h3>
+<pre><code class="language-javascript">const API_BASE = &quot;http://localhost:3000&quot;;
+const TOKEN = &quot;&lt;your bearer token&gt;&quot;;
+
+async function* streamSession(sessionId) {
+  const url = `${API_BASE}/api/v1/sessions/${sessionId}/stream`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Accept: &quot;text/event-stream&quot;,
+    },
+  });
+  if (!res.ok) throw new Error(`SSE connect failed: ${res.status}`);
+
+  const reader = res.body.pipeThrough(new TextDecoderStream()).getReader();
+  let buffer = &quot;&quot;;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) return;
+    buffer += value;
+    let idx;
+    while ((idx = buffer.indexOf(&quot;\n\n&quot;)) !== -1) {
+      const event = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 2);
+      for (const line of event.split(&quot;\n&quot;)) {
+        if (line.startsWith(&quot;data: &quot;)) {
+          yield JSON.parse(line.slice(6));
+        }
+      }
+    }
+  }
+}
+
+// Usage with backoff
+async function streamWithReconnect(sessionId, onEvent) {
+  const delays = [1, 2, 4, 8, 16, 30];
+  let attempt = 0;
+  while (true) {
+    try {
+      for await (const event of streamSession(sessionId)) {
+        attempt = 0;
+        await onEvent(event);
+      }
+    } catch (err) {
+      if (err.message.includes(&quot;401&quot;)) throw err;  // auth dead
+      const delay = delays[Math.min(attempt, delays.length - 1)] * 1000;
+      console.warn(`[reconnect in ${delay}ms]`, err.message);
+      await new Promise((r) =&gt; setTimeout(r, delay));
+      attempt++;
+    }
+  }
+}
+
+// Run
+streamWithReconnect(&quot;01J7...&quot;, (event) =&gt; {
+  if (event.type === &quot;agent_end&quot;) console.log(&quot;Turn complete&quot;);
+});
+</code></pre>
+<h3>curl (one-shot, for debugging)</h3>
+<pre><code class="language-bash">curl -N -H &quot;Authorization: Bearer $TOKEN&quot; \
+  http://localhost:3000/api/v1/sessions/$SESSION_ID/stream
+</code></pre>
+<p><code>-N</code> disables curl&#39;s output buffering so events appear as they arrive.
+Press Ctrl+C to disconnect.</p>
+<h2>Building it yourself</h2>
+<p>The reference client implementation is <code>packages/client/src/lib/sse-client.ts</code>
+in this repo. ~150 lines of TypeScript, MIT-licensed, free to port.</p>
+<h2>See also</h2>
+<ul>
+<li><a href="./api-examples.md"><code>docs/api-examples.md</code></a> — REST + SSE end-to-end
+examples (create session → prompt → stream → abort)</li>
+<li><a href="./architecture.md"><code>docs/architecture.md</code></a> — request lifecycles
+including SSE</li>
+<li><code>/api/docs</code> (live OpenAPI in your deploy) — every route&#39;s schema</li>
+</ul>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pi-workbench — Browser workbench for the pi coding agent</title>
+  <meta name="description" content="A self-hosted browser workbench for the pi coding agent. Chat with the agent against your code, browse files, run a terminal, review diffs — all from one tab.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-workbench
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="#features">Features</a>
+        <a href="#quickstart">Quick Start</a>
+        <a href="docs/architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="hero-badge">
+      <span>Open Source</span> &middot; Self-Hosted &middot; Single-Tenant
+    </div>
+    <h1>
+      The pi coding agent,<br>
+      <span class="gradient-text">in your browser</span>
+    </h1>
+    <p>
+      A self-hosted browser workbench for the
+      <a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener noreferrer">pi coding agent</a>.
+      Chat with the agent against your code, browse files, run a terminal,
+      review diffs — all from one tab. Your container, your provider keys,
+      your data.
+    </p>
+    <div class="hero-buttons">
+      <a href="#quickstart" class="btn-primary">Get Started &darr;</a>
+      <a href="https://github.com/Devin-Marks/pi-workbench" class="btn-secondary" target="_blank" rel="noopener noreferrer">
+        <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        View on GitHub
+      </a>
+    </div>
+  </section>
+
+  <div class="demo-section">
+    <div class="demo-window">
+      <div class="demo-titlebar">
+        <div class="demo-dot red"></div>
+        <div class="demo-dot yellow"></div>
+        <div class="demo-dot green"></div>
+      </div>
+      <div class="demo-content">
+        <p style="padding: 60px;">Screenshot or demo GIF goes here &mdash; drop a recording as <code>docs/site/demo.gif</code> (or screenshot as <code>docs/site/hero.png</code>) and replace this placeholder.</p>
+      </div>
+    </div>
+  </div>
+
+  <section class="section" id="features">
+    <div class="section-label">Features</div>
+    <h2>Everything you need to drive the agent from a browser</h2>
+    <p>The workbench wraps the pi SDK with the affordances most coding workflows want — and keeps every surface scriptable behind the same REST + SSE API the UI calls.</p>
+
+    <div class="feature-grid">
+      <div class="feature-card">
+        <div class="feature-icon">&#128172;</div>
+        <h3>Streaming chat</h3>
+        <p>Token-by-token rendering over SSE. Tool calls and their results materialize in the transcript as they happen — no waiting until the end of a turn.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#127807;</div>
+        <h3>Branchable session tree</h3>
+        <p>Fork at any prior turn, navigate the resulting tree, bookmark abandoned branches, summarize-on-navigate to keep context bounded.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128221;</div>
+        <h3>Per-turn diff panel</h3>
+        <p>Every file the agent touched in the last turn, aggregated into one reviewable changeset. Inline edit results and project-wide diffs share one renderer.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128193;</div>
+        <h3>File browser + editor</h3>
+        <p>Tree view, tabbed CodeMirror with syntax highlighting and autosave, ripgrep-backed workspace search, path-traversal protection on every operation.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128187;</div>
+        <h3>Integrated terminal</h3>
+        <p>node-pty over WebSocket, persistent across page refresh and project switch. Per-tab scrollback, multi-tab, env-allowlist for the spawned shell.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#127760;</div>
+        <h3>Git panel</h3>
+        <p>Status, unified or split diff, stage / unstage per file, commit, push, fetch, pull, branch checkout / create / delete, log with ref decorations.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128279;</div>
+        <h3>MCP integration</h3>
+        <p>Connect remote Model Context Protocol servers over StreamableHTTP or SSE. Per-project overrides, master kill-switch, header status badge.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128640;</div>
+        <h3>Provider freedom</h3>
+        <p>Built-in Anthropic / OpenAI / Google / OpenRouter plus any OpenAI-compatible endpoint (vLLM, LiteLLM, Ollama, internal gateways) via models.json.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128202;</div>
+        <h3>Context inspector</h3>
+        <p>Token + cost breakdown per turn, lifetime spend, raw message inspector with syntax highlighting, search across long conversations.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128274;</div>
+        <h3>Auth that fits ops</h3>
+        <p>Browser password + JWT (auto-generated signing key, force-change first login) and a separate static API key for scripts and CI. Both can be on at once.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128295;</div>
+        <h3>OpenAPI spec</h3>
+        <p>Every route auto-documented at /api/docs (Swagger UI) and /api/docs/json. The same routes the React UI calls — no shadow surface.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128241;</div>
+        <h3>Installable PWA</h3>
+        <p>Proper manifest with raster + maskable icons, offline page when the server is unreachable, "Add to Home Screen" on desktop and mobile.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" id="quickstart">
+    <div class="section-label">Quick Start</div>
+    <h2>Up and running in minutes</h2>
+    <p>All you need is Docker and a provider API key (or OAuth credentials).</p>
+
+    <div class="quickstart-steps">
+      <div class="qs-step">
+        <div class="qs-number">1</div>
+        <div class="qs-content">
+          <h3>Clone the repo</h3>
+          <pre><span class="code-cmd">git</span> clone https://github.com/Devin-Marks/pi-workbench.git
+<span class="code-cmd">cd</span> pi-workbench</pre>
+        </div>
+      </div>
+
+      <div class="qs-step">
+        <div class="qs-number">2</div>
+        <div class="qs-content">
+          <h3>Set deployment env</h3>
+          <pre><span class="code-cmd">cp</span> docker/.env.example docker/.env
+<span class="code-comment"># edit docker/.env to set UI_PASSWORD or API_KEY,</span>
+<span class="code-comment"># and adjust workspace / data dir paths if you want.</span></pre>
+        </div>
+      </div>
+
+      <div class="qs-step">
+        <div class="qs-number">3</div>
+        <div class="qs-content">
+          <h3>Build and start</h3>
+          <pre><span class="code-cmd">cd</span> docker
+docker compose up -d --build</pre>
+        </div>
+      </div>
+
+      <div class="qs-step">
+        <div class="qs-number">4</div>
+        <div class="qs-content">
+          <h3>Add your provider key</h3>
+          <p>Open <code>http://&lt;host&gt;:3000</code>, go to <strong>Settings &rarr; Providers</strong>, and paste an Anthropic / OpenAI / etc. API key. Or set keys directly in <code>~/.pi/agent/auth.json</code> and bind-mount it into the container.</p>
+        </div>
+      </div>
+
+      <div class="qs-step">
+        <div class="qs-number">5</div>
+        <div class="qs-content">
+          <h3>Add a project and start chatting</h3>
+          <p>Click <strong>+ Project</strong>, point at any folder under <code>WORKSPACE_PATH</code> (or its bind-mount). The project's files become the agent's working tree; chat opens in the same view.</p>
+        </div>
+      </div>
+    </div>
+
+    <div style="margin-top: 32px;">
+      <p style="color: var(--text-secondary); font-size: 14px;">
+        For Kubernetes, OpenShift, reverse-proxy + TLS, and other production deployments, see
+        <a href="docs/deployment.html">Deployment</a> and
+        <a href="docs/configuration.html">Configuration</a>.
+      </p>
+    </div>
+  </section>
+
+  <section class="section" id="api">
+    <div class="section-label">Programmatic API</div>
+    <h2>Same routes the UI calls</h2>
+    <p>Every browser interaction is a documented REST or SSE call. Scripts, CI pipelines, and the React UI all hit the same endpoints — no shadow surface, no separate "API mode."</p>
+
+    <pre><span class="code-comment"># Authenticate with the API_KEY you set in env</span>
+<span class="code-cmd">BASE</span>=http://localhost:3000
+<span class="code-cmd">KEY</span>=your-api-key
+
+<span class="code-comment"># Create a session under a project</span>
+<span class="code-cmd">SESSION</span>=$(curl -s -X POST $BASE/api/v1/sessions \
+  -H <span class="code-string">"Authorization: Bearer $KEY"</span> \
+  -H <span class="code-string">"Content-Type: application/json"</span> \
+  -d <span class="code-string">'{"projectId":"&lt;projectId&gt;"}'</span> | jq -r .sessionId)
+
+<span class="code-comment"># Send a prompt (fire-and-forget; response streams over SSE)</span>
+curl -s -X POST $BASE/api/v1/sessions/$SESSION/prompt \
+  -H <span class="code-string">"Authorization: Bearer $KEY"</span> \
+  -H <span class="code-string">"Content-Type: application/json"</span> \
+  -d <span class="code-string">'{"text":"Write a test for the auth module"}'</span>
+
+<span class="code-comment"># Stream the response</span>
+curl -N -H <span class="code-string">"Authorization: Bearer $KEY"</span> \
+  $BASE/api/v1/sessions/$SESSION/stream</pre>
+
+    <p style="margin-top: 16px; color: var(--text-secondary); font-size: 14px;">
+      Full recipes (multipart attachments, branch / fork, abort, model switch, MCP wiring): see
+      <a href="docs/api.html">API Examples</a>.
+      Live OpenAPI spec at <code>/api/docs</code> on a running deploy.
+    </p>
+  </section>
+
+  <section class="section" id="why">
+    <div class="section-label">Why pi-workbench</div>
+    <h2>Self-hosted, single-tenant, scriptable</h2>
+
+    <div class="comparison-grid">
+      <div class="comparison-col">
+        <h3 class="comparison-header comparison-before">What it isn't</h3>
+        <ul class="comparison-list">
+          <li>A SaaS product — no cloud, no analytics, no telemetry</li>
+          <li>A reimplementation of pi's agent loop (it embeds the SDK)</li>
+          <li>A multi-tenant platform — one container, one user, one workspace</li>
+          <li>A code editor replacement — point it at your existing repos</li>
+          <li>Certified for safety-critical or regulated-data workloads</li>
+        </ul>
+      </div>
+      <div class="comparison-col">
+        <h3 class="comparison-header comparison-after">What it is</h3>
+        <ul class="comparison-list">
+          <li>An HTTP / SSE bridge over the pi SDK with a React chat UI on top</li>
+          <li>Container-native: Docker Compose, Kubernetes, OpenShift manifests included</li>
+          <li>Provider-agnostic: built-in providers plus any OpenAI-compatible endpoint</li>
+          <li>API-first: every UI action is a documented REST call</li>
+          <li>Open under MIT, no warranty, no support obligation</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" style="text-align: center;">
+    <h2>Ready to dig in?</h2>
+    <p style="margin-left: auto; margin-right: auto;">The architecture, configuration, and API references all live in the docs. The full source is on GitHub.</p>
+    <div class="hero-buttons" style="margin-top: 32px;">
+      <a href="docs/architecture.html" class="btn-primary">Read the Docs &rarr;</a>
+      <a href="https://github.com/Devin-Marks/pi-workbench" class="btn-secondary" target="_blank" rel="noopener noreferrer">
+        View Source
+      </a>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p>pi-workbench &mdash; MIT licensed, no warranty.</p>
+      <div class="footer-links">
+        <a href="docs/architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/issues">Issues</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/CHANGELOG.md">Changelog</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/style.css
+++ b/docs/site/style.css
@@ -1,0 +1,698 @@
+/* ===============================================================
+   pi-workbench GitHub Pages site
+
+   Adapted from the multiplex docs site (../../multiplex/docs/site/),
+   recolored with an emerald accent that matches the app's "context
+   goes to LLM" indicator. Same dark surface palette as the
+   workbench UI itself so the site reads as part of the same
+   product.
+
+   Loaded by:
+     - docs/site/index.html       (landing)
+     - docs/site/docs/*.html      (every generated doc page)
+
+   Generated docs reference this via `../style.css`. Don't move it
+   without updating scripts/build-site.mjs's chromeDocs template.
+   =============================================================== */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg: #0a0a0c;
+  --bg-surface: #101012;
+  --bg-card: #16161a;
+  --bg-card-hover: #1c1c22;
+  --bg-code: #0d0d10;
+  --border: #25252e;
+  --border-light: #2e2e3a;
+  --text: #e6e7eb;
+  --text-secondary: #989aa6;
+  --text-muted: #5f6172;
+  --accent: #10b981;
+  --accent-light: #34d399;
+  --accent-glow: rgba(16, 185, 129, 0.15);
+  --accent-gradient: linear-gradient(135deg, #10b981 0%, #34d399 100%);
+  --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+  --radius: 12px;
+  --radius-sm: 8px;
+  --max-width: 1140px;
+  --header-height: 64px;
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.7;
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent-light); text-decoration: none; transition: color 0.2s; }
+a:hover { color: #6ee7c8; }
+
+img { max-width: 100%; height: auto; }
+
+/* === Header / Nav === */
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  height: var(--header-height);
+  background: rgba(10, 10, 12, 0.85);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--border);
+}
+
+.header-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 24px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 19px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+
+.logo svg, .logo img { width: 28px; height: 28px; }
+
+.nav-links { display: flex; align-items: center; gap: 28px; }
+.nav-links a {
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+.nav-links a:hover { color: var(--text); }
+
+.nav-cta {
+  background: var(--accent-gradient);
+  color: #0a0a0c !important;
+  padding: 8px 18px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  transition: opacity 0.2s;
+}
+.nav-cta:hover { opacity: 0.9; color: #0a0a0c !important; }
+
+.mobile-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: 24px;
+  cursor: pointer;
+}
+
+/* === Hero === */
+.hero {
+  padding: 160px 24px 100px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: -40%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 800px;
+  height: 800px;
+  background: radial-gradient(circle, var(--accent-glow) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 16px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 28px;
+}
+
+.hero-badge span { color: var(--accent-light); font-weight: 600; }
+
+.hero h1 {
+  font-size: clamp(36px, 6vw, 60px);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  margin-bottom: 20px;
+  max-width: 960px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.hero h1 .gradient-text {
+  background: var(--accent-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero p {
+  font-size: 18px;
+  color: var(--text-secondary);
+  max-width: 640px;
+  margin: 0 auto 40px;
+  line-height: 1.7;
+}
+
+.hero-buttons { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  background: var(--accent-gradient);
+  color: #0a0a0c;
+  padding: 14px 28px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 15px;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.2s, transform 0.2s;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.btn-primary:hover { opacity: 0.9; transform: translateY(-1px); color: #0a0a0c; }
+
+.btn-secondary {
+  background: var(--bg-card);
+  color: var(--text);
+  padding: 14px 28px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 15px;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s, transform 0.2s;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.btn-secondary:hover { background: var(--bg-card-hover); border-color: var(--border-light); transform: translateY(-1px); }
+
+/* === Demo / GIF area === */
+.demo-section {
+  max-width: var(--max-width);
+  margin: -20px auto 80px;
+  padding: 0 24px;
+}
+
+.demo-window {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+}
+
+.demo-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 18px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.demo-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+.demo-dot.red { background: #ff5f57; }
+.demo-dot.yellow { background: #ffbd2e; }
+.demo-dot.green { background: #28c840; }
+
+.demo-content {
+  padding: 0;
+  min-height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.demo-content img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* === Sections === */
+.section {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 80px 24px;
+}
+
+.section-label {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent-light);
+  margin-bottom: 14px;
+}
+
+.section h2 {
+  font-size: clamp(28px, 4vw, 40px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 16px;
+}
+
+.section > p {
+  color: var(--text-secondary);
+  font-size: 17px;
+  max-width: 800px;
+  margin-bottom: 48px;
+}
+
+/* === Feature Grid === */
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.feature-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 26px;
+  transition: border-color 0.3s, background 0.3s, transform 0.2s;
+}
+
+.feature-card:hover {
+  border-color: var(--border-light);
+  background: var(--bg-card-hover);
+  transform: translateY(-2px);
+}
+
+.feature-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 10px;
+  background: var(--accent-glow);
+  border: 1px solid rgba(16, 185, 129, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 18px;
+  font-size: 20px;
+}
+
+.feature-card h3 {
+  font-size: 17px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.feature-card p {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* === Quick Start === */
+.quickstart-steps { display: flex; flex-direction: column; gap: 24px; }
+
+.qs-step {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.qs-number {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--accent-glow);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--accent-light);
+  margin-top: 2px;
+}
+
+.qs-content { flex: 1; min-width: 0; }
+.qs-content h3 { font-size: 16px; font-weight: 600; margin-bottom: 8px; }
+.qs-content p { font-size: 14px; color: var(--text-secondary); margin-bottom: 12px; }
+.qs-content pre { margin-bottom: 12px; }
+
+/* === Code Blocks === */
+pre {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 16px 18px;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+:not(pre) > code {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  padding: 2px 6px;
+  border-radius: 5px;
+  font-size: 0.85em;
+  color: var(--text);
+}
+
+.code-comment { color: var(--text-muted); }
+.code-string { color: #a8d8a8; }
+.code-cmd { color: var(--accent-light); }
+
+/* === Comparison === */
+.comparison-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.comparison-col {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 28px;
+}
+
+.comparison-header {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 18px;
+  padding-bottom: 12px;
+  border-bottom: 2px solid var(--border);
+}
+
+.comparison-before { color: var(--text-muted); border-bottom-color: var(--text-muted); }
+.comparison-after { color: var(--accent-light); border-bottom-color: var(--accent); }
+
+.comparison-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.comparison-list li {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  padding-left: 22px;
+  position: relative;
+}
+
+.comparison-before + .comparison-list li::before {
+  content: '\2717';
+  position: absolute;
+  left: 0;
+  color: var(--text-muted);
+}
+
+.comparison-after + .comparison-list li::before {
+  content: '\2713';
+  position: absolute;
+  left: 0;
+  color: var(--accent-light);
+}
+
+@media (max-width: 768px) {
+  .comparison-grid { grid-template-columns: 1fr; }
+}
+
+/* === Footer === */
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 48px 24px;
+  margin-top: 80px;
+}
+
+.footer-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.footer-inner p {
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.footer-links { display: flex; gap: 24px; flex-wrap: wrap; }
+.footer-links a { color: var(--text-secondary); font-size: 14px; }
+
+/* === Docs Layout === */
+.docs-layout {
+  display: flex;
+  min-height: calc(100vh - var(--header-height));
+  padding-top: var(--header-height);
+}
+
+.docs-sidebar {
+  width: 260px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  padding: 32px 20px;
+  position: sticky;
+  top: var(--header-height);
+  height: calc(100vh - var(--header-height));
+  overflow-y: auto;
+  background: var(--bg-surface);
+}
+
+.sidebar-section { margin-bottom: 28px; }
+.sidebar-section h4 {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+  padding-left: 12px;
+}
+
+.sidebar-section a {
+  display: block;
+  padding: 7px 12px;
+  border-radius: 6px;
+  font-size: 14px;
+  color: var(--text-secondary);
+  transition: color 0.2s, background 0.2s;
+}
+
+.sidebar-section a:hover {
+  color: var(--text);
+  background: var(--bg-card);
+}
+
+.sidebar-section a.active {
+  color: var(--accent-light);
+  background: var(--accent-glow);
+}
+
+.docs-main {
+  flex: 1;
+  min-width: 0;
+  padding: 40px 48px 80px;
+  max-width: 880px;
+}
+
+.docs-main h1 {
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 8px;
+}
+
+.docs-main .docs-subtitle {
+  font-size: 17px;
+  color: var(--text-secondary);
+  margin-bottom: 40px;
+}
+
+.docs-main h2 {
+  font-size: 22px;
+  font-weight: 700;
+  margin-top: 48px;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.docs-main h3 {
+  font-size: 17px;
+  font-weight: 600;
+  margin-top: 32px;
+  margin-bottom: 12px;
+}
+
+.docs-main h4 {
+  font-size: 15px;
+  font-weight: 600;
+  margin-top: 24px;
+  margin-bottom: 8px;
+}
+
+.docs-main p { margin-bottom: 16px; color: var(--text); font-size: 15px; }
+.docs-main ul, .docs-main ol { margin-bottom: 16px; padding-left: 24px; }
+.docs-main li { margin-bottom: 6px; font-size: 15px; color: var(--text); }
+.docs-main li code { font-size: 13px; }
+.docs-main pre { margin-bottom: 20px; }
+.docs-main blockquote {
+  border-left: 3px solid var(--accent);
+  padding: 12px 20px;
+  margin-bottom: 20px;
+  background: var(--accent-glow);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.docs-main blockquote p:last-child { margin-bottom: 0; }
+
+.docs-main hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 40px 0;
+}
+
+/* === Tables === */
+.docs-main table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 24px;
+  font-size: 14px;
+}
+
+.docs-main th {
+  text-align: left;
+  padding: 10px 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.docs-main td {
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.docs-main td code {
+  background: var(--bg-code);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12.5px;
+}
+
+/* === Mobile Sidebar Toggle === */
+.sidebar-toggle {
+  display: none;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 200;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--accent-gradient);
+  border: none;
+  color: #0a0a0c;
+  font-size: 20px;
+  cursor: pointer;
+  box-shadow: 0 4px 20px rgba(16, 185, 129, 0.3);
+}
+
+/* === Responsive === */
+@media (max-width: 900px) {
+  .docs-sidebar {
+    position: fixed;
+    left: -280px;
+    top: var(--header-height);
+    z-index: 90;
+    width: 280px;
+    transition: left 0.3s ease;
+    box-shadow: 4px 0 20px rgba(0, 0, 0, 0.3);
+  }
+  .docs-sidebar.open { left: 0; }
+  .sidebar-toggle { display: flex; align-items: center; justify-content: center; }
+  .docs-main { padding: 32px 20px 80px; }
+}
+
+@media (max-width: 768px) {
+  .nav-links { display: none; }
+  .nav-links.open {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    top: var(--header-height);
+    left: 0;
+    right: 0;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+    padding: 16px 24px;
+    gap: 12px;
+  }
+  .mobile-toggle { display: block; }
+
+  .hero { padding: 120px 20px 60px; }
+  .hero h1 { font-size: 32px; }
+  .hero p { font-size: 16px; }
+
+  .feature-grid { grid-template-columns: 1fr; }
+  .footer-inner { flex-direction: column; text-align: center; }
+}
+
+/* === Scrollbar === */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: var(--bg); }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-light); }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -122,11 +122,14 @@ export default tseslint.config(
       "@typescript-eslint/prefer-for-of": "off",
     },
   },
-  // Plain JS files (this very config) don't have a tsconfig; turn off
-  // the type-aware rules for them so the project can lint cleanly.
+  // Plain JS files (this very config, scripts/*.mjs) don't have a
+  // tsconfig; turn off the type-aware rules and inject Node globals
+  // so they lint cleanly without a per-file `/* global console */`
+  // ceremony.
   {
     files: ["**/*.{js,mjs,cjs}"],
     ...tseslint.configs.disableTypeChecked,
+    languageOptions: { globals: { ...globals.node } },
   },
   prettier,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.0.0",
+        "marked": "^16.4.1",
         "prettier": "^3.5.3",
         "tsx": "^4.19.4",
         "typescript": "^5.8.3",
@@ -4357,6 +4358,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@mariozechner/pi-coding-agent/node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -4401,6 +4414,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@mariozechner/pi-tui/node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@mistralai/mistralai": {
@@ -11722,15 +11747,16 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format:check": "prettier --check .",
     "check": "npm run typecheck && npm run lint && npm run format:check",
     "test": "scripts/run-tests.sh",
-    "test:ci": "scripts/run-tests.sh --ci"
+    "test:ci": "scripts/run-tests.sh --ci",
+    "build:site": "node scripts/build-site.mjs"
   },
   "overrides": {
     "serialize-javascript": ">=6.0.2"
@@ -30,6 +31,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.0.0",
     "prettier": "^3.5.3",
+    "marked": "^16.4.1",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.31.0"

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -1,0 +1,506 @@
+#!/usr/bin/env node
+//
+// Build the GitHub Pages site under docs/site/ from the project's
+// markdown sources.
+//
+// Why a build step at all (vs hand-writing the HTML, like multiplex):
+//   - The .md files in docs/ are the canonical source — they live next
+//     to the code, get updated in normal PRs, and are read by humans
+//     in the GitHub repo browser. Keeping a parallel HTML copy in
+//     sync by hand would silently rot.
+//   - GitHub Pages can run Jekyll, but Jekyll's frontmatter + layouts
+//     model fights this repo's "docs are real markdown that github
+//     renders sensibly" posture. A one-shot build that emits plain
+//     HTML keeps both surfaces honest.
+//
+// What it does:
+//   - Walks `SOURCES` (each entry maps a .md → an output html), runs
+//     `marked` over the markdown body, drops the result inside the
+//     CHROME template (sidebar + header), and writes to
+//     `docs/site/docs/<slug>.html`.
+//   - Writes index.html separately from the LANDING template — the
+//     landing page is hand-curated marketing copy, not a converted
+//     doc.
+//
+// Run: `npm run build:site` (or `node scripts/build-site.mjs` once
+// `marked` is installed). The output goes into docs/site/, which the
+// `Deploy to GitHub Pages` workflow uploads as the Pages artifact.
+//
+// Dependencies: just `marked`. Installed as a devDep so the
+// production install doesn't pull it.
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Marked } from "marked";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const siteRoot = join(repoRoot, "docs", "site");
+const docsOut = join(siteRoot, "docs");
+
+mkdirSync(docsOut, { recursive: true });
+
+// Sidebar entries — drives the docs nav order. Order = visual order
+// in the sidebar.
+const SOURCES = [
+  {
+    src: "docs/architecture.md",
+    out: "architecture.html",
+    title: "Architecture",
+    subtitle: "How requests flow through the workbench, from the browser to the pi SDK.",
+  },
+  {
+    src: "docs/configuration.md",
+    out: "configuration.html",
+    title: "Configuration",
+    subtitle: "Every environment variable the workbench reads, with defaults and intent.",
+  },
+  {
+    src: "docs/CONTAINERS.md",
+    out: "containers.html",
+    title: "Containers",
+    subtitle: "What's inside the Docker image, how it's structured, and why.",
+  },
+  {
+    src: "docs/deployment.md",
+    out: "deployment.html",
+    title: "Deployment",
+    subtitle: "Getting the workbench running in production: TLS, auth, reverse proxies.",
+  },
+  {
+    src: "docs/api-examples.md",
+    out: "api.html",
+    title: "API Examples",
+    subtitle: "End-to-end scripting recipes against the REST + SSE surface.",
+  },
+  {
+    src: "docs/mcp.md",
+    out: "mcp.html",
+    title: "MCP Servers",
+    subtitle: "Connecting external Model Context Protocol servers to the workbench.",
+  },
+  {
+    src: "docs/sse-events.md",
+    out: "sse-events.html",
+    title: "SSE Events",
+    subtitle: "The agent event stream: every event type, payload, and UI affordance.",
+  },
+];
+
+// Marked instance with GFM enabled (tables, strikethrough, autolinks
+// — same dialect ChatMarkdown uses in the app for consistency).
+const marked = new Marked({ gfm: true, breaks: false });
+
+// Add target=_blank to external links via a renderer override —
+// internal anchors (#section) and relative links shouldn't get it.
+const renderer = {
+  link(token) {
+    const href = token.href;
+    const text = this.parser.parseInline(token.tokens);
+    const isExternal = /^https?:/i.test(href);
+    const attrs = isExternal ? ` target="_blank" rel="noopener noreferrer"` : "";
+    const titleAttr = token.title ? ` title="${escapeAttr(token.title)}"` : "";
+    return `<a href="${escapeAttr(href)}"${attrs}${titleAttr}>${text}</a>`;
+  },
+};
+marked.use({ renderer });
+
+function escapeAttr(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+// Inline SVG logo — mirrors the project's `<π>` icon (docs/images/icon.png).
+const LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>`;
+
+// Sidebar HTML, with the active-page link highlighted.
+function sidebar(activeOut) {
+  const links = SOURCES.map((s) => {
+    const cls = s.out === activeOut ? ' class="active"' : "";
+    return `        <a href="${s.out}"${cls}>${s.title}</a>`;
+  }).join("\n");
+  return `      <div class="sidebar-section">
+        <h4>Documentation</h4>
+${links}
+      </div>`;
+}
+
+const HEADER_NAV = `      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench" class="nav-cta">GitHub</a>
+      </nav>`;
+
+const HEADER_NAV_LANDING = `      <nav class="nav-links" id="navLinks">
+        <a href="#features">Features</a>
+        <a href="#quickstart">Quick Start</a>
+        <a href="docs/architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench" class="nav-cta">GitHub</a>
+      </nav>`;
+
+function chromeDocs({ title, subtitle, body, activeOut }) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title} — pi-workbench</title>
+  <meta name="description" content="${escapeAttr(subtitle)}">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        ${LOGO_SVG}
+        pi-workbench
+      </a>
+${HEADER_NAV}
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+${sidebar(activeOut)}
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-workbench">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>${title}</h1>
+      <p class="docs-subtitle">${subtitle}</p>
+${body}
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>
+`;
+}
+
+// Strip the first H1 from a converted doc — `docs/*.md` files start
+// with their title, but the chrome template already prints the title.
+// Without this we get a duplicate heading on every doc page.
+function stripLeadingH1(html) {
+  return html.replace(/^\s*<h1[^>]*>[^<]*<\/h1>\s*/i, "");
+}
+
+let count = 0;
+for (const { src, out, title, subtitle } of SOURCES) {
+  const md = readFileSync(join(repoRoot, src), "utf8");
+  const body = stripLeadingH1(marked.parse(md));
+  const html = chromeDocs({ title, subtitle, body, activeOut: out });
+  writeFileSync(join(docsOut, out), html);
+  count += 1;
+}
+
+// ---- index.html (landing) ----
+const LANDING = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pi-workbench — Browser workbench for the pi coding agent</title>
+  <meta name="description" content="A self-hosted browser workbench for the pi coding agent. Chat with the agent against your code, browse files, run a terminal, review diffs — all from one tab.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="index.html" class="logo">
+        ${LOGO_SVG}
+        pi-workbench
+      </a>
+${HEADER_NAV_LANDING}
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="hero-badge">
+      <span>Open Source</span> &middot; Self-Hosted &middot; Single-Tenant
+    </div>
+    <h1>
+      The pi coding agent,<br>
+      <span class="gradient-text">in your browser</span>
+    </h1>
+    <p>
+      A self-hosted browser workbench for the
+      <a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener noreferrer">pi coding agent</a>.
+      Chat with the agent against your code, browse files, run a terminal,
+      review diffs — all from one tab. Your container, your provider keys,
+      your data.
+    </p>
+    <div class="hero-buttons">
+      <a href="#quickstart" class="btn-primary">Get Started &darr;</a>
+      <a href="https://github.com/Devin-Marks/pi-workbench" class="btn-secondary" target="_blank" rel="noopener noreferrer">
+        <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        View on GitHub
+      </a>
+    </div>
+  </section>
+
+  <div class="demo-section">
+    <div class="demo-window">
+      <div class="demo-titlebar">
+        <div class="demo-dot red"></div>
+        <div class="demo-dot yellow"></div>
+        <div class="demo-dot green"></div>
+      </div>
+      <div class="demo-content">
+        <p style="padding: 60px;">Screenshot or demo GIF goes here &mdash; drop a recording as <code>docs/site/demo.gif</code> (or screenshot as <code>docs/site/hero.png</code>) and replace this placeholder.</p>
+      </div>
+    </div>
+  </div>
+
+  <section class="section" id="features">
+    <div class="section-label">Features</div>
+    <h2>Everything you need to drive the agent from a browser</h2>
+    <p>The workbench wraps the pi SDK with the affordances most coding workflows want — and keeps every surface scriptable behind the same REST + SSE API the UI calls.</p>
+
+    <div class="feature-grid">
+      <div class="feature-card">
+        <div class="feature-icon">&#128172;</div>
+        <h3>Streaming chat</h3>
+        <p>Token-by-token rendering over SSE. Tool calls and their results materialize in the transcript as they happen — no waiting until the end of a turn.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#127807;</div>
+        <h3>Branchable session tree</h3>
+        <p>Fork at any prior turn, navigate the resulting tree, bookmark abandoned branches, summarize-on-navigate to keep context bounded.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128221;</div>
+        <h3>Per-turn diff panel</h3>
+        <p>Every file the agent touched in the last turn, aggregated into one reviewable changeset. Inline edit results and project-wide diffs share one renderer.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128193;</div>
+        <h3>File browser + editor</h3>
+        <p>Tree view, tabbed CodeMirror with syntax highlighting and autosave, ripgrep-backed workspace search, path-traversal protection on every operation.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128187;</div>
+        <h3>Integrated terminal</h3>
+        <p>node-pty over WebSocket, persistent across page refresh and project switch. Per-tab scrollback, multi-tab, env-allowlist for the spawned shell.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#127760;</div>
+        <h3>Git panel</h3>
+        <p>Status, unified or split diff, stage / unstage per file, commit, push, fetch, pull, branch checkout / create / delete, log with ref decorations.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128279;</div>
+        <h3>MCP integration</h3>
+        <p>Connect remote Model Context Protocol servers over StreamableHTTP or SSE. Per-project overrides, master kill-switch, header status badge.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128640;</div>
+        <h3>Provider freedom</h3>
+        <p>Built-in Anthropic / OpenAI / Google / OpenRouter plus any OpenAI-compatible endpoint (vLLM, LiteLLM, Ollama, internal gateways) via models.json.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128202;</div>
+        <h3>Context inspector</h3>
+        <p>Token + cost breakdown per turn, lifetime spend, raw message inspector with syntax highlighting, search across long conversations.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128274;</div>
+        <h3>Auth that fits ops</h3>
+        <p>Browser password + JWT (auto-generated signing key, force-change first login) and a separate static API key for scripts and CI. Both can be on at once.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128295;</div>
+        <h3>OpenAPI spec</h3>
+        <p>Every route auto-documented at /api/docs (Swagger UI) and /api/docs/json. The same routes the React UI calls — no shadow surface.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128241;</div>
+        <h3>Installable PWA</h3>
+        <p>Proper manifest with raster + maskable icons, offline page when the server is unreachable, "Add to Home Screen" on desktop and mobile.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" id="quickstart">
+    <div class="section-label">Quick Start</div>
+    <h2>Up and running in minutes</h2>
+    <p>All you need is Docker and a provider API key (or OAuth credentials).</p>
+
+    <div class="quickstart-steps">
+      <div class="qs-step">
+        <div class="qs-number">1</div>
+        <div class="qs-content">
+          <h3>Clone the repo</h3>
+          <pre><span class="code-cmd">git</span> clone https://github.com/Devin-Marks/pi-workbench.git
+<span class="code-cmd">cd</span> pi-workbench</pre>
+        </div>
+      </div>
+
+      <div class="qs-step">
+        <div class="qs-number">2</div>
+        <div class="qs-content">
+          <h3>Set deployment env</h3>
+          <pre><span class="code-cmd">cp</span> docker/.env.example docker/.env
+<span class="code-comment"># edit docker/.env to set UI_PASSWORD or API_KEY,</span>
+<span class="code-comment"># and adjust workspace / data dir paths if you want.</span></pre>
+        </div>
+      </div>
+
+      <div class="qs-step">
+        <div class="qs-number">3</div>
+        <div class="qs-content">
+          <h3>Build and start</h3>
+          <pre><span class="code-cmd">cd</span> docker
+docker compose up -d --build</pre>
+        </div>
+      </div>
+
+      <div class="qs-step">
+        <div class="qs-number">4</div>
+        <div class="qs-content">
+          <h3>Add your provider key</h3>
+          <p>Open <code>http://&lt;host&gt;:3000</code>, go to <strong>Settings &rarr; Providers</strong>, and paste an Anthropic / OpenAI / etc. API key. Or set keys directly in <code>~/.pi/agent/auth.json</code> and bind-mount it into the container.</p>
+        </div>
+      </div>
+
+      <div class="qs-step">
+        <div class="qs-number">5</div>
+        <div class="qs-content">
+          <h3>Add a project and start chatting</h3>
+          <p>Click <strong>+ Project</strong>, point at any folder under <code>WORKSPACE_PATH</code> (or its bind-mount). The project's files become the agent's working tree; chat opens in the same view.</p>
+        </div>
+      </div>
+    </div>
+
+    <div style="margin-top: 32px;">
+      <p style="color: var(--text-secondary); font-size: 14px;">
+        For Kubernetes, OpenShift, reverse-proxy + TLS, and other production deployments, see
+        <a href="docs/deployment.html">Deployment</a> and
+        <a href="docs/configuration.html">Configuration</a>.
+      </p>
+    </div>
+  </section>
+
+  <section class="section" id="api">
+    <div class="section-label">Programmatic API</div>
+    <h2>Same routes the UI calls</h2>
+    <p>Every browser interaction is a documented REST or SSE call. Scripts, CI pipelines, and the React UI all hit the same endpoints — no shadow surface, no separate "API mode."</p>
+
+    <pre><span class="code-comment"># Authenticate with the API_KEY you set in env</span>
+<span class="code-cmd">BASE</span>=http://localhost:3000
+<span class="code-cmd">KEY</span>=your-api-key
+
+<span class="code-comment"># Create a session under a project</span>
+<span class="code-cmd">SESSION</span>=$(curl -s -X POST $BASE/api/v1/sessions \\
+  -H <span class="code-string">"Authorization: Bearer $KEY"</span> \\
+  -H <span class="code-string">"Content-Type: application/json"</span> \\
+  -d <span class="code-string">'{"projectId":"&lt;projectId&gt;"}'</span> | jq -r .sessionId)
+
+<span class="code-comment"># Send a prompt (fire-and-forget; response streams over SSE)</span>
+curl -s -X POST $BASE/api/v1/sessions/$SESSION/prompt \\
+  -H <span class="code-string">"Authorization: Bearer $KEY"</span> \\
+  -H <span class="code-string">"Content-Type: application/json"</span> \\
+  -d <span class="code-string">'{"text":"Write a test for the auth module"}'</span>
+
+<span class="code-comment"># Stream the response</span>
+curl -N -H <span class="code-string">"Authorization: Bearer $KEY"</span> \\
+  $BASE/api/v1/sessions/$SESSION/stream</pre>
+
+    <p style="margin-top: 16px; color: var(--text-secondary); font-size: 14px;">
+      Full recipes (multipart attachments, branch / fork, abort, model switch, MCP wiring): see
+      <a href="docs/api.html">API Examples</a>.
+      Live OpenAPI spec at <code>/api/docs</code> on a running deploy.
+    </p>
+  </section>
+
+  <section class="section" id="why">
+    <div class="section-label">Why pi-workbench</div>
+    <h2>Self-hosted, single-tenant, scriptable</h2>
+
+    <div class="comparison-grid">
+      <div class="comparison-col">
+        <h3 class="comparison-header comparison-before">What it isn't</h3>
+        <ul class="comparison-list">
+          <li>A SaaS product — no cloud, no analytics, no telemetry</li>
+          <li>A reimplementation of pi's agent loop (it embeds the SDK)</li>
+          <li>A multi-tenant platform — one container, one user, one workspace</li>
+          <li>A code editor replacement — point it at your existing repos</li>
+          <li>Certified for safety-critical or regulated-data workloads</li>
+        </ul>
+      </div>
+      <div class="comparison-col">
+        <h3 class="comparison-header comparison-after">What it is</h3>
+        <ul class="comparison-list">
+          <li>An HTTP / SSE bridge over the pi SDK with a React chat UI on top</li>
+          <li>Container-native: Docker Compose, Kubernetes, OpenShift manifests included</li>
+          <li>Provider-agnostic: built-in providers plus any OpenAI-compatible endpoint</li>
+          <li>API-first: every UI action is a documented REST call</li>
+          <li>Open under MIT, no warranty, no support obligation</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" style="text-align: center;">
+    <h2>Ready to dig in?</h2>
+    <p style="margin-left: auto; margin-right: auto;">The architecture, configuration, and API references all live in the docs. The full source is on GitHub.</p>
+    <div class="hero-buttons" style="margin-top: 32px;">
+      <a href="docs/architecture.html" class="btn-primary">Read the Docs &rarr;</a>
+      <a href="https://github.com/Devin-Marks/pi-workbench" class="btn-secondary" target="_blank" rel="noopener noreferrer">
+        View Source
+      </a>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p>pi-workbench &mdash; MIT licensed, no warranty.</p>
+      <div class="footer-links">
+        <a href="docs/architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/issues">Issues</a>
+        <a href="https://github.com/Devin-Marks/pi-workbench/blob/main/CHANGELOG.md">Changelog</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>
+`;
+writeFileSync(join(siteRoot, "index.html"), LANDING);
+
+console.log(`[build-site] wrote ${count} doc page(s) + index.html under ${siteRoot}`);


### PR DESCRIPTION
## Summary

Adds a GitHub Pages site under \`docs/site/\` with a landing page and 7 styled doc pages generated from the existing \`docs/*.md\` sources. Adapts the structural template from \`../multiplex/docs/site/\` (per request), recolored with the emerald accent that matches the workbench app's UI palette.

## Layout

| Path | Purpose |
|---|---|
| \`docs/site/index.html\` | Hand-curated landing page (hero, 12-feature grid, 5-step quick start, API example, comparison, footer) |
| \`docs/site/style.css\` | Shared chrome — emerald-accent dark theme |
| \`docs/site/docs/*.html\` | 7 doc pages: architecture, configuration, containers, deployment, api, mcp, sse-events |
| \`scripts/build-site.mjs\` | Markdown → HTML build (uses \`marked\`, GFM enabled — same dialect ChatMarkdown uses in the app) |
| \`.github/workflows/pages.yml\` | Deploy job; mirrors multiplex's pages workflow |

## Build pipeline

- \`scripts/build-site.mjs\` reads each entry in its \`SOURCES\` list, runs the markdown through \`marked\`, drops it into a chrome template (sidebar + header), and writes to \`docs/site/docs/<slug>.html\`. The leading H1 is stripped because the template already prints the title.
- External links get \`target="_blank" rel="noopener noreferrer"\`; internal anchors and relative links are left alone.
- **Generated HTML is committed** alongside the script. The deploy step is a pure file copy — no Node install, no \`marked\` dep in CI, no version surprises. To regenerate after touching any \`docs/*.md\`, run \`npm run build:site\` and commit the result.
- \`docs/site/\` is added to \`.prettierignore\` so the emitted HTML doesn't get formatter-shaped on every commit.
- \`marked\` added as a root devDep.
- \`eslint.config.js\` gets Node globals on the plain JS files block (the spread of \`disableTypeChecked\` was overriding per-file \`languageOptions\`; reordered so globals win).

## Deploy workflow

\`.github/workflows/pages.yml\` mirrors multiplex's:
- Triggers on \`docs/site/**\` changes on \`main\`, plus \`workflow_dispatch\`.
- Uploads \`docs/site\` as the Pages artifact.
- Deploys via \`actions/deploy-pages@v4\`.

**One-time setup after merge:** in repo Settings → Pages, set the source to "GitHub Actions". The workflow then auto-fires on every push that touches \`docs/site/**\`. Site URL will be \`https://devin-marks.github.io/pi-workbench/\`.

## Local preview

\`\`\`bash
npm run build:site                     # regenerate after editing docs/*.md
python3 -m http.server -d docs/site    # http://localhost:8000
\`\`\`

## Two things worth eyeballing

1. **Hero placeholder.** The landing page has a \`<demo-window>\` placeholder where a chat-UI screenshot or recording would go. Drop \`docs/site/hero.png\` (or \`docs/site/demo.gif\`) and replace the placeholder text in \`scripts/build-site.mjs\` (around line 360 of the script) — or leave it; the page reads fine without.
2. **Logo SVG.** Stylized \`<π>\` mark, recreated inline as SVG so favicons work without an asset round-trip. To use the actual \`docs/images/icon.png\` instead, swap the \`LOGO_SVG\` constant for an \`<img src="...">\` and copy the PNG into \`docs/site/\`.

## Test plan

- [x] \`npm run check\` clean.
- [x] \`npm run test:ci\` — all 17 tests PASS.
- [x] \`npm run build:site\` produces 7 doc pages + index.html with no errors.
- [ ] **Manual**: open \`docs/site/index.html\` in a browser locally — landing renders, all nav links work.
- [ ] **Manual**: click through each sidebar link on a doc page — navigation works, active page highlights, sidebar collapses on mobile.
- [ ] **Repo Settings**: enable Pages source = "GitHub Actions" after merge.
- [ ] **Workflow**: push \`docs/site/**\` change after enabling → \`Deploy GitHub Pages\` job goes green, site URL appears in the workflow output.