### PR TITLE
feat: pane toggles, QOL controls, multiselect, skills backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,32 @@ the README for the support window policy.
 
 ## [Unreleased]
 
-## [1.0.1] — 2026-05-03
+### Added
+
+- **Pane toggles for chat and editor.** New **Chat** and **Editor**
+  buttons in the header alongside the existing **Files** and
+  **Terminal** toggles. Each pane is independently hideable so a
+  user can collapse the workbench down to whichever surface
+  matters for the task at hand (e.g. just editor + terminal for a
+  test-running flow, or just chat for an agent-driving flow).
+  Persistence mirrors the existing toggles: `localStorage` keys
+  `pi-workbench/chat-open` and `pi-workbench/editor-open`, both
+  defaulting to OPEN.
+- **Editor pane decoupled from the file browser.** The Files
+  toggle previously controlled both the file tree AND the editor
+  visibility; closing the tree also hid any open tabs. Now the
+  Editor toggle is independent — keep one file open without the
+  280px file tree taking room, or browse the tree without the
+  editor pane materialising.
+- **Editor tabs persist across page reloads.** Open tab paths and
+  the active path are now saved to `sessionStorage` per project
+  (`pi.editor.tabs.v1:<projectId>`), mirroring the terminal store's
+  per-browser-tab persistence. On reload the tabs reopen via the
+  existing `openFile` read; files that have been deleted since
+  persist time are silently dropped. Only paths + active path are
+  stored — file content stays on the server.
+
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,62 @@ the README for the support window policy.
   existing `openFile` read; files that have been deleted since
   persist time are silently dropped. Only paths + active path are
   stored — file content stays on the server.
-
-
+- **Chat-hidden layout fills the viewport.** When the chat pane is
+  toggled off, the leftmost visible pane (editor, then files) expands
+  to `flex-1` and its leading ResizableDivider is dropped, so two
+  visible panes fill the entire main area with a single slider between
+  them instead of leaving blank space on the right.
+- **Editor/Files button order matches pane order.** The **Editor**
+  toggle button now appears before **Files** in the header bar,
+  matching the left-to-right render order (chat → editor → files).
+- **Close-all tabs button in editor.** An XSquare icon at the left
+  edge of the editor tab bar closes every open tab at once; prompts
+  for confirmation when any tab has unsaved changes.
+- **MCP status badge opens MCP settings.** Clicking the MCP badge in
+  the header navigates directly to **Settings → MCP** instead of
+  doing nothing.
+- **Dismissable project picker.** When no projects exist, the project
+  picker can be dismissed with the X so the user can explore the
+  workbench before creating a project. A "New project" link in the
+  empty state re-opens it.
+- **New-session shortcut in chat pane.** When a project is selected
+  but no session is active, the chat column shows a "+ New session"
+  button that creates and navigates to a new session directly.
+- **Always-visible sidebar controls.** The + (new session) and X
+  (delete project) buttons in the project sidebar are now always
+  visible instead of appearing only on hover.
+- **Always-visible tab close buttons.** X buttons on editor tabs and
+  terminal tabs are always visible (previously required hovering over
+  the tab).
+- **8 px left padding in terminal pane.** The xterm viewport now has a
+  small left inset so terminal text isn't flush against the panel edge.
+- **Prompt history includes slash commands and bash execs.** All
+  submitted prompts (agent prose, `/` slash commands, `!` / `!!` bash
+  execs) are now persisted to `localStorage` per session
+  (`pi.input.history.v1:<sessionId>`, capped at 100, consecutive
+  duplicates skipped). The up-arrow history merges this store with the
+  existing message-derived history.
+- **Block workspace-root folder as a project path.** The folder picker
+  rejects the workspace root itself; the "Select this folder" button
+  is disabled and a tooltip explains why.
+- **Recursive folder delete with confirmation.** Deleting a non-empty
+  folder now opens a second confirmation dialog (instead of returning
+  an error); the confirmed action sends `?recursive=true` to the server
+  and removes the directory tree atomically.
+- **Multiselect for files.** Cmd/Ctrl+click in the file browser
+  toggles rows into a selection set; a toolbar appears with a
+  "Delete selected" action that removes all selected items.
+- **Multiselect for sessions.** Same Cmd/Ctrl+click pattern in the
+  session list enables bulk-delete of multiple sessions at once.
+- **Skills backup.** New section in **Settings → Backup**:
+  - **Export**: downloads a `.tar.gz` of every file under the skills
+    directory (`${piConfigDir}/skills/`) via
+    `GET /api/v1/config/skills/export`.
+  - **Import**: uploads either a `.tar.gz` archive or a folder
+    (via `<input webkitdirectory>`) via
+    `POST /api/v1/config/skills/import`; paths are validated before
+    write (no `..`, no absolute paths); existing files at colliding
+    paths are overwritten atomically.
 
 ### Changed
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -72,8 +72,6 @@ function extractToolFilePath(message: Record<string, unknown>): string | undefin
   return undefined;
 }
 
-const noop = (): void => undefined;
-
 export function App() {
   const ready = useAuthStore((s) => s.ready);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
@@ -147,6 +145,14 @@ export function App() {
     setEditorOpen(v);
     localStorage.setItem("pi-workbench/editor-open", v ? "true" : "false");
   };
+
+  // First-run picker dismissal. When no projects exist we render the
+  // ProjectPicker by default, but the user can dismiss it to take a
+  // look around the empty workbench. Re-opens via the sidebar's
+  // "+ New project" button. Reset whenever a project is created so
+  // the picker doesn't reappear if the user later deletes all
+  // projects in the same browser tab.
+  const [setupPickerDismissed, setSetupPickerDismissed] = useState(false);
   const [terminalHeight, setTerminalHeight] = useState<number>(() =>
     readPersistedWidth(TERMINAL_HEIGHT_KEY, DEFAULT_TERMINAL_HEIGHT),
   );
@@ -362,18 +368,6 @@ export function App() {
             Chat
           </button>
           <button
-            onClick={() => setFilesOpenPersisted(!filesOpen)}
-            className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
-              filesOpen
-                ? "border-neutral-500 bg-neutral-800 text-neutral-100"
-                : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
-            }`}
-            title="Toggle the file browser tree"
-          >
-            <FolderTree size={13} />
-            Files
-          </button>
-          <button
             onClick={() => setEditorOpenPersisted(!editorOpen)}
             className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
               editorOpen
@@ -384,6 +378,18 @@ export function App() {
           >
             <FileCode size={13} />
             Editor
+          </button>
+          <button
+            onClick={() => setFilesOpenPersisted(!filesOpen)}
+            className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
+              filesOpen
+                ? "border-neutral-500 bg-neutral-800 text-neutral-100"
+                : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
+            }`}
+            title="Toggle the file browser tree"
+          >
+            <FolderTree size={13} />
+            Files
           </button>
           {!minimal && (
             <button
@@ -448,9 +454,27 @@ export function App() {
             {(chatOpen || activeSessionId === undefined) && (
               <div className="flex flex-1 flex-col overflow-hidden">
                 {projectsLoaded && projects.length === 0 ? (
-                  <div className="flex flex-1 items-center justify-center">
-                    <ProjectPicker required onClose={noop} />
-                  </div>
+                  setupPickerDismissed ? (
+                    // Picker dismissed — show a friendly empty state
+                    // pointing back at the sidebar's + button. The
+                    // header buttons (settings, theme, etc.) stay
+                    // reachable from this state too.
+                    <div className="flex flex-1 items-center justify-center px-6 text-center">
+                      <div className="space-y-3 text-sm text-neutral-400">
+                        <p>No projects yet.</p>
+                        <button
+                          onClick={() => setSetupPickerDismissed(false)}
+                          className="rounded-md bg-neutral-100 px-3 py-1.5 text-sm font-medium text-neutral-900 hover:bg-white"
+                        >
+                          + New project
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex flex-1 items-center justify-center">
+                      <ProjectPicker onClose={() => setSetupPickerDismissed(true)} />
+                    </div>
+                  )
                 ) : activeSessionId !== undefined ? (
                   <>
                     <ChatView sessionId={activeSessionId} />
@@ -468,12 +492,23 @@ export function App() {
                   </>
                 ) : active ? (
                   <div className="flex flex-1 items-center justify-center px-6 text-center">
-                    <div className="space-y-2 text-sm text-neutral-400">
+                    <div className="space-y-3 text-sm text-neutral-400">
                       <h2 className="text-xl font-semibold text-neutral-100">{active.name}</h2>
                       <p className="font-mono text-xs">{active.path}</p>
-                      <p>
-                        Pick a session from the sidebar — or click "+ New session" to start one.
-                      </p>
+                      <p>Pick a session from the sidebar — or start a new one here.</p>
+                      <button
+                        onClick={() => {
+                          // Fire-and-forget; createSession sets the
+                          // active session id on success which routes
+                          // this branch into the ChatView render
+                          // above. Failures surface via the session
+                          // store's `error` field.
+                          void useSessionStore.getState().createSession(active.id);
+                        }}
+                        className="rounded-md bg-neutral-100 px-3 py-1.5 text-sm font-medium text-neutral-900 hover:bg-white"
+                      >
+                        + New session
+                      </button>
                     </div>
                   </div>
                 ) : (
@@ -484,112 +519,152 @@ export function App() {
               </div>
             )}
 
-            {editorVisible && (
-              <>
-                <ResizableDivider
-                  getStartSize={() => editorWidthRef.current}
-                  onResize={(next) => setEditorWidth(next)}
-                  /* Pane is to the RIGHT of the divider, so drag-right
-                   shrinks the editor. direction: -1 → grow as user drags left. */
-                  direction={-1}
-                  minSize={MIN_EDITOR_WIDTH}
-                  maxSize={Math.max(
-                    MIN_EDITOR_WIDTH,
-                    window.innerWidth - (filesOpen ? filesWidth : 0) - MIN_CHAT_WIDTH - 240, // 240 ≈ ProjectSidebar
-                  )}
-                />
-                <div
-                  className="flex shrink-0 flex-col border-l border-neutral-800"
-                  style={{ width: `${editorWidth}px` }}
-                >
-                  <EditorPanel />
-                </div>
-              </>
-            )}
+            {/* Layout rule when chat is hidden: whichever pane is
+                LEFTMOST in the render order (editor, then files) takes
+                flex-1 + drops its leading divider so the visible panes
+                fill the entire main area with at most one slider
+                between them. With chat visible, the chat column is
+                always the flex-1 leftmost and editor + files keep
+                their persisted widths + dividers as before.
 
-            {filesOpen && (
-              <>
-                <ResizableDivider
-                  getStartSize={() => filesWidthRef.current}
-                  onResize={(next) => setFilesWidth(next)}
-                  direction={-1}
-                  minSize={MIN_FILES_WIDTH}
-                  maxSize={Math.max(
-                    MIN_FILES_WIDTH,
-                    window.innerWidth -
-                      MIN_CHAT_WIDTH -
-                      240 -
-                      (editorVisible ? MIN_EDITOR_WIDTH : 0),
-                  )}
-                />
-                <div
-                  className="flex shrink-0 flex-col border-l border-neutral-800"
-                  style={{ width: `${filesWidth}px` }}
-                >
-                  {/* Right-pane tabs: file browser vs the turn-diff
-                      "Changes" view. Both share width + position so
-                      they don't compete for screen real estate. */}
-                  <div className="flex border-b border-neutral-800 bg-neutral-900/40">
-                    {(minimal
-                      ? // Minimal mode keeps Files + Search + Context.
-                        // Context (token usage / message inspector) is
-                        // useful even in locked-down deploys — it's
-                        // read-only and helps users debug their own
-                        // sessions without needing the full diff/git
-                        // toolchain.
-                        (["files", "search", "context"] as const)
-                      : (["files", "search", "changes", "git", "context"] as const)
-                    ).map((t) => (
-                      <button
-                        key={t}
-                        onClick={() => setRightTabPersisted(t)}
-                        className={`flex items-center gap-1 px-3 py-1.5 text-[11px] uppercase tracking-wider ${
-                          rightTab === t
-                            ? "border-b border-neutral-100 text-neutral-100"
-                            : "text-neutral-500 hover:text-neutral-300"
-                        }`}
-                      >
-                        {/* Internal key stays "changes" for backwards-compat with
-                            persisted localStorage; user-visible label is "Last turn"
-                            so it's distinct from the Git tab's working-tree changes. */}
-                        {t === "files"
-                          ? "Files"
-                          : t === "search"
-                            ? "Search"
-                            : t === "changes"
-                              ? "Last turn"
-                              : t === "git"
-                                ? "Git"
-                                : "Context"}
-                        {t === "git" && gitChangedCount > 0 && (
-                          <span className="rounded bg-amber-900/40 px-1 py-0.5 text-[9px] text-amber-300">
-                            {gitChangedCount}
-                          </span>
-                        )}
-                      </button>
-                    ))}
-                  </div>
-                  <div className="flex-1 overflow-hidden">
-                    {rightTab === "files" ? (
-                      <FileBrowserPanel />
-                    ) : rightTab === "search" ? (
-                      <SearchPanel />
-                    ) : !minimal && rightTab === "changes" ? (
-                      <TurnDiffPanel />
-                    ) : !minimal && rightTab === "git" ? (
-                      <GitPanel />
-                    ) : rightTab === "context" ? (
-                      <ContextInspectorPanel />
-                    ) : (
-                      // minimal mode: stale persisted "changes"/"git"/"context"
-                      // falls back to the file browser rather than rendering
-                      // a tab the user can't even see.
-                      <FileBrowserPanel />
-                    )}
-                  </div>
-                </div>
-              </>
-            )}
+                `chatColumnVisible` mirrors the rendering condition for
+                the chat column above (it stays mounted on empty-state
+                branches so onboarding messaging always renders). */}
+            {editorVisible &&
+              (() => {
+                const chatColumnVisible = chatOpen || activeSessionId === undefined;
+                const editorIsLeftmost = !chatColumnVisible;
+                if (editorIsLeftmost) {
+                  return (
+                    <div className="flex flex-1 flex-col overflow-hidden">
+                      <EditorPanel />
+                    </div>
+                  );
+                }
+                return (
+                  <>
+                    <ResizableDivider
+                      getStartSize={() => editorWidthRef.current}
+                      onResize={(next) => setEditorWidth(next)}
+                      /* Pane is to the RIGHT of the divider, so drag-right
+                       shrinks the editor. direction: -1 → grow as user drags left. */
+                      direction={-1}
+                      minSize={MIN_EDITOR_WIDTH}
+                      maxSize={Math.max(
+                        MIN_EDITOR_WIDTH,
+                        window.innerWidth - (filesOpen ? filesWidth : 0) - MIN_CHAT_WIDTH - 240, // 240 ≈ ProjectSidebar
+                      )}
+                    />
+                    <div
+                      className="flex shrink-0 flex-col border-l border-neutral-800"
+                      style={{ width: `${editorWidth}px` }}
+                    >
+                      <EditorPanel />
+                    </div>
+                  </>
+                );
+              })()}
+
+            {filesOpen &&
+              (() => {
+                const chatColumnVisible = chatOpen || activeSessionId === undefined;
+                const filesIsLeftmost = !chatColumnVisible && !editorVisible;
+                // Inner content (tabs + selected panel) — identical in
+                // both layout branches. Extracted so we can wrap it in
+                // either a flex-1 container (leftmost) or a shrink-0
+                // fixed-width container (with a divider in front).
+                const filesContent = (
+                  <>
+                    {/* Right-pane tabs: file browser vs the turn-diff
+                        "Changes" view. Both share width + position so
+                        they don't compete for screen real estate. */}
+                    <div className="flex border-b border-neutral-800 bg-neutral-900/40">
+                      {(minimal
+                        ? // Minimal mode keeps Files + Search + Context.
+                          // Context (token usage / message inspector) is
+                          // useful even in locked-down deploys — it's
+                          // read-only and helps users debug their own
+                          // sessions without needing the full diff/git
+                          // toolchain.
+                          (["files", "search", "context"] as const)
+                        : (["files", "search", "changes", "git", "context"] as const)
+                      ).map((t) => (
+                        <button
+                          key={t}
+                          onClick={() => setRightTabPersisted(t)}
+                          className={`flex items-center gap-1 px-3 py-1.5 text-[11px] uppercase tracking-wider ${
+                            rightTab === t
+                              ? "border-b border-neutral-100 text-neutral-100"
+                              : "text-neutral-500 hover:text-neutral-300"
+                          }`}
+                        >
+                          {/* Internal key stays "changes" for backwards-compat with
+                              persisted localStorage; user-visible label is "Last turn"
+                              so it's distinct from the Git tab's working-tree changes. */}
+                          {t === "files"
+                            ? "Files"
+                            : t === "search"
+                              ? "Search"
+                              : t === "changes"
+                                ? "Last turn"
+                                : t === "git"
+                                  ? "Git"
+                                  : "Context"}
+                          {t === "git" && gitChangedCount > 0 && (
+                            <span className="rounded bg-amber-900/40 px-1 py-0.5 text-[9px] text-amber-300">
+                              {gitChangedCount}
+                            </span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="flex-1 overflow-hidden">
+                      {rightTab === "files" ? (
+                        <FileBrowserPanel />
+                      ) : rightTab === "search" ? (
+                        <SearchPanel />
+                      ) : !minimal && rightTab === "changes" ? (
+                        <TurnDiffPanel />
+                      ) : !minimal && rightTab === "git" ? (
+                        <GitPanel />
+                      ) : rightTab === "context" ? (
+                        <ContextInspectorPanel />
+                      ) : (
+                        // minimal mode: stale persisted "changes"/"git"/"context"
+                        // falls back to the file browser rather than rendering
+                        // a tab the user can't even see.
+                        <FileBrowserPanel />
+                      )}
+                    </div>
+                  </>
+                );
+                if (filesIsLeftmost) {
+                  return <div className="flex flex-1 flex-col overflow-hidden">{filesContent}</div>;
+                }
+                return (
+                  <>
+                    <ResizableDivider
+                      getStartSize={() => filesWidthRef.current}
+                      onResize={(next) => setFilesWidth(next)}
+                      direction={-1}
+                      minSize={MIN_FILES_WIDTH}
+                      maxSize={Math.max(
+                        MIN_FILES_WIDTH,
+                        window.innerWidth -
+                          MIN_CHAT_WIDTH -
+                          240 -
+                          (editorVisible ? MIN_EDITOR_WIDTH : 0),
+                      )}
+                    />
+                    <div
+                      className="flex shrink-0 flex-col border-l border-neutral-800"
+                      style={{ width: `${filesWidth}px` }}
+                    >
+                      {filesContent}
+                    </div>
+                  </>
+                );
+              })()}
           </main>
         </div>
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { FolderTree, MessageSquare, Terminal as TerminalIcon } from "lucide-react";
+import { FileCode, FolderTree, MessageSquare, Terminal as TerminalIcon } from "lucide-react";
 import { useAuthStore } from "./store/auth-store";
 import { useActiveProject, useProjectStore } from "./store/project-store";
 import { useSessionStore } from "./store/session-store";
@@ -134,6 +134,19 @@ export function App() {
     setChatOpen(v);
     localStorage.setItem("pi-workbench/chat-open", v ? "true" : "false");
   };
+
+  // Editor pane visibility — independent of `filesOpen` (the file
+  // browser tree). Defaults to OPEN so a user with persisted tabs from
+  // the previous session sees them on reload. Tabs themselves persist
+  // in sessionStorage via file-store; this toggle just controls
+  // visibility of the rendered pane.
+  const [editorOpen, setEditorOpen] = useState<boolean>(
+    () => localStorage.getItem("pi-workbench/editor-open") !== "false",
+  );
+  const setEditorOpenPersisted = (v: boolean): void => {
+    setEditorOpen(v);
+    localStorage.setItem("pi-workbench/editor-open", v ? "true" : "false");
+  };
   const [terminalHeight, setTerminalHeight] = useState<number>(() =>
     readPersistedWidth(TERMINAL_HEIGHT_KEY, DEFAULT_TERMINAL_HEIGHT),
   );
@@ -165,7 +178,7 @@ export function App() {
   }, [editorWidth]);
 
   const openFilesCount = useFileStore((s) => s.openFiles.length);
-  const editorVisible = filesOpen && openFilesCount > 0;
+  const editorVisible = editorOpen && openFilesCount > 0;
 
   // Drives the modified-file count badge on the Git tab. Polls every
   // 5s via the hook regardless of which tab is currently visible —
@@ -185,11 +198,22 @@ export function App() {
     activeSessionId !== undefined ? (s.streamingBySession[activeSessionId] ?? false) : false,
   );
   const loadFileTree = useFileStore((s) => s.loadTree);
+  const restoreTabs = useFileStore((s) => s.restoreTabs);
   useEffect(() => {
     if (active === undefined || isStreaming) return;
     void loadFileTree(active.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active?.id, isStreaming, agentEndCount]);
+
+  // Re-open the editor tabs persisted for this project. No-op if any
+  // tabs are already open, so a project hot-switch doesn't fight a
+  // user who's mid-edit. Runs only on project change (not on every
+  // agent_end / streaming flip the tree refresh keys off of).
+  useEffect(() => {
+    if (active === undefined) return;
+    void restoreTabs(active.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active?.id]);
 
   // Agent file-change awareness for open editor tabs. Walks NEW
   // tool_result messages since we last looked, finds write/edit
@@ -344,10 +368,22 @@ export function App() {
                 ? "border-neutral-500 bg-neutral-800 text-neutral-100"
                 : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
             }`}
-            title="Toggle the file browser + editor pane"
+            title="Toggle the file browser tree"
           >
             <FolderTree size={13} />
             Files
+          </button>
+          <button
+            onClick={() => setEditorOpenPersisted(!editorOpen)}
+            className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
+              editorOpen
+                ? "border-neutral-500 bg-neutral-800 text-neutral-100"
+                : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
+            }`}
+            title="Toggle the editor pane (open tabs persist across reloads)"
+          >
+            <FileCode size={13} />
+            Editor
           </button>
           {!minimal && (
             <button
@@ -448,7 +484,7 @@ export function App() {
               </div>
             )}
 
-            {filesOpen && editorVisible && (
+            {editorVisible && (
               <>
                 <ResizableDivider
                   getStartSize={() => editorWidthRef.current}
@@ -459,7 +495,7 @@ export function App() {
                   minSize={MIN_EDITOR_WIDTH}
                   maxSize={Math.max(
                     MIN_EDITOR_WIDTH,
-                    window.innerWidth - filesWidth - MIN_CHAT_WIDTH - 240, // 240 ≈ ProjectSidebar
+                    window.innerWidth - (filesOpen ? filesWidth : 0) - MIN_CHAT_WIDTH - 240, // 240 ≈ ProjectSidebar
                   )}
                 />
                 <div

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { FolderTree, Terminal as TerminalIcon } from "lucide-react";
+import { FolderTree, MessageSquare, Terminal as TerminalIcon } from "lucide-react";
 import { useAuthStore } from "./store/auth-store";
 import { useActiveProject, useProjectStore } from "./store/project-store";
 import { useSessionStore } from "./store/session-store";
@@ -121,6 +121,18 @@ export function App() {
   const setTerminalOpenPersisted = (v: boolean): void => {
     setTerminalOpen(v);
     localStorage.setItem("pi-workbench/terminal-open", v ? "true" : "false");
+  };
+
+  // Chat pane visibility — defaults to OPEN (the chat is the workbench's
+  // primary surface), and the persistence key is absence-means-open so a
+  // user who has never touched the toggle gets the chat. Hide is for the
+  // "I just want to use the file editor + terminal" focus mode.
+  const [chatOpen, setChatOpen] = useState<boolean>(
+    () => localStorage.getItem("pi-workbench/chat-open") !== "false",
+  );
+  const setChatOpenPersisted = (v: boolean): void => {
+    setChatOpen(v);
+    localStorage.setItem("pi-workbench/chat-open", v ? "true" : "false");
   };
   const [terminalHeight, setTerminalHeight] = useState<number>(() =>
     readPersistedWidth(TERMINAL_HEIGHT_KEY, DEFAULT_TERMINAL_HEIGHT),
@@ -314,6 +326,18 @@ export function App() {
         </div>
         <div className="flex items-center gap-2">
           <button
+            onClick={() => setChatOpenPersisted(!chatOpen)}
+            className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
+              chatOpen
+                ? "border-neutral-500 bg-neutral-800 text-neutral-100"
+                : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
+            }`}
+            title="Toggle the chat pane"
+          >
+            <MessageSquare size={13} />
+            Chat
+          </button>
+          <button
             onClick={() => setFilesOpenPersisted(!filesOpen)}
             className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
               filesOpen
@@ -380,40 +404,49 @@ export function App() {
               materialises between chat and files only when at least
               one file is open. Both right-side panes are user-resizable
               via their dividers; widths persist in localStorage. */}
-            <div className="flex flex-1 flex-col overflow-hidden">
-              {projectsLoaded && projects.length === 0 ? (
-                <div className="flex flex-1 items-center justify-center">
-                  <ProjectPicker required onClose={noop} />
-                </div>
-              ) : activeSessionId !== undefined ? (
-                <>
-                  <ChatView sessionId={activeSessionId} />
-                  {!minimal && (
-                    <ChangedFilesBadge
-                      sessionId={activeSessionId}
-                      alreadyOnChangesTab={filesOpen && rightTab === "changes"}
-                      onOpen={() => {
-                        if (!filesOpen) setFilesOpenPersisted(true);
-                        setRightTabPersisted("changes");
-                      }}
-                    />
-                  )}
-                  <ChatInput sessionId={activeSessionId} />
-                </>
-              ) : active ? (
-                <div className="flex flex-1 items-center justify-center px-6 text-center">
-                  <div className="space-y-2 text-sm text-neutral-400">
-                    <h2 className="text-xl font-semibold text-neutral-100">{active.name}</h2>
-                    <p className="font-mono text-xs">{active.path}</p>
-                    <p>Pick a session from the sidebar — or click "+ New session" to start one.</p>
+            {/* Chat column is suppressed when chatOpen=false. Empty-
+                state branches (no project, no session) still render so
+                the user gets the picker / "select a session" prompt
+                even when chat is hidden — those messages aren't really
+                "chat", they're load-bearing onboarding. */}
+            {(chatOpen || activeSessionId === undefined) && (
+              <div className="flex flex-1 flex-col overflow-hidden">
+                {projectsLoaded && projects.length === 0 ? (
+                  <div className="flex flex-1 items-center justify-center">
+                    <ProjectPicker required onClose={noop} />
                   </div>
-                </div>
-              ) : (
-                <div className="flex flex-1 items-center justify-center">
-                  <p className="text-sm text-neutral-400">Select a project from the sidebar.</p>
-                </div>
-              )}
-            </div>
+                ) : activeSessionId !== undefined ? (
+                  <>
+                    <ChatView sessionId={activeSessionId} />
+                    {!minimal && (
+                      <ChangedFilesBadge
+                        sessionId={activeSessionId}
+                        alreadyOnChangesTab={filesOpen && rightTab === "changes"}
+                        onOpen={() => {
+                          if (!filesOpen) setFilesOpenPersisted(true);
+                          setRightTabPersisted("changes");
+                        }}
+                      />
+                    )}
+                    <ChatInput sessionId={activeSessionId} />
+                  </>
+                ) : active ? (
+                  <div className="flex flex-1 items-center justify-center px-6 text-center">
+                    <div className="space-y-2 text-sm text-neutral-400">
+                      <h2 className="text-xl font-semibold text-neutral-100">{active.name}</h2>
+                      <p className="font-mono text-xs">{active.path}</p>
+                      <p>
+                        Pick a session from the sidebar — or click "+ New session" to start one.
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex flex-1 items-center justify-center">
+                    <p className="text-sm text-neutral-400">Select a project from the sidebar.</p>
+                  </div>
+                )}
+              </div>
+            )}
 
             {filesOpen && editorVisible && (
               <>

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -64,6 +64,46 @@ function buildFileRefRegex(path: string): RegExp {
   return new RegExp(`(^|\\s)@(?:"${escaped}"|${escaped})\\s?`, "g");
 }
 
+/**
+ * Per-session input history backed by localStorage. Captures EVERY
+ * submission (regular prompts, `/slash` commands, `!bash` execs,
+ * mid-turn steers) so up-arrow recall surfaces the same set of
+ * inputs the user actually typed — not just the ones that round-
+ * tripped to the agent. Newest first; capped at HISTORY_LIMIT to
+ * keep storage bounded across long-lived sessions.
+ */
+const HISTORY_LIMIT = 100;
+const HISTORY_KEY_PREFIX = "pi.input.history.v1:";
+
+function readInputHistory(sessionId: string): string[] {
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY_PREFIX + sessionId);
+    if (raw === null) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((s): s is string => typeof s === "string").slice(0, HISTORY_LIMIT);
+  } catch {
+    return [];
+  }
+}
+
+function pushInputHistory(sessionId: string, text: string): void {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return;
+  try {
+    const cur = readInputHistory(sessionId);
+    // Skip if the most recent entry is identical (no point recording
+    // back-to-back duplicates the same way bash's `HISTCONTROL=ignoredups`
+    // works).
+    if (cur[0] === trimmed) return;
+    const next = [trimmed, ...cur].slice(0, HISTORY_LIMIT);
+    localStorage.setItem(HISTORY_KEY_PREFIX + sessionId, JSON.stringify(next));
+  } catch {
+    // private-mode storage failure — still works for the current
+    // browser-tab session via the ref-based fallback below.
+  }
+}
+
 function userHistory(messages: readonly AgentMessageLike[]): string[] {
   const out: string[] = [];
   let last: string | undefined;
@@ -518,7 +558,32 @@ export function ChatInput({ sessionId }: Props) {
   // the user had typed BEFORE pressing Up, so Down past the newest
   // entry restores it instead of leaving the textarea blank.
   const messages = useSessionStore((s) => s.messagesBySession[sessionId] ?? EMPTY_MESSAGES);
-  const history = useMemo(() => userHistory(messages), [messages]);
+  // localStorage tick — bumped after each pushInputHistory so the
+  // memo recomputes and the new entry shows up on the next Up press
+  // without needing a full re-render of the message list.
+  const [historyTick, setHistoryTick] = useState(0);
+  const history = useMemo(() => {
+    // Merge the localStorage record (which captures slash commands +
+    // bash exec + steers) with the message-derived history (which
+    // captures regular prompts and survives across browser tabs /
+    // sessionStorage clears). localStorage takes precedence because
+    // it preserves exact submission order including non-LLM inputs;
+    // message history backfills anything not yet persisted (e.g. a
+    // session opened in a fresh tab where localStorage is empty).
+    const persisted = readInputHistory(sessionId);
+    const fromMessages = userHistory(messages);
+    const seen = new Set<string>();
+    const merged: string[] = [];
+    for (const t of [...persisted, ...fromMessages]) {
+      if (seen.has(t)) continue;
+      seen.add(t);
+      merged.push(t);
+    }
+    return merged;
+    // historyTick is intentionally in the deps — bumping it
+    // invalidates this memo when we push to localStorage.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messages, sessionId, historyTick]);
   const [historyIdx, setHistoryIdx] = useState<number | undefined>(undefined);
   const historyDraftRef = useRef<string>("");
   // Reset history navigation when the session changes — each session
@@ -647,6 +712,14 @@ export function ChatInput({ sessionId }: Props) {
     // sending "look at this" with an image but no caption is a
     // common path. Server still rejects entirely-empty prompts.
     if ((value.length === 0 && attachments.length === 0) || submitting) return;
+    // Record EVERY submission (slash command, bash exec, prompt,
+    // steer) in the per-session input history so up-arrow recall
+    // includes commands. Done up front so a slash command that
+    // never returns from slashRunSelected still gets recorded.
+    if (value.length > 0) {
+      pushInputHistory(sessionId, value);
+      setHistoryTick((t) => t + 1);
+    }
     // /-command dispatch — the keyboard path (Enter) handles this
     // first, but a click on Send also lands here and a `/foo` typed
     // input shouldn't slip through to the LLM as a regular prompt.

--- a/packages/client/src/components/EditorPanel.tsx
+++ b/packages/client/src/components/EditorPanel.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { useFileStore, type OpenFile } from "../store/file-store";
 import { useActiveProject } from "../store/project-store";
-import { WrapText, X } from "lucide-react";
+import { WrapText, X, XSquare } from "lucide-react";
 
 const WRAP_KEY_PREFIX = "pi.editor.wrap.";
 
@@ -73,6 +73,7 @@ export function EditorPanel() {
   const activePath = useFileStore((s) => s.activePath);
   const setActiveFile = useFileStore((s) => s.setActiveFile);
   const closeFile = useFileStore((s) => s.closeFile);
+  const closeAllFiles = useFileStore((s) => s.closeAllFiles);
   const updateDraft = useFileStore((s) => s.updateDraft);
   const saveFile = useFileStore((s) => s.saveFile);
   const reloadFile = useFileStore((s) => s.reloadFile);
@@ -102,6 +103,7 @@ export function EditorPanel() {
         activePath={activePath}
         onActivate={setActiveFile}
         onClose={closeFile}
+        onCloseAll={closeAllFiles}
       />
       {active === undefined ? (
         <div className="flex flex-1 items-center justify-center text-xs italic text-neutral-500">
@@ -156,41 +158,69 @@ function Tabs({
   activePath,
   onActivate,
   onClose,
+  onCloseAll,
 }: {
   files: OpenFile[];
   activePath: string | undefined;
   onActivate: (path: string | undefined) => void;
   onClose: (path: string) => void;
+  onCloseAll: () => void;
 }) {
   if (files.length === 0) return null;
+  const dirtyCount = files.filter((f) => f.dirty).length;
+  const handleCloseAll = (): void => {
+    if (
+      dirtyCount > 0 &&
+      !window.confirm(
+        `Close ${files.length} tab${files.length === 1 ? "" : "s"}? ${dirtyCount} ha${
+          dirtyCount === 1 ? "s" : "ve"
+        } unsaved changes that will be lost.`,
+      )
+    ) {
+      return;
+    }
+    onCloseAll();
+  };
   return (
-    <div className="flex overflow-x-auto border-b border-neutral-800 bg-neutral-900/40">
-      {files.map((f) => {
-        const name = f.path.split("/").pop() ?? f.path;
-        const active = f.path === activePath;
-        return (
-          <div
-            key={f.tabId}
-            className={`group flex items-center gap-1 border-r border-neutral-800 px-3 py-1.5 text-xs ${
-              active
-                ? "bg-neutral-950 text-neutral-100"
-                : "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
-            }`}
-          >
-            <button onClick={() => onActivate(f.path)} className="truncate" title={f.path}>
-              {f.dirty && <span className="mr-1 text-amber-400">•</span>}
-              {name}
-            </button>
-            <button
-              onClick={() => onClose(f.path)}
-              className="rounded p-1 text-neutral-600 opacity-0 hover:bg-neutral-800 hover:text-neutral-200 group-hover:opacity-100"
-              title="Close (any unsaved changes are lost)"
+    <div className="flex border-b border-neutral-800 bg-neutral-900/40">
+      {/* Close-all sits before the tab strip so its position is
+          stable regardless of how many tabs are open. Confirmation
+          prompt only when there are unsaved changes. */}
+      <button
+        onClick={handleCloseAll}
+        className="flex shrink-0 items-center justify-center border-r border-neutral-800 px-2 py-1.5 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
+        title={`Close all ${files.length} tab${files.length === 1 ? "" : "s"}`}
+      >
+        <XSquare size={14} />
+      </button>
+      <div className="flex flex-1 overflow-x-auto">
+        {files.map((f) => {
+          const name = f.path.split("/").pop() ?? f.path;
+          const active = f.path === activePath;
+          return (
+            <div
+              key={f.tabId}
+              className={`group flex items-center gap-1 border-r border-neutral-800 px-3 py-1.5 text-xs ${
+                active
+                  ? "bg-neutral-950 text-neutral-100"
+                  : "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
+              }`}
             >
-              <X size={16} />
-            </button>
-          </div>
-        );
-      })}
+              <button onClick={() => onActivate(f.path)} className="truncate" title={f.path}>
+                {f.dirty && <span className="mr-1 text-amber-400">•</span>}
+                {name}
+              </button>
+              <button
+                onClick={() => onClose(f.path)}
+                className="rounded p-1 text-neutral-600 hover:bg-neutral-800 hover:text-neutral-200"
+                title="Close (any unsaved changes are lost)"
+              >
+                <X size={16} />
+              </button>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/packages/client/src/components/FileBrowserPanel.tsx
+++ b/packages/client/src/components/FileBrowserPanel.tsx
@@ -15,7 +15,7 @@ import {
 import { useFileStore } from "../store/file-store";
 import { useActiveProject } from "../store/project-store";
 import { useUiStore } from "../store/ui-store";
-import { api, type FileTreeNode } from "../lib/api-client";
+import { api, ApiError, type FileTreeNode } from "../lib/api-client";
 import { ConfirmDialog, PromptDialog } from "./Modal";
 
 /**
@@ -26,7 +26,8 @@ import { ConfirmDialog, PromptDialog } from "./Modal";
  */
 type DialogState =
   | { kind: "create"; entryKind: "file" | "folder" }
-  | { kind: "delete"; absPath: string; name: string; isDir: boolean }
+  | { kind: "delete"; absPath: string; name: string; isDir: boolean; recursive: boolean }
+  | { kind: "deleteMany"; paths: string[] }
   | undefined;
 
 /**
@@ -76,6 +77,11 @@ export function FileBrowserPanel() {
     { x: number; y: number; absPath: string; isDir: boolean } | undefined
   >(undefined);
   const requestChatInsert = useUiStore((s) => s.requestChatInsert);
+  // Selected paths for the multiselect / bulk-delete affordance.
+  // Cmd/Ctrl+click on a row toggles selection; plain click clears and
+  // opens/expands as before. Hoisted above the early-return below so
+  // hook ordering stays stable across renders (rules-of-hooks).
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (project !== undefined) void loadTree(project.id);
@@ -121,19 +127,56 @@ export function FileBrowserPanel() {
     }
   };
 
+  const clearSelection = (): void => setSelectedPaths(new Set());
+  const toggleSelected = (absPath: string): void => {
+    setSelectedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(absPath)) next.delete(absPath);
+      else next.add(absPath);
+      return next;
+    });
+  };
+
   const requestDelete = (absPath: string, name: string, isDir: boolean): void => {
-    setDialog({ kind: "delete", absPath, name, isDir });
+    setDialog({ kind: "delete", absPath, name, isDir, recursive: false });
   };
 
   const submitDelete = async (): Promise<void> => {
     if (dialog?.kind !== "delete") return;
-    const { absPath } = dialog;
+    const { absPath, name, isDir, recursive } = dialog;
     setDialog(undefined);
     try {
-      await deleteEntry(project.id, absPath);
-    } catch {
+      await deleteEntry(project.id, absPath, recursive ? { recursive: true } : undefined);
+    } catch (err) {
+      // If the folder turned out to be non-empty, re-open the dialog
+      // in "recursive" mode with a stronger message instead of just
+      // surfacing the error code. The user already wanted to delete
+      // it; we just need a second confirmation that they accept the
+      // contents going too.
+      if (err instanceof ApiError && err.code === "directory_not_empty") {
+        setDialog({ kind: "delete", absPath, name, isDir, recursive: true });
+        return;
+      }
       // store.error renders
     }
+  };
+
+  const submitDeleteMany = async (): Promise<void> => {
+    if (dialog?.kind !== "deleteMany") return;
+    const { paths } = dialog;
+    setDialog(undefined);
+    // Bulk delete is always recursive — the user explicitly opted into
+    // a multi-item action, so re-prompting per non-empty directory
+    // would be obnoxious.
+    for (const p of paths) {
+      try {
+        await deleteEntry(project.id, p, { recursive: true });
+      } catch {
+        // store.error renders the first failure; keep going so a single
+        // missing path doesn't strand the rest of the selection.
+      }
+    }
+    clearSelection();
   };
 
   const onClickEntry = async (node: FileTreeNode): Promise<void> => {
@@ -348,6 +391,28 @@ export function FileBrowserPanel() {
           {error}
         </div>
       )}
+      {selectedPaths.size > 0 && (
+        <div className="flex items-center justify-between gap-2 border-b border-neutral-800 bg-neutral-900/60 px-3 py-1.5 text-[11px] text-neutral-300">
+          <span>
+            {selectedPaths.size} selected
+            <span className="ml-2 text-neutral-500">(Cmd/Ctrl+click rows to add or remove)</span>
+          </span>
+          <div className="flex gap-1">
+            <button
+              onClick={() => setDialog({ kind: "deleteMany", paths: Array.from(selectedPaths) })}
+              className="rounded border border-red-700/50 px-2 py-0.5 text-red-300 hover:bg-red-900/20"
+            >
+              Delete selected
+            </button>
+            <button
+              onClick={clearSelection}
+              className="rounded border border-neutral-700 px-2 py-0.5 text-neutral-300 hover:border-neutral-500"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      )}
       <div
         className="flex-1 overflow-y-auto py-1"
         // Empty-area drop = move/upload to the project root. dragover
@@ -387,6 +452,8 @@ export function FileBrowserPanel() {
             onDropTargetChange={setDropTarget}
             onDrop={(e, dir) => void handleDrop(e, dir)}
             onContextMenu={openContextMenu}
+            selectedPaths={selectedPaths}
+            onToggleSelect={toggleSelected}
           />
         )}
       </div>
@@ -414,13 +481,40 @@ export function FileBrowserPanel() {
         open={dialog?.kind === "delete"}
         onClose={() => setDialog(undefined)}
         onConfirm={() => void submitDelete()}
-        title={dialog?.kind === "delete" && dialog.isDir ? "Delete directory" : "Delete file"}
-        message={
+        title={
           dialog?.kind === "delete"
-            ? `Delete ${dialog.isDir ? "directory" : "file"} "${dialog.name}"? This cannot be undone.`
+            ? dialog.recursive
+              ? `"${dialog.name}" is not empty`
+              : dialog.isDir
+                ? "Delete directory"
+                : "Delete file"
             : ""
         }
-        primaryLabel="Delete"
+        message={
+          dialog?.kind === "delete"
+            ? dialog.recursive
+              ? `"${dialog.name}" contains files. Delete the directory and ALL its contents? This cannot be undone.`
+              : `Delete ${dialog.isDir ? "directory" : "file"} "${dialog.name}"? This cannot be undone.`
+            : ""
+        }
+        primaryLabel={dialog?.kind === "delete" && dialog.recursive ? "Delete contents" : "Delete"}
+        tone="danger"
+      />
+      <ConfirmDialog
+        open={dialog?.kind === "deleteMany"}
+        onClose={() => setDialog(undefined)}
+        onConfirm={() => void submitDeleteMany()}
+        title={
+          dialog?.kind === "deleteMany"
+            ? `Delete ${dialog.paths.length} item${dialog.paths.length === 1 ? "" : "s"}`
+            : ""
+        }
+        message={
+          dialog?.kind === "deleteMany"
+            ? `Delete the ${dialog.paths.length} selected file${dialog.paths.length === 1 ? "" : "s"} / folder${dialog.paths.length === 1 ? "" : "s"}? Folders are deleted recursively. This cannot be undone.`
+            : ""
+        }
+        primaryLabel="Delete all"
         tone="danger"
       />
       {contextMenu !== undefined && (
@@ -513,6 +607,10 @@ interface TreeProps {
   onDrop: (e: DragEvent<HTMLElement>, targetDirAbsPath: string) => void;
   /** Right-click handler — opens the per-row context menu. */
   onContextMenu: (e: React.MouseEvent, absPath: string, isDir: boolean) => void;
+  /** Set of absolute paths currently selected (for bulk actions). */
+  selectedPaths: Set<string>;
+  /** Toggle one path in the selection set. */
+  onToggleSelect: (absPath: string) => void;
 }
 
 function Tree(props: TreeProps) {
@@ -533,12 +631,13 @@ function Tree(props: TreeProps) {
   const open = isDir && (props.expanded[node.path] ?? false);
   const isRenaming = props.renaming === absPath;
   const isDropTarget = isDir && props.dropTarget === absPath;
+  const isSelected = props.selectedPaths.has(absPath);
   return (
     <li>
       <div
         className={`group flex items-center gap-1 px-2 py-0.5 hover:bg-neutral-900 ${
-          isDropTarget ? "bg-emerald-900/30 ring-1 ring-emerald-700/50" : ""
-        }`}
+          isSelected ? "bg-emerald-900/20" : ""
+        } ${isDropTarget ? "bg-emerald-900/30 ring-1 ring-emerald-700/50" : ""}`}
         style={{ paddingLeft: `${depth * 12 + 6}px` }}
         // Right-click → context menu. Skip while renaming so the input
         // keeps its native context menu (paste, etc.).
@@ -585,7 +684,19 @@ function Tree(props: TreeProps) {
         }
       >
         <button
-          onClick={() => props.onOpen(node)}
+          onClick={(e) => {
+            // Cmd (mac) / Ctrl (win/linux) toggles selection without
+            // opening or expanding the row, so users can build up a
+            // multi-row selection for the bulk-delete action without
+            // navigating away. Plain click keeps the open / expand
+            // behavior; meta-click never touches the editor / tree
+            // expansion state.
+            if (e.metaKey || e.ctrlKey) {
+              props.onToggleSelect(absPath);
+              return;
+            }
+            props.onOpen(node);
+          }}
           className="flex flex-1 items-center gap-1 truncate text-left"
           title={absPath}
         >

--- a/packages/client/src/components/McpStatusBadge.tsx
+++ b/packages/client/src/components/McpStatusBadge.tsx
@@ -1,4 +1,5 @@
 import { useMcpStore } from "../store/mcp-store";
+import { useUiStore } from "../store/ui-store";
 
 /**
  * Compact MCP connection-status indicator for the App header. Reads
@@ -6,6 +7,10 @@ import { useMcpStore } from "../store/mcp-store";
  * Settings tab — see store doc-comment). Renders nothing when MCP is
  * enabled but no servers are configured, so deployments that don't
  * use MCP get a clean header.
+ *
+ * Click opens Settings → MCP via the same ui-store request the
+ * `/mcp` slash command uses, so the badge doubles as a one-click
+ * jump to the configuration surface.
  *
  * Color rules:
  *   - emerald: every configured server is connected
@@ -15,6 +20,7 @@ import { useMcpStore } from "../store/mcp-store";
  */
 export function McpStatusBadge() {
   const data = useMcpStore((s) => s.settings);
+  const openSettings = useUiStore((s) => s.openSettings);
   if (data === undefined) return null;
   if (data.total === 0 && data.enabled) return null;
 
@@ -32,16 +38,18 @@ export function McpStatusBadge() {
 
   const label = !enabled ? "MCP off" : `MCP ${connected}/${total}`;
   const title = !enabled
-    ? "MCP tools disabled. Enable in Settings → MCP."
-    : `${connected} of ${total} MCP server(s) connected. Open Settings → MCP for details.`;
+    ? "MCP tools disabled. Click to open Settings → MCP."
+    : `${connected} of ${total} MCP server(s) connected. Click to open Settings → MCP.`;
 
   return (
-    <span
-      className="inline-flex items-center gap-1.5 rounded-md border border-neutral-700 px-2 py-1 text-xs text-neutral-300"
+    <button
+      type="button"
+      onClick={() => openSettings("mcp")}
+      className="inline-flex items-center gap-1.5 rounded-md border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:border-neutral-500 hover:text-neutral-100"
       title={title}
     >
       <span className={`h-2 w-2 rounded-full ${dotClass}`} />
       {label}
-    </span>
+    </button>
   );
 }

--- a/packages/client/src/components/ProjectPicker.tsx
+++ b/packages/client/src/components/ProjectPicker.tsx
@@ -87,6 +87,14 @@ export function ProjectPicker({ onClose, required = false }: Props) {
 
   const select = async (selected: string): Promise<void> => {
     if (submitting) return;
+    // Refuse the workspace root itself as a project folder. Pi-workbench
+    // expects each project to be a sub-tree of WORKSPACE_PATH; the
+    // root is the boundary, not a project. Picking it would let the
+    // agent see every other project's files in one session.
+    if (workspaceRoot.length > 0 && selected === workspaceRoot) {
+      setError("workspace_root_not_allowed");
+      return;
+    }
     setSubmitting(true);
     setError(undefined);
     try {
@@ -254,8 +262,15 @@ export function ProjectPicker({ onClose, required = false }: Props) {
                   </button>
                   <button
                     onClick={() => path && void select(path)}
-                    disabled={!path || submitting}
+                    disabled={
+                      !path || submitting || (workspaceRoot.length > 0 && path === workspaceRoot)
+                    }
                     className="rounded-md bg-neutral-100 px-3 py-2 text-sm font-medium text-neutral-900 disabled:opacity-50"
+                    title={
+                      workspaceRoot.length > 0 && path === workspaceRoot
+                        ? "Pick a sub-folder — the workspace root itself can't be a project."
+                        : "Use this folder as the project root"
+                    }
                   >
                     Select this folder
                   </button>
@@ -269,15 +284,17 @@ export function ProjectPicker({ onClose, required = false }: Props) {
           <p className="mt-3 text-sm text-red-400">
             {error === "path_not_allowed"
               ? "That folder is outside the workspace root."
-              : error === "not_a_directory"
-                ? "That path is not a directory."
-                : error === "already_exists"
-                  ? "A folder with that name already exists."
-                  : error === "duplicate_path"
-                    ? "Another project already points at that folder."
-                    : error === "network_error"
-                      ? "Couldn't reach the server."
-                      : `Error: ${error}`}
+              : error === "workspace_root_not_allowed"
+                ? "Pick a sub-folder — the workspace root itself can't be a project."
+                : error === "not_a_directory"
+                  ? "That path is not a directory."
+                  : error === "already_exists"
+                    ? "A folder with that name already exists."
+                    : error === "duplicate_path"
+                      ? "Another project already points at that folder."
+                      : error === "network_error"
+                        ? "Couldn't reach the server."
+                        : `Error: ${error}`}
           </p>
         )}
       </div>

--- a/packages/client/src/components/ProjectSidebar.tsx
+++ b/packages/client/src/components/ProjectSidebar.tsx
@@ -151,14 +151,14 @@ export function ProjectSidebar() {
                 )}
                 <button
                   onClick={() => void handleNewSession(p.id)}
-                  className="invisible inline-flex p-1 text-neutral-500 hover:text-neutral-200 group-hover:visible"
+                  className="inline-flex p-1 text-neutral-500 hover:text-neutral-200"
                   title="New session in this project"
                 >
                   <Plus size={16} />
                 </button>
                 <button
                   onClick={() => handleDelete(p.id, p.name)}
-                  className="invisible inline-flex items-center p-1 text-neutral-500 hover:text-red-400 group-hover:visible"
+                  className="inline-flex items-center p-1 text-neutral-500 hover:text-red-400"
                   title="Delete project (blocked while live sessions exist)"
                 >
                   <X size={16} />

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -55,18 +55,46 @@ export function SessionList({ projectId }: Props) {
    * confirm = gone, end of story.
    */
   const [deleteDialog, setDeleteDialog] = useState<
-    { sessionId: string; label: string; isLive: boolean } | undefined
+    | { kind: "single"; sessionId: string; label: string; isLive: boolean }
+    | { kind: "many"; sessionIds: string[] }
+    | undefined
   >(undefined);
+
+  // Selected session ids for the multiselect / bulk-delete affordance.
+  // Cmd/Ctrl+click on a session row toggles selection; plain click
+  // selects the session as before.
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const clearSelection = (): void => setSelectedIds(new Set());
+  const toggleSelected = (sessionId: string): void => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(sessionId)) next.delete(sessionId);
+      else next.add(sessionId);
+      return next;
+    });
+  };
 
   const submitDelete = async (): Promise<void> => {
     if (deleteDialog === undefined) return;
-    const { sessionId } = deleteDialog;
     setDeleteDialog(undefined);
     // hard:true unconditionally — server's DELETE route handles the
     // live + hard case by disposing the in-memory entry AND
     // removing the on-disk JSONL atomically. The route's docs spell
     // out the full matrix; we always pick the "actually delete" leg.
-    void disposeSession(sessionId, { hard: true });
+    if (deleteDialog.kind === "single") {
+      void disposeSession(deleteDialog.sessionId, { hard: true });
+      return;
+    }
+    for (const id of deleteDialog.sessionIds) {
+      try {
+        await disposeSession(id, { hard: true });
+      } catch {
+        // store.error renders the first failure; keep going so a
+        // single missing/blocked session doesn't strand the rest of
+        // the bulk action.
+      }
+    }
+    clearSelection();
   };
 
   useEffect(() => {
@@ -118,8 +146,28 @@ export function SessionList({ projectId }: Props) {
       {sessions.length === 0 && (
         <p className="px-2 py-1 text-xs italic text-neutral-600">No sessions yet.</p>
       )}
+      {selectedIds.size > 0 && (
+        <div className="flex items-center justify-between gap-2 rounded bg-neutral-900/60 px-2 py-1 text-[11px] text-neutral-300">
+          <span>{selectedIds.size} selected</span>
+          <div className="flex gap-1">
+            <button
+              onClick={() => setDeleteDialog({ kind: "many", sessionIds: Array.from(selectedIds) })}
+              className="rounded border border-red-700/50 px-1.5 py-0.5 text-red-300 hover:bg-red-900/20"
+            >
+              Delete
+            </button>
+            <button
+              onClick={clearSelection}
+              className="rounded border border-neutral-700 px-1.5 py-0.5 text-neutral-300 hover:border-neutral-500"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      )}
       {sessions.map((s) => {
         const isActive = s.sessionId === activeSessionId;
+        const isSelected = selectedIds.has(s.sessionId);
         const label =
           s.name ??
           (s.firstMessage.length > 0
@@ -130,9 +178,11 @@ export function SessionList({ projectId }: Props) {
           <div
             key={s.sessionId}
             className={`group flex items-center gap-1 rounded px-2 py-0.5 text-xs ${
-              isActive
-                ? "bg-neutral-800 text-neutral-100"
-                : "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
+              isSelected
+                ? "bg-emerald-900/20 text-neutral-100"
+                : isActive
+                  ? "bg-neutral-800 text-neutral-100"
+                  : "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
             }`}
           >
             {isRenaming ? (
@@ -148,10 +198,19 @@ export function SessionList({ projectId }: Props) {
               />
             ) : (
               <button
-                onClick={() => selectSession(s.sessionId)}
+                onClick={(e) => {
+                  // Cmd/Ctrl+click toggles selection without switching
+                  // the active session, so the user can build up a
+                  // selection for bulk delete without page churn.
+                  if (e.metaKey || e.ctrlKey) {
+                    toggleSelected(s.sessionId);
+                    return;
+                  }
+                  selectSession(s.sessionId);
+                }}
                 onDoubleClick={() => startRename(s.sessionId, s.name ?? "")}
                 className="flex-1 truncate text-left"
-                title={`${s.sessionId} — double-click to rename`}
+                title={`${s.sessionId} — double-click to rename, Cmd/Ctrl+click to select for bulk delete`}
               >
                 {s.isLive && <span className="mr-1 text-emerald-500">●</span>}
                 {label}
@@ -159,8 +218,15 @@ export function SessionList({ projectId }: Props) {
             )}
             {!isRenaming && (
               <button
-                onClick={() => setDeleteDialog({ sessionId: s.sessionId, label, isLive: s.isLive })}
-                className="invisible inline-flex items-center p-1 text-neutral-500 hover:text-red-400 group-hover:visible"
+                onClick={() =>
+                  setDeleteDialog({
+                    kind: "single",
+                    sessionId: s.sessionId,
+                    label,
+                    isLive: s.isLive,
+                  })
+                }
+                className="inline-flex items-center p-1 text-neutral-500 hover:text-red-400"
                 title={
                   s.isLive
                     ? "Delete session — also kills the live shell"
@@ -177,13 +243,21 @@ export function SessionList({ projectId }: Props) {
         open={deleteDialog !== undefined}
         onClose={() => setDeleteDialog(undefined)}
         onConfirm={() => void submitDelete()}
-        title={`Delete session "${deleteDialog?.label ?? ""}"`}
-        message={
-          deleteDialog?.isLive === true
-            ? `Delete "${deleteDialog.label}"? This kills the live shell AND removes the on-disk JSONL. Cannot be undone.`
-            : `Delete the on-disk JSONL for "${deleteDialog?.label ?? ""}"? Cannot be undone — the file is the only copy.`
+        title={
+          deleteDialog?.kind === "many"
+            ? `Delete ${deleteDialog.sessionIds.length} session${deleteDialog.sessionIds.length === 1 ? "" : "s"}`
+            : `Delete session "${deleteDialog?.label ?? ""}"`
         }
-        primaryLabel="Delete"
+        message={
+          deleteDialog?.kind === "many"
+            ? `Delete the ${deleteDialog.sessionIds.length} selected session${deleteDialog.sessionIds.length === 1 ? "" : "s"}? Live sessions are killed and on-disk JSONLs are removed. Cannot be undone.`
+            : deleteDialog?.kind === "single" && deleteDialog.isLive
+              ? `Delete "${deleteDialog.label}"? This kills the live shell AND removes the on-disk JSONL. Cannot be undone.`
+              : deleteDialog?.kind === "single"
+                ? `Delete the on-disk JSONL for "${deleteDialog.label}"? Cannot be undone — the file is the only copy.`
+                : ""
+        }
+        primaryLabel={deleteDialog?.kind === "many" ? "Delete all" : "Delete"}
         tone="danger"
       />
     </div>

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -1429,6 +1429,21 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
     | undefined
   >(undefined);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Skills export / import state. Kept separate from the config
+  // export/import state above so each section's "last result" message
+  // doesn't bleed into the other.
+  const [lastSkillsExport, setLastSkillsExport] = useState<
+    { filename: string; fileCount: number } | undefined
+  >(undefined);
+  const [lastSkillsImport, setLastSkillsImport] = useState<
+    | {
+        imported: string[];
+        skipped: { name: string; reason: string }[];
+      }
+    | undefined
+  >(undefined);
+  const skillsTarInputRef = useRef<HTMLInputElement>(null);
+  const skillsFolderInputRef = useRef<HTMLInputElement>(null);
 
   const onExport = async (): Promise<void> => {
     onError(undefined);
@@ -1468,6 +1483,49 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
     } finally {
       setBusy(false);
       if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const triggerDownload = (blob: Blob, filename: string): void => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    requestAnimationFrame(() => URL.revokeObjectURL(url));
+  };
+
+  const onExportSkills = async (): Promise<void> => {
+    onError(undefined);
+    setBusy(true);
+    setLastSkillsImport(undefined);
+    try {
+      const { blob, filename, fileCount } = await api.exportSkills();
+      triggerDownload(blob, filename);
+      setLastSkillsExport({ filename, fileCount });
+    } catch (err) {
+      onError(`Skills export failed: ${errorCode(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onImportSkills = async (files: File[]): Promise<void> => {
+    if (files.length === 0) return;
+    onError(undefined);
+    setBusy(true);
+    setLastSkillsExport(undefined);
+    try {
+      const summary = await api.importSkills(files);
+      setLastSkillsImport(summary);
+    } catch (err) {
+      onError(`Skills import failed: ${errorCode(err)}`);
+    } finally {
+      setBusy(false);
+      if (skillsTarInputRef.current) skillsTarInputRef.current.value = "";
+      if (skillsFolderInputRef.current) skillsFolderInputRef.current.value = "";
     }
   };
 
@@ -1549,6 +1607,112 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
               lastImport.skipped.length === 0 && (
                 <p className="italic text-neutral-500">Archive was empty.</p>
               )}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h3 className="mb-2 text-sm font-medium text-neutral-100">Export skills</h3>
+        <p className="mb-3 text-xs text-neutral-400">
+          Downloads a <code className="font-mono">.tar.gz</code> of every file under{" "}
+          <code className="font-mono">~/.pi/agent/skills/</code> — both single-file (
+          <code className="font-mono">{`<name>.md`}</code>) and directory skills (
+          <code className="font-mono">{`<name>/SKILL.md`}</code> + assets) round-trip verbatim.
+        </p>
+        <button
+          onClick={() => void onExportSkills()}
+          disabled={busy}
+          className="rounded border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-xs text-neutral-100 hover:border-neutral-500 disabled:opacity-50"
+        >
+          {busy ? "Working…" : "Download skills archive"}
+        </button>
+        {lastSkillsExport !== undefined && (
+          <p className="mt-2 text-xs text-emerald-400">
+            Exported <code className="font-mono">{lastSkillsExport.filename}</code> (
+            {lastSkillsExport.fileCount === 0
+              ? "no skills on disk"
+              : `${lastSkillsExport.fileCount} file${lastSkillsExport.fileCount === 1 ? "" : "s"} packed`}
+            )
+          </p>
+        )}
+      </section>
+
+      <section>
+        <h3 className="mb-2 text-sm font-medium text-neutral-100">Import skills</h3>
+        <p className="mb-3 text-xs text-neutral-400">
+          Restore skills from a previously-exported <code className="font-mono">.tar.gz</code>, OR
+          upload a folder of skill files directly. Existing files at the same path are{" "}
+          <strong>overwritten</strong>; new files are added. Path traversal and absolute paths are
+          rejected.
+        </p>
+        <div className="space-y-3">
+          <label className="block space-y-1">
+            <span className="text-[11px] uppercase tracking-wider text-neutral-500">
+              From tar.gz
+            </span>
+            <input
+              ref={skillsTarInputRef}
+              type="file"
+              accept=".gz,.tgz,application/gzip,application/x-gzip"
+              disabled={busy}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file !== undefined) void onImportSkills([file]);
+              }}
+              className="block text-xs text-neutral-300 file:mr-3 file:rounded file:border file:border-neutral-700 file:bg-neutral-900 file:px-3 file:py-1.5 file:text-xs file:text-neutral-100 hover:file:border-neutral-500 disabled:opacity-50"
+            />
+          </label>
+          <label className="block space-y-1">
+            <span className="text-[11px] uppercase tracking-wider text-neutral-500">
+              From folder (Chromium / WebKit only)
+            </span>
+            <input
+              ref={skillsFolderInputRef}
+              type="file"
+              multiple
+              // `webkitdirectory` lets the user pick a directory; the
+              // browser sends each contained file as a separate
+              // multipart entry with the relative path in
+              // `webkitRelativePath`. Firefox doesn't implement this
+              // attribute — fall back to the tar.gz path above.
+              {...({ webkitdirectory: "" } as Record<string, string>)}
+              disabled={busy}
+              onChange={(e) => {
+                const files = e.target.files;
+                if (files === null || files.length === 0) return;
+                void onImportSkills(Array.from(files));
+              }}
+              className="block text-xs text-neutral-300 file:mr-3 file:rounded file:border file:border-neutral-700 file:bg-neutral-900 file:px-3 file:py-1.5 file:text-xs file:text-neutral-100 hover:file:border-neutral-500 disabled:opacity-50"
+            />
+          </label>
+        </div>
+        {lastSkillsImport !== undefined && (
+          <div className="mt-3 space-y-1 text-xs">
+            {lastSkillsImport.imported.length > 0 && (
+              <p className="text-emerald-400">
+                Imported {lastSkillsImport.imported.length} file
+                {lastSkillsImport.imported.length === 1 ? "" : "s"}:{" "}
+                <code className="font-mono">{lastSkillsImport.imported.join(", ")}</code>
+              </p>
+            )}
+            {lastSkillsImport.skipped.length > 0 && (
+              <div className="text-amber-400">
+                <p>
+                  Skipped {lastSkillsImport.skipped.length} entr
+                  {lastSkillsImport.skipped.length === 1 ? "y" : "ies"}:
+                </p>
+                <ul className="ml-4 list-disc">
+                  {lastSkillsImport.skipped.map((s) => (
+                    <li key={s.name}>
+                      <code className="font-mono">{s.name}</code> ({s.reason})
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {lastSkillsImport.imported.length === 0 && lastSkillsImport.skipped.length === 0 && (
+              <p className="italic text-neutral-500">No files were imported.</p>
+            )}
           </div>
         )}
       </section>

--- a/packages/client/src/components/TerminalPanel.tsx
+++ b/packages/client/src/components/TerminalPanel.tsx
@@ -132,7 +132,7 @@ export function TerminalPanel() {
                 </button>
                 <button
                   onClick={() => onCloseTab(t.id)}
-                  className="rounded p-1 text-neutral-600 opacity-0 hover:bg-neutral-800 hover:text-neutral-200 group-hover:opacity-100"
+                  className="rounded p-1 text-neutral-600 hover:bg-neutral-800 hover:text-neutral-200"
                   title="Close terminal (kills the PTY)"
                 >
                   <X size={16} />
@@ -419,7 +419,13 @@ function TerminalHost({
     <div
       ref={hostRef}
       onClick={onHostClick}
-      className="absolute inset-0"
+      // Left offset so text doesn't sit flush against the pane edge.
+      // Using `left-2` instead of `pl-2` because the host is the
+      // xterm parent — fit-addon reads its padding-box width to
+      // compute cols, so padding would cause horizontal overflow.
+      // An absolute offset shrinks the box xterm sees, which is what
+      // we want.
+      className="absolute inset-y-0 left-2 right-0"
       // `visibility: hidden` instead of `display: none` so every host
       // keeps real layout dimensions whether or not it's the active
       // tab. That way fit() always reads the correct cols/rows on

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1358,6 +1358,77 @@ export const api = {
     );
   },
 
+  /**
+   * Download a `.tar.gz` of the skills directory (`${piConfigDir}/
+   * skills/`). Same blob+filename shape as `exportConfig` so the
+   * download trigger logic in the UI can be shared.
+   */
+  exportSkills: async (): Promise<{ blob: Blob; filename: string; fileCount: number }> => {
+    const headers: Record<string, string> = {};
+    const stored = getStoredToken();
+    if (stored !== undefined) headers.Authorization = `Bearer ${stored.token}`;
+    const res = await fetch("/api/v1/config/skills/export", { headers });
+    if (res.status === 401) {
+      clearStoredToken();
+      window.dispatchEvent(new Event(UNAUTHORIZED_EVENT));
+      throw new ApiError(401, "unauthorized");
+    }
+    if (!res.ok) {
+      let code = "request_failed";
+      try {
+        const body = (await res.json()) as { error?: unknown };
+        if (typeof body.error === "string") code = body.error;
+      } catch {
+        // body wasn't JSON — keep generic code
+      }
+      throw new ApiError(res.status, code);
+    }
+    const blob = await res.blob();
+    const cd = res.headers.get("Content-Disposition") ?? "";
+    const filename = parseContentDispositionFilename(cd) ?? "pi-workbench-skills.tar.gz";
+    const countHeader = res.headers.get("X-Pi-Workbench-File-Count") ?? "0";
+    const fileCount = Number.parseInt(countHeader, 10) || 0;
+    return { blob, filename, fileCount };
+  },
+
+  /**
+   * Upload skills to the server. Accepts either a single tar.gz
+   * (auto-detected by `.tar.gz` / `.tgz` suffix) OR a list of files
+   * from a folder picker (`<input webkitdirectory>`); each file's
+   * `webkitRelativePath` is sent as the multipart `filename` so the
+   * server can preserve directory shape inside the skills tree.
+   * Existing files at colliding paths are overwritten.
+   */
+  importSkills: (
+    files: File[],
+  ): Promise<{
+    imported: string[];
+    skipped: { name: string; reason: string }[];
+  }> => {
+    const fd = new FormData();
+    for (const f of files) {
+      // `webkitRelativePath` is non-empty only for entries from a
+      // directory picker. Falls back to `f.name` for plain file
+      // pickers (the tar.gz case).
+      const relPath = (f as File & { webkitRelativePath?: string }).webkitRelativePath;
+      const name = relPath !== undefined && relPath.length > 0 ? relPath : f.name;
+      fd.append("file", f, name);
+    }
+    return request(
+      "/api/v1/config/skills/import",
+      (v) => {
+        if (!isObject(v) || !Array.isArray(v.imported) || !Array.isArray(v.skipped)) {
+          throw new ApiError(0, "invalid_response_body");
+        }
+        return v as {
+          imported: string[];
+          skipped: { name: string; reason: string }[];
+        };
+      },
+      { method: "POST", body: fd },
+    );
+  },
+
   // ---------------- files ----------------
   filesTree: (projectId: string, maxDepth?: number) => {
     const qs = new URLSearchParams({ projectId });
@@ -1388,8 +1459,9 @@ export const api = {
       method: "POST",
       body: { projectId, src, dest },
     }),
-  filesDelete: (projectId: string, path: string) => {
+  filesDelete: (projectId: string, path: string, opts?: { recursive?: boolean }) => {
     const qs = new URLSearchParams({ projectId, path });
+    if (opts?.recursive === true) qs.set("recursive", "true");
     return request(`/api/v1/files/delete?${qs.toString()}`, vVoid, { method: "DELETE" });
   },
   /**

--- a/packages/client/src/store/file-store.ts
+++ b/packages/client/src/store/file-store.ts
@@ -126,6 +126,9 @@ interface FileState {
   /** Clear `pendingNav` on a tab after the editor has consumed it. */
   consumePendingNav: (path: string) => void;
   closeFile: (path: string) => void;
+  /** Close every open editor tab. Persisted state for the active
+   *  project is also cleared so a reload doesn't reopen them. */
+  closeAllFiles: () => void;
   setActiveFile: (path: string | undefined) => void;
   updateDraft: (path: string, draft: string) => void;
   saveFile: (projectId: string, path: string) => Promise<void>;
@@ -182,7 +185,11 @@ interface FileState {
    * editor stays open without a flash.
    */
   moveEntry: (projectId: string, srcAbsPath: string, destAbsPath: string) => Promise<string>;
-  deleteEntry: (projectId: string, absPath: string) => Promise<void>;
+  deleteEntry: (
+    projectId: string,
+    absPath: string,
+    opts?: { recursive?: boolean },
+  ) => Promise<void>;
 }
 
 export const EMPTY_OPEN_FILES: OpenFile[] = [];
@@ -318,6 +325,14 @@ export const useFileStore = create<FileState>((set, get) => ({
       const ext = { ...s.externallyChanged };
       delete ext[path];
       const result = { openFiles: next, activePath, externallyChanged: ext };
+      persist(currentProjectId, result);
+      return result;
+    });
+  },
+
+  closeAllFiles: () => {
+    set(() => {
+      const result = { openFiles: [], activePath: undefined, externallyChanged: {} };
       persist(currentProjectId, result);
       return result;
     });
@@ -499,11 +514,19 @@ export const useFileStore = create<FileState>((set, get) => ({
     }
   },
 
-  deleteEntry: async (projectId, absPath) => {
+  deleteEntry: async (projectId, absPath, opts) => {
     set({ error: undefined });
     try {
-      await api.filesDelete(projectId, absPath);
-      // Close any tab the user had open on this path.
+      await api.filesDelete(
+        projectId,
+        absPath,
+        opts?.recursive === true ? { recursive: true } : undefined,
+      );
+      // Close any tab the user had open on this path. For recursive
+      // dir delete we'd ideally also close any child-of-absPath tabs;
+      // those will surface "file_not_found" on the next save / reload
+      // and the user can close them — keeping the tab close logic
+      // simple here.
       const open = get().openFiles.find((f) => f.path === absPath);
       if (open !== undefined) get().closeFile(absPath);
       await get().loadTree(projectId);

--- a/packages/client/src/store/file-store.ts
+++ b/packages/client/src/store/file-store.ts
@@ -49,6 +49,54 @@ export interface OpenFile {
   pendingNav?: { line: number; column?: number };
 }
 
+/**
+ * sessionStorage key for the per-project editor tab list. Same
+ * persistence posture as the terminal store: per-browser-tab so
+ * sibling tabs don't fight over the same UI state. Survives
+ * in-tab reload, doesn't bleed across browser tabs.
+ *
+ * Stored shape: `{ paths: string[]; activePath: string | null }`.
+ * Per-project key so switching projects doesn't pull the previous
+ * project's files into view.
+ */
+const TABS_KEY_PREFIX = "pi.editor.tabs.v1:";
+
+interface PersistedTabs {
+  paths: string[];
+  activePath: string | null;
+}
+
+function readPersistedTabs(projectId: string): PersistedTabs {
+  try {
+    const raw = sessionStorage.getItem(TABS_KEY_PREFIX + projectId);
+    if (raw === null) return { paths: [], activePath: null };
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return { paths: [], activePath: null };
+    const obj = parsed as { paths?: unknown; activePath?: unknown };
+    const paths = Array.isArray(obj.paths)
+      ? obj.paths.filter((p): p is string => typeof p === "string")
+      : [];
+    const activePath = typeof obj.activePath === "string" ? obj.activePath : null;
+    return {
+      paths,
+      activePath: paths.includes(activePath ?? "") ? activePath : (paths[0] ?? null),
+    };
+  } catch {
+    return { paths: [], activePath: null };
+  }
+}
+
+function writePersistedTabs(projectId: string, paths: string[], activePath: string | undefined) {
+  try {
+    sessionStorage.setItem(
+      TABS_KEY_PREFIX + projectId,
+      JSON.stringify({ paths, activePath: activePath ?? null }),
+    );
+  } catch {
+    // ignore — choice still applies for this tab session
+  }
+}
+
 interface FileState {
   /** Most-recently-fetched tree, keyed by projectId. */
   treeByProject: Record<string, FileTreeNode | undefined>;
@@ -62,6 +110,14 @@ interface FileState {
   error: string | undefined;
 
   loadTree: (projectId: string) => Promise<void>;
+  /**
+   * Re-open every tab persisted for `projectId` in sessionStorage and
+   * restore the active path. No-op if tabs are already open (avoids
+   * double-restore when called twice for the same project). Failures
+   * to read individual files are silently dropped — a file that's
+   * been deleted since persist time just doesn't reappear.
+   */
+  restoreTabs: (projectId: string) => Promise<void>;
   openFile: (
     projectId: string,
     absPath: string,
@@ -131,6 +187,24 @@ interface FileState {
 
 export const EMPTY_OPEN_FILES: OpenFile[] = [];
 
+// Module-level pointer to the project the open tabs belong to.
+// Updated whenever openFile is called; consumed by closeFile /
+// setActiveFile so they know which sessionStorage key to write to
+// without dragging projectId through every callsite.
+let currentProjectId: string | undefined;
+
+function persist(
+  projectId: string | undefined,
+  state: { openFiles: OpenFile[]; activePath: string | undefined },
+) {
+  if (projectId === undefined) return;
+  writePersistedTabs(
+    projectId,
+    state.openFiles.map((f) => f.path),
+    state.activePath,
+  );
+}
+
 export const useFileStore = create<FileState>((set, get) => ({
   treeByProject: {},
   treeLoading: {},
@@ -155,19 +229,52 @@ export const useFileStore = create<FileState>((set, get) => ({
     }
   },
 
+  restoreTabs: async (projectId) => {
+    currentProjectId = projectId;
+    // Skip if anything is already open for this project — the
+    // restore is meant for the cold-boot path, not to clobber
+    // mid-session state.
+    if (get().openFiles.length > 0) return;
+    const persisted = readPersistedTabs(projectId);
+    if (persisted.paths.length === 0) return;
+    // Open files in order so the tab strip matches the persisted
+    // layout. Each openFile awaits the server fetch; if a file
+    // 404s (deleted since persist time), we drop it and continue.
+    for (const path of persisted.paths) {
+      try {
+        await get().openFile(projectId, path);
+      } catch {
+        // Silently skip — the server-side miss is the expected
+        // outcome for files that no longer exist; we don't want a
+        // stale tab list to block the rest of the restore.
+      }
+    }
+    if (persisted.activePath !== null) {
+      get().setActiveFile(persisted.activePath);
+    }
+  },
+
   openFile: async (projectId, absPath, nav) => {
+    currentProjectId = projectId;
     // If already open, just activate. When `nav` is supplied, also
     // patch the existing tab so the editor scrolls to the requested
     // line on its next render.
     const existing = get().openFiles.find((f) => f.path === absPath);
     if (existing !== undefined) {
       if (nav !== undefined) {
-        set((s) => ({
-          openFiles: s.openFiles.map((f) => (f.path === absPath ? { ...f, pendingNav: nav } : f)),
-          activePath: absPath,
-        }));
+        set((s) => {
+          const next = {
+            openFiles: s.openFiles.map((f) => (f.path === absPath ? { ...f, pendingNav: nav } : f)),
+            activePath: absPath,
+          };
+          persist(currentProjectId, next);
+          return next;
+        });
       } else {
-        set({ activePath: absPath });
+        set((s) => {
+          persist(currentProjectId, { openFiles: s.openFiles, activePath: absPath });
+          return { activePath: absPath };
+        });
       }
       return;
     }
@@ -188,10 +295,14 @@ export const useFileStore = create<FileState>((set, get) => ({
         loadingError: r.binary ? "Binary file — open externally to edit." : undefined,
       };
       if (nav !== undefined) tab.pendingNav = nav;
-      set((s) => ({
-        openFiles: [...s.openFiles, tab],
-        activePath: absPath,
-      }));
+      set((s) => {
+        const next = {
+          openFiles: [...s.openFiles, tab],
+          activePath: absPath,
+        };
+        persist(currentProjectId, next);
+        return next;
+      });
     } catch (err) {
       set({ error: err instanceof ApiError ? err.code : (err as Error).message });
     }
@@ -206,11 +317,17 @@ export const useFileStore = create<FileState>((set, get) => ({
         s.activePath === path ? (next[idx] ?? next[idx - 1] ?? next[0])?.path : s.activePath;
       const ext = { ...s.externallyChanged };
       delete ext[path];
-      return { openFiles: next, activePath, externallyChanged: ext };
+      const result = { openFiles: next, activePath, externallyChanged: ext };
+      persist(currentProjectId, result);
+      return result;
     });
   },
 
-  setActiveFile: (path) => set({ activePath: path }),
+  setActiveFile: (path) =>
+    set((s) => {
+      persist(currentProjectId, { openFiles: s.openFiles, activePath: path });
+      return { activePath: path };
+    }),
 
   consumePendingNav: (path) => {
     set((s) => ({

--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -686,7 +686,11 @@ export async function moveEntry(
 
 /* ----------------------------- delete ----------------------------- */
 
-export async function deleteEntry(absPath: string, root: string): Promise<void> {
+export async function deleteEntry(
+  absPath: string,
+  root: string,
+  opts?: { recursive?: boolean },
+): Promise<void> {
   const resolved = await verifyPathSafe(absPath, root);
   // Defense in depth: never let a delete reach the project root itself
   // even if it slips past assertInsideRoot's "equal-to-root" allowance.
@@ -696,9 +700,15 @@ export async function deleteEntry(absPath: string, root: string): Promise<void> 
   const st = await stat(resolved).catch(() => undefined);
   if (st === undefined) throw new NotFoundError(resolved);
   if (st.isDirectory()) {
-    // We don't recursively force-delete. Empty-dir delete is fine; non-empty
-    // surfaces a clear error so the UI can ask the user to clean up first.
-    // The dev plan explicitly calls this out as a deliberate non-feature.
+    // Empty dirs are always safe to remove. Non-empty dirs require an
+    // explicit `recursive: true` from the caller — the route plumbs
+    // this from a `?recursive=true` query param which the UI sets only
+    // after a second confirmation prompt. Without the flag, a non-
+    // empty dir surfaces DirectoryNotEmptyError so the UI can prompt.
+    if (opts?.recursive === true) {
+      await rm(resolved, { recursive: true, force: false });
+      return;
+    }
     try {
       await rmdir(resolved);
     } catch (err) {

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -17,6 +17,12 @@ import {
 } from "../config-manager.js";
 import { buildExportTar, importConfigFromBuffer, MAX_IMPORT_BYTES } from "../config-export.js";
 import {
+  buildSkillsExportTar,
+  importSkillsFromFiles,
+  importSkillsFromTar,
+  MAX_SKILLS_IMPORT_BYTES,
+} from "../skills-export.js";
+import {
   ensureProjectLoaded as mcpEnsureProjectLoaded,
   getStatus as mcpGetStatus,
 } from "../mcp/manager.js";
@@ -675,6 +681,143 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
       }
       try {
         const summary = await importConfigFromBuffer(buf);
+        return summary;
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  // ---------------------- skills export / import ----------------------
+  // Skills tree export. Streams a tar.gz of every file under
+  // `${piConfigDir}/skills/` — single-file skills (`<name>.md`) and
+  // directory skills (`<name>/SKILL.md` plus assets) round-trip
+  // verbatim. Empty exports are valid (zero-entry tar) so the route
+  // doesn't 404 on a fresh install.
+  fastify.get(
+    "/config/skills/export",
+    {
+      schema: {
+        description:
+          "Stream a `.tar.gz` of every file under `${piConfigDir}/skills/`. " +
+          "Single-file (`<name>.md`) and directory skills (`<name>/SKILL.md` + " +
+          "assets) both round-trip. Empty trees produce a zero-entry tar — " +
+          "consumers should accept that.",
+        tags: ["config"],
+        response: {
+          200: {
+            description: "gzip-compressed tar of the skills directory contents",
+            type: "string",
+            format: "binary",
+          },
+          500: errorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      try {
+        const { fileCount, stream } = await buildSkillsExportTar();
+        const ts = new Date().toISOString().replace(/[:.]/g, "-");
+        reply
+          .header("Content-Type", "application/gzip")
+          .header("Content-Disposition", `attachment; filename="pi-workbench-skills-${ts}.tar.gz"`)
+          .header("X-Pi-Workbench-File-Count", String(fileCount));
+        return reply.send(stream);
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  // Skills tree import. Two shapes accepted:
+  //   1. A single multipart file part — server treats it as a tar.gz
+  //      and delegates to `importSkillsFromTar`.
+  //   2. Multiple multipart file parts — typical of an
+  //      `<input webkitdirectory>` folder pick. Each part's `filename`
+  //      carries the relative path inside the picked folder; server
+  //      writes each into the skills tree after the path-safety
+  //      filter.
+  // The route auto-detects: if exactly one part is present AND its
+  // filename ends in `.tar.gz` / `.tgz`, it's treated as a tar; in any
+  // other case the parts are imported as discrete files.
+  fastify.post(
+    "/config/skills/import",
+    {
+      schema: {
+        description:
+          "Restore a skills tar.gz OR upload a folder of skill files. " +
+          "Tar.gz path: must contain only relative paths under the skills " +
+          "directory; absolute paths and `..` traversal are rejected. " +
+          "Folder upload path: each multipart `filename` is treated as a " +
+          "relative path inside the skills tree (same safety filter). " +
+          "Existing files at colliding paths are overwritten.",
+        tags: ["config"],
+        consumes: ["multipart/form-data"],
+        response: {
+          200: {
+            type: "object",
+            required: ["imported", "skipped"],
+            properties: {
+              imported: { type: "array", items: { type: "string" } },
+              skipped: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["name", "reason"],
+                  properties: {
+                    name: { type: "string" },
+                    reason: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+          400: errorSchema,
+          413: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req: FastifyRequest, reply) => {
+      // Collect every multipart file part up front. We need to know the
+      // count + filenames before deciding tar-vs-folder, so we buffer
+      // each part's bytes (capped per-part by the multipart limit) and
+      // then dispatch to the right importer.
+      const parts: { filename: string; buffer: Buffer }[] = [];
+      try {
+        const iter = req.files({ limits: { fileSize: MAX_SKILLS_IMPORT_BYTES } });
+        for await (const f of iter) {
+          if (f.file.truncated) {
+            return reply.code(413).send({
+              error: "file_too_large",
+              message: `part "${f.filename}" exceeds ${MAX_SKILLS_IMPORT_BYTES} bytes`,
+            });
+          }
+          const buf = await f.toBuffer();
+          if (f.file.truncated) {
+            return reply.code(413).send({
+              error: "file_too_large",
+              message: `part "${f.filename}" exceeds ${MAX_SKILLS_IMPORT_BYTES} bytes`,
+            });
+          }
+          parts.push({ filename: f.filename, buffer: buf });
+        }
+      } catch (err) {
+        return reply.code(400).send({
+          error: "invalid_multipart",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+      if (parts.length === 0) {
+        return reply.code(400).send({ error: "no_file" });
+      }
+      try {
+        const isTarball =
+          parts.length === 1 &&
+          (parts[0]!.filename.endsWith(".tar.gz") || parts[0]!.filename.endsWith(".tgz"));
+        const summary = isTarball
+          ? await importSkillsFromTar(parts[0]!.buffer)
+          : await importSkillsFromFiles(parts);
         return summary;
       } catch (err) {
         return internalError(reply, err);

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -600,15 +600,16 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
   );
 
-  fastify.delete<{ Querystring: { projectId: string; path: string } }>(
+  fastify.delete<{ Querystring: { projectId: string; path: string; recursive?: string } }>(
     "/files/delete",
     {
       schema: {
         description:
-          "Delete a file or empty directory. Non-empty directories return " +
-          "409 — recursive delete is intentionally NOT supported (single-user " +
-          "single-tenant: an accidental rm -rf is a worse failure mode than " +
-          "a mildly inconvenient extra step).",
+          "Delete a file or directory. Empty directories delete unconditionally. " +
+          "Non-empty directories return 409 unless `?recursive=true` is set, in " +
+          "which case the entire subtree is removed. The UI prompts the user with " +
+          "a second confirmation before retrying with the recursive flag — single- " +
+          "user single-tenant, but `rm -rf` should still be an explicit choice.",
         tags: ["files"],
         querystring: {
           type: "object",
@@ -616,6 +617,7 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
           properties: {
             projectId: { type: "string", minLength: 1 },
             path: { type: "string", minLength: 1 },
+            recursive: { type: "string", enum: ["true", "false"] },
           },
         },
         response: {
@@ -632,7 +634,8 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
       const project = await resolveProject(req.query.projectId, reply);
       if (project === undefined) return;
       try {
-        await deleteEntry(req.query.path, project.path);
+        const recursive = req.query.recursive === "true";
+        await deleteEntry(req.query.path, project.path, { recursive });
         return reply.code(204).send();
       } catch (err) {
         return mapError(reply, err);

--- a/packages/server/src/skills-export.ts
+++ b/packages/server/src/skills-export.ts
@@ -1,0 +1,263 @@
+/**
+ * Skills export / import as a flat `.tar.gz`.
+ *
+ * What's included: every file under `${piConfigDir}/skills/`. Skills
+ * come in two shapes — single-file (`<name>.md`) or directory
+ * (`<name>/SKILL.md` plus any assets the skill references). The
+ * exporter mirrors the source tree verbatim; the importer extracts
+ * back into the same shape.
+ *
+ * What's deliberately EXCLUDED on import: anything outside the skills
+ * subtree. The tar is rooted AT the skills directory contents (no
+ * leading `skills/` prefix), so an entry like `../auth.json` or
+ * `/etc/passwd` is rejected by the path-safety filter before any
+ * bytes touch disk.
+ *
+ * Two import shapes are supported by the route layer:
+ *   - A single `.tar.gz` upload (this module's `importSkillsFromTar`).
+ *   - A multi-file folder upload (`importSkillsFromFiles`) — when the
+ *     user picks a folder via `<input webkitdirectory>` the browser
+ *     sends one multipart entry per file with the relative path in the
+ *     filename. Same safety rules apply: relative paths only, no
+ *     traversal, regular files only.
+ *
+ * Restore policy: per-file `.tmp` + rename so a partially-uploaded
+ * archive never leaves a half-written file behind. Directories are
+ * created with `recursive: true` as needed. Existing files in the
+ * skills tree are OVERWRITTEN — the export is the source of truth on
+ * restore, mirroring the config-export contract.
+ */
+import { mkdir, mkdtemp, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, normalize, relative, sep } from "node:path";
+import { Readable } from "node:stream";
+import { create as tarCreate, extract as tarExtract } from "tar";
+import { config } from "./config.js";
+
+/**
+ * Hard cap on uploaded archive / folder size. Skills directories are
+ * usually a handful of small markdown files (<100 KB total); 50 MB
+ * accommodates large directory skills with images / scripts while
+ * still bounding accidental or malicious uploads.
+ */
+export const MAX_SKILLS_IMPORT_BYTES = 50 * 1024 * 1024;
+
+function skillsDir(): string {
+  return join(config.piConfigDir, "skills");
+}
+
+export interface SkillsExportResult {
+  /** Number of files actually packed (for the X-header / log line). */
+  fileCount: number;
+  /** Gzipped tar stream — pipe to the HTTP response. */
+  stream: Readable;
+}
+
+export interface SkillsImportSummary {
+  /** Relative paths of files written into the skills directory. */
+  imported: string[];
+  /**
+   * Entries the input contained that we refused. Reasons surface
+   * compactly via the `reason` field — "absolute_path",
+   * "traversal", "non_file", "size_cap".
+   */
+  skipped: { name: string; reason: string }[];
+}
+
+/**
+ * Build the export tar. Skips silently when the skills directory
+ * doesn't exist — empty exports are valid (returns a tar with zero
+ * entries, matching the config-export shape on a fresh install).
+ *
+ * Streams from the source dir directly; no staging copy is needed
+ * because the skills tree is read-only from this module's
+ * perspective (the only writers are the user via the file system or
+ * the import path below, which never overlaps with an in-flight
+ * export).
+ */
+export async function buildSkillsExportTar(): Promise<SkillsExportResult> {
+  const src = skillsDir();
+  let fileCount = 0;
+  let entries: string[] = [];
+  try {
+    entries = await listFilesRelative(src);
+    fileCount = entries.length;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  // tar.create accepts a list of paths relative to `cwd`. An empty
+  // list still produces a valid (empty) gzipped tar.
+  const pack = tarCreate({ gzip: true, cwd: src }, entries);
+  const stream = pack as unknown as Readable;
+  return { fileCount, stream };
+}
+
+/**
+ * Recursive walk; returns POSIX-style relative paths for each
+ * regular file under `dir`. Symlinks are followed via `stat` so a
+ * symlinked file gets included as a regular file (matches the
+ * upstream pi behavior — a skill can be `ln -s`'d in from elsewhere
+ * on the filesystem).
+ */
+async function listFilesRelative(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(current: string): Promise<void> {
+    const ents = await readdir(current, { withFileTypes: true });
+    for (const ent of ents) {
+      const abs = join(current, ent.name);
+      const st = await stat(abs).catch(() => undefined);
+      if (st === undefined) continue;
+      if (st.isDirectory()) {
+        await walk(abs);
+      } else if (st.isFile()) {
+        out.push(relative(dir, abs).split(sep).join("/"));
+      }
+    }
+  }
+  await walk(dir);
+  return out;
+}
+
+/**
+ * Validate a relative path proposed for write. Returns the safe
+ * relative form (using POSIX separators) or `undefined` to reject.
+ *
+ * Rejection reasons (all silent — caller logs the skip):
+ *   - absolute path (Windows or POSIX)
+ *   - parent traversal (`..` segment)
+ *   - leading dot at the path root (`.` / `..` / `.git` / etc.)
+ *   - empty after normalisation
+ */
+function safeRelativePath(name: string): string | undefined {
+  if (name.length === 0) return undefined;
+  // Block absolute paths early. POSIX leading slash and Windows-style
+  // drive letters (`C:\...`) both rejected.
+  if (name.startsWith("/") || name.startsWith("\\") || /^[A-Za-z]:[\\/]/.test(name)) {
+    return undefined;
+  }
+  const normalized = normalize(name).split(sep).join("/");
+  if (normalized.startsWith("../") || normalized === "..") return undefined;
+  if (normalized.split("/").some((seg) => seg === "..")) return undefined;
+  if (normalized.startsWith("./")) return undefined;
+  if (normalized.length === 0 || normalized === ".") return undefined;
+  return normalized;
+}
+
+/**
+ * Extract a tar.gz buffer into the skills directory. Path safety is
+ * enforced by `tar`'s `strict: true` (rejects absolute paths and
+ * `..`) plus our own `filter` callback (final enforcement against
+ * the skills root). Each extracted file is renamed atomically into
+ * place after the tar finishes — partial failures don't leave
+ * mixed state.
+ */
+export async function importSkillsFromTar(buf: Buffer): Promise<SkillsImportSummary> {
+  if (buf.byteLength > MAX_SKILLS_IMPORT_BYTES) {
+    throw new Error(
+      `archive exceeds ${MAX_SKILLS_IMPORT_BYTES} bytes (got ${buf.byteLength}); refusing to import`,
+    );
+  }
+  const stage = await mkdtemp(join(tmpdir(), "pi-skills-import-"));
+  try {
+    const accepted: string[] = [];
+    const skipped: { name: string; reason: string }[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const extractStream = tarExtract({
+        cwd: stage,
+        strict: true,
+        filter: (path, entry) => {
+          const entryType = (entry as { type?: string }).type;
+          if (entryType !== undefined && entryType !== "File") {
+            skipped.push({ name: path, reason: "non_file" });
+            return false;
+          }
+          const safe = safeRelativePath(path);
+          if (safe === undefined) {
+            skipped.push({ name: path, reason: "unsafe_path" });
+            return false;
+          }
+          accepted.push(safe);
+          return true;
+        },
+      });
+      extractStream.on("error", reject);
+      extractStream.on("finish", () => resolve());
+      Readable.from(buf).pipe(extractStream);
+    });
+    return await commitStaged(stage, accepted, skipped);
+  } finally {
+    await rm(stage, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+/**
+ * Write a list of pre-buffered files (e.g. from a folder upload via
+ * `<input webkitdirectory>`) into the skills directory. The browser
+ * gives us one entry per file with `filename` carrying the relative
+ * path inside the user-picked folder. We apply the same path-safety
+ * filter as the tar path.
+ *
+ * Sums each part's size against `MAX_SKILLS_IMPORT_BYTES` so a
+ * many-file folder can't bypass the cap by being split across parts.
+ */
+export async function importSkillsFromFiles(
+  files: { filename: string; buffer: Buffer }[],
+): Promise<SkillsImportSummary> {
+  let total = 0;
+  for (const f of files) total += f.buffer.byteLength;
+  if (total > MAX_SKILLS_IMPORT_BYTES) {
+    throw new Error(
+      `combined files exceed ${MAX_SKILLS_IMPORT_BYTES} bytes (got ${total}); refusing to import`,
+    );
+  }
+  const stage = await mkdtemp(join(tmpdir(), "pi-skills-folder-import-"));
+  try {
+    const accepted: string[] = [];
+    const skipped: { name: string; reason: string }[] = [];
+    for (const f of files) {
+      const safe = safeRelativePath(f.filename);
+      if (safe === undefined) {
+        skipped.push({ name: f.filename, reason: "unsafe_path" });
+        continue;
+      }
+      const dest = join(stage, safe);
+      await mkdir(dirname(dest), { recursive: true });
+      await writeFile(dest, f.buffer);
+      accepted.push(safe);
+    }
+    return await commitStaged(stage, accepted, skipped);
+  } finally {
+    await rm(stage, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+/**
+ * Move every staged file into the skills directory atomically.
+ * Shared by both import paths so the on-disk write contract is
+ * identical regardless of input shape.
+ */
+async function commitStaged(
+  stage: string,
+  accepted: string[],
+  skipped: { name: string; reason: string }[],
+): Promise<SkillsImportSummary> {
+  const dst = skillsDir();
+  await mkdir(dst, { recursive: true });
+  const imported: string[] = [];
+  for (const name of accepted) {
+    const src = join(stage, name);
+    const target = join(dst, name);
+    await mkdir(dirname(target), { recursive: true });
+    const tmpDst = `${target}.${Date.now()}.import.tmp`;
+    try {
+      await rename(src, tmpDst);
+      await rename(tmpDst, target);
+      imported.push(name);
+    } catch (err) {
+      // Best-effort cleanup of the .tmp if rename-into-place failed.
+      await rm(tmpDst, { force: true }).catch(() => undefined);
+      skipped.push({ name, reason: (err as Error).message });
+    }
+  }
+  return { imported, skipped };
+}


### PR DESCRIPTION
## Summary

This branch adds a set of quality-of-life improvements across the workbench UI, project management, file operations, and the settings panel.

### Pane layout & header controls
- **Chat-hidden layout fills the viewport** — when chat is toggled off, the leftmost visible pane becomes `flex-1` and its leading divider is dropped, so two panes fill the full width with a single slider between them (previously left blank space on the right)
- **Editor/Files button order** swapped to match left-to-right pane render order (chat → editor → files)
- **Close-all tabs button** (XSquare) at the left edge of the editor tab bar; confirms before closing when any tab has unsaved changes
- **MCP status badge** is now a button that navigates directly to Settings → MCP
- **Dismissable project picker** — when no projects exist the picker can be dismissed; a "+ New project" link in the empty state re-opens it
- **New-session shortcut** — when a project is selected but no session is active, the chat column shows a "+ New session" button

### UI polish
- Always-visible X/+ buttons in the project sidebar and tab bars (previously required hover to reveal)
- 8 px left inset in the terminal pane so text isn't flush against the edge
- Prompt history now persists all submitted input (agent prose, `/` commands, `!` bash execs) to `localStorage` per session

### Project creation
- Workspace root folder is blocked as a project path — "Select this folder" is disabled when the current path equals `workspaceRoot`

### File & session operations
- **Recursive folder delete with confirmation** — first attempt is non-recursive; on `directory_not_empty` a second dialog opens explaining recursive delete and the confirmed action sends `?recursive=true`
- **Multiselect for files** — Cmd/Ctrl+click toggles rows; a toolbar appears with "Delete selected"
- **Multiselect for sessions** — same pattern in the session list for bulk-delete

### Skills backup (Settings → Backup)
- **Export**: `GET /api/v1/config/skills/export` streams a `.tar.gz` of `${piConfigDir}/skills/`
- **Import**: `POST /api/v1/config/skills/import` accepts a `.tar.gz` archive or a folder upload (`webkitdirectory`); paths are validated (no `..`, no absolute), existing files overwritten atomically

## Test plan

- [ ] Toggle chat off — editor + files should fill full width with one slider; toggle back on restores layout
- [ ] Editor/Files buttons appear in correct order (Editor left of Files)
- [ ] XSquare closes all tabs; dirty-tab confirm fires when applicable
- [ ] Click MCP badge → navigates to Settings → MCP tab
- [ ] With no projects: dismiss picker → empty state shown; click "+ New project" → picker re-opens
- [ ] With project but no session: "+ New session" button creates and navigates to new session
- [ ] Sidebar + and X buttons are always visible (no hover required)
- [ ] Terminal left padding visible; text not flush to edge
- [ ] Submit a `/` command and `!` bash exec, navigate history with up-arrow — both appear
- [ ] Try to select workspace root in folder picker — button disabled
- [ ] Delete a non-empty folder — first attempt shows recursive confirm; second confirm deletes
- [ ] Cmd+click multiple files → toolbar with count; "Delete selected" removes all
- [ ] Cmd+click multiple sessions → toolbar; "Delete selected" removes all
- [ ] Settings → Backup → Export skills → downloads `.tar.gz`
- [ ] Import skills via tar.gz → accepted/skipped counts shown
- [ ] Import skills via folder upload → files land in skills directory
- [ ] `npm run check` passes (typecheck + lint + format)
- [ ] `npm run test:ci` — all 18 tests pass