### PR TITLE
chore(release): v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.0.1] — 2026-05-03
+
 ### Changed
 
 - **Markdown + syntax-highlighted code in chat messages.** User

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,27 @@ the README for the support window policy.
   in the freshly-spawned shell. Reattach to an existing PTY does not
   re-source so manually-switched venvs are preserved.
 
+### Fixed
+
+- **`@<path>` file references preserved in chat history.** When a
+  referenced file was small enough to inline, the server previously
+  emitted only the fenced code block — the user's prose lost the
+  `@<filename>` they typed (`look at @README.md and explain` rendered
+  as `look at and explain`). The server now keeps the literal marker
+  for every outcome (inline, defer, error), the client no longer
+  strips bare markers from the rendered bubble, and the fence-stripper
+  consumes adjacent newlines so the marker flows inline with
+  surrounding prose instead of leaving an orphan blank line.
+- **Trailing-punctuation file references resolve correctly.**
+  `@README.md?`, `@src/foo.ts,`, `@build.js)` etc. used to greedy-match
+  the trailing punctuation as part of the filename, so the server
+  couldn't resolve the file. The bare-form regex is now lazy + uses a
+  lookahead so trailing `?,;:!)]` followed by whitespace or EOS
+  isn't pulled into the path. Dot is intentionally not in the strip
+  set (filenames have dots); the autocomplete now always inserts the
+  quoted form (`@"src/foo.ts"`) so users can type any punctuation
+  directly after an autocompleted reference.
+
 ### Security
 
 - **Agent secret-hygiene system-prompt rule (opt-in).** When

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-workbench",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-workbench",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "workspaces": [
         "packages/*"
       ],
@@ -17268,7 +17268,7 @@
     },
     "packages/client": {
       "name": "@pi-workbench/client",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17311,7 +17311,7 @@
     },
     "packages/server": {
       "name": "@pi-workbench/server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-workbench",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-workbench/client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-workbench/server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

First post-v1.0.0 release. Bumps the root and both workspace
`package.json` files in lockstep (1.0.0 → 1.0.1), refreshes the
lockfile, and renames the `## [Unreleased]` CHANGELOG section to
`## [1.0.1] — 2026-05-03` with a fresh empty Unreleased above it.

Also backfills a `### Fixed` section under Unreleased for the
`@<path>` reference fixes from #14, which merged without a
changelog entry.

## What's in 1.0.1

Cherry of the highlights — full notes in
[`CHANGELOG.md`](./CHANGELOG.md):

**Added**
- Pi's read-only built-in tools (`grep`, `find`, `ls`) now activated
  on every session.
- Per-tool enable / disable in Settings → Tools and Settings → MCP
  cascade, with per-project overrides via the same cascade UX as
  the Skills tab.
- Config export / import as `.tar.gz` (Settings → Backup).
- Terminal venv auto-activation.

**Changed**
- Markdown + syntax-highlighted code in chat messages (with raw /
  rendered toggle).
- Tool calls render as one collapsed entry per call (paired by
  `toolCallId`).

**Fixed**
- `@<path>` file references preserved in chat history (server no
  longer drops the marker on inline expansion; client no longer
  strips bare markers from rendered bubbles; fence-stripper eats
  adjacent newlines so prose flows inline).
- Trailing-punctuation file references (`@README.md?`,
  `@src/foo.ts,`, `@build.js)`) resolve correctly. Autocomplete
  always inserts the quoted form.

**Security**
- Opt-in agent secret-hygiene system-prompt rule.
- Terminal env-var allowlist (replaces the prior fail-open
  denylist).

**Build & release**
- `scripts/bump-version.sh` automation.
- Tag/version drift gate in the release workflow.

## Release flow (after merge)

```
git checkout main && git pull --ff-only
git tag v1.0.1
git push origin v1.0.1
```

The release workflow builds the multi-arch Docker image and
creates the GitHub Release automatically.

## Test plan

- [x] `npm run check` (typecheck + eslint + prettier) — clean
- [x] All three `package.json` files at 1.0.1 (lockstep enforced
  by the tag/version drift gate on tag push)
- [x] `package-lock.json` refreshed to match
- [x] CHANGELOG section renamed `[Unreleased]` → `[1.0.1] — 2026-05-03`,
  fresh empty `[Unreleased]` heading inserted above
- [ ] After merge: tag `v1.0.1` from main, confirm the release
  workflow builds + publishes