### PR TITLE
fix: file viewer auto-refresh, explicit save, project scope, chat scroll, session names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,37 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+### Changed
+
+- **Editor saves are now explicit.** Removed the 1-second autosave
+  debounce. Saves go through Cmd/Ctrl+S (already wired in the
+  CodeMirror keymap) or a new **Save** button in the editor's status
+  bar. The status bar still shows the dirty / saving / save-error
+  / saved-at indicator next to the button. The button is disabled
+  when there's nothing to save (clean buffer, save in flight, or
+  binary file).
+- **File browser scopes to the active project.** Switching projects
+  now clears the in-memory open editor tabs in place before
+  restoring the new project's persisted tab list. Previously the
+  old project's tabs stayed visible until the user closed them
+  manually, because `restoreTabs` early-returned when any tab was
+  open. The old project's persisted tab paths in sessionStorage are
+  preserved (re-enter the project to restore them); only the
+  in-memory state is cleared.
+
+### Fixed
+
+- **Editor refreshes when the agent edits an open file.** The
+  per-tool-result reload logic existed but silently missed every
+  fire because the agent's tool calls emit project-relative paths
+  (`src/foo.ts`) while open editor tabs are keyed by absolute path
+  (`/Users/.../proj/src/foo.ts`). Path matching now tries both:
+  exact match against the open file's absolute path, then a
+  project-root-prefixed resolution as a fallback. Also: if any
+  write/edit tool result lands in a batch, the file browser tree
+  refreshes immediately (instead of waiting for `agent_end`) so
+  newly-created files appear without a perceptible lag.
+
 ### Added
 
 - **Git init button in the Git pane.** When the active project isn't

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,16 +34,31 @@ the README for the support window policy.
 
 ### Fixed
 
-- **Editor refreshes when the agent edits an open file.** The
-  per-tool-result reload logic existed but silently missed every
-  fire because the agent's tool calls emit project-relative paths
-  (`src/foo.ts`) while open editor tabs are keyed by absolute path
-  (`/Users/.../proj/src/foo.ts`). Path matching now tries both:
-  exact match against the open file's absolute path, then a
-  project-root-prefixed resolution as a fallback. Also: if any
-  write/edit tool result lands in a batch, the file browser tree
-  refreshes immediately (instead of waiting for `agent_end`) so
-  newly-created files appear without a perceptible lag.
+- **Editor refreshes when the agent edits an open file.** Replaces
+  the per-tool-result detection (which was fragile against SDK
+  changes — the latest `EditToolDetails` only exposes `{ diff,
+  firstChangedLine }`, no path field) with a single
+  `agent_end`-triggered refresh that re-reads every open editor
+  tab from disk and reconciles per file: silent reload for clean
+  buffers, externally-changed banner for dirty buffers. Catches
+  every change source (built-in tools, MCP tools, terminal commands
+  the agent shelled out to, git ops) without needing to know the
+  shape of any tool's result.
+- **Auto-scroll to bottom when a new user message lands.** The
+  chat already auto-scrolled while following the bottom, but a
+  user who'd scrolled up to read history and then submitted a
+  prompt stayed parked in history while the agent's response
+  streamed off-screen. New rule: any time a user-role message
+  appears at the tail, force-scroll to bottom and re-engage
+  follow mode. Catches both the local-submit path and cross-tab
+  delivery.
+- **New sessions get distinct names.** `createSession` now sets a
+  `New session` default name (with `New session (2)`, `(3)`, …
+  suffixes to disambiguate against existing siblings in the same
+  project), mirroring the `(clone)` suffix logic the fork path
+  added in v1.0.3. Previously fresh sessions all fell back to the
+  `session abc1234` sessionId-based fallback in the sidebar, which
+  reads as effectively-identical at a glance.
 
 ### Added
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,7 +3,7 @@ import { FileCode, FolderTree, MessageSquare, Terminal as TerminalIcon } from "l
 import { useAuthStore } from "./store/auth-store";
 import { useActiveProject, useProjectStore } from "./store/project-store";
 import { useSessionStore } from "./store/session-store";
-import { useFileStore } from "./store/file-store";
+import { useFileStore, type OpenFile } from "./store/file-store";
 import { useUiConfigStore } from "./store/ui-config-store";
 import { LoginScreen } from "./components/LoginScreen";
 import { ChangePasswordScreen } from "./components/ChangePasswordScreen";
@@ -248,23 +248,47 @@ export function App() {
       return;
     }
     const fileStore = useFileStore.getState();
+    // Open files are keyed by absolute path (the file browser's
+    // joinPath(project.path, node.path) result). The pi tool result's
+    // `details.path` may be either absolute OR project-relative
+    // depending on how the agent invoked the tool — match against
+    // both so we don't silently miss reloads.
     const openByPath = new Map(fileStore.openFiles.map((f) => [f.path, f]));
+    const projectRoot = active.path.replace(/\/+$/, "");
+    const resolveOpen = (raw: string): { path: string; file: OpenFile } | undefined => {
+      const direct = openByPath.get(raw);
+      if (direct !== undefined) return { path: raw, file: direct };
+      // Treat as project-relative — strip a leading "./" or "/" then
+      // join with the project root. This is the common case (agents
+      // emit cwd-relative paths via the edit/write tools).
+      const trimmed = raw.replace(/^\.\/+/, "").replace(/^\/+/, "");
+      const joined = `${projectRoot}/${trimmed.replaceAll("\\", "/")}`;
+      const found = openByPath.get(joined);
+      return found !== undefined ? { path: joined, file: found } : undefined;
+    };
+    let sawWriteOrEdit = false;
     for (let i = lastSeen; i < sessionMessages.length; i++) {
       const m = sessionMessages[i];
       if (m === undefined) continue;
       if (m.role !== "toolResult") continue;
       const toolName = String(m.toolName ?? "");
       if (toolName !== "write" && toolName !== "edit") continue;
-      const path = extractToolFilePath(m);
-      if (path === undefined) continue;
-      const open = openByPath.get(path);
-      if (open === undefined) continue;
-      if (open.dirty) {
-        fileStore.markExternallyChanged(path);
+      sawWriteOrEdit = true;
+      const raw = extractToolFilePath(m);
+      if (raw === undefined) continue;
+      const match = resolveOpen(raw);
+      if (match === undefined) continue;
+      if (match.file.dirty) {
+        fileStore.markExternallyChanged(match.path);
       } else {
-        void fileStore.reloadFile(active.id, path);
+        void fileStore.reloadFile(active.id, match.path);
       }
     }
+    // If the agent wrote or edited any file in this batch, refresh the
+    // file browser tree so newly-created files / renamed entries
+    // appear without waiting for the next agent_end. Cheap call —
+    // server side just walks the workspace once.
+    if (sawWriteOrEdit) void fileStore.loadTree(active.id);
     lastProcessedRef.current[activeSessionId] = sessionMessages.length;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active?.id, activeSessionId, sessionMessages]);

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,7 +3,7 @@ import { FileCode, FolderTree, MessageSquare, Terminal as TerminalIcon } from "l
 import { useAuthStore } from "./store/auth-store";
 import { useActiveProject, useProjectStore } from "./store/project-store";
 import { useSessionStore } from "./store/session-store";
-import { useFileStore, type OpenFile } from "./store/file-store";
+import { useFileStore } from "./store/file-store";
 import { useUiConfigStore } from "./store/ui-config-store";
 import { LoginScreen } from "./components/LoginScreen";
 import { ChangePasswordScreen } from "./components/ChangePasswordScreen";
@@ -47,29 +47,6 @@ function readPersistedWidth(key: string, fallback: number): number {
   if (raw === null) return fallback;
   const n = Number.parseInt(raw, 10);
   return Number.isFinite(n) && n > 0 ? n : fallback;
-}
-
-/**
- * Best-effort extraction of the affected file path from a write/edit
- * tool_result message. The SDK's exact field name varies across
- * versions and tool flavours; we try the common ones (same heuristic
- * the chat renderer uses for the tool-call summary).
- */
-function extractToolFilePath(message: Record<string, unknown>): string | undefined {
-  const details = message.details as
-    | { path?: unknown; filePath?: unknown; file?: unknown; file_path?: unknown }
-    | undefined;
-  const input = message.input as
-    | { path?: unknown; filePath?: unknown; file?: unknown; file_path?: unknown }
-    | undefined;
-  for (const src of [details, input]) {
-    if (src === undefined) continue;
-    if (typeof src.path === "string") return src.path;
-    if (typeof src.filePath === "string") return src.filePath;
-    if (typeof src.file === "string") return src.file;
-    if (typeof src.file_path === "string") return src.file_path;
-  }
-  return undefined;
 }
 
 export function App() {
@@ -205,9 +182,18 @@ export function App() {
   );
   const loadFileTree = useFileStore((s) => s.loadTree);
   const restoreTabs = useFileStore((s) => s.restoreTabs);
+  const refreshOpenFiles = useFileStore((s) => s.refreshOpenFiles);
+  // After every agent turn, reconcile the file browser tree AND the
+  // open editor tabs against on-disk state. Decoupled from
+  // tool-result inspection: this fires once per `agent_end` and
+  // catches every kind of change — built-in edit/write tools, MCP
+  // tools, terminal commands the agent shelled out to, git ops, etc.
+  // Refresh helper handles per-tab reconciliation (silent reload
+  // for clean buffers, externally-changed banner for dirty ones).
   useEffect(() => {
     if (active === undefined || isStreaming) return;
     void loadFileTree(active.id);
+    void refreshOpenFiles(active.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active?.id, isStreaming, agentEndCount]);
 
@@ -220,78 +206,6 @@ export function App() {
     void restoreTabs(active.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active?.id]);
-
-  // Agent file-change awareness for open editor tabs. Walks NEW
-  // tool_result messages since we last looked, finds write/edit
-  // results, and either silently reloads the file (clean tab) or
-  // surfaces an "external change" banner (dirty tab). The
-  // last-processed pointer is keyed by sessionId — switching sessions
-  // restarts the cursor from the end of that session's history so we
-  // don't re-fire reloads for messages already on screen.
-  const lastProcessedRef = useRef<Record<string, number>>({});
-  const sessionMessages = useSessionStore((s) =>
-    activeSessionId !== undefined ? s.messagesBySession[activeSessionId] : undefined,
-  );
-  useEffect(() => {
-    if (active === undefined || activeSessionId === undefined || sessionMessages === undefined) {
-      return;
-    }
-    const lastSeen = lastProcessedRef.current[activeSessionId] ?? sessionMessages.length;
-    // First time we see this session: skip the existing history,
-    // start watching from the next change forward.
-    if (lastProcessedRef.current[activeSessionId] === undefined) {
-      lastProcessedRef.current[activeSessionId] = sessionMessages.length;
-      return;
-    }
-    if (sessionMessages.length <= lastSeen) {
-      lastProcessedRef.current[activeSessionId] = sessionMessages.length;
-      return;
-    }
-    const fileStore = useFileStore.getState();
-    // Open files are keyed by absolute path (the file browser's
-    // joinPath(project.path, node.path) result). The pi tool result's
-    // `details.path` may be either absolute OR project-relative
-    // depending on how the agent invoked the tool — match against
-    // both so we don't silently miss reloads.
-    const openByPath = new Map(fileStore.openFiles.map((f) => [f.path, f]));
-    const projectRoot = active.path.replace(/\/+$/, "");
-    const resolveOpen = (raw: string): { path: string; file: OpenFile } | undefined => {
-      const direct = openByPath.get(raw);
-      if (direct !== undefined) return { path: raw, file: direct };
-      // Treat as project-relative — strip a leading "./" or "/" then
-      // join with the project root. This is the common case (agents
-      // emit cwd-relative paths via the edit/write tools).
-      const trimmed = raw.replace(/^\.\/+/, "").replace(/^\/+/, "");
-      const joined = `${projectRoot}/${trimmed.replaceAll("\\", "/")}`;
-      const found = openByPath.get(joined);
-      return found !== undefined ? { path: joined, file: found } : undefined;
-    };
-    let sawWriteOrEdit = false;
-    for (let i = lastSeen; i < sessionMessages.length; i++) {
-      const m = sessionMessages[i];
-      if (m === undefined) continue;
-      if (m.role !== "toolResult") continue;
-      const toolName = String(m.toolName ?? "");
-      if (toolName !== "write" && toolName !== "edit") continue;
-      sawWriteOrEdit = true;
-      const raw = extractToolFilePath(m);
-      if (raw === undefined) continue;
-      const match = resolveOpen(raw);
-      if (match === undefined) continue;
-      if (match.file.dirty) {
-        fileStore.markExternallyChanged(match.path);
-      } else {
-        void fileStore.reloadFile(active.id, match.path);
-      }
-    }
-    // If the agent wrote or edited any file in this batch, refresh the
-    // file browser tree so newly-created files / renamed entries
-    // appear without waiting for the next agent_end. Cheap call —
-    // server side just walks the workspace once.
-    if (sawWriteOrEdit) void fileStore.loadTree(active.id);
-    lastProcessedRef.current[activeSessionId] = sessionMessages.length;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active?.id, activeSessionId, sessionMessages]);
 
   useEffect(() => {
     if (!settingsOpen) return;

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -133,6 +133,23 @@ export function ChatView({ sessionId }: Props) {
     if (isFollowingBottomRef.current) el.scrollTop = el.scrollHeight;
   }, [messages, streamingText, isStreaming]);
 
+  // Force scroll-to-bottom + re-engage follow mode whenever a NEW
+  // user message lands at the tail. Catches both the "user typed in
+  // the input box" path AND the "user message arrived via cross-tab
+  // sync" path. Without this, a user who scrolled up to read history
+  // and then submits a prompt stays parked in history while the
+  // agent's response streams off-screen.
+  const lastUserMessageCountRef = useRef(0);
+  useEffect(() => {
+    const userCount = messages.reduce((n, m) => (m.role === "user" ? n + 1 : n), 0);
+    if (userCount > lastUserMessageCountRef.current) {
+      const el = scrollRef.current;
+      if (el !== null) el.scrollTop = el.scrollHeight;
+      isFollowingBottomRef.current = true;
+    }
+    lastUserMessageCountRef.current = userCount;
+  }, [messages]);
+
   return (
     <ChatDiffViewContext.Provider
       value={{ viewType: chatViewType, setViewType: setAndPersistChatViewType }}

--- a/packages/client/src/components/CodeMirrorEditor.tsx
+++ b/packages/client/src/components/CodeMirrorEditor.tsx
@@ -49,8 +49,6 @@ import { cmake } from "@codemirror/legacy-modes/mode/cmake";
 import { nginx } from "@codemirror/legacy-modes/mode/nginx";
 import type { OpenFile } from "../store/file-store";
 
-const AUTOSAVE_DEBOUNCE_MS = 1000;
-
 /**
  * CodeMirror host. Lives in its own module so EditorPanel can pull it
  * in via `React.lazy()` — the CM bundle is ~700 KB minified and the
@@ -187,18 +185,11 @@ export function CodeMirrorEditor({
     });
   }, [file.draft]);
 
-  // Debounced autosave: schedule a save 1s after the last `dirty`
-  // transition. Cleared on tab switch (component unmounts via key).
-  // Skipped when `saveError` is set — the user has to explicitly
-  // retry (Cmd/Ctrl+S) so we don't hammer a broken endpoint and
-  // overwrite the diagnostic that explains why saves are failing.
-  useEffect(() => {
-    if (!file.dirty || file.binary || file.saveError !== undefined) return undefined;
-    const timer = window.setTimeout(() => {
-      onSaveRef.current();
-    }, AUTOSAVE_DEBOUNCE_MS);
-    return () => window.clearTimeout(timer);
-  }, [file.dirty, file.draft, file.binary, file.saveError]);
+  // No autosave. Saves go through Cmd/Ctrl+S (handled by the editor's
+  // keymap and routed via `onSaveShortcut`) or the explicit Save
+  // button in EditorPanel's toolbar. The `dirty` flag on each tab
+  // surfaces unsaved state in the tab strip so the user knows when a
+  // save is needed.
 
   // Pending-navigation effect: when the file-store sets `pendingNav`
   // on this tab (e.g. from a search-result click), scroll the editor

--- a/packages/client/src/components/EditorPanel.tsx
+++ b/packages/client/src/components/EditorPanel.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { useFileStore, type OpenFile } from "../store/file-store";
 import { useActiveProject } from "../store/project-store";
-import { WrapText, X, XSquare } from "lucide-react";
+import { Save, WrapText, X, XSquare } from "lucide-react";
 
 const WRAP_KEY_PREFIX = "forge.editor.wrap.";
 
@@ -138,7 +138,14 @@ export function EditorPanel() {
               />
             </Suspense>
           )}
-          <StatusBar file={active} wrap={wrap} onToggleWrap={toggleWrap} />
+          <StatusBar
+            file={active}
+            wrap={wrap}
+            onToggleWrap={toggleWrap}
+            onSave={() => {
+              if (project !== undefined) void saveFile(project.id, active.path);
+            }}
+          />
         </>
       )}
     </div>
@@ -262,10 +269,12 @@ function StatusBar({
   file,
   wrap,
   onToggleWrap,
+  onSave,
 }: {
   file: OpenFile;
   wrap: boolean;
   onToggleWrap: () => void;
+  onSave: () => void;
 }) {
   const dirty = file.dirty;
   const saving = file.saving;
@@ -277,7 +286,7 @@ function StatusBar({
   // because the user needs to see the failure before deciding to keep
   // editing or retry. Cleared on the next successful save.
   if (saveError !== undefined) {
-    label = `Save failed (${saveError}) — Cmd/Ctrl+S to retry`;
+    label = `Save failed (${saveError}) — Cmd/Ctrl+S or Save to retry`;
     className = "text-rose-400";
   } else if (saving) {
     label = "Saving…";
@@ -291,6 +300,10 @@ function StatusBar({
   } else {
     label = "Up to date";
   }
+  // Save button is only meaningful when there's something to save
+  // (dirty buffer) or something to retry (last save errored). Stays
+  // disabled while a save is in flight to avoid double-fire.
+  const canSave = (dirty || saveError !== undefined) && !saving && !file.binary;
   return (
     <div className="flex items-center justify-between gap-3 border-t border-neutral-800 bg-neutral-900/40 px-3 py-1 text-[11px]">
       <div className="flex items-center gap-2">
@@ -310,7 +323,18 @@ function StatusBar({
           {wrap ? "wrap" : "no wrap"}
         </button>
       </div>
-      <span className={className}>{label}</span>
+      <div className="flex items-center gap-2">
+        <span className={className}>{label}</span>
+        <button
+          onClick={onSave}
+          disabled={!canSave}
+          className="flex items-center gap-1 rounded border border-neutral-700 px-1.5 py-0.5 text-[10px] text-neutral-200 hover:border-neutral-500 disabled:cursor-not-allowed disabled:border-neutral-800 disabled:text-neutral-600"
+          title="Save (Cmd/Ctrl+S)"
+        >
+          <Save size={11} />
+          Save
+        </button>
+      </div>
     </div>
   );
 }

--- a/packages/client/src/store/file-store.ts
+++ b/packages/client/src/store/file-store.ts
@@ -141,6 +141,22 @@ interface FileState {
    */
   reloadFile: (projectId: string, path: string) => Promise<void>;
   /**
+   * Re-read every open editor tab from disk and reconcile with the
+   * in-memory state. Per-file decision:
+   *   - on-disk content matches the current `saved` field → no-op
+   *   - on-disk content differs AND tab is clean → reload (replace
+   *     `saved` + `draft`); CodeMirror's draft-watching effect
+   *     replays the new doc into the editor
+   *   - on-disk content differs AND tab is dirty → markExternallyChanged
+   *     so the user sees the banner instead of losing their work
+   * Used by App.tsx on every `agent_end` (and any other point we know
+   * the workspace may have shifted underneath us). Intentionally
+   * decoupled from tool-result detection — this works for ANY change
+   * the agent's run produced (tool calls, terminal commands the
+   * agent shelled out to, git operations, etc.).
+   */
+  refreshOpenFiles: (projectId: string) => Promise<void>;
+  /**
    * Mark a tab as having received an external change while dirty. The
    * editor renders a banner offering to discard or reload. Cleared by
    * the next successful saveFile or reloadFile, OR by an explicit
@@ -441,6 +457,57 @@ export const useFileStore = create<FileState>((set, get) => ({
     } catch (err) {
       set({ error: err instanceof ApiError ? err.code : (err as Error).message });
     }
+  },
+
+  refreshOpenFiles: async (projectId) => {
+    // Snapshot the open paths so concurrent close/open doesn't reshape
+    // the array while we iterate. Reads are issued in parallel — each
+    // one is independent and the worst case is O(open_tabs) requests
+    // (typically 0–3).
+    const snapshot = get().openFiles.map((f) => ({
+      path: f.path,
+      saved: f.saved,
+      dirty: f.dirty,
+    }));
+    if (snapshot.length === 0) return;
+    const results = await Promise.allSettled(snapshot.map((s) => api.filesRead(projectId, s.path)));
+    set((state) => {
+      let openFilesNext = state.openFiles;
+      let externallyChanged = state.externallyChanged;
+      for (let i = 0; i < snapshot.length; i++) {
+        const res = results[i];
+        const snap = snapshot[i];
+        if (res === undefined || snap === undefined) continue;
+        // Ignore failures here — a 404 on a deleted file should
+        // surface via the user's next interaction, not as a noisy
+        // banner during a refresh sweep.
+        if (res.status !== "fulfilled") continue;
+        const r = res.value;
+        // No-op when content matches — avoids spurious CodeMirror
+        // doc replays + flickers.
+        if (r.content === snap.saved && !snap.dirty) continue;
+        if (r.content === snap.saved) continue;
+        if (snap.dirty) {
+          externallyChanged = { ...externallyChanged, [snap.path]: true };
+        } else {
+          openFilesNext = openFilesNext.map((f) =>
+            f.path === snap.path
+              ? {
+                  ...f,
+                  saved: r.content,
+                  draft: r.content,
+                  dirty: false,
+                  language: r.language,
+                  binary: r.binary,
+                  loadingError: r.binary ? "Binary file — open externally to edit." : undefined,
+                }
+              : f,
+          );
+          externallyChanged = omitKey(externallyChanged, snap.path);
+        }
+      }
+      return { openFiles: openFilesNext, externallyChanged };
+    });
   },
 
   markExternallyChanged: (path) => {

--- a/packages/client/src/store/file-store.ts
+++ b/packages/client/src/store/file-store.ts
@@ -237,11 +237,22 @@ export const useFileStore = create<FileState>((set, get) => ({
   },
 
   restoreTabs: async (projectId) => {
+    // Two cases:
+    // 1. Same project as the current in-memory state — preserve
+    //    whatever the user has open (cold-boot already ran, or this
+    //    is a redundant call). Early-return.
+    // 2. Different project (project switch) — clear in-memory state
+    //    in place so the editor pane stops showing the OLD project's
+    //    tabs while we load the new project's persisted list.
+    //    Crucially, we DON'T persist the empty state to the old
+    //    project's storage key; the old tabs were already persisted
+    //    by every prior edit, so the data is intact for when the
+    //    user switches back. We just clear what's in the store.
+    if (currentProjectId === projectId && get().openFiles.length > 0) return;
+    if (currentProjectId !== projectId) {
+      set({ openFiles: [], activePath: undefined, externallyChanged: {} });
+    }
     currentProjectId = projectId;
-    // Skip if anything is already open for this project — the
-    // restore is meant for the cold-boot path, not to clobber
-    // mid-session state.
-    if (get().openFiles.length > 0) return;
     const persisted = readPersistedTabs(projectId);
     if (persisted.paths.length === 0) return;
     // Open files in order so the tab strip matches the persisted

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -400,6 +400,33 @@ export async function createSession(
   };
   live.unsubscribe = makeSubscribeHandler(live);
   registry.set(live.sessionId, live);
+
+  // Set a meaningful default name on the new session so the sidebar
+  // doesn't show every fresh-create as the indistinguishable
+  // "session abc1234" fallback. Pattern: "New session" with a numeric
+  // suffix to disambiguate against existing siblings in this project.
+  // Best-effort — the session is fully usable regardless. The user
+  // can rename via the sidebar's inline rename at any time.
+  try {
+    const siblings = await listSessionsForProject(projectId, workspacePath);
+    const existingNames = new Set(
+      siblings
+        .filter((s) => s.sessionId !== live.sessionId)
+        .map((s) => s.name)
+        .filter((n): n is string => typeof n === "string"),
+    );
+    let candidate = "New session";
+    let n = 2;
+    while (existingNames.has(candidate)) {
+      candidate = `New session (${n})`;
+      n += 1;
+    }
+    session.setSessionName(candidate);
+  } catch {
+    // Naming failure is non-fatal; leave the SDK default and let the
+    // sidebar fall back to "session <id>" if needed.
+  }
+
   return live;
 }
 


### PR DESCRIPTION
## Summary

File-viewer correctness pass + a couple of related UX fixes the user flagged in the same conversation.

### File viewer

- **Editor refreshes when the agent (or anything else) edits an open file.** Replaces a fragile per-tool-result detection with a single `agent_end`-triggered reconciliation. New file-store action `refreshOpenFiles(projectId)` re-reads each open editor tab in parallel and applies per file: silent reload for clean buffers, externally-changed banner for dirty buffers, no-op when on-disk content matches `saved`. Catches every change source — built-in tools, MCP tools, terminal commands the agent shelled out to, git ops — without coupling to any tool's result shape. (The previous attempt's per-tool-result code was always a no-op because the current SDK's `EditToolDetails` only exposes `{ diff, firstChangedLine }`, no path field.)
- **Editor saves are explicit.** Removed the 1-second autosave debounce. Saves go through Cmd/Ctrl+S (already wired in CodeMirror's keymap) or a new **Save** button in the editor's status bar. Status bar still shows the dirty / saving / save-error / saved-at indicator next to the button. Disabled when there's nothing to save.
- **File browser scopes to the active project.** Switching projects now clears the in-memory open editor tabs in place before restoring the new project's persisted tab list. Previously the old project's tabs stayed visible until the user closed them manually because `restoreTabs` early-returned when any tab was open. The old project's persisted tab paths in sessionStorage are preserved (re-enter the project to restore them); only the in-memory state is cleared.

### Chat

- **Force-scroll to bottom when a new user message lands.** A user who'd scrolled up to read history and then submitted a prompt previously stayed parked in history while the agent's response streamed off-screen. New rule: any user-role message at the tail forces scrollTop to scrollHeight AND re-engages follow-mode. Catches both the local-submit path and cross-tab delivery.

### Sessions

- **Fresh sessions get distinct names.** `createSession` now sets a `New session` default with a numeric suffix (`New session (2)`, `(3)`, …) to disambiguate against existing siblings in the project. Mirrors the `(clone)` suffix the fork path got in v1.0.3. Previously fresh sessions all fell through to the `session abc1234` sessionId-based fallback in the sidebar, which reads as effectively-identical at a glance.

## Commit ordering

8 commits, mostly mechanical:

1. `83a25d4` Remove 1s autosave debounce; add Save button + Cmd+S still wired
2. `bc10723` Clear open editor tabs in memory on project switch
3. `d30b505` First (failed) attempt at file-viewer refresh — kept in history; superseded by commit #5
4. `08df1b8` First CHANGELOG entry — superseded by commit #8
5. `fcc3de8` Replace tool-result detection with `agent_end`-triggered `refreshOpenFiles`
6. `4c81efc` Force-scroll on new user message
7. `33a3ed0` Default session name `New session (n)`
8. `dff19f1` CHANGELOG entry covering all the above

The git history shows commits #3 and #4 (the first refresh attempt) followed by #5 (the working replacement) — kept rather than rewritten so future archaeology can see why we abandoned the tool-result path. The live code at HEAD reflects only the new approach.

## Test plan

- [x] `npm run check` (typecheck + eslint + prettier) — green
- [x] `npm run build` — green
- [x] `npm run test:ci` — 18/18 tests pass
- [x] Have the agent edit a file currently open in the editor — editor content updates after the agent finishes its turn
- [x] Same, but with the editor buffer dirty — yellow "external change" banner appears, "Reload" pulls in the agent's version, "Discard" keeps yours
- [x] Edit a file in the editor, switch tabs without saving — Save button + dirty indicator visible until clicked
- [x] Cmd/Ctrl+S triggers immediate save (status flips from dirty → saving → saved-at hh:mm:ss)
- [x] Switch from project A (with editor tabs open) to project B — A's tabs disappear, B's persisted tabs (if any) restore
- [x] Switch back to A — A's tabs restore from sessionStorage
- [x] Scroll up in chat to read history, submit a new prompt — chat snaps to bottom and follows the streaming response
- [x] Create three new sessions in a fresh project — sidebar shows "New session", "New session (2)", "New session (3)"