### PR TITLE
chore(release): v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.1.1] — 2026-05-05
+
 ### Changed
 
 - **Editor saves are now explicit.** Removed the 1-second autosave

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "workspaces": [
         "packages/*"
       ],
@@ -17268,7 +17268,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17311,7 +17311,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts v1.1.1. The `[Unreleased]` section of CHANGELOG.md is dated to 2026-05-05 and version numbers in `package.json`, `packages/server/package.json`, `packages/client/package.json`, and `package-lock.json` are bumped to 1.1.1.

Notable contents (from already-merged PRs):
- File viewer auto-refreshes when the agent edits open files (PR #25)
- Editor saves are now explicit — Cmd/Ctrl+S or Save button (PR #25)
- File browser scopes to the active project (PR #25)
- Force-scroll to chat bottom on user prompt submit (PR #25)
- New sessions get distinct names — `New session (n)` (PR #25)
- Git init button in Git pane for non-repo projects (PR #24)
- About tab in Settings showing the deployed version (PR #24)
- Chat toggle now fully hides the chat column (PR #24)
- Skills export returns 409 instead of 500 on empty skills directory (PR #24)

## Test plan

- [x] After merge: tag from main with `git tag v1.1.1 && git push origin v1.1.1`
- [x] Release workflow builds multi-arch image and creates GitHub Release
- [x] check-version job passes (tag matches package.json across workspaces)
- [x] About tab in Settings shows version `1.1.1` after deploy