### PR TITLE
feat: chat copy buttons, model picker default name, swagger auth, session cloning, graph default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,49 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+### Added
+
+- **Copy buttons on chat messages and code blocks.** Each user and
+  assistant message bubble now has a Copy icon next to the
+  raw/rendered toggle that copies the message text to the clipboard.
+  Fenced code blocks rendered by `ChatMarkdown` get an additional
+  hover-revealed Copy button in the top-right corner. Both fall back
+  to a synthetic textarea + `document.execCommand('copy')` when the
+  async clipboard API is unavailable (older Safari, insecure HTTP).
+- **Default model named in the model picker.** The "Use agent
+  default" row in the chat-input model dropdown now shows the
+  resolved provider/model from `settings.json` (e.g. `anthropic /
+  claude-sonnet-4-5 (default)` in the trigger label, monospace name
+  in the dropdown row). The picker now fetches `settings.json`
+  alongside the providers listing.
+- **`API Docs ↗` button in the Settings header.** Opens the
+  OpenAPI / Swagger UI in a new tab and carries the user's auth
+  token across via a one-shot `?token=...` query param. The server-
+  side bootstrap script strips the token from the URL on page load
+  and re-presents it as a Bearer header on every API call swagger
+  UI makes — so logged-in users can explore and exercise the API
+  surface without manually pasting their JWT into the swagger
+  Authorize dialog.
+
+### Changed
+
+- **Forked sessions get disambiguated names.** When a session is
+  forked from another, the new session's name is set to
+  `<source name> (clone)` (or `(clone)` if the source has no
+  explicit name). Subsequent forks within the same project bump the
+  suffix (`(clone) 2`, `(clone) 3`, …) so the sidebar doesn't show
+  multiple identically-named entries.
+
+### Fixed
+
+- **Text selection no longer bleeds across chat message bubbles.**
+  Selection in Safari (and other browsers) was extending past the
+  bubble's rounded border and across adjacent messages, making it
+  impossible to copy a single message cleanly. The chat message
+  list is now `user-select: none` and each `.message-bubble` re-
+  enables `user-select: text` with `isolation: isolate` so each
+  bubble is its own selection root.
+
 ## [1.0.2] — 2026-05-04
 
 ### Added

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -609,6 +609,14 @@ export function ChatInput({ sessionId }: Props) {
   // of relying on useState's mount-only initializer.
   const storageKey = MODEL_KEY_PREFIX + sessionId;
   const [providers, setProviders] = useState<ProvidersListing | undefined>(undefined);
+  // The configured default in `settings.json` ({defaultProvider, defaultModel}).
+  // Fetched once per mount; passed to ModelPicker so the "Use agent default"
+  // row can name the actual model the agent would pick instead of just saying
+  // "default". Undefined while loading; { provider: "", modelId: "" } if the
+  // user hasn't set a default at all.
+  const [defaultModel, setDefaultModel] = useState<
+    { provider: string; modelId: string } | undefined
+  >(undefined);
   const [modelChoice, setModelChoice] = useState<string>(
     () => localStorage.getItem(MODEL_KEY_PREFIX + sessionId) ?? "",
   );
@@ -622,6 +630,20 @@ export function ChatInput({ sessionId }: Props) {
         // Surface as a non-fatal hint; chat still works with the default model.
         const code = err instanceof ApiError ? err.code : (err as Error).message;
         setModelError(`models unavailable (${code})`);
+      });
+    // settings.json — split fetch from providers because the picker UI
+    // needs to render even when settings is empty / missing.
+    void api
+      .getSettings()
+      .then((s) => {
+        setDefaultModel({
+          provider: typeof s.defaultProvider === "string" ? s.defaultProvider : "",
+          modelId: typeof s.defaultModel === "string" ? s.defaultModel : "",
+        });
+      })
+      .catch(() => {
+        // Settings unreadable — keep defaultModel undefined; the picker
+        // gracefully falls back to "Use agent default" with no name.
       });
   }, []);
 
@@ -1060,6 +1082,7 @@ export function ChatInput({ sessionId }: Props) {
         <div className="flex flex-wrap items-center gap-2">
           <ModelPicker
             providers={providers}
+            defaultModel={defaultModel}
             value={modelChoice}
             onChange={(v) => void onModelChange(v)}
           />
@@ -1309,10 +1332,20 @@ export function ChatInput({ sessionId }: Props) {
  */
 function ModelPicker({
   providers,
+  defaultModel,
   value,
   onChange,
 }: {
   providers: ProvidersListing | undefined;
+  /**
+   * The configured default from `settings.json`. When present and
+   * non-empty, the "Use agent default" row in the dropdown shows the
+   * actual provider/model the agent would pick (so users don't have
+   * to flip to Settings → Agent to find out). Undefined while
+   * loading; both fields can be empty strings if no default has been
+   * configured at all (rare on a working install).
+   */
+  defaultModel: { provider: string; modelId: string } | undefined;
   value: string;
   onChange: (next: string) => void;
 }) {
@@ -1339,8 +1372,21 @@ function ModelPicker({
   }, [options, query]);
 
   const selected = options.find((o) => o.value === value);
+  // Resolved default label — used both in the trigger when no override
+  // is set, and in the "Use agent default" row of the dropdown.
+  // Empty if defaultModel hasn't loaded or no default is configured.
+  const defaultLabel =
+    defaultModel !== undefined &&
+    defaultModel.provider.length > 0 &&
+    defaultModel.modelId.length > 0
+      ? `${defaultModel.provider} / ${defaultModel.modelId}`
+      : "";
   const triggerLabel =
-    selected !== undefined ? `${selected.provider} / ${selected.name}` : "default model";
+    selected !== undefined
+      ? `${selected.provider} / ${selected.name}`
+      : defaultLabel.length > 0
+        ? `${defaultLabel} (default)`
+        : "default model";
 
   // Close on outside click.
   useEffect(() => {
@@ -1431,7 +1477,14 @@ function ModelPicker({
                 activeIdx === -1 ? "bg-neutral-800 text-neutral-100" : "text-neutral-400"
               }`}
             >
-              <span>Use agent default</span>
+              <span className="flex min-w-0 items-baseline gap-2">
+                <span>Use agent default</span>
+                {defaultLabel.length > 0 && (
+                  <span className="truncate font-mono text-[10px] text-neutral-500">
+                    {defaultLabel}
+                  </span>
+                )}
+              </span>
               {value === "" && <span className="text-emerald-400">●</span>}
             </button>
             {filtered.length === 0 ? (

--- a/packages/client/src/components/ChatMarkdown.tsx
+++ b/packages/client/src/components/ChatMarkdown.tsx
@@ -38,10 +38,59 @@
  *   here.
  */
 import { Highlight, themes as prismThemes } from "prism-react-renderer";
-import type { HTMLAttributes, ReactNode } from "react";
+import { useState, type HTMLAttributes, type ReactNode } from "react";
+import { Check, Copy } from "lucide-react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
+
+/**
+ * Small copy-to-clipboard control rendered in the top-right corner of
+ * each fenced code block. Async clipboard API with a synthetic-textarea
+ * fallback for old Safari / insecure HTTP origins. Two-step state:
+ * idle → copied (1.2s) → idle, so the user gets a visible confirmation.
+ */
+function CodeCopyButton({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+  const onClick = (): void => {
+    if (code.length === 0) return;
+    const flash = (): void => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    };
+    const writeAsync = navigator.clipboard?.writeText?.bind(navigator.clipboard);
+    if (writeAsync !== undefined) {
+      void writeAsync(code).then(flash).catch(fallback);
+      return;
+    }
+    fallback();
+    function fallback(): void {
+      try {
+        const ta = document.createElement("textarea");
+        ta.value = code;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+        flash();
+      } catch {
+        // No clipboard available; user can still select + Cmd+C.
+      }
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="absolute right-1 top-1 rounded bg-neutral-800/80 p-1 text-neutral-400 opacity-0 transition-opacity hover:text-neutral-100 group-hover:opacity-100 focus:opacity-100"
+      title="Copy code block"
+    >
+      {copied ? <Check size={12} /> : <Copy size={12} />}
+    </button>
+  );
+}
 
 interface Props {
   text: string;
@@ -112,26 +161,31 @@ const CodeRenderer = ({ className, children, ...rest }: HTMLAttributes<HTMLEleme
   const language = langMatch?.[1] ?? "text";
 
   return (
-    <Highlight code={code} language={language} theme={prismThemes.vsDark}>
-      {({ style, tokens, getLineProps, getTokenProps }) => (
-        <pre
-          className="overflow-x-auto rounded border border-neutral-800 p-2 font-mono text-[12px]"
-          style={{ ...style, background: "#0d0d0d" }}
-        >
-          {tokens.map((line, i) => {
-            const lineProps = getLineProps({ line });
-            return (
-              <div key={i} {...lineProps}>
-                {line.map((token, key) => {
-                  const tokenProps = getTokenProps({ token });
-                  return <span key={key} {...tokenProps} />;
-                })}
-              </div>
-            );
-          })}
-        </pre>
-      )}
-    </Highlight>
+    // `group` enables the hover-revealed copy button positioned via
+    // `group-hover:opacity-100` inside CodeCopyButton.
+    <div className="group relative">
+      <CodeCopyButton code={code} />
+      <Highlight code={code} language={language} theme={prismThemes.vsDark}>
+        {({ style, tokens, getLineProps, getTokenProps }) => (
+          <pre
+            className="overflow-x-auto rounded border border-neutral-800 p-2 font-mono text-[12px]"
+            style={{ ...style, background: "#0d0d0d" }}
+          >
+            {tokens.map((line, i) => {
+              const lineProps = getLineProps({ line });
+              return (
+                <div key={i} {...lineProps}>
+                  {line.map((token, key) => {
+                    const tokenProps = getTokenProps({ token });
+                    return <span key={key} {...tokenProps} />;
+                  })}
+                </div>
+              );
+            })}
+          </pre>
+        )}
+      </Highlight>
+    </div>
   );
 };
 

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1,9 +1,11 @@
 import { createContext, useContext, useEffect, useRef, useState } from "react";
 import {
   AtSign,
+  Check,
   ChevronDown,
   ChevronRight,
   Columns2,
+  Copy,
   FileCode,
   GitBranch,
   Rows2,
@@ -166,7 +168,7 @@ export function ChatView({ sessionId }: Props) {
               No messages yet. Send a prompt to get started.
             </p>
           )}
-          <div className="mx-auto max-w-3xl space-y-4">
+          <div className="chat-message-list mx-auto max-w-3xl space-y-4">
             {(() => {
               // Pair toolCall blocks (in assistant messages) with their
               // matching toolResult messages (by toolCallId) so each
@@ -201,7 +203,7 @@ export function ChatView({ sessionId }: Props) {
               });
             })()}
             {streamingText.length > 0 && (
-              <div className="rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3">
+              <div className="message-bubble rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3">
                 <div className="mb-1 text-[10px] uppercase tracking-wider text-neutral-500">
                   assistant (streaming)
                 </div>
@@ -522,10 +524,15 @@ function Message({
       }
     }
     return (
-      <div className="rounded-lg bg-neutral-800 px-4 py-3">
+      <div className="message-bubble rounded-lg bg-neutral-800 px-4 py-3" data-message-role="user">
         <div className="mb-1 flex items-center justify-between">
           <span className="text-[10px] uppercase tracking-wider text-neutral-400">you</span>
-          {text.length > 0 && <RawToggle showRaw={showRaw} onToggle={setShowRaw} />}
+          {text.length > 0 && (
+            <div className="flex items-center gap-1">
+              <CopyButton getText={() => text} title="Copy message text" />
+              <RawToggle showRaw={showRaw} onToggle={setShowRaw} />
+            </div>
+          )}
         </div>
         {text.length > 0 && (
           <div className="text-neutral-100">
@@ -593,10 +600,21 @@ function Message({
     // the toggle would do nothing useful for them.
     const hasTextBlock = content.some((b) => (b as Record<string, unknown>).type === "text");
     return (
-      <div className="rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3">
+      <div
+        className="message-bubble rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3"
+        data-message-role="assistant"
+      >
         <div className="mb-1 flex items-center justify-between">
           <span className="text-[10px] uppercase tracking-wider text-neutral-500">assistant</span>
-          {hasTextBlock && <RawToggle showRaw={showRaw} onToggle={setShowRaw} />}
+          {hasTextBlock && (
+            <div className="flex items-center gap-1">
+              <CopyButton
+                getText={() => assistantTextContent(content as Record<string, unknown>[])}
+                title="Copy all text from this assistant message"
+              />
+              <RawToggle showRaw={showRaw} onToggle={setShowRaw} />
+            </div>
+          )}
         </div>
         <div className="space-y-2 text-sm text-neutral-100">
           {content.map((block, i) => {
@@ -977,6 +995,76 @@ function BashExecution({ message }: { message: AgentMessageLike }) {
  * Defaults to "rendered" — click flips to raw, click again flips
  * back. Per-session, per-message; not persisted.
  */
+/**
+ * Copy-to-clipboard button rendered next to the raw/rendered toggle on
+ * each message bubble (and inside fenced code blocks via ChatMarkdown).
+ * `getText` is invoked on click so callers don't have to keep a copy
+ * of the (potentially large) message text in a closure when the
+ * button isn't used. Shows a brief check-mark confirmation; falls
+ * back to a synthetic textarea when the async clipboard API isn't
+ * available (older Safari, insecure HTTP origins).
+ */
+function CopyButton({ getText, title }: { getText: () => string; title: string }) {
+  const [copied, setCopied] = useState(false);
+  const onClick = (): void => {
+    const text = getText();
+    if (text.length === 0) return;
+    const writeAsync = navigator.clipboard?.writeText?.bind(navigator.clipboard);
+    if (writeAsync !== undefined) {
+      void writeAsync(text)
+        .then(() => {
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1200);
+        })
+        .catch(() => fallback(text));
+    } else {
+      fallback(text);
+    }
+  };
+  const fallback = (text: string): void => {
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // Clipboard unavailable; do nothing — user can still select + Cmd+C.
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded px-1.5 py-0.5 text-neutral-500 hover:bg-neutral-700/40 hover:text-neutral-300"
+      title={title}
+    >
+      {copied ? <Check size={12} /> : <Copy size={12} />}
+    </button>
+  );
+}
+
+/**
+ * Concatenate every text-typed block in an assistant message's content
+ * array into one newline-separated string for the message-level Copy
+ * button. Tool calls and thinking blocks are skipped — they have their
+ * own copy affordances inside their respective renderers.
+ */
+function assistantTextContent(content: Record<string, unknown>[]): string {
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    }
+  }
+  return parts.join("\n\n");
+}
+
 function RawToggle({ showRaw, onToggle }: { showRaw: boolean; onToggle: (next: boolean) => void }) {
   return (
     <button

--- a/packages/client/src/components/SessionTreePanel.tsx
+++ b/packages/client/src/components/SessionTreePanel.tsx
@@ -130,13 +130,18 @@ export function SessionTreePanel({ sessionId, projectId, onClose }: Props) {
   }, [tree]);
 
   // View toggle persists across mounts so users who prefer the
-  // graph don't have to flip it every time they open the panel.
+  // other mode don't have to flip it every time they open the
+  // panel. Default is the branching graph — it's the more useful
+  // view for sessions with multiple branches and reads fine for
+  // linear sessions too. Honours an explicitly-stored "list"
+  // preference; anything else (including absent / corrupt) falls
+  // back to graph.
   const [view, setView] = useState<"list" | "graph">(() => {
     try {
-      return localStorage.getItem(VIEW_KEY) === "graph" ? "graph" : "list";
+      return localStorage.getItem(VIEW_KEY) === "list" ? "list" : "graph";
     } catch {
-      // Private-mode storage — fall back to the default list view.
-      return "list";
+      // Private-mode storage — fall back to the default graph view.
+      return "graph";
     }
   });
   const setViewPersisted = (next: "list" | "graph"): void => {

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -15,6 +15,7 @@ import { useActiveProject, useProjectStore } from "../store/project-store";
 import { useUiConfigStore } from "../store/ui-config-store";
 import { EMPTY_STATUS, useMcpStore } from "../store/mcp-store";
 import { THEME_DEFS, useThemeStore, type ThemeId } from "../lib/theme";
+import { getStoredToken } from "../lib/auth-client";
 
 type Tab = "providers" | "agent" | "mcp" | "tools" | "skills" | "appearance" | "backup";
 
@@ -118,13 +119,37 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
               </button>
             ))}
           </div>
-          <button
-            onClick={onClose}
-            className="rounded border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:border-neutral-500"
-            title="Close (Esc)"
-          >
-            Close
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => {
+                // Carry the user's current token over to the swagger
+                // UI page via a one-shot `?token=...` query param. The
+                // server-side bootstrap (see swaggerThemeJs in
+                // packages/server/src/index.ts) strips the token from
+                // the URL on load and re-presents it as a Bearer
+                // header on every API call from swagger UI. When auth
+                // is disabled the token is absent and the page loads
+                // unconditionally.
+                const stored = getStoredToken();
+                const url =
+                  stored !== undefined
+                    ? `/api/docs?token=${encodeURIComponent(stored.token)}`
+                    : "/api/docs";
+                window.open(url, "_blank", "noopener,noreferrer");
+              }}
+              className="rounded border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:border-neutral-500"
+              title="Open the OpenAPI / Swagger UI in a new tab. Carries your auth token automatically."
+            >
+              API Docs ↗
+            </button>
+            <button
+              onClick={onClose}
+              className="rounded border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:border-neutral-500"
+              title="Close (Esc)"
+            >
+              Close
+            </button>
+          </div>
         </header>
 
         {error !== undefined && (

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -260,3 +260,31 @@
 .pi-diff-block .token.italic {
   font-style: italic;
 }
+
+/* ----------------------------- chat selection -----------------------------
+   Constrain text selection so each message bubble is its own selection
+   root. Without these rules, dragging a selection from inside one
+   message into the next picks up everything in between (including the
+   raw/copy/toggle controls and the visible gap), and on Safari the
+   selection highlight visually extends past the bubble's rounded
+   border. The combo below keeps selection cleanly within a single
+   bubble:
+   - The chat scroll container disables selection by default.
+   - Each `.message-bubble` re-enables it, and `isolation: isolate`
+     forces a new stacking / paint context so Safari draws the
+     selection highlight inside the bubble rather than bleeding it
+     across siblings.
+*/
+.chat-message-list {
+  user-select: none;
+  -webkit-user-select: none;
+}
+.message-bubble {
+  user-select: text;
+  -webkit-user-select: text;
+  isolation: isolate;
+  /* Long unbroken tokens (URLs, hashes, code snippets) wrap inside
+     the bubble instead of pushing the selection rectangle out past
+     the right edge. */
+  overflow-wrap: anywhere;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -231,18 +231,21 @@ export async function buildServer(): Promise<FastifyInstance> {
     },
   });
 
-  // Bootstrap script injected into the swagger UI page. Three jobs:
-  //   1. Capture the `?token=...` from the URL on load and stash it in
-  //      sessionStorage (so it survives intra-page nav within swagger
-  //      UI but not other tabs).
-  //   2. Strip the token from the URL via history.replaceState the
-  //      moment the page mounts so it doesn't sit in the URL bar /
-  //      browser history.
-  //   3. Patch fetch() so every same-origin request swagger UI makes
-  //      to /api/v1/* carries the bearer header automatically. Means
-  //      the user doesn't have to copy-paste their JWT into the
-  //      swagger "Authorize" dialog after navigating from the UI.
-  // No-op when no token is in the URL (e.g. when auth is disabled).
+  // Bootstrap script injected into the swagger UI page. Resolves an
+  // auth token in priority order — URL ?token=, then sessionStorage
+  // (set by an earlier visit), then localStorage["pi-workbench/auth-
+  // token"] (the JWT the main UI persisted on login). Same-origin so
+  // the localStorage read is allowed. Then patches fetch() to attach
+  // the token as a Bearer header on every call swagger UI makes to
+  // /api/v1/*.
+  //
+  // Cleanup: if the token came from ?token=, strip it from the URL
+  // via history.replaceState so it doesn't sit in the URL bar /
+  // browser history. The sessionStorage stash is for in-tab nav only;
+  // closing the tab clears it.
+  //
+  // No-op when no token is found anywhere (e.g. unauthenticated
+  // visitor with auth disabled — fetch is left unpatched).
   const swaggerThemeJs = `(function () {
     try {
       var url = new URL(window.location.href);
@@ -252,7 +255,9 @@ export async function buildServer(): Promise<FastifyInstance> {
         url.searchParams.delete("token");
         window.history.replaceState({}, document.title, url.toString());
       }
-      var token = sessionStorage.getItem("pi-workbench/docs-token");
+      var token =
+        sessionStorage.getItem("pi-workbench/docs-token") ||
+        localStorage.getItem("pi-workbench/auth-token");
       if (token && window.fetch) {
         var origFetch = window.fetch.bind(window);
         window.fetch = function (input, init) {
@@ -307,28 +312,22 @@ export async function buildServer(): Promise<FastifyInstance> {
         reply.code(404).send({ error: "not_found" });
         return;
       }
-      if (!authEnabled()) return;
-      // Browsers can't attach an Authorization header on top-level
-      // navigation, so the swagger UI page itself accepts a token
-      // from the `?token=<jwt-or-api-key>` query string as well.
-      // The injected swagger UI bootstrap (see swaggerThemeJs)
-      // strips the token from the URL via history.replaceState the
-      // moment the page loads and re-presents it via a Bearer header
-      // on every subsequent API call, so the token only appears in
-      // the URL bar for the initial GET.
-      const headerToken = extractBearer(req.headers.authorization);
-      const queryToken =
-        typeof (req.query as Record<string, unknown>).token === "string"
-          ? ((req.query as Record<string, string>).token ?? "")
-          : "";
-      const presented = headerToken ?? (queryToken.length > 0 ? queryToken : undefined);
-      if (
-        presented === undefined ||
-        (verifyToken(presented) === undefined && !verifyApiKey(presented))
-      ) {
-        reply.code(401).send({ error: "auth_required" });
-        return;
-      }
+      // The /api/docs static UI (HTML / JS / CSS / OpenAPI spec) is
+      // open when EXPOSE_DOCS=true, regardless of auth. Browsers
+      // can't attach an Authorization header on top-level
+      // navigation, so gating the UI page itself on a Bearer header
+      // would 401 every logged-in user who hits /api/docs from a
+      // new tab. The route catalog the docs page exposes is the
+      // same one this project's CLAUDE.md / repo already publish, so
+      // the asset-level exposure is the same as before.
+      //
+      // Real protection lives at the actual API surface: every
+      // /api/v1/* call swagger UI makes still goes through the
+      // auth gate below. The injected theme bootstrap (see
+      // swaggerThemeJs) reads the JWT/API-key out of localStorage
+      // (same-origin) — or the one-shot ?token=<...> query param
+      // the Settings → "API Docs ↗" button passes — and injects
+      // it as a Bearer header on every fetch swagger UI issues.
       return;
     }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -231,9 +231,53 @@ export async function buildServer(): Promise<FastifyInstance> {
     },
   });
 
+  // Bootstrap script injected into the swagger UI page. Three jobs:
+  //   1. Capture the `?token=...` from the URL on load and stash it in
+  //      sessionStorage (so it survives intra-page nav within swagger
+  //      UI but not other tabs).
+  //   2. Strip the token from the URL via history.replaceState the
+  //      moment the page mounts so it doesn't sit in the URL bar /
+  //      browser history.
+  //   3. Patch fetch() so every same-origin request swagger UI makes
+  //      to /api/v1/* carries the bearer header automatically. Means
+  //      the user doesn't have to copy-paste their JWT into the
+  //      swagger "Authorize" dialog after navigating from the UI.
+  // No-op when no token is in the URL (e.g. when auth is disabled).
+  const swaggerThemeJs = `(function () {
+    try {
+      var url = new URL(window.location.href);
+      var qpToken = url.searchParams.get("token");
+      if (qpToken && qpToken.length > 0) {
+        sessionStorage.setItem("pi-workbench/docs-token", qpToken);
+        url.searchParams.delete("token");
+        window.history.replaceState({}, document.title, url.toString());
+      }
+      var token = sessionStorage.getItem("pi-workbench/docs-token");
+      if (token && window.fetch) {
+        var origFetch = window.fetch.bind(window);
+        window.fetch = function (input, init) {
+          init = init || {};
+          var url2 = typeof input === "string" ? input : input.url;
+          if (url2 && url2.indexOf("/api/v1/") !== -1) {
+            init.headers = new Headers(init.headers || {});
+            if (!init.headers.has("Authorization")) {
+              init.headers.set("Authorization", "Bearer " + token);
+            }
+          }
+          return origFetch(input, init);
+        };
+      }
+    } catch (err) {
+      console.warn("pi-workbench docs auth bootstrap failed:", err);
+    }
+  })();`;
+
   await fastify.register(swaggerUi, {
     routePrefix: "/api/docs",
-    uiConfig: { docExpansion: "list" },
+    uiConfig: { docExpansion: "list", persistAuthorization: true },
+    theme: {
+      js: [{ filename: "pi-workbench-auth.js", content: swaggerThemeJs }],
+    },
   });
 
   /**
@@ -264,7 +308,20 @@ export async function buildServer(): Promise<FastifyInstance> {
         return;
       }
       if (!authEnabled()) return;
-      const presented = extractBearer(req.headers.authorization);
+      // Browsers can't attach an Authorization header on top-level
+      // navigation, so the swagger UI page itself accepts a token
+      // from the `?token=<jwt-or-api-key>` query string as well.
+      // The injected swagger UI bootstrap (see swaggerThemeJs)
+      // strips the token from the URL via history.replaceState the
+      // moment the page loads and re-presents it via a Bearer header
+      // on every subsequent API call, so the token only appears in
+      // the URL bar for the initial GET.
+      const headerToken = extractBearer(req.headers.authorization);
+      const queryToken =
+        typeof (req.query as Record<string, unknown>).token === "string"
+          ? ((req.query as Record<string, string>).token ?? "")
+          : "";
+      const presented = headerToken ?? (queryToken.length > 0 ? queryToken : undefined);
       if (
         presented === undefined ||
         (verifyToken(presented) === undefined && !verifyApiKey(presented))

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -923,6 +923,36 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
   live.unsubscribe = makeSubscribeHandler(live);
   registry.set(live.sessionId, live);
 
+  // Disambiguate the fork's display name from its source. The SDK
+  // copies session_info entries forward when forking, so the new
+  // session has the same `sessionName` as the source — making it
+  // hard to tell them apart in the sidebar. Rename to "<source>
+  // (clone)", or "<source> (clone N)" if other clones already exist
+  // in this project. Plain "(clone)" is used when the source has no
+  // explicit name. Failures are non-fatal (the fork is otherwise
+  // fully usable).
+  try {
+    const sourceName = source.session.sessionName;
+    const baseName =
+      sourceName !== undefined && sourceName.length > 0 ? `${sourceName} (clone)` : "(clone)";
+    const siblings = await listSessionsForProject(source.projectId, source.workspacePath);
+    const existingNames = new Set(
+      siblings
+        .filter((s) => s.sessionId !== live.sessionId)
+        .map((s) => s.name)
+        .filter((n): n is string => typeof n === "string"),
+    );
+    let candidate = baseName;
+    let n = 2;
+    while (existingNames.has(candidate)) {
+      candidate = `${baseName} ${n}`;
+      n += 1;
+    }
+    session.setSessionName(candidate);
+  } catch {
+    // Naming is best-effort; the new session still works without it.
+  }
+
   // Undo the SDK's in-place mutation on the source LiveSession by
   // reopening the original .jsonl with a fresh SessionManager +
   // AgentSession. Without this, the source's sessionId field still


### PR DESCRIPTION
## Summary

Quality-of-life batch covering chat affordances, the model picker, the swagger UI, session forking, and the session-tree default view.

### Chat
- **Copy buttons** on every user / assistant message bubble (next to the raw/rendered toggle) and on every fenced code block (hover-revealed top-right).
- **Selection containment fix.** Each `.message-bubble` is now its own selection root (`isolation: isolate` + `user-select: text`); the chat list itself is `user-select: none`. Selecting text inside one message no longer bleeds across adjacent bubbles or extends past the bubble's rounded border in Safari.

### Model picker
- The "Use agent default" row now names the resolved provider/model from `settings.json`, so users don't have to flip to **Settings → Agent** to see which model "default" actually means. The trigger label reads `<provider> / <modelId> (default)` when no per-session override is set.

### `/api/docs` swagger UI auth
- `/api/docs*` static UI loads without auth when `EXPOSE_DOCS=true` — the route shapes it exposes are already in CLAUDE.md / the public repo. Real protection is unchanged at the actual API surface (every `/api/v1/*` call still requires a valid token).
- Injected theme JS resolves an auth token in priority order: URL `?token=`, then `sessionStorage`, then `localStorage["pi-workbench/auth-token"]` (same-origin, set by the main UI on login). Any token found is attached as `Authorization: Bearer …` on every `/api/v1/*` fetch swagger UI issues.
- New **API Docs ↗** button in the Settings header opens `/api/docs` in a new tab and carries the user's current JWT via the one-shot `?token=` param. The bootstrap script strips it from the URL on load.
- Net effect: a logged-in browser user can navigate directly to `/api/docs` (or click the button) and Try-it-out works end-to-end without manually pasting their JWT.

### Sessions
- **Forked sessions get disambiguated names.** New session is renamed to `<source name> (clone)` (or just `(clone)` if the source had no name). Subsequent forks bump the suffix (`(clone) 2`, `(clone) 3`, …) so the sidebar doesn't show multiple identically-named entries.
- **Session-tree panel defaults to graph view.** The branching graph is more useful for non-trivial sessions and reads fine for linear ones too. Existing users who explicitly toggled to "list" keep that preference.

## Test plan

- [ ] Click Copy on a user message — clipboard receives the raw text; check-mark flashes
- [ ] Click Copy on an assistant message with multiple text blocks — clipboard receives them joined with `\n\n`
- [ ] Hover a fenced code block — Copy button appears top-right; click copies just the code body
- [ ] In Safari: drag-select inside a message — selection stays within the bubble; doesn't bleed into neighbours
- [ ] Open the model picker — "Use agent default" row shows the configured `defaultProvider / defaultModel` in monospace
- [ ] Trigger label reads `<provider> / <modelId> (default)` when no override is set
- [ ] Log in to the UI; navigate directly to `/api/docs` — page loads, Try-it-out on any route succeeds
- [ ] Click **API Docs ↗** in Settings header — new tab opens, URL has `?token=` momentarily then is stripped
- [ ] Set `EXPOSE_DOCS=false` — `/api/docs` returns 404
- [ ] Fork a session named "thing" — new session is named "thing (clone)"
- [ ] Fork the same source again — new session is named "thing (clone) 2"
- [ ] Open the session-tree panel — defaults to the branching graph
- [ ] Toggle to list, close, reopen — list view persists
- [ ] `npm run check` passes (typecheck + lint + format)
- [ ] `npm run test:ci` — all 18 tests pass