### PR TITLE
feat(release): publish pi-forge to npm via trusted-publisher OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,3 +212,74 @@ jobs:
           generate_release_notes: ${{ steps.notes.outputs.have_notes != 'true' }}
           prerelease: ${{ contains(github.ref_name, '-') }}
           fail_on_unmatched_files: false
+
+  npm-publish:
+    name: Publish pi-forge to npm
+    needs: check-version
+    runs-on: ubuntu-latest
+    # Trusted Publisher (npm OIDC) is configured on the npm side to
+    # require this environment claim. The `production` GitHub
+    # Environment must exist under repo Settings → Environments — if
+    # it's missing the workflow fails with "Environment 'production'
+    # not found" before any step runs. Match this name to whatever
+    # was set in the trusted publisher config on npmjs.com.
+    environment: production
+    permissions:
+      # `id-token: write` is what `npm publish` uses to mint a sigstore
+      # OIDC token. With trusted publishers configured, npm exchanges
+      # that token for a short-lived publish credential — no long-lived
+      # NPM_TOKEN secret in the repo. Provenance attestation is the
+      # same mechanism, attached automatically when this permission +
+      # publishConfig.provenance are both set.
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        # Setting registry-url switches the npm CLI's auth flow into
+        # the registry-aware mode required for OIDC. Without this,
+        # `npm publish` would silently use the default user-level
+        # config and fail authentication.
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace
+        # Produces packages/server/dist/ + packages/client/dist/, the
+        # inputs to the publish-dir assembler.
+        run: npm run build
+
+      - name: Assemble publish/ staging dir
+        # Synthesizes publish/package.json (name=pi-forge, version
+        # from root, server's deps hoisted), copies built server +
+        # client artifacts, copies the bin shim and LICENSE.
+        run: npm run build:publish
+
+      - name: Verify staged version matches tag
+        # Belt-and-suspenders. check-version already verified all three
+        # source package.json files agree with the tag, but the synthetic
+        # publish/package.json is a NEW input — assert it independently
+        # so a bug in build-publish-dir.mjs can't ship a mislabeled
+        # tarball.
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          synth=$(node -p "require('./publish/package.json').version")
+          if [ "$synth" != "$tag" ]; then
+            echo "::error::publish/package.json version $synth does not match tag $tag" >&2
+            exit 1
+          fi
+          echo "publish/package.json version $synth ✓"
+
+      - name: Publish to npm
+        # publishConfig in the synthetic package.json sets access=public
+        # and provenance=true, so this is a one-line invocation. The
+        # OIDC dance happens automatically because of `id-token: write`
+        # and the trusted publisher config on the npm side.
+        working-directory: publish
+        run: npm publish

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist/
 packages/*/dist/
 *.tgz
 
+# npm publish staging (assembled by scripts/build-publish-dir.mjs)
+publish/
+
 # TypeScript incremental build info
 *.tsbuildinfo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+### Added
+
+- **npm distribution.** pi-forge now publishes to npm as `pi-forge` on
+  every `v*` tag, in lockstep with the GHCR Docker image. Install via
+  `npm i -g pi-forge` or `npx pi-forge` for a no-Docker run path with
+  the embedded SPA. Published as a flat single-package layout — server
+  + client + bin shim assembled by `scripts/build-publish-dir.mjs` from
+  the workspace builds, with the server's runtime deps hoisted as the
+  published package's dependencies. Authentication uses npm Trusted
+  Publishers (OIDC) — no long-lived `NPM_TOKEN` secret in the repo —
+  and every release ships with a sigstore-signed provenance attestation.
+
 ## [1.1.1] — 2026-05-05
 
 ### Changed

--- a/bin/pi-forge.mjs
+++ b/bin/pi-forge.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * pi-forge CLI launcher.
+ *
+ * The published npm package layout is:
+ *
+ *   pi-forge/
+ *   ├── bin/pi-forge.mjs       (this file)
+ *   ├── dist/server/           (built Fastify server — copy of packages/server/dist/)
+ *   └── dist/client/           (built Vite SPA — copy of packages/client/dist/)
+ *
+ * The server's default `CLIENT_DIST_PATH` resolves relative to its own
+ * compiled file (`dist/server/config.js` → `../../client/dist`), which
+ * works for the in-repo `npm run build && node dist/index.js` flow and
+ * the Docker image (both share the `packages/server/dist/` +
+ * `packages/client/dist/` layout) but NOT for the flat published
+ * package. We override `CLIENT_DIST_PATH` here so the same server entry
+ * works in all three deployment shapes without touching server code.
+ *
+ * Everything else (workspace path, pi config dir, forge data dir, port,
+ * auth) is read from env vars and uses the server's existing defaults
+ * (`~/.pi-forge/workspace`, `~/.pi/agent`, `~/.pi-forge`, port 3000) —
+ * users who installed via `npm i -g pi-forge` get sensible per-user
+ * paths under their home directory without any setup.
+ */
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(here, "..");
+
+process.env.CLIENT_DIST_PATH ??= resolve(packageRoot, "dist", "client");
+process.env.NODE_ENV ??= "production";
+
+const serverEntry = resolve(packageRoot, "dist", "server", "index.js");
+const { start } = await import(pathToFileURL(serverEntry).href);
+await start();

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check": "npm run typecheck && npm run lint && npm run format:check",
     "test": "scripts/run-tests.sh",
     "test:ci": "scripts/run-tests.sh --ci",
-    "build:site": "node scripts/build-site.mjs"
+    "build:site": "node scripts/build-site.mjs",
+    "build:publish": "node scripts/build-publish-dir.mjs"
   },
   "overrides": {
     "serialize-javascript": ">=6.0.2"

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -466,7 +466,7 @@ export async function buildServer(): Promise<FastifyInstance> {
   return fastify;
 }
 
-async function start(): Promise<void> {
+export async function start(): Promise<void> {
   // Ensure the workspace + forge data dirs exist before anything
   // tries to write under them. mkdir(recursive:true) is a no-op on an
   // existing dir, so this is safe to run on every boot. We do NOT

--- a/scripts/build-publish-dir.mjs
+++ b/scripts/build-publish-dir.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * Assemble `publish/` — the staging directory we ship to npm as the
+ * `pi-forge` package.
+ *
+ * What this does:
+ *   1. Sanity-checks that both server and client builds exist (caller
+ *      must have already run `npm run build`).
+ *   2. Wipes any prior `publish/` dir.
+ *   3. Copies built server + client artifacts into `publish/dist/`.
+ *   4. Copies the bin shim into `publish/bin/`.
+ *   5. Synthesizes `publish/package.json` by reading the root version,
+ *      hoisting the SERVER's runtime `dependencies` (the server's
+ *      package.json is the source of truth — no manual duplication),
+ *      and adding `bin`, `engines`, `files`, `repository`, etc.
+ *   6. Copies `LICENSE` and writes a focused `README.md` that explains
+ *      the npm consumer flow (different from the repo's contributor
+ *      README, which assumes you cloned).
+ *
+ * Why a staging dir instead of flipping the root `private: false`:
+ * keeps the source tree clean. The published artifact is a flat
+ * single-package layout; the dev-time monorepo layout stays as it is.
+ * No drift risk from manually keeping a hoisted-deps list in sync —
+ * we read the server's deps fresh on every build.
+ *
+ * Run via: `npm run build:publish` (which depends on `npm run build`).
+ *
+ * The CI release workflow runs this between `npm run build` and
+ * `npm publish ./publish`. Locally you can also run it for a smoke
+ * test or to inspect the tarball with `npm pack` from `publish/`.
+ */
+import { existsSync } from "node:fs";
+import { copyFile, cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PUBLISH_DIR = resolve(REPO_ROOT, "publish");
+
+const SERVER_DIST = resolve(REPO_ROOT, "packages/server/dist");
+const CLIENT_DIST = resolve(REPO_ROOT, "packages/client/dist");
+const BIN_SRC = resolve(REPO_ROOT, "bin/pi-forge.mjs");
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function main() {
+  // 1. Sanity-check inputs
+  for (const [label, path] of [
+    ["server dist", SERVER_DIST],
+    ["client dist", CLIENT_DIST],
+    ["bin shim", BIN_SRC],
+  ]) {
+    if (!existsSync(path)) {
+      console.error(
+        `[build-publish-dir] missing ${label} at ${path}\n` +
+          `  Run 'npm run build' first to produce server + client artifacts.`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const rootPkg = await readJson(resolve(REPO_ROOT, "package.json"));
+  const serverPkg = await readJson(resolve(REPO_ROOT, "packages/server/package.json"));
+
+  // 2. Reset the staging dir
+  await rm(PUBLISH_DIR, { recursive: true, force: true });
+  await mkdir(PUBLISH_DIR, { recursive: true });
+
+  // 3. Copy artifacts
+  // recursive copy with `cp` (Node >=16.7) preserves directory structure
+  // including nested `core/`, `mcp/`, `routes/` etc. under the server dist.
+  await cp(SERVER_DIST, resolve(PUBLISH_DIR, "dist/server"), { recursive: true });
+  await cp(CLIENT_DIST, resolve(PUBLISH_DIR, "dist/client"), { recursive: true });
+
+  // 4. Bin shim
+  await mkdir(resolve(PUBLISH_DIR, "bin"), { recursive: true });
+  await copyFile(BIN_SRC, resolve(PUBLISH_DIR, "bin/pi-forge.mjs"));
+
+  // 5. Synthetic package.json
+  // Hoist the server's runtime deps verbatim — the server is the only
+  // thing the bin actually loads, and its package.json is the
+  // authoritative dep list. If a dep is added there, it's automatically
+  // picked up by the next publish; nothing manual to edit here.
+  if (serverPkg.dependencies === undefined) {
+    console.error("[build-publish-dir] packages/server/package.json has no dependencies field");
+    process.exit(1);
+  }
+  const publishPkg = {
+    name: "pi-forge",
+    version: rootPkg.version,
+    description:
+      "Browser UI for the pi coding agent — embedded HTTP server with a React workbench (chat, file browser, terminal, git, MCP).",
+    keywords: ["pi", "coding-agent", "ai", "llm", "agent", "workbench", "fastify"],
+    homepage: "https://github.com/Devin-Marks/pi-forge#readme",
+    bugs: { url: "https://github.com/Devin-Marks/pi-forge/issues" },
+    repository: {
+      type: "git",
+      url: "git+https://github.com/Devin-Marks/pi-forge.git",
+    },
+    license: "MIT",
+    author: "Devin Marks",
+    type: "module",
+    bin: { "pi-forge": "bin/pi-forge.mjs" },
+    files: ["bin/", "dist/", "README.md", "LICENSE"],
+    // Same node target as the server workspace + CI matrix.
+    engines: { node: ">=20" },
+    dependencies: serverPkg.dependencies,
+    // `publishConfig.provenance: true` makes `npm publish` attach a
+    // sigstore-signed provenance attestation tying this version to the
+    // GitHub Actions run that produced it. Free with the trusted-
+    // publisher OIDC flow we use in `.github/workflows/release.yml`.
+    publishConfig: { access: "public", provenance: true },
+  };
+  await writeFile(resolve(PUBLISH_DIR, "package.json"), JSON.stringify(publishPkg, null, 2) + "\n");
+
+  // 6. LICENSE + README
+  await copyFile(resolve(REPO_ROOT, "LICENSE"), resolve(PUBLISH_DIR, "LICENSE"));
+  await writeFile(resolve(PUBLISH_DIR, "README.md"), buildPublishReadme(rootPkg.version));
+
+  // Friendly summary
+  console.log(`[build-publish-dir] assembled publish/ for pi-forge@${rootPkg.version}`);
+  console.log(`  server dist: ${relativeFromRoot(SERVER_DIST)} → publish/dist/server/`);
+  console.log(`  client dist: ${relativeFromRoot(CLIENT_DIST)} → publish/dist/client/`);
+  console.log(`  bin: bin/pi-forge.mjs → publish/bin/pi-forge.mjs`);
+  console.log(`  ${Object.keys(publishPkg.dependencies).length} runtime deps hoisted from server`);
+  console.log(`Inspect with: cd publish && npm pack --dry-run`);
+}
+
+function relativeFromRoot(p) {
+  return p.startsWith(REPO_ROOT) ? p.slice(REPO_ROOT.length + 1) : p;
+}
+
+function buildPublishReadme(version) {
+  // Consumer-focused README — the in-repo README assumes you cloned
+  // and want to contribute. npm users want to know how to install,
+  // run, and configure.
+  return `# pi-forge
+
+Browser UI for the [pi coding agent](https://github.com/badlogic/pi-mono) —
+an embedded HTTP server with a React workbench (chat, file browser,
+terminal, git integration, MCP support).
+
+## Install
+
+\`\`\`bash
+# One-shot
+npx pi-forge
+
+# Or install globally
+npm i -g pi-forge
+pi-forge
+\`\`\`
+
+Open <http://localhost:3000> and pick a workspace folder.
+
+## Configuration
+
+All knobs are environment variables. Sensible defaults — set only what
+you need.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| \`PORT\` | \`3000\` | HTTP listen port |
+| \`WORKSPACE_PATH\` | \`~/.pi-forge/workspace\` | Where project code lives |
+| \`PI_CONFIG_DIR\` | \`~/.pi/agent\` | Pi SDK config (auth, models, settings) |
+| \`FORGE_DATA_DIR\` | \`~/.pi-forge\` | pi-forge state (project list) |
+| \`UI_PASSWORD\` | (unset) | Enables browser login if set |
+| \`API_KEY\` | (unset) | Enables \`Authorization: Bearer\` for programmatic use |
+
+If both \`UI_PASSWORD\` and \`API_KEY\` are unset, auth is disabled. For
+production, set at minimum \`API_KEY\`.
+
+## Programmatic API
+
+REST + Server-Sent Events under \`/api/v1/\`. Interactive docs at
+\`/api/docs\`. See the [project README](https://github.com/Devin-Marks/pi-forge#readme)
+for the full surface and example curl flows.
+
+## Versioning
+
+This package version (\`${version}\`) tracks the [GitHub release](https://github.com/Devin-Marks/pi-forge/releases)
+of the same name. Docker images and the npm package are published in
+lockstep on each \`v*\` tag.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).
+`;
+}
+
+main().catch((err) => {
+  console.error("[build-publish-dir] failed:", err);
+  process.exit(1);
+});

--- a/tests/test-publish-package.ts
+++ b/tests/test-publish-package.ts
@@ -1,0 +1,262 @@
+/**
+ * Smoke test for the assembled npm publish package.
+ *
+ * What this verifies:
+ *   1. `scripts/build-publish-dir.mjs` runs cleanly and produces the
+ *      expected layout (publish/bin, publish/dist/server, publish/dist/client,
+ *      publish/package.json).
+ *   2. The synthetic package.json has the right shape — name, version
+ *      from root, bin entry, deps hoisted from the server workspace,
+ *      provenance enabled, public access.
+ *   3. `node publish/bin/pi-forge.mjs` boots the workbench, serves
+ *      `/api/v1/health`, and serves the embedded SPA (`/`).
+ *
+ * Why this is its own test (not folded into test-scaffold):
+ * test-scaffold runs the in-tree compiled server directly. This test
+ * exercises the BIN SHIM specifically — env-var defaulting,
+ * CLIENT_DIST_PATH override, dynamic import of the server entry. A
+ * regression in the shim would only surface here.
+ *
+ * Note: this test runs `node publish/bin/pi-forge.mjs` while still
+ * inside the repo, so Node's module resolution finds the server's
+ * runtime deps via the hoisted root `node_modules/`. A real `npm i
+ * pi-forge` install gets its deps from the synthetic package.json's
+ * `dependencies` field — which we assert separately by shape.
+ *
+ * Builds the workspace + assembles publish/ on every run (~5s warm,
+ * ~30s cold). Costly but we want the assertion that "the publish
+ * artifact is bootable" to be green every CI run, not just on tag.
+ */
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+const publishDir = resolve(repoRoot, "publish");
+const binPath = resolve(publishDir, "bin/pi-forge.mjs");
+const synthPkgPath = resolve(publishDir, "package.json");
+const rootPkg = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf8")) as {
+  version: string;
+};
+const serverPkg = JSON.parse(
+  readFileSync(resolve(repoRoot, "packages/server/package.json"), "utf8"),
+) as { dependencies: Record<string, string> };
+
+let failures = 0;
+
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`  PASS  ${label}`);
+  } else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail !== undefined ? ` — ${detail}` : ""}`);
+  }
+}
+
+async function pickFreePort(): Promise<number> {
+  return new Promise((resolveFn, rejectFn) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on("error", rejectFn);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === "string") {
+        rejectFn(new Error("failed to acquire free port"));
+        return;
+      }
+      const { port } = addr;
+      srv.close(() => resolveFn(port));
+    });
+  });
+}
+
+async function waitForHealth(url: string, timeoutMs: number): Promise<Response> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      return await fetch(url);
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 150));
+    }
+  }
+  throw new Error(`server did not respond on ${url} within ${timeoutMs}ms: ${String(lastErr)}`);
+}
+
+function killServer(child: ChildProcess): Promise<void> {
+  return new Promise((resolveFn) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolveFn();
+      return;
+    }
+    child.once("exit", () => resolveFn());
+    child.kill("SIGTERM");
+    setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+    }, 2000).unref();
+  });
+}
+
+async function main(): Promise<void> {
+  console.log("[test-publish-package] building workspace…");
+  const build = spawnSync("npm", ["run", "build"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+  assert("npm run build exits 0", build.status === 0, `exit=${build.status ?? "null"}`);
+  if (build.status !== 0) process.exit(1);
+
+  console.log("[test-publish-package] assembling publish/…");
+  const assemble = spawnSync("npm", ["run", "build:publish"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+  assert(
+    "npm run build:publish exits 0",
+    assemble.status === 0,
+    `exit=${assemble.status ?? "null"}`,
+  );
+  if (assemble.status !== 0) process.exit(1);
+
+  // --- Layout assertions ---------------------------------------------
+  for (const path of [
+    binPath,
+    synthPkgPath,
+    resolve(publishDir, "dist/server/index.js"),
+    resolve(publishDir, "dist/client/index.html"),
+    resolve(publishDir, "README.md"),
+    resolve(publishDir, "LICENSE"),
+  ]) {
+    assert(`publish/ contains ${path.slice(publishDir.length + 1)}`, existsSync(path));
+  }
+
+  // --- Synthetic package.json shape ----------------------------------
+  const synth = JSON.parse(readFileSync(synthPkgPath, "utf8")) as {
+    name: string;
+    version: string;
+    bin: Record<string, string>;
+    dependencies: Record<string, string>;
+    files: string[];
+    publishConfig: { access?: string; provenance?: boolean };
+    engines: { node?: string };
+    type: string;
+  };
+  assert("synth name === 'pi-forge'", synth.name === "pi-forge", synth.name);
+  assert(
+    "synth version matches root version",
+    synth.version === rootPkg.version,
+    `${synth.version} vs ${rootPkg.version}`,
+  );
+  assert(
+    "synth bin entry points at bin/pi-forge.mjs",
+    synth.bin["pi-forge"] === "bin/pi-forge.mjs",
+    JSON.stringify(synth.bin),
+  );
+  assert("synth type === 'module'", synth.type === "module");
+  assert("synth files includes bin/", synth.files.includes("bin/"));
+  assert("synth files includes dist/", synth.files.includes("dist/"));
+  assert(
+    "synth publishConfig.access === 'public'",
+    synth.publishConfig.access === "public",
+    JSON.stringify(synth.publishConfig),
+  );
+  assert(
+    "synth publishConfig.provenance === true",
+    synth.publishConfig.provenance === true,
+    JSON.stringify(synth.publishConfig),
+  );
+  assert(
+    "synth engines.node specified",
+    typeof synth.engines.node === "string" && synth.engines.node.length > 0,
+    JSON.stringify(synth.engines),
+  );
+  // Every server runtime dep must be present in the synthetic package
+  // (we hoist verbatim — a missing entry means the bin would fail to
+  // import on a real `npm i pi-forge` install).
+  for (const [dep, version] of Object.entries(serverPkg.dependencies)) {
+    assert(
+      `synth dependencies has ${dep}@${version}`,
+      synth.dependencies[dep] === version,
+      `got ${synth.dependencies[dep] ?? "<missing>"}`,
+    );
+  }
+
+  // --- Boot the bin shim ---------------------------------------------
+  // Use isolated dirs so this test doesn't touch the user's real
+  // ~/.pi-forge or ~/.pi/agent.
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-pub-ws-"));
+  const piConfigDir = await mkdtemp(join(tmpdir(), "pi-forge-pub-pi-"));
+  const forgeDataDir = await mkdtemp(join(tmpdir(), "pi-forge-pub-data-"));
+  const port = await pickFreePort();
+  console.log(`[test-publish-package] launching publish/bin/pi-forge.mjs on :${port}`);
+
+  const child = spawn(process.execPath, [binPath], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      WORKSPACE_PATH: workspacePath,
+      PI_CONFIG_DIR: piConfigDir,
+      FORGE_DATA_DIR: forgeDataDir,
+      LOG_LEVEL: "warn",
+    },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+
+  let exitedEarly = false;
+  child.on("exit", (code, signal) => {
+    if (code !== 0 && signal === null) {
+      exitedEarly = true;
+      console.log(`[test-publish-package] bin exited unexpectedly with code=${code ?? "null"}`);
+    }
+  });
+
+  try {
+    const health = await waitForHealth(`http://127.0.0.1:${port}/api/v1/health`, 20_000);
+    assert("GET /api/v1/health returns 200", health.status === 200, `status=${health.status}`);
+    const healthBody = (await health.json()) as { status?: string };
+    assert("health body.status === 'ok'", healthBody.status === "ok", JSON.stringify(healthBody));
+
+    // The shim's reason for existing: pointing CLIENT_DIST_PATH at the
+    // bundled SPA so `/` serves the workbench. If the shim broke or the
+    // copy missed index.html, this 200 would become a 404.
+    const root = await fetch(`http://127.0.0.1:${port}/`);
+    assert("GET / returns 200 (SPA index served)", root.status === 200, `status=${root.status}`);
+    const html = await root.text();
+    assert(
+      "GET / body looks like an HTML document",
+      html.toLowerCase().includes("<!doctype html") || html.toLowerCase().includes("<html"),
+      html.slice(0, 80),
+    );
+
+    assert("bin did not exit during test", !exitedEarly);
+  } finally {
+    await killServer(child);
+    await rm(workspacePath, { recursive: true, force: true });
+    await rm(piConfigDir, { recursive: true, force: true });
+    await rm(forgeDataDir, { recursive: true, force: true });
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-publish-package] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-publish-package] PASS");
+}
+
+main().catch((err) => {
+  console.error("[test-publish-package] uncaught error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds an `npm-publish` job to `release.yml` that fires alongside the existing Docker build on every `v*` tag — npm and GHCR stay in lockstep at the same version, gated by the existing `check-version` job.
- Authenticates via npm **Trusted Publishers** (OIDC) — no `NPM_TOKEN` secret in the repo. Every release ships with a sigstore-signed provenance attestation.
- Source tree stays a two-workspace monorepo for development; flattening into a single `pi-forge` package only happens at publish time (locally via `npm run build:publish`, in CI between `npm run build` and `npm publish`).

## Consumer flow

```
npx pi-forge                # one-shot
npm i -g pi-forge && pi-forge   # global install
```

Honors the same env vars as the Docker image (`PORT`, `WORKSPACE_PATH`, `PI_CONFIG_DIR`, `FORGE_DATA_DIR`, `UI_PASSWORD`, `API_KEY`) with sensible per-user defaults under `~/.pi-forge` and `~/.pi/agent`.

## What's in the box

| File | Purpose |
|---|---|
| `bin/pi-forge.mjs` | CLI launcher. Sets `CLIENT_DIST_PATH` to the bundled SPA (the server's default resolution doesn't fit the flat layout), defaults `NODE_ENV=production`, dynamic-imports the server entry's exported `start()`. |
| `scripts/build-publish-dir.mjs` | Assembles `publish/` from built server + client artifacts. Synthesizes `pi-forge` `package.json` reading version from root and **hoisting server's runtime deps verbatim** — add a server dep, the next publish picks it up automatically. |
| `tests/test-publish-package.ts` | End-to-end smoke test (40 assertions): assembler shape, synthetic package.json correctness, every dep hoisted, bin shim boots, `/api/v1/health` responds, SPA `/` serves. Auto-discovered by the runner; bumps the suite from 19→20 tests. |
| `.github/workflows/release.yml` | New `npm-publish` job. `environment: production` + `id-token: write` for OIDC. Independently verifies `publish/package.json` version matches the tag (defense against an assembler bug). |
| `packages/server/src/index.ts` | One-line change: `export async function start()` so the bin can call it. |
| `package.json`, `.gitignore`, `CHANGELOG.md` | `build:publish` script, `publish/` ignored, Unreleased entry. |

## Why a staging dir, not flipping root `private: false`

Keeps the dev-time monorepo (good for parallel server + client work, isolated builds, independent dev servers) decoupled from the publish unit. The synthetic `package.json` is regenerated every build from authoritative sources (root version + server deps), so there's nothing to manually keep in sync. `publish/` is gitignored.

## Required GitHub-side setup before the next `v*` tag

These are operator tasks, **not** part of this PR:

- [ ] **GitHub Environment exists**: Settings → Environments → New environment → name exactly `production`. Without this, the workflow fails with `Environment 'production' not found` before any step runs. Protection rules can be empty — the OIDC binding is what restricts who publishes.
- [ ] **Trusted publisher config matches**: on npmjs.com under `pi-forge` settings, the trusted publisher should reference `Devin-Marks/pi-forge`, workflow filename `release.yml`, environment `production`. (User confirmed already done.)

## Test plan

- [x] `npm run check` (tsc + eslint + prettier) — green
- [x] `npm run build` — green
- [x] `npm run build:publish` produces a 2.9 MB tarball with 107 files; 18 deps hoisted from server
- [x] `tests/test-publish-package.ts` — 40 assertions pass; bin boots on a free port, health 200s, SPA index 200s
- [x] `npm run test:ci` — 20/20 pass
- [ ] **Pre-first-tag manual check**: install the local tarball into a fresh dir as a real user would, confirm it boots:
  ```
  cd publish && npm pack
  cd /tmp && mkdir test-install && cd test-install
  npm init -y && npm install /path/to/pi-forge-X.Y.Z.tgz
  PORT=4567 npx pi-forge   # ctrl-c after "listening on :4567"
  curl localhost:4567/api/v1/health
  ```
- [ ] **First real run** is the next `v*` tag — the OIDC handshake can only be tested from GitHub Actions. If trusted-publisher config is misaligned, `npm-publish` fails cleanly, Docker job still succeeds independently, fix npm side and re-tag.

## Out of scope

No version bump in this PR. The next normal release cycle (cut via `scripts/bump-version.sh`) will be the first one to publish to npm. Existing `v1.1.1` tag is not retroactively published.