### PR TITLE
feat(settings): collapse About into General tab; add password change

### DIFF
--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -2489,7 +2489,7 @@ function GeneralTab() {
       <header className="space-y-1">
         <h2 className="text-base font-semibold text-neutral-100">pi-forge</h2>
         <p className="text-xs text-neutral-500">
-          Browser workbench for the{" "}
+          Browser interface for the{" "}
           <a
             href="https://github.com/badlogic/pi-mono"
             target="_blank"

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import {
   api,
@@ -16,8 +16,9 @@ import { useUiConfigStore } from "../store/ui-config-store";
 import { EMPTY_STATUS, useMcpStore } from "../store/mcp-store";
 import { THEME_DEFS, useThemeStore, type ThemeId } from "../lib/theme";
 import { getStoredToken } from "../lib/auth-client";
+import { useAuthStore } from "../store/auth-store";
 
-type Tab = "providers" | "agent" | "mcp" | "tools" | "skills" | "appearance" | "backup" | "about";
+type Tab = "providers" | "agent" | "mcp" | "tools" | "skills" | "appearance" | "backup" | "general";
 
 interface Props {
   onClose: () => void;
@@ -61,7 +62,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           // deployments often want to disable bash/edit/write at the
           // tool level, regardless of what providers / agent settings
           // are exposed.
-          (["skills", "tools", "appearance", "backup", "about"] as const)
+          (["skills", "tools", "appearance", "backup", "general"] as const)
         : ([
             "providers",
             "agent",
@@ -70,7 +71,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
             "skills",
             "appearance",
             "backup",
-            "about",
+            "general",
           ] as const),
     [minimal],
   );
@@ -126,7 +127,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
                             ? "Appearance"
                             : t === "backup"
                               ? "Backup"
-                              : "About"}
+                              : "General"}
               </button>
             ))}
           </div>
@@ -177,7 +178,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           {tab === "skills" && <SkillsTab onError={setError} />}
           {tab === "appearance" && <AppearanceTab />}
           {tab === "backup" && <BackupTab onError={setError} />}
-          {tab === "about" && <AboutTab />}
+          {tab === "general" && <GeneralTab />}
         </div>
       </div>
     </div>
@@ -2468,17 +2469,21 @@ function McpDraftForm(props: {
   );
 }
 
-// ---------------- About tab ----------------
+// ---------------- General tab ----------------
+
+const MIN_PASSWORD_LENGTH = 8;
 
 /**
- * Read-only "what am I running" pane. Shows the deployed server
- * version (from `/ui-config`) plus a couple of orienting links —
- * GitHub repo, CHANGELOG, security policy. Useful for confirming a
- * deploy actually rolled forward without shelling into the container.
+ * Catch-all "what am I running + account" pane. Combines the previous
+ * About pane (version + links) with an in-place password-change form
+ * for deployments that use UI_PASSWORD auth. The password section
+ * hides on API-key-only deployments — there's nothing to change in
+ * that case.
  */
-function AboutTab() {
+function GeneralTab() {
   const version = useUiConfigStore((s) => s.version);
   const loaded = useUiConfigStore((s) => s.loaded);
+  const passwordAuthEnabled = useUiConfigStore((s) => s.passwordAuthEnabled);
   return (
     <div className="space-y-6 text-sm text-neutral-300">
       <header className="space-y-1">
@@ -2547,6 +2552,144 @@ function AboutTab() {
           </li>
         </ul>
       </section>
+
+      {passwordAuthEnabled && <ChangePasswordSection />}
     </div>
   );
+}
+
+/**
+ * Inline password-change form mirroring the UX of the forced
+ * first-login ChangePasswordScreen but rendered inside Settings →
+ * General. Reuses the existing useAuthStore.changePassword action
+ * (which handles hashing on the server, atomic write to
+ * password-hash, and re-issuing the JWT). Reads pending + error
+ * state from the same store so a failed change persists across
+ * re-renders.
+ */
+function ChangePasswordSection() {
+  const changePassword = useAuthStore((s) => s.changePassword);
+  const pending = useAuthStore((s) => s.changePasswordPending);
+  const remoteError = useAuthStore((s) => s.changePasswordError);
+
+  const [current, setCurrent] = useState("");
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [localError, setLocalError] = useState<string | undefined>(undefined);
+  // Prior pending state — rising-edge detect on `pending` flipping
+  // false with no remoteError tells us a successful save just landed,
+  // so we can clear the form fields and surface a confirmation.
+  const [savedFlash, setSavedFlash] = useState(false);
+  const wasPendingRef = useRef(false);
+  useEffect(() => {
+    if (wasPendingRef.current && !pending && remoteError === undefined) {
+      setCurrent("");
+      setNext("");
+      setConfirm("");
+      setSavedFlash(true);
+      const t = window.setTimeout(() => setSavedFlash(false), 2500);
+      return () => window.clearTimeout(t);
+    }
+    wasPendingRef.current = pending;
+    return undefined;
+  }, [pending, remoteError]);
+
+  const onSubmit = (e: FormEvent<HTMLFormElement>): void => {
+    e.preventDefault();
+    setLocalError(undefined);
+    setSavedFlash(false);
+    if (next.length < MIN_PASSWORD_LENGTH) {
+      setLocalError(`New password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+    if (next !== confirm) {
+      setLocalError("New password and confirmation do not match.");
+      return;
+    }
+    if (next === current) {
+      setLocalError("New password must differ from the current one.");
+      return;
+    }
+    void changePassword(current, next);
+  };
+
+  const error = localError ?? friendlyChangePasswordError(remoteError);
+
+  return (
+    <section className="space-y-2 border-t border-neutral-800 pt-5">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+        Change password
+      </h3>
+      <p className="text-xs text-neutral-500">
+        Updates the scrypt hash on disk; existing browser sessions stay signed in.
+      </p>
+      <form onSubmit={onSubmit} className="space-y-2">
+        <label className="block space-y-1">
+          <span className="text-xs text-neutral-400">Current password</span>
+          <input
+            type="password"
+            value={current}
+            onChange={(e) => setCurrent(e.target.value)}
+            autoComplete="current-password"
+            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-1.5 text-sm outline-none focus:border-neutral-500"
+          />
+        </label>
+        <label className="block space-y-1">
+          <span className="text-xs text-neutral-400">New password</span>
+          <input
+            type="password"
+            value={next}
+            onChange={(e) => setNext(e.target.value)}
+            autoComplete="new-password"
+            minLength={MIN_PASSWORD_LENGTH}
+            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-1.5 text-sm outline-none focus:border-neutral-500"
+          />
+        </label>
+        <label className="block space-y-1">
+          <span className="text-xs text-neutral-400">Confirm new password</span>
+          <input
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            autoComplete="new-password"
+            minLength={MIN_PASSWORD_LENGTH}
+            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-1.5 text-sm outline-none focus:border-neutral-500"
+          />
+        </label>
+        {error !== undefined && (
+          <p role="alert" className="text-xs text-red-400">
+            {error}
+          </p>
+        )}
+        {savedFlash && (
+          <p role="status" className="text-xs text-emerald-400">
+            Password updated.
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={pending || current.length === 0 || next.length === 0}
+          className="rounded-md bg-neutral-100 px-3 py-1.5 text-xs font-medium text-neutral-900 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {pending ? "Saving…" : "Update password"}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+function friendlyChangePasswordError(code: string | undefined): string | undefined {
+  if (code === undefined) return undefined;
+  switch (code) {
+    case "invalid_password":
+      return "Current password is incorrect.";
+    case "password_unchanged":
+      return "New password must differ from the current one.";
+    case "ui_password_not_configured":
+      return "Password auth is not configured on this server.";
+    case "auth_required":
+      return "Session expired — sign in again.";
+    default:
+      return `Could not change password: ${code}`;
+  }
 }

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -117,10 +117,21 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
   ) {
     fail(status, "expected { minimal: boolean, workspaceRoot: string }");
   }
-  // `version` is forward-compatible: older servers without the field
-  // fall through to "unknown" so the About tab still renders.
+  // `version` and `passwordAuthEnabled` are forward-compatible: older
+  // servers without the fields fall through to safe defaults.
+  // - version → "unknown" so the General tab still renders.
+  // - passwordAuthEnabled → true so the password section still shows
+  //   (the worst case is a confusing 400 on submit; better than
+  //   silently hiding the form on a server that does support it).
   const version = typeof value.version === "string" ? value.version : "unknown";
-  return { minimal: value.minimal, workspaceRoot: value.workspaceRoot, version };
+  const passwordAuthEnabled =
+    typeof value.passwordAuthEnabled === "boolean" ? value.passwordAuthEnabled : true;
+  return {
+    minimal: value.minimal,
+    workspaceRoot: value.workspaceRoot,
+    version,
+    passwordAuthEnabled,
+  };
 }
 
 function vHealth(value: unknown, status: number): HealthResponse {

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -116,6 +116,13 @@ export interface UiConfigResponse {
   workspaceRoot: string;
   /** Server build version (mirrors packages/server's package.json). */
   version: string;
+  /**
+   * True when the server supports the browser password-change flow
+   * (env UI_PASSWORD set OR a persisted password-hash exists).
+   * False on API-key-only deployments — the General settings tab
+   * hides the password section in that case.
+   */
+  passwordAuthEnabled: boolean;
 }
 
 export interface UnifiedSession {

--- a/packages/client/src/store/ui-config-store.ts
+++ b/packages/client/src/store/ui-config-store.ts
@@ -22,6 +22,13 @@ interface UiConfigState {
   workspaceRoot: string;
   /** Server build version (mirrors packages/server's package.json). */
   version: string;
+  /**
+   * True when the server supports the browser password-change flow.
+   * Defaults to true so the General settings tab still shows the
+   * password section before /ui-config has loaded — better than
+   * flashing the form away on first paint.
+   */
+  passwordAuthEnabled: boolean;
   /** Last load error (sticky until a retry succeeds), for diagnostics. */
   error: string | undefined;
   load: () => Promise<void>;
@@ -32,6 +39,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
   minimal: false,
   workspaceRoot: "",
   version: "",
+  passwordAuthEnabled: true,
   error: undefined,
   load: async () => {
     try {
@@ -41,6 +49,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
         minimal: cfg.minimal,
         workspaceRoot: cfg.workspaceRoot,
         version: cfg.version,
+        passwordAuthEnabled: cfg.passwordAuthEnabled,
         error: undefined,
       });
     } catch (err) {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -327,3 +327,14 @@ export function authEnabled(): boolean {
     existsSync(config.auth.passwordHashFile)
   );
 }
+
+/**
+ * True iff this deployment supports the browser password-change flow:
+ * either an env-supplied UI_PASSWORD is in use OR a hash has already
+ * been persisted from a prior change. API-key-only deployments don't
+ * have a password to change, so the Settings → General password
+ * section hides on them. Read by /ui-config.
+ */
+export function passwordAuthEnabled(): boolean {
+  return config.auth.uiPassword !== undefined || existsSync(config.auth.passwordHashFile);
+}

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { FastifyPluginAsync } from "fastify";
 import { sessionCount } from "../session-registry.js";
 import { ptyCount } from "../pty-manager.js";
-import { config } from "../config.js";
+import { config, passwordAuthEnabled } from "../config.js";
 
 /**
  * Read the server's own package.json once at module load. Used by the
@@ -72,7 +72,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
         response: {
           200: {
             type: "object",
-            required: ["minimal", "workspaceRoot", "version"],
+            required: ["minimal", "workspaceRoot", "version", "passwordAuthEnabled"],
             properties: {
               // True when MINIMAL_UI is set: hides terminal, git pane,
               // last-turn pane, and providers/agent settings sections;
@@ -83,10 +83,16 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
               // project creation builds `<workspaceRoot>/<name>`.
               workspaceRoot: { type: "string" },
               // Server build version (mirrors packages/server's
-              // package.json). Surfaced in the About tab so users can
-              // confirm which release they're hitting without shelling
-              // into the container.
+              // package.json). Surfaced in the General settings tab
+              // so users can confirm which release they're hitting
+              // without shelling into the container.
               version: { type: "string" },
+              // True when the deployment supports the browser
+              // password-change flow (env UI_PASSWORD set OR a
+              // persisted password-hash exists). API-key-only
+              // deployments report false; the Settings → General
+              // password change section hides in that case.
+              passwordAuthEnabled: { type: "boolean" },
             },
           },
         },
@@ -96,6 +102,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
       minimal: config.minimalUi,
       workspaceRoot: config.workspacePath,
       version: SERVER_VERSION,
+      passwordAuthEnabled: passwordAuthEnabled(),
     }),
   );
 };


### PR DESCRIPTION
## Summary

Folds the read-only **About** tab into a broader **General** tab and adds an in-place password-change form for deployments that use `UI_PASSWORD` auth.

### General tab content

Same Version + Links sections that lived under About, plus a new **Change password** section below them. The password section auto-hides on deployments where there's nothing to change.

### Password-change form

- 8-char minimum, confirm-match, must-differ-from-current
- Reuses the existing `useAuthStore.changePassword` action from the forced first-login flow — same `POST /auth/change-password` endpoint, same scrypt hashing, same JWT re-issue. **No new server surface.**
- Rising-edge detect on `pending` flipping false (with no remote error) clears the fields and surfaces a brief "Password updated." confirmation
- Friendly error mapping mirrors the ChangePasswordScreen — `invalid_password`, `password_unchanged`, `ui_password_not_configured`, `auth_required`

### Visibility gate

The form only renders when the server reports `passwordAuthEnabled: true` — i.e. either `UI_PASSWORD` env is set OR a `password-hash` file already exists. API-key-only deployments (no password to change) hide the section entirely. New `passwordAuthEnabled()` predicate in `config.ts`, exposed via `/api/v1/ui-config`.

### Forward compatibility

`vUiConfig` defaults `passwordAuthEnabled` to `true` when the field is absent, so older clients hitting newer servers (and vice versa) still render the form. Worst case is a clear server-side 400 on submit, never a silently-missing form on a server that does support it.

### Drive-by

Last `workbench` literal in the active codebase outside CHANGELOG history is gone — the General tab tagline now reads "Browser interface for the pi coding agent" instead of "Browser workbench…". Verified by `git grep -i workbench` returning zero non-history matches.

## Test plan

- [x] Deployment with `UI_PASSWORD` set: open Settings → General. Password section visible. Submit → password updates, brief "Password updated." confirmation, fields clear.
- [x] Deployment with API key only (no `UI_PASSWORD`, no `password-hash`): Password section hidden entirely.
- [x] Same `UI_PASSWORD` deployment, submit with wrong current password: red "Current password is incorrect." inline.
- [x] Submit new and confirm fields differing: "New password and confirmation do not match."
- [x] Submit new equal to current: "New password must differ from the current one."
- [x] After successful change, hard-refresh the page and log in with the new password (the env var is no longer used; on-disk hash takes over).
- [x] `/api/v1/ui-config` JSON response includes `passwordAuthEnabled: <bool>`.

## Notes

- For operators wanting to enable password auth from a fresh install: set `UI_PASSWORD` once in `.env` (the docker compose example), restart, log in, then change to your real password via the General tab. The env var is consulted only until the first successful change.