### PR TITLE
chore(release): v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.1.2] — 2026-05-06
+
 ### Added
 
 - **npm distribution.** pi-forge now publishes to npm as `pi-forge` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,56 @@ the README for the support window policy.
   published package's dependencies. Authentication uses npm Trusted
   Publishers (OIDC) — no long-lived `NPM_TOKEN` secret in the repo —
   and every release ships with a sigstore-signed provenance attestation.
+- **Inline compaction archive.** When the agent compacts its context,
+  archived messages no longer disappear — they collapse into an
+  expandable `CompactionCard` placed inline in the chat at the
+  compaction boundary. New `GET /sessions/:id/compactions` API returns
+  the per-compaction archived message arrays; the client lazy-loads on
+  expand. The previously-rendered "unknown message" synthesized
+  compaction summary is now hidden (its content already lives in the
+  card's disclosure body).
+- **Pi-package tools and skills surface in Settings.** Tools registered
+  by installed pi packages (npm/git, managed by `DefaultPackageManager`)
+  now appear in Settings → Tools grouped by package source, with the
+  same global enable/disable + per-project tri-state override UX as
+  builtin and MCP tools. Skills contributed by packages appear in
+  Settings → Skills with `source: extension`. Both are also wired into
+  the agent's tool allowlist so the model can actually invoke
+  package-registered tools (previously silently filtered out).
+
+### Changed
+
+- **MCP tool result text capped at ~25k tokens.** `mcp/tool-bridge.ts`
+  truncates over-cap text content with a 60/40 head/tail split and an
+  imperative marker that nudges the model to refine its query rather
+  than re-run the same call. Image content blocks pass through
+  untouched. Defaults: 100,000 chars, configurable via constants at
+  the top of the file.
+- **Pi SDK bumped to 0.73.0** (`@mariozechner/pi-coding-agent`,
+  `@mariozechner/pi-agent-core`, `@mariozechner/pi-ai` from 0.70.5).
+  No breaking changes affect pi-forge directly. End users running pi
+  alongside pi-forge with custom `models.json` may need to migrate
+  `compat.reasoningEffortMap` → `thinkingLevelMap` (v0.72.0 SDK
+  rename). Free win: bash tool output now streams incrementally
+  while commands run instead of only after completion (v0.73.0).
+
+### Fixed
+
+- **Disabling a per-project package-tool override no longer crashes the
+  Tools tab.** `GET /config/tools/overrides`'s response schema was
+  missing the `extension` family, so Fastify's serializer stripped the
+  field and SettingsPanel exploded on `fam.enable.includes(...)`.
+  Schema now requires it; client validator backfills defensively.
+- **Per-project skill disable now works for package-contributed
+  skills.** Pi's `DefaultPackageManager.collectPackageResources` marks
+  package skills `enabled: true` unconditionally and never consults
+  `settings.skills` patterns, so the existing pattern-based override
+  silently no-op'd for them. Fix uses the SDK-supported
+  `skillsOverride` callback on `DefaultResourceLoader` to apply a
+  source-agnostic name-based filter at session create.
+- **Test isolation.** Every spawned-server test now `mkdtemp`s its own
+  `FORGE_DATA_DIR` so the user's real `password-hash` can't leak into
+  CI auth scenarios.
 
 ## [1.1.1] — 2026-05-05
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "workspaces": [
         "packages/*"
       ],
@@ -17268,7 +17268,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17311,7 +17311,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Release cut for **v1.1.2**. First release that publishes to npm in addition to GHCR — both registries will land at 1.1.2 in lockstep when the tag fires.

Two commits on this branch:

1. `9904772` `docs(changelog): catch up Unreleased with PR #29 contents` — PR #29 merged without updating CHANGELOG. This back-fills the entries so the auto-extracted release notes describe what 1.1.2 actually ships.
2. `17feefc` `chore(release): v1.1.2` — generated by `scripts/bump-version.sh`. Bumps all three `package.json` versions + `package-lock.json`; renames `## [Unreleased]` → `## [1.1.2] — 2026-05-06`.

## What's in 1.1.2 (since 1.1.1)

### Added
- **npm distribution** via `npx pi-forge` / `npm i -g pi-forge` (PR #30). Trusted-Publisher OIDC, sigstore provenance, in lockstep with the GHCR image.
- **Inline compaction archive** — archived messages collapse into an expandable `CompactionCard` instead of vanishing.
- **Pi-package tools and skills surface in Settings → Tools / Skills** with the same global enable/disable + per-project tri-state override UX as builtin and MCP. Package tools are now actually visible to the agent (previously silently filtered).

### Changed
- MCP tool result text capped at ~25k tokens with head/tail truncation.
- Pi SDK trio bumped 0.70.5 → 0.73.0. No code-level breaking changes for pi-forge; users running pi alongside with custom `models.json` may need the v0.72 `reasoningEffortMap` → `thinkingLevelMap` migration.

### Fixed
- Tools tab no longer crashes when disabling a per-project package-tool override.
- Per-project skill disable now works for package-contributed skills.
- Test isolation — every spawned-server test now gets its own `FORGE_DATA_DIR`.

## Tag-firing checklist (for after merge)

After this PR merges into main:

```
git checkout main && git pull --ff-only
git tag v1.1.2
git push origin v1.1.2
```

The release workflow then runs in parallel:
- ✅ Multi-arch Docker image to GHCR (existing flow)
- 🆕 **First-ever npm publish** via Trusted-Publisher OIDC
- ✅ GitHub Release with notes auto-extracted from CHANGELOG

### Operator preconditions for the npm-publish job (one-time setup)

- [x] `pi-forge` package owned by `devin-marks` on npm — confirmed
- [x] Trusted Publisher configured on npmjs.com → workflow `release.yml`, environment `production` — user confirmed
- [x] **GitHub Environment `production` exists** under repo Settings → Environments. Without this the npm-publish job fails with "Environment 'production' not found" before any step runs. Verify before pushing the tag.

If the npm-publish job fails (misaligned config, etc.), the Docker job still succeeds independently. Fix the npm side, delete and re-push the tag — no harm done.

## Test plan

- [x] `npm run build` — green at 1.1.2
- [x] `npm run check` (tsc + eslint + prettier) — green
- [x] **Pre-tag local verification** — recommended before pushing `v1.1.2`:
  ```
  npm run build && npm run build:publish
  cd publish && npm pack
  cd /tmp && mkdir test-install && cd test-install
  npm init -y && npm install /path/to/pi-forge-1.1.2.tgz
  PORT=4567 npx pi-forge   # ctrl-c after "listening on :4567"
  curl localhost:4567/api/v1/health
  ```
- [ ] After tag, verify both `ghcr.io/devin-marks/pi-forge:1.1.2` AND `npm view pi-forge version` show `1.1.2`