### PR TITLE
feat: git init button, About tab, chat toggle fix, skills empty fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,42 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+### Added
+
+- **Git init button in the Git pane.** When the active project isn't
+  a git repository yet, the Git tab shows an "Initialize git repo"
+  button instead of the previous text-only hint. Click runs `git init
+  -b main` (default branch `main`) on the project root via a new
+  `POST /api/v1/git/init` route, then re-polls status so the panel
+  flips into the normal Staged / Unstaged layout. Idempotent — the
+  route returns `{ alreadyInitialised: true }` if the project is
+  already a repo. Falls back to plain `git init` on git versions older
+  than 2.28 (which don't recognise `-b`).
+- **About tab in Settings.** New tab at the end of the settings tab
+  bar showing the deployed server version (read from the server's
+  `package.json` and surfaced via `/api/v1/ui-config`), plus links to
+  the GitHub repo, CHANGELOG, and SECURITY policy. Useful for
+  confirming a deploy actually rolled forward without shelling into
+  the container.
+
+### Fixed
+
+- **Chat toggle now fully hides the chat column**, including the
+  empty-state branches (project picker, "no project" placeholder,
+  "+ New session" prompt). Previously the column stayed mounted when
+  there was no active session even after the user toggled chat off,
+  leaving the project-first-open page visible. The header chat button
+  is the single source of truth for chat-column visibility now.
+- **Skills export no longer 500s on an empty skills directory.**
+  `GET /api/v1/config/skills/export` now returns `409
+  skills_directory_empty` when `${piConfigDir}/skills/` is missing or
+  contains no files, and the Settings → Backup tab surfaces this as a
+  neutral "No skills to export" info line instead of a red error
+  banner. (Background: tar 7.x's `create()` throws synchronously on
+  an empty entries list, and a hand-rolled empty tar is rejected by
+  tar 7.x's reader as `TAR_BAD_ARCHIVE` — refusing the export with a
+  clear message is better than shipping a download nobody can use.)
+
 ## [1.1.0] — 2026-05-05
 
 ### Renamed

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -446,12 +446,13 @@ export function App() {
               materialises between chat and files only when at least
               one file is open. Both right-side panes are user-resizable
               via their dividers; widths persist in localStorage. */}
-            {/* Chat column is suppressed when chatOpen=false. Empty-
-                state branches (no project, no session) still render so
-                the user gets the picker / "select a session" prompt
-                even when chat is hidden — those messages aren't really
-                "chat", they're load-bearing onboarding. */}
-            {(chatOpen || activeSessionId === undefined) && (
+            {/* Chat column is suppressed when chatOpen=false — fully.
+                Includes the empty-state branches (project picker,
+                "no session" prompt). When chat is closed AND there's
+                no project, the main area is empty and the user can
+                re-open chat from the header to reach the picker, or
+                use the sidebar's "+ New project" button. */}
+            {chatOpen && (
               <div className="flex flex-1 flex-col overflow-hidden">
                 {projectsLoaded && projects.length === 0 ? (
                   setupPickerDismissed ? (
@@ -528,11 +529,10 @@ export function App() {
                 their persisted widths + dividers as before.
 
                 `chatColumnVisible` mirrors the rendering condition for
-                the chat column above (it stays mounted on empty-state
-                branches so onboarding messaging always renders). */}
+                the chat column above — strictly chatOpen now. */}
             {editorVisible &&
               (() => {
-                const chatColumnVisible = chatOpen || activeSessionId === undefined;
+                const chatColumnVisible = chatOpen;
                 const editorIsLeftmost = !chatColumnVisible;
                 if (editorIsLeftmost) {
                   return (
@@ -567,7 +567,7 @@ export function App() {
 
             {filesOpen &&
               (() => {
-                const chatColumnVisible = chatOpen || activeSessionId === undefined;
+                const chatColumnVisible = chatOpen;
                 const filesIsLeftmost = !chatColumnVisible && !editorVisible;
                 // Inner content (tabs + selected panel) — identical in
                 // both layout branches. Extracted so we can wrap it in

--- a/packages/client/src/components/GitPanel.tsx
+++ b/packages/client/src/components/GitPanel.tsx
@@ -289,13 +289,38 @@ export function GitPanel() {
   }
 
   if (status?.isGitRepo === false) {
+    const handleInit = async (): Promise<void> => {
+      setBusy(true);
+      setOpError(undefined);
+      try {
+        await api.gitInit(project.id);
+        // Re-poll status so the panel flips out of the empty-state
+        // branch into the normal Staged / Unstaged layout. Branch
+        // will read "main" — that's git init -b main behaviour.
+        await refresh();
+      } catch (err) {
+        setOpError(err instanceof ApiError ? err.code : (err as Error).message);
+      } finally {
+        setBusy(false);
+      }
+    };
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-2 px-4 text-center text-xs italic text-neutral-500">
-        <p>{project.name} isn't a git repository.</p>
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-4 text-center text-xs text-neutral-500">
+        <p className="italic">{project.name} isn't a git repository.</p>
+        <button
+          onClick={() => void handleInit()}
+          disabled={busy}
+          className="rounded-md bg-neutral-100 px-3 py-1.5 text-xs font-medium text-neutral-900 hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+          title="Run `git init -b main` in the project root"
+        >
+          {busy ? "Initializing…" : "Initialize git repo"}
+        </button>
         <p className="text-[10px] text-neutral-600">
-          Run <code className="font-mono text-neutral-400">git init</code> in the project dir to
-          enable git features.
+          Default branch will be <code className="font-mono text-neutral-400">main</code>.
         </p>
+        {opError !== undefined && (
+          <p className="text-[10px] text-red-400">git init failed: {opError}</p>
+        )}
       </div>
     );
   }

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -17,7 +17,7 @@ import { EMPTY_STATUS, useMcpStore } from "../store/mcp-store";
 import { THEME_DEFS, useThemeStore, type ThemeId } from "../lib/theme";
 import { getStoredToken } from "../lib/auth-client";
 
-type Tab = "providers" | "agent" | "mcp" | "tools" | "skills" | "appearance" | "backup";
+type Tab = "providers" | "agent" | "mcp" | "tools" | "skills" | "appearance" | "backup" | "about";
 
 interface Props {
   onClose: () => void;
@@ -61,8 +61,17 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           // deployments often want to disable bash/edit/write at the
           // tool level, regardless of what providers / agent settings
           // are exposed.
-          (["skills", "tools", "appearance", "backup"] as const)
-        : (["providers", "agent", "mcp", "tools", "skills", "appearance", "backup"] as const),
+          (["skills", "tools", "appearance", "backup", "about"] as const)
+        : ([
+            "providers",
+            "agent",
+            "mcp",
+            "tools",
+            "skills",
+            "appearance",
+            "backup",
+            "about",
+          ] as const),
     [minimal],
   );
   const [tab, setTab] = useState<Tab>(initialTab ?? (minimal ? "skills" : "providers"));
@@ -115,7 +124,9 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
                           ? "Skills"
                           : t === "appearance"
                             ? "Appearance"
-                            : "Backup"}
+                            : t === "backup"
+                              ? "Backup"
+                              : "About"}
               </button>
             ))}
           </div>
@@ -166,6 +177,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           {tab === "skills" && <SkillsTab onError={setError} />}
           {tab === "appearance" && <AppearanceTab />}
           {tab === "backup" && <BackupTab onError={setError} />}
+          {tab === "about" && <AboutTab />}
         </div>
       </div>
     </div>
@@ -1526,12 +1538,21 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
     onError(undefined);
     setBusy(true);
     setLastSkillsImport(undefined);
+    setLastSkillsExport(undefined);
     try {
       const { blob, filename, fileCount } = await api.exportSkills();
       triggerDownload(blob, filename);
       setLastSkillsExport({ filename, fileCount });
     } catch (err) {
-      onError(`Skills export failed: ${errorCode(err)}`);
+      // Empty-skills is the most common reason this fails on a fresh
+      // install — surface it as an info message via the result slot
+      // (`fileCount: 0`) instead of a red error banner. Other errors
+      // keep the generic banner.
+      if (err instanceof ApiError && err.code === "skills_directory_empty") {
+        setLastSkillsExport({ filename: "", fileCount: 0 });
+      } else {
+        onError(`Skills export failed: ${errorCode(err)}`);
+      }
     } finally {
       setBusy(false);
     }
@@ -1651,15 +1672,20 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
         >
           {busy ? "Working…" : "Download skills archive"}
         </button>
-        {lastSkillsExport !== undefined && (
-          <p className="mt-2 text-xs text-emerald-400">
-            Exported <code className="font-mono">{lastSkillsExport.filename}</code> (
-            {lastSkillsExport.fileCount === 0
-              ? "no skills on disk"
-              : `${lastSkillsExport.fileCount} file${lastSkillsExport.fileCount === 1 ? "" : "s"} packed`}
-            )
-          </p>
-        )}
+        {lastSkillsExport !== undefined &&
+          (lastSkillsExport.fileCount === 0 ? (
+            // Empty-skills sentinel: server returned 409
+            // skills_directory_empty. Show as a neutral info line, not
+            // an error — there's nothing wrong, just nothing to ship.
+            <p className="mt-2 text-xs text-neutral-400">
+              No skills to export — your skills directory is empty.
+            </p>
+          ) : (
+            <p className="mt-2 text-xs text-emerald-400">
+              Exported <code className="font-mono">{lastSkillsExport.filename}</code> (
+              {lastSkillsExport.fileCount} file{lastSkillsExport.fileCount === 1 ? "" : "s"} packed)
+            </p>
+          ))}
       </section>
 
       <section>
@@ -2438,6 +2464,89 @@ function McpDraftForm(props: {
           {busy ? "Saving…" : "Save"}
         </button>
       </div>
+    </div>
+  );
+}
+
+// ---------------- About tab ----------------
+
+/**
+ * Read-only "what am I running" pane. Shows the deployed server
+ * version (from `/ui-config`) plus a couple of orienting links —
+ * GitHub repo, CHANGELOG, security policy. Useful for confirming a
+ * deploy actually rolled forward without shelling into the container.
+ */
+function AboutTab() {
+  const version = useUiConfigStore((s) => s.version);
+  const loaded = useUiConfigStore((s) => s.loaded);
+  return (
+    <div className="space-y-6 text-sm text-neutral-300">
+      <header className="space-y-1">
+        <h2 className="text-base font-semibold text-neutral-100">pi-forge</h2>
+        <p className="text-xs text-neutral-500">
+          Browser workbench for the{" "}
+          <a
+            href="https://github.com/badlogic/pi-mono"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-400 underline hover:text-blue-300"
+          >
+            pi coding agent
+          </a>
+          .
+        </p>
+      </header>
+
+      <section className="space-y-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">Version</h3>
+        <p className="font-mono text-sm">
+          {loaded ? (
+            version.length > 0 ? (
+              version
+            ) : (
+              <span className="text-neutral-500">unknown</span>
+            )
+          ) : (
+            <span className="text-neutral-500">loading…</span>
+          )}
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">Links</h3>
+        <ul className="space-y-1 text-xs">
+          <li>
+            <a
+              href="https://github.com/Devin-Marks/pi-forge"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 underline hover:text-blue-300"
+            >
+              github.com/Devin-Marks/pi-forge
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/Devin-Marks/pi-forge/blob/main/CHANGELOG.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 underline hover:text-blue-300"
+            >
+              Changelog
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/Devin-Marks/pi-forge/blob/main/SECURITY.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 underline hover:text-blue-300"
+            >
+              Security
+            </a>
+          </li>
+        </ul>
+      </section>
     </div>
   );
 }

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -117,7 +117,10 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
   ) {
     fail(status, "expected { minimal: boolean, workspaceRoot: string }");
   }
-  return { minimal: value.minimal, workspaceRoot: value.workspaceRoot };
+  // `version` is forward-compatible: older servers without the field
+  // fall through to "unknown" so the About tab still renders.
+  const version = typeof value.version === "string" ? value.version : "unknown";
+  return { minimal: value.minimal, workspaceRoot: value.workspaceRoot, version };
 }
 
 function vHealth(value: unknown, status: number): HealthResponse {

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1596,6 +1596,21 @@ export const api = {
   },
 
   // ---------------- git ----------------
+  gitInit: (projectId: string) =>
+    request<{ alreadyInitialised: boolean; isGitRepo: boolean }>(
+      `/api/v1/git/init`,
+      (v, status) => {
+        if (
+          !isObject(v) ||
+          typeof v.alreadyInitialised !== "boolean" ||
+          typeof v.isGitRepo !== "boolean"
+        ) {
+          fail(status, "expected { alreadyInitialised, isGitRepo }");
+        }
+        return { alreadyInitialised: v.alreadyInitialised, isGitRepo: v.isGitRepo };
+      },
+      { method: "POST", body: { projectId } },
+    ),
   gitStatus: (projectId: string) =>
     request(`/api/v1/git/status?projectId=${encodeURIComponent(projectId)}`, vGitStatus),
   gitDiff: (projectId: string) =>

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -114,6 +114,8 @@ export interface UiConfigResponse {
   minimal: boolean;
   /** Absolute path to the workspace root, used by minimal-mode project create. */
   workspaceRoot: string;
+  /** Server build version (mirrors packages/server's package.json). */
+  version: string;
 }
 
 export interface UnifiedSession {

--- a/packages/client/src/store/ui-config-store.ts
+++ b/packages/client/src/store/ui-config-store.ts
@@ -20,6 +20,8 @@ interface UiConfigState {
   minimal: boolean;
   /** Absolute workspace root reported by the server. */
   workspaceRoot: string;
+  /** Server build version (mirrors packages/server's package.json). */
+  version: string;
   /** Last load error (sticky until a retry succeeds), for diagnostics. */
   error: string | undefined;
   load: () => Promise<void>;
@@ -29,6 +31,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
   loaded: false,
   minimal: false,
   workspaceRoot: "",
+  version: "",
   error: undefined,
   load: async () => {
     try {
@@ -37,6 +40,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
         loaded: true,
         minimal: cfg.minimal,
         workspaceRoot: cfg.workspaceRoot,
+        version: cfg.version,
         error: undefined,
       });
     } catch (err) {

--- a/packages/server/src/git-runner.ts
+++ b/packages/server/src/git-runner.ts
@@ -255,6 +255,30 @@ function sanitizeStderr(stderr: string, cwd?: string): string {
 }
 
 /**
+ * Initialize a fresh git repo at `cwd` with `main` as the initial
+ * branch. `git init -b main` requires git ≥ 2.28; below that the
+ * `--initial-branch` flag is unrecognized and we fall back to a
+ * plain `git init` — caller can still rename to main on the first
+ * commit if desired. Idempotent: if `cwd` is already a repo, this
+ * resolves without changing anything (git's own `init` is a no-op
+ * on an existing repo).
+ */
+export async function initRepo(cwd: string): Promise<void> {
+  try {
+    await runGit(cwd, ["init", "-b", "main"]);
+  } catch (err) {
+    // Older git versions (< 2.28) don't recognise `-b`. Detect via
+    // the stderr message and retry without it. Other errors propagate.
+    const msg = err instanceof Error ? err.message : "";
+    if (/unknown (option|switch).*-b|invalid option.*initial-branch/i.test(msg)) {
+      await runGit(cwd, ["init"]);
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
  * True iff `cwd` is inside a git working tree. Cheap probe used by
  * every public function so "not a repo" can return the empty default
  * rather than throw. Exported so route helpers (e.g. for the diff

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -18,6 +18,7 @@ import {
 import { buildExportTar, importConfigFromBuffer, MAX_IMPORT_BYTES } from "../config-export.js";
 import {
   buildSkillsExportTar,
+  SkillsDirectoryEmptyError,
   importSkillsFromFiles,
   importSkillsFromTar,
   MAX_SKILLS_IMPORT_BYTES,
@@ -692,8 +693,11 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
   // Skills tree export. Streams a tar.gz of every file under
   // `${piConfigDir}/skills/` — single-file skills (`<name>.md`) and
   // directory skills (`<name>/SKILL.md` plus assets) round-trip
-  // verbatim. Empty exports are valid (zero-entry tar) so the route
-  // doesn't 404 on a fresh install.
+  // verbatim. When the skills directory is missing or empty, the
+  // route returns 409 with a stable code so the UI can show "no
+  // skills to export" instead of triggering a download — see the
+  // SkillsDirectoryEmptyError class in skills-export.ts for why we
+  // don't ship an empty archive.
   fastify.get(
     "/config/skills/export",
     {
@@ -701,8 +705,8 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
         description:
           "Stream a `.tar.gz` of every file under `${piConfigDir}/skills/`. " +
           "Single-file (`<name>.md`) and directory skills (`<name>/SKILL.md` + " +
-          "assets) both round-trip. Empty trees produce a zero-entry tar — " +
-          "consumers should accept that.",
+          "assets) both round-trip. Returns 409 `skills_directory_empty` when " +
+          "the skills tree is missing or contains no files.",
         tags: ["config"],
         response: {
           200: {
@@ -710,6 +714,7 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
             type: "string",
             format: "binary",
           },
+          409: errorSchema,
           500: errorSchema,
         },
       },
@@ -724,6 +729,9 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
           .header("X-Pi-Forge-File-Count", String(fileCount));
         return reply.send(stream);
       } catch (err) {
+        if (err instanceof SkillsDirectoryEmptyError) {
+          return reply.code(409).send({ error: "skills_directory_empty" });
+        }
         return internalError(reply, err);
       }
     },

--- a/packages/server/src/routes/git.ts
+++ b/packages/server/src/routes/git.ts
@@ -17,6 +17,8 @@ import {
   getLog,
   getStagedDiff,
   getStatus,
+  initRepo,
+  isGitRepo,
   pull,
   push,
   revertPaths,
@@ -210,6 +212,52 @@ async function withProject<T>(
 /* ----------------------------- routes ----------------------------- */
 
 export const gitRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{ Body: { projectId: string } }>(
+    "/git/init",
+    {
+      schema: {
+        description:
+          "Initialize a fresh git repo at the project's path with `main` as the " +
+          "initial branch. Idempotent: returns 200 with `{ alreadyInitialised: " +
+          "true }` if the project is already a git working tree. Falls back to " +
+          "plain `git init` (no `-b main`) on git versions < 2.28.",
+        tags: ["git"],
+        body: {
+          type: "object",
+          required: ["projectId"],
+          additionalProperties: false,
+          properties: { projectId: { type: "string", minLength: 1 } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["alreadyInitialised", "isGitRepo"],
+            properties: {
+              alreadyInitialised: { type: "boolean" },
+              isGitRepo: { type: "boolean" },
+            },
+          },
+          400: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const project = await resolveProject(req.body.projectId, reply);
+      if (project === undefined) return;
+      try {
+        if (await isGitRepo(project.path)) {
+          return { alreadyInitialised: true, isGitRepo: true };
+        }
+        await initRepo(project.path);
+        return { alreadyInitialised: false, isGitRepo: true };
+      } catch (err) {
+        return mapError(reply, err);
+      }
+    },
+  );
+
   fastify.get<{ Querystring: { projectId: string } }>(
     "/git/status",
     {

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -1,7 +1,30 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { FastifyPluginAsync } from "fastify";
 import { sessionCount } from "../session-registry.js";
 import { ptyCount } from "../pty-manager.js";
 import { config } from "../config.js";
+
+/**
+ * Read the server's own package.json once at module load. Used by the
+ * /ui-config response so the browser can render an "About" footer
+ * with the deployed version. Resolves relative to the compiled
+ * server file (`packages/server/dist/routes/health.js`) — three
+ * `../` to reach the package root regardless of whether this runs
+ * from `dist/` (production) or `src/` (tsx watch dev mode).
+ */
+const SERVER_VERSION: string = (() => {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkgPath = join(here, "..", "..", "package.json");
+    const raw = readFileSync(pkgPath, "utf8");
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    return typeof parsed.version === "string" ? parsed.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+})();
 
 export const healthRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get(
@@ -49,7 +72,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
         response: {
           200: {
             type: "object",
-            required: ["minimal", "workspaceRoot"],
+            required: ["minimal", "workspaceRoot", "version"],
             properties: {
               // True when MINIMAL_UI is set: hides terminal, git pane,
               // last-turn pane, and providers/agent settings sections;
@@ -59,6 +82,11 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
               // Absolute path of the workspace root. Minimal-mode
               // project creation builds `<workspaceRoot>/<name>`.
               workspaceRoot: { type: "string" },
+              // Server build version (mirrors packages/server's
+              // package.json). Surfaced in the About tab so users can
+              // confirm which release they're hitting without shelling
+              // into the container.
+              version: { type: "string" },
             },
           },
         },
@@ -67,6 +95,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
     async () => ({
       minimal: config.minimalUi,
       workspaceRoot: config.workspacePath,
+      version: SERVER_VERSION,
     }),
   );
 };

--- a/packages/server/src/skills-export.ts
+++ b/packages/server/src/skills-export.ts
@@ -65,9 +65,28 @@ export interface SkillsImportSummary {
 }
 
 /**
- * Build the export tar. Skips silently when the skills directory
- * doesn't exist — empty exports are valid (returns a tar with zero
- * entries, matching the config-export shape on a fresh install).
+ * Thrown by `buildSkillsExportTar` when the skills directory is
+ * missing or empty. The route layer catches this and returns a 409
+ * with a structured body so the UI can show "No skills to export"
+ * instead of triggering a download of an empty / malformed archive.
+ *
+ * (Background: tar 7.x's `create()` throws synchronously with "no
+ * paths specified to add to archive" on an empty entries list, and a
+ * hand-rolled 1024-zero-byte tar is rejected by tar 7.x's reader as
+ * `TAR_BAD_ARCHIVE`. Both round-trip and "ship something to satisfy
+ * the download" approaches are worse than just refusing the export.)
+ */
+export class SkillsDirectoryEmptyError extends Error {
+  constructor() {
+    super("skills directory is empty");
+    this.name = "SkillsDirectoryEmptyError";
+  }
+}
+
+/**
+ * Build the export tar. Throws `SkillsDirectoryEmptyError` when the
+ * skills tree is missing or contains no files — see the class
+ * docstring for why we don't ship an empty archive.
  *
  * Streams from the source dir directly; no staging copy is needed
  * because the skills tree is read-only from this module's
@@ -77,19 +96,16 @@ export interface SkillsImportSummary {
  */
 export async function buildSkillsExportTar(): Promise<SkillsExportResult> {
   const src = skillsDir();
-  let fileCount = 0;
   let entries: string[] = [];
   try {
     entries = await listFilesRelative(src);
-    fileCount = entries.length;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
   }
-  // tar.create accepts a list of paths relative to `cwd`. An empty
-  // list still produces a valid (empty) gzipped tar.
+  if (entries.length === 0) throw new SkillsDirectoryEmptyError();
   const pack = tarCreate({ gzip: true, cwd: src }, entries);
   const stream = pack as unknown as Readable;
-  return { fileCount, stream };
+  return { fileCount: entries.length, stream };
 }
 
 /**


### PR DESCRIPTION
## Summary

Quality-of-life batch for v1.1.1.

### Git init button
When the active project isn't a git repository, the Git tab now shows an **Initialize git repo** button instead of the previous text-only hint. Click runs `git init -b main` (default branch `main`) on the project root via a new `POST /api/v1/git/init` route, then refreshes status so the panel flips into the normal Staged / Unstaged layout. Idempotent (returns `alreadyInitialised: true` if the project is already a repo). Falls back to plain `git init` on git versions older than 2.28.

### About tab in Settings
New tab at the end of the settings tab bar (also visible in MINIMAL_UI mode). Shows the deployed server version + links to GitHub repo, CHANGELOG, and SECURITY policy. The version is read from `packages/server/package.json` once at module load and surfaced via the existing public `/api/v1/ui-config` endpoint, so no separate fetch is needed. Forward-compatible: older servers without the field render "unknown".

### Chat toggle fix
The chat-column visibility condition was `chatOpen || activeSessionId === undefined` — meant to keep the project picker visible even with chat off, but in practice it meant the user couldn't actually hide chat on the first-open empty state. Tightened to plain `chatOpen` everywhere it's checked (column itself + the chat-leftmost layout calculation in editor / files panes). When chat is closed and there's no project, the main area is empty; the user can re-open chat from the header to reach the picker, or use the sidebar's "+ New project" button.

### Skills export empty fix
`GET /api/v1/config/skills/export` was returning 500 on a fresh install with an empty / missing skills directory. tar 7.x's `create()` throws synchronously on an empty entries list, and a hand-rolled empty tar is rejected by tar 7.x's reader as `TAR_BAD_ARCHIVE` — there's no working "empty download" path. The route now returns **409 `skills_directory_empty`** instead, and the Settings → Backup tab surfaces this as a neutral "No skills to export — your skills directory is empty" info line under the export button instead of a red error banner.

## Test plan

- [x] Open a project that isn't a git repo — Git tab shows "Initialize git repo" button. Click → button shows "Initializing…" then panel flips to normal layout. `git -C <project> branch --show-current` returns `main`.
- [x] Open a project that's already a git repo — no init button visible (status panel renders normally).
- [x] Open Settings → About — shows version `1.1.0`, links to GitHub / CHANGELOG / SECURITY.
- [x] Toggle chat off on the project-picker first-open page — chat column disappears entirely. Toggle back on — picker re-appears.
- [x] Settings → Backup → Export skills (with empty `~/.pi-forge/skills/`) — neutral "No skills to export" message under the button, no red error banner.
- [x] Settings → Backup → Export skills (with skills present) — download triggers normally with the file count line.
- [x] `npm run check` (typecheck + eslint + prettier) — green
- [x] `npm run test:ci` — all 18 tests pass

## Notes

- Version stays at 1.1.0 in this PR per the user request — the bump to 1.1.1 happens at release time. The About tab reads from `packages/server/package.json` at module load so it'll show the new version automatically once bumped.