### PR TITLE
chore(release): v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.0.2] — 2026-05-04
+
 ### Added
 
 - **Pane toggles for chat and editor.** New **Chat** and **Editor**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-workbench",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-workbench",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "workspaces": [
         "packages/*"
       ],
@@ -17268,7 +17268,7 @@
     },
     "packages/client": {
       "name": "@pi-workbench/client",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17311,7 +17311,7 @@
     },
     "packages/server": {
       "name": "@pi-workbench/server",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-workbench",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-workbench/client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-workbench/server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts v1.0.2. The Unreleased section of CHANGELOG.md is dated to 2026-05-04 and version numbers in `package.json`, `packages/server/package.json`, `packages/client/package.json`, and `package-lock.json` are bumped to 1.0.2.

Notable contents (from #18, already merged):
- Pane layout fills viewport when chat hidden; Editor/Files button order swap
- Close-all tabs, MCP badge opens settings, dismissable picker, new-session shortcut
- Always-visible sidebar/tab controls, terminal left padding, prompt history persistence
- Workspace-root folder selection block
- Recursive folder delete with second-confirm dialog
- Multiselect bulk-delete for files and sessions
- Skills export/import as tar.gz

## Test plan

- [ ] After merge: tag from main with \`git tag v1.0.2 && git push origin v1.0.2\`
- [ ] Release workflow builds multi-arch image and creates GitHub Release
- [ ] check-version job passes (tag matches package.json across workspaces)