### PR TITLE
fix(chat): preserve @<path> marker in user messages, fix trailing-punct refs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,11 @@ export default tseslint.config(
       "**/.vite/**",
       "**/dev-dist/**",
       "packages/client/public/**",
+      // Local dev WORKSPACE_PATH default ($repo/workspace) is gitignored
+      // already; mirror it here so a project the user has cloned inside
+      // their dev workspace doesn't get picked up by the typed lint
+      // (which then errors because those files aren't in any tsconfig).
+      "workspace/**",
     ],
   },
   js.configs.recommended,

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -31,7 +31,11 @@ import { useUiStore } from "../store/ui-store";
  * will reference.
  */
 function parseChatFileReferences(text: string): string[] {
-  const re = /(?:^|\s)@(?:"([^"\n]+)"|([^\s]+))/g;
+  // Lazy bare alternation + lookahead so trailing sentence punctuation
+  // (`?`, `,`, `;`, `:`, `!`, `)`, `]`) doesn't get glued onto the
+  // path — kept in sync with the server-side REF_RE in
+  // file-references.ts. See that file for the rationale.
+  const re = /(?:^|\s)@(?:"([^"\n]+)"|([^\s]+?))(?=[?,;:!)\]]?(?:\s|$))/g;
   const out: string[] = [];
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {
@@ -933,11 +937,13 @@ export function ChatInput({ sessionId }: Props) {
     if (acToken === undefined) return;
     const before = text.slice(0, acToken.start);
     const after = text.slice(acToken.end);
-    // Wrap paths containing whitespace in double quotes so the
-    // server-side `expandFileReferences` regex can recognize the full
-    // path. The quoted form is documented at file-references.ts.
-    const needsQuotes = /\s/.test(path);
-    const replacement = needsQuotes ? `@"${path}"` : `@${path}`;
+    // Always wrap in double quotes. The quoted form lets users type
+    // punctuation directly after the path (`@"src/foo.ts".`,
+    // `@"src/foo.ts",`) — the bare form's `[^\s]+` rule would otherwise
+    // greedy-match the trailing `.` or `,` as part of the filename and
+    // break the reference. The quoted form is documented at
+    // file-references.ts.
+    const replacement = `@"${path}"`;
     const next = `${before}${replacement}${after}`;
     setText(next);
     setAcToken(undefined);

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -384,27 +384,46 @@ type FileRef =
 
 function extractFileRefs(text: string): { stripped: string; refs: FileRef[] } {
   const refs: FileRef[] = [];
-  // Step 1: pull out fenced "<lang> file: <path>" blocks.
-  const fenceRe = /(`{3,})(\w*)\s+file:\s+([^\n]+)\n([\s\S]*?)\n\1(?=\n|$)/g;
+  // Step 1: pull out fenced "<lang> file: <path>" blocks. The server
+  // (after the file-references fix) emits the literal `@<path>` marker
+  // immediately before each fenced block, so dropping just the block
+  // here leaves the marker in place inline with the user's prose.
+  //
+  // Eat the `\n` immediately before AND after the fence too so the
+  // marker flows inline with surrounding prose — without this, the
+  // server's mandatory `marker\nfence\ntail` framing leaves an
+  // orphan blank line between the marker and the rest of the
+  // sentence after the fence is stripped. The leading `\n?` is
+  // optional because the marker may be at start-of-string.
+  const fenceRe = /\n?(`{3,})(\w*)\s+file:\s+([^\n]+)\n([\s\S]*?)\n\1\n?/g;
   let stripped = text.replace(
     fenceRe,
     (_match, _fence: string, lang: string, path: string, content: string) => {
       refs.push({ kind: "inline", path: path.trim(), lang, content });
-      return "\n";
+      return "";
     },
   );
-  // Step 2: pull out bare `@<path>` (or `@"path"`) deferred refs from
-  // what's left. Same prefix anchor as the server regex.
-  const deferRe = /(^|\s)@(?:"([^"\n]+)"|([^\s]+))/g;
-  stripped = stripped.replace(deferRe, (_match, lead: string, quoted: string, bare: string) => {
-    const path = (quoted ?? bare ?? "").trim();
-    if (path.length > 0) refs.push({ kind: "defer", path });
-    // Preserve the leading whitespace/anchor so surrounding text
-    // doesn't fuse together.
-    return lead;
-  });
-  // Collapse any 3+ consecutive newlines (from fenced removal) to a
-  // single blank line, then trim the whole string.
+  // Step 2: collect bare `@<path>` (or `@"path"`) deferred refs WITHOUT
+  // stripping them — the marker stays visible in the bubble so the
+  // user's sentence still reads as typed ("look at @src/foo.ts and
+  // explain"). The badge rendered below is the expandable affordance
+  // for inline content; deferred refs no longer get a separate badge
+  // since the inline marker already carries the information.
+  // Lazy bare alternation + lookahead so trailing sentence punctuation
+  // (`?`, `,`, `;`, `:`, `!`, `)`, `]`) doesn't end up in the path —
+  // kept in sync with file-references.ts#REF_RE.
+  const deferRe = /(^|\s)@(?:"([^"\n]+)"|([^\s]+?))(?=[?,;:!)\]]?(?:\s|$))/g;
+  let m: RegExpExecArray | null;
+  while ((m = deferRe.exec(stripped)) !== null) {
+    const path = (m[2] ?? m[3] ?? "").trim();
+    if (path.length === 0) continue;
+    // Avoid duplicating the inline ref we already collected above —
+    // when the server inlines a file, the marker AND the fenced block
+    // both appear, and we want a single badge for that pair.
+    if (refs.some((r) => r.kind === "inline" && r.path === path)) continue;
+    refs.push({ kind: "defer", path });
+  }
+  // Collapse runs of blank lines created by the fence removal.
   stripped = stripped.replace(/\n{3,}/g, "\n\n").trim();
   return { stripped, refs };
 }

--- a/packages/server/src/file-references.ts
+++ b/packages/server/src/file-references.ts
@@ -49,8 +49,17 @@ const INLINE_THRESHOLD_BYTES = 128 * 1024;
  * Regex shared by `findRefs` and `parseFileReferences`. Match `@` at
  * start-or-after-whitespace then either a `"path with spaces"` quoted
  * form or a bare non-whitespace token.
+ *
+ * The bare alternation is lazy + uses a lookahead so trailing
+ * sentence punctuation (`?`, `,`, `;`, `:`, `!`, `)`, `]`) followed by
+ * whitespace or end-of-string isn't pulled into the path. Without
+ * this, `@README.md?` matches `README.md?` and the server can't
+ * resolve the file. The `.` is intentionally NOT in the strip set
+ * because dots are common in filenames (`README.md`, `tsconfig.json`)
+ * — users who want a literal trailing period should use the quoted
+ * form (`@"file.txt".`), same escape hatch as filenames with spaces.
  */
-const REF_RE = /(^|\s)@(?:"([^"\n]+)"|([^\s]+))/g;
+const REF_RE = /(^|\s)@(?:"([^"\n]+)"|([^\s]+?))(?=[?,;:!)\]]?(?:\s|$))/g;
 
 interface RefMatch {
   start: number;
@@ -139,14 +148,18 @@ export async function expandFileReferences(text: string, workspacePath: string):
     if (outcome === undefined || mm === undefined) continue;
     const before = out.slice(0, mm.start) + mm.lead;
     const after = out.slice(mm.end);
+    // Re-emit the marker (preserve quoting if path has whitespace) so
+    // the user's prose still reads "look at @src/foo.ts and explain"
+    // after expansion. Previously the inline branch dropped the marker
+    // entirely and only kept the fenced block, which broke the flow of
+    // the surrounding sentence in the chat history.
+    const marker = /\s/.test(mm.path) ? `@"${mm.path}"` : `@${mm.path}`;
     if (outcome.kind === "inline") {
-      out = `${before}\n${outcome.text}\n${after}`;
+      out = `${before}${marker}\n${outcome.text}\n${after}`;
     } else if (outcome.kind === "defer") {
-      // Re-emit the marker (preserve quoting if path has whitespace).
-      const marker = /\s/.test(mm.path) ? `@"${mm.path}"` : `@${mm.path}`;
       out = `${before}${marker}${after}`;
     } else {
-      out = `${before}[@${mm.path} not included: ${outcome.reason}]${after}`;
+      out = `${before}[${marker} not included: ${outcome.reason}]${after}`;
     }
   }
   return out;


### PR DESCRIPTION
## Summary

Fixes three related issues in the `@<path>` file-reference flow plus
an unrelated lint config tweak.

### Bugs fixed

1. **`@<filename>` was being stripped from the rendered chat content.**
   When a referenced file was small enough to inline, the server emitted
   only the fenced code block — the user's prose lost the `@<filename>`
   they typed (`look at @README.md and explain` rendered as `look at
   and explain`). Server's `expandFileReferences` now preserves the
   literal marker for every outcome (inline, defer, error), and the
   client's `extractFileRefs` no longer strips bare markers from the
   bubble. The expandable inline-content badge still renders below.

2. **Forced blank line after each file reference.** The fence-stripping
   regex left the surrounding `\n` characters behind, so even with the
   marker preserved you got an orphan blank line between the marker and
   the rest of the sentence. Regex now eats the leading + trailing
   newline adjacent to the fenced block so prose flows inline. Explicit
   paragraph breaks (marker on its own line) are still preserved.

3. **Trailing punctuation broke `@README.md?` (and `,`, `;`, `:`,
   `!`, `)`, `]`).** The bare `[^\s]+` regex greedy-matched the `?` as
   part of the path, so the server tried to resolve `README.md?` and
   failed. Bare alternation is now lazy + uses a lookahead so trailing
   sentence punctuation followed by whitespace/EOS isn't pulled into
   the path. `.` is intentionally NOT in the strip set (filenames have
   dots — `README.md`, `tsconfig.json`); for the rare trailing-period
   case, the always-quoted autocomplete handles it cleanly.

   Also: `acInsert` (the autocomplete handler) now ALWAYS wraps the
   inserted path in double quotes, regardless of whether the path
   contains whitespace. Users can type any punctuation directly after
   an autocompleted path without thinking about escaping.

### Bonus

- `eslint.config.js` ignores the gitignored `./workspace` directory
  (the dev-server `WORKSPACE_PATH` default). A project the user has
  cloned into their dev workspace was tripping the typed lint because
  those files aren't in any tsconfig.

## Files touched

- `packages/server/src/file-references.ts` — preserve marker in all
  three branches; bare `REF_RE` tightened.
- `packages/client/src/components/ChatInput.tsx` — `acInsert` always
  quotes; `parseChatFileReferences` regex tightened.
- `packages/client/src/components/ChatView.tsx` — `extractFileRefs`
  no longer strips bare markers; fence regex eats adjacent newlines;
  defer regex tightened.
- `eslint.config.js` — ignore `workspace/**`.

## Test plan

- [x] `npm run check` (typecheck + eslint + prettier) — clean
- [x] `npm run test:ci` — all 18 suites pass
- [ ] Manual smoke: type `look at @README.md and explain` — verify
  the `@README.md` text stays inline in the bubble, the expandable
  content badge renders below, no orphan blank line
- [ ] Manual smoke: type `@README.md?` (no autocomplete) — verify
  the `?` doesn't end up as part of the path; reference resolves
- [ ] Manual smoke: autocomplete a file then type punctuation
  (`@"src/foo.ts".`) — verify the period is treated as sentence
  punctuation, not part of the filename
- [ ] Manual smoke: large file (>128 KB) reference — verify the
  deferred marker stays visible inline