### PR TITLE
fix(release): upgrade npm CLI so trusted-publisher OIDC fires

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,19 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm to a version that supports Trusted Publishers
+        # Node 22 LTS ships with npm 10.x by default, which predates
+        # Trusted Publisher OIDC support (added in npm 11.5.1, July
+        # 2025). On npm 10.x, `npm publish` silently ignores the
+        # GitHub OIDC token even with `id-token: write` granted, sends
+        # an unauthenticated PUT, and the registry replies 404
+        # (npm doesn't leak package existence to anonymous requesters,
+        # so "not authorized" surfaces as "not found"). The first
+        # v1.1.2 tag hit exactly this — Docker shipped, npm-publish
+        # 404'd. Upgrading globally before any subsequent npm command
+        # also applies the new version to `npm ci` and `npm publish`.
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

The first `v1.1.2` tag fired the release workflow as expected — Docker shipped to GHCR, but the new `npm-publish` job 404'd:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/pi-forge - Not found
npm error 404  'pi-forge@1.1.2' is not in this registry.
```

Misleading error. The publish actually attempted **as anonymous**, not as a trusted publisher. npm doesn't leak package existence to anonymous requesters, so "not authorized" surfaces as "not found".

## Root cause

Trusted Publisher OIDC support was added in **npm CLI 11.5.1** (July 2025). Node 22 LTS still ships with **npm 10.x** by default. On npm 10.x, `npm publish` silently ignores the GitHub OIDC token even with `id-token: write` granted — it just sends an unauthenticated PUT.

`actions/setup-node@v4` doesn't auto-upgrade npm; it uses whatever the Node binary ships with.

## Fix

One step added between `setup-node` and `npm ci`:

```yaml
- name: Upgrade npm to a version that supports Trusted Publishers
  run: npm install -g npm@latest
```

Globally upgrading means `npm ci`, `npm run build`, and `npm publish` all use the new version — no risk of inconsistency mid-job.

## v1.1.2 status

| Registry | State |
|---|---|
| GHCR `ghcr.io/devin-marks/pi-forge:1.1.2` | ✅ shipped |
| npm `pi-forge@1.1.2` | ❌ never published, will not be backfilled |

**Why no backfill**: re-running the failed `npm-publish` job from the v1.1.2 workflow run page wouldn't help — GitHub Actions re-runs use the workflow file from the **original tag SHA**, not current main. Force-moving the v1.1.2 tag would also re-trigger the Docker build with the same tag, which is messy.

The cleanest path is for npm to start at the **next** release. CHANGELOG entry for 1.1.2 already accurately describes the npm distribution feature; the actual first published version slips by one. Worth a brief mention in the next release's notes.

## Test plan

- [x] `npm run check` (tsc + eslint + prettier) — green
- [ ] **Real test is the next `v*` tag.** OIDC handshake can only be exercised from GitHub Actions; no way to validate locally. If trusted publisher is still misaligned (env name, workflow path, etc.), the publish job fails with a clearer error than the 404 — the upgraded npm CLI prints `npm error code OIDC_NO_OIDC_TOKEN` or similar.

## After this merges

To exercise the fix, cut a small follow-up release (e.g. `1.1.3`) via `scripts/bump-version.sh 1.1.3 --allow-empty` (no Unreleased content needed since this is purely a release-pipeline fix). That tag will be the first to actually publish to npm.