### PR TITLE
feat(subagents): integrate pi-subagents — child sessions in sidebar + rich tool card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+### Added
+
+- **pi-subagents integration.** When the `pi-subagents` package is
+  installed (`pi install npm:pi-subagents`), three things turn on:
+  (1) the existing tool/extension surface already enables the plugin's
+  `subagent` tool — sessions get it via the regular allowlist; (2) tool
+  call cards in the chat for `subagent` are replaced with a richer
+  `SubagentResultCard` that lists each spawned sub-agent's name + task
+  + exit code and exposes an "Open" button that switches the active
+  session to the child JSONL; (3) the session sidebar now groups
+  sub-agent sessions under a chevron dropdown on their parent row.
+  Server-side, `discoverSessionsOnDisk` now walks one level deeper
+  into `<sessionDir>/<parentId>/<runId>/*.jsonl` (the path layout
+  pi-subagents writes to) and tags each child with `parentSessionId`
+  and `runId`; `findSessionLocation` and `resumeSession` resolve child
+  UUIDs the same as top-level sessions. Coverage in
+  `tests/test-subagent-discovery.ts` (registry-level) and
+  `tests/test-subagent-parser.ts` (pure parser).
+
 ## [1.1.2] — 2026-05-06
 
 ### Added

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -842,6 +842,25 @@ function ToolCallEntry({
   const editFn = name === "edit" && result !== undefined ? extractFilename(result) : undefined;
   const editStats = editDiff !== undefined ? countDiffLines(editDiff) : undefined;
 
+  // pi-subagents tool gets a dedicated rich card instead of the
+  // generic toolCall+result rendering. Short-circuit BEFORE the
+  // generic render path: the user's eye should land on the violet
+  // sub-agent card with its prominent Open button, not on a row of
+  // small "subagent" badges nested under "Input/Output" details.
+  // Pre-result (running) state still fires through here — the card
+  // surfaces the input args (which agent + task) so the user sees
+  // what's running.
+  if (name === "subagent") {
+    return (
+      <SubagentInflightOrResult
+        input={argsObj}
+        result={result}
+        isError={isError}
+        outputText={outputText}
+      />
+    );
+  }
+
   // Border tint reflects success/error/pending so the user can scan
   // a long thread without expanding every entry.
   const borderClass =
@@ -1015,6 +1034,71 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
  * calls (`mode: "management"`) and details we couldn't parse fall
  * back to a plain text block so we never lose information silently.
  */
+/**
+ * Wrapper that picks the right sub-agent card variant based on
+ * whether the tool has finished:
+ *   - in-flight (no result yet) → "Sub-agent running…" card with the
+ *     requested agent name + task pulled out of the input args
+ *   - completed → the rich SubagentResultCard with per-result rows + Open buttons
+ *
+ * Used by ToolCallEntry (paired result) so the user sees a violet
+ * sub-agent treatment for BOTH states — pre-result and post-result.
+ * The standalone ToolResult branch reaches SubagentResultCard
+ * directly since by the time it's rendered the result always exists.
+ */
+function SubagentInflightOrResult({
+  input,
+  result,
+  isError,
+  outputText,
+}: {
+  input: Record<string, unknown> | undefined;
+  result: AgentMessageLike | undefined;
+  isError: boolean;
+  outputText: string;
+}) {
+  if (result !== undefined) {
+    return <SubagentResultCard message={result} fallbackText={outputText} isError={isError} />;
+  }
+  // In-flight: pull a friendly preview out of the SubagentParams shape
+  // (single mode → input.agent / input.task; parallel/chain mode →
+  // count of tasks; management mode → input.action). Best-effort —
+  // schema-bumps on the plugin side just degrade to "running" with
+  // no detail, never crash.
+  let summary: string | undefined;
+  if (input !== undefined) {
+    const agent = typeof input.agent === "string" ? input.agent : undefined;
+    const task = typeof input.task === "string" ? input.task : undefined;
+    const action = typeof input.action === "string" ? input.action : undefined;
+    const tasks = Array.isArray(input.tasks) ? input.tasks.length : undefined;
+    const chain = Array.isArray(input.chain) ? input.chain.length : undefined;
+    if (action !== undefined) summary = `action: ${action}`;
+    else if (tasks !== undefined) summary = `${tasks} parallel task${tasks === 1 ? "" : "s"}`;
+    else if (chain !== undefined) summary = `${chain}-step chain`;
+    else if (agent !== undefined && task !== undefined) summary = `${agent} — ${task}`;
+    else if (agent !== undefined) summary = agent;
+  }
+  return (
+    <div className="overflow-hidden rounded-lg border border-violet-800/50 border-l-4 border-l-violet-500 bg-violet-950/20 shadow-sm">
+      <div className="flex items-center justify-between gap-2 border-b border-violet-900/40 bg-violet-950/30 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Users size={14} className="shrink-0 text-violet-300" />
+          <span className="truncate font-semibold text-violet-100">Sub-agent running…</span>
+        </div>
+        <span className="shrink-0 rounded bg-violet-900/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-violet-200">
+          in-flight
+        </span>
+      </div>
+      {summary !== undefined && (
+        <div className="px-3 py-2 text-xs text-neutral-300">
+          <span className="text-neutral-500">running:</span>{" "}
+          <span className="font-mono">{summary}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function SubagentResultCard({
   message,
   fallbackText,

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1028,32 +1028,48 @@ function SubagentResultCard({
   const parsed = parseSubagentDetails(message.details);
   const isManagement = parsed.mode === "management";
   const isUnknown = parsed.mode === "unknown";
+  const count = parsed.results.length;
   const headline =
-    parsed.results.length === 1
-      ? `subagent → ${parsed.results[0]!.agent}`
-      : parsed.results.length > 1
-        ? `subagent → ${parsed.results.length} agents (${parsed.mode})`
+    count === 1
+      ? `Sub-agent: ${parsed.results[0]!.agent}`
+      : count > 1
+        ? `${count} sub-agents (${parsed.mode})`
         : isManagement
-          ? "subagent management"
-          : "subagent";
+          ? "Sub-agent management"
+          : "Sub-agent";
+  // Saturated violet treatment + thicker border so the card pops out
+  // of the chat stream — sub-agent runs are a different *kind* of
+  // event than a normal tool call, and the visual weight should
+  // reflect that. Border-l accent strip mirrors the gh PR-review
+  // surface for a "this matters" feel.
   return (
-    <details
-      open
-      className={`rounded border ${isError ? "border-red-700/40" : "border-purple-900/40"} bg-purple-950/10 text-xs`}
+    <div
+      className={`overflow-hidden rounded-lg border-l-4 ${
+        isError
+          ? "border-l-red-500 border border-red-700/40 bg-red-950/10"
+          : "border-l-violet-500 border border-violet-800/50 bg-violet-950/20"
+      } shadow-sm`}
     >
-      <summary className="cursor-pointer px-3 py-2 text-neutral-200">
-        <span className="inline-flex items-center gap-1.5">
-          <Users size={12} className="text-purple-400" />
-          <span className="font-medium">{headline}</span>
+      <div className="flex items-center justify-between gap-2 border-b border-violet-900/40 bg-violet-950/30 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Users size={14} className="shrink-0 text-violet-300" />
+          <span className="truncate font-semibold text-violet-100">{headline}</span>
           {parsed.context !== undefined && (
-            <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400">
+            <span
+              className="shrink-0 rounded bg-violet-900/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-violet-200"
+              title={parsed.context === "fork" ? "Forked from parent context" : "Fresh context"}
+            >
               {parsed.context}
             </span>
           )}
-          {isError && <span className="ml-1 text-red-400">error</span>}
-        </span>
-      </summary>
-      <div className="space-y-2 px-3 pb-3">
+        </div>
+        {isError && (
+          <span className="shrink-0 rounded bg-red-900/40 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-red-200">
+            error
+          </span>
+        )}
+      </div>
+      <div className="space-y-2 p-3">
         {parsed.results.map((r, i) => (
           <SubagentResultRow
             key={r.sessionId ?? `${i}-${r.agent}`}
@@ -1061,7 +1077,7 @@ function SubagentResultCard({
             onOpen={(sid) => setActiveSession(sid)}
           />
         ))}
-        {parsed.results.length === 0 && (isManagement || isUnknown) && (
+        {count === 0 && (isManagement || isUnknown) && (
           // Management calls + unrecognised payloads: keep the raw text
           // visible so the user / a future debugger can see the response.
           <pre className="overflow-auto rounded bg-neutral-950 p-2 font-mono text-[11px] text-neutral-400">
@@ -1069,7 +1085,7 @@ function SubagentResultCard({
           </pre>
         )}
       </div>
-    </details>
+    </div>
   );
 }
 
@@ -1083,34 +1099,40 @@ function SubagentResultRow({
   const failed = result.exitCode !== 0;
   return (
     <div
-      className={`rounded border ${failed ? "border-red-700/40" : "border-neutral-800"} bg-neutral-950 px-2.5 py-2`}
+      className={`rounded border ${failed ? "border-red-700/40" : "border-violet-900/40"} bg-neutral-950/60 p-3`}
     >
-      <div className="flex items-start justify-between gap-2">
+      <div className="mb-2 flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5 text-neutral-300">
-            <span className="font-mono text-purple-300">{result.agent}</span>
-            {failed && <span className="text-red-400">exit {result.exitCode}</span>}
+          <div className="flex items-baseline gap-2">
+            <span className="font-mono text-sm font-medium text-violet-200">{result.agent}</span>
+            {failed && (
+              <span className="text-[11px] font-medium text-red-400">exit {result.exitCode}</span>
+            )}
           </div>
           {result.task.length > 0 && (
-            <div className="mt-0.5 truncate text-neutral-500" title={result.task}>
+            <div className="mt-1 line-clamp-2 text-xs text-neutral-300" title={result.task}>
               {result.task}
             </div>
           )}
         </div>
-        {result.sessionId !== undefined && (
-          <button
-            onClick={() => onOpen(result.sessionId!)}
-            className="inline-flex shrink-0 items-center gap-1 rounded border border-neutral-700 px-2 py-1 text-[11px] text-neutral-300 hover:border-neutral-500 hover:text-neutral-100"
-            title={result.sessionFile ?? "Open sub-agent session"}
-          >
-            <ExternalLink size={11} />
-            Open
-          </button>
-        )}
       </div>
+      {/* Primary CTA — full-width violet button so it reads as the
+          main action. Keyboard-accessible (button, not anchor) since
+          the navigation is purely client-side store mutation, not a
+          URL change. */}
+      {result.sessionId !== undefined && (
+        <button
+          onClick={() => onOpen(result.sessionId!)}
+          className="mb-1 flex w-full items-center justify-center gap-1.5 rounded bg-violet-700 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-violet-600 focus:outline-none focus:ring-2 focus:ring-violet-400"
+          title={result.sessionFile ?? "Open sub-agent session"}
+        >
+          <ExternalLink size={12} />
+          Open sub-agent session
+        </button>
+      )}
       {result.finalOutput !== undefined && (
-        <details className="mt-1.5">
-          <summary className="cursor-pointer text-[11px] text-neutral-500 hover:text-neutral-300">
+        <details className="mt-2">
+          <summary className="cursor-pointer text-[11px] text-neutral-400 hover:text-neutral-200">
             output
           </summary>
           <pre className="mt-1 max-h-48 overflow-auto rounded bg-neutral-900 p-2 font-mono text-[11px] text-neutral-300">

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1236,11 +1236,10 @@ function SubagentResultCard({
       )}
       {outputText.length > 0 && (
         <details
-          // For management mode + errors the output IS the body, so open
-          // by default — otherwise a failed call or "list agents" call
-          // looks blank. Normal successful runs collapse the verbose
-          // sub-agent output by default so the chat stays scannable.
-          open={isError || (isManagement && count === 0)}
+          // Errors open by default so failures aren't blank cards.
+          // Management calls and successful runs stay collapsed so the
+          // chat is scannable — the user can click to inspect.
+          open={isError}
           className="border-t border-sky-900/30"
         >
           <summary className="cursor-pointer px-2.5 py-1 text-[11px] text-neutral-500 hover:text-neutral-300">

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -6,9 +6,11 @@ import {
   ChevronRight,
   Columns2,
   Copy,
+  ExternalLink,
   FileCode,
   GitBranch,
   Rows2,
+  Users,
 } from "lucide-react";
 import {
   EMPTY_COMPACTIONS,
@@ -24,6 +26,7 @@ import { ChatMarkdown } from "./ChatMarkdown";
 import { CompactionCard } from "./CompactionCard";
 import { DiffBlock } from "./DiffBlock";
 import { SessionTreePanel } from "./SessionTreePanel";
+import { parseSubagentDetails, type SubagentResult } from "../lib/subagent-parser";
 
 /**
  * Per-ChatView diff view-type preference. Each diff-rendering surface
@@ -984,6 +987,12 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
     );
   }
 
+  // pi-subagents: replace the generic tool card with a richer surface
+  // listing each spawned sub-agent + a "open session" affordance.
+  if (toolName === "subagent") {
+    return <SubagentResultCard message={message} fallbackText={text} isError={isError} />;
+  }
+
   // Generic tool result fallback.
   return (
     <details
@@ -995,6 +1004,121 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
       </summary>
       <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">{text}</pre>
     </details>
+  );
+}
+
+/**
+ * Render a `subagent` tool result with one row per spawned sub-agent.
+ * Each row's "open session" button switches the active session to the
+ * child via `setActiveSession(childSessionId)` — the sidebar's chevron
+ * grouping then reveals the child under its parent. Management-mode
+ * calls (`mode: "management"`) and details we couldn't parse fall
+ * back to a plain text block so we never lose information silently.
+ */
+function SubagentResultCard({
+  message,
+  fallbackText,
+  isError,
+}: {
+  message: AgentMessageLike;
+  fallbackText: string;
+  isError: boolean;
+}) {
+  const setActiveSession = useSessionStore((s) => s.setActiveSession);
+  const parsed = parseSubagentDetails(message.details);
+  const isManagement = parsed.mode === "management";
+  const isUnknown = parsed.mode === "unknown";
+  const headline =
+    parsed.results.length === 1
+      ? `subagent → ${parsed.results[0]!.agent}`
+      : parsed.results.length > 1
+        ? `subagent → ${parsed.results.length} agents (${parsed.mode})`
+        : isManagement
+          ? "subagent management"
+          : "subagent";
+  return (
+    <details
+      open
+      className={`rounded border ${isError ? "border-red-700/40" : "border-purple-900/40"} bg-purple-950/10 text-xs`}
+    >
+      <summary className="cursor-pointer px-3 py-2 text-neutral-200">
+        <span className="inline-flex items-center gap-1.5">
+          <Users size={12} className="text-purple-400" />
+          <span className="font-medium">{headline}</span>
+          {parsed.context !== undefined && (
+            <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400">
+              {parsed.context}
+            </span>
+          )}
+          {isError && <span className="ml-1 text-red-400">error</span>}
+        </span>
+      </summary>
+      <div className="space-y-2 px-3 pb-3">
+        {parsed.results.map((r, i) => (
+          <SubagentResultRow
+            key={r.sessionId ?? `${i}-${r.agent}`}
+            result={r}
+            onOpen={(sid) => setActiveSession(sid)}
+          />
+        ))}
+        {parsed.results.length === 0 && (isManagement || isUnknown) && (
+          // Management calls + unrecognised payloads: keep the raw text
+          // visible so the user / a future debugger can see the response.
+          <pre className="overflow-auto rounded bg-neutral-950 p-2 font-mono text-[11px] text-neutral-400">
+            {fallbackText}
+          </pre>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function SubagentResultRow({
+  result,
+  onOpen,
+}: {
+  result: SubagentResult;
+  onOpen: (sessionId: string) => void;
+}) {
+  const failed = result.exitCode !== 0;
+  return (
+    <div
+      className={`rounded border ${failed ? "border-red-700/40" : "border-neutral-800"} bg-neutral-950 px-2.5 py-2`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5 text-neutral-300">
+            <span className="font-mono text-purple-300">{result.agent}</span>
+            {failed && <span className="text-red-400">exit {result.exitCode}</span>}
+          </div>
+          {result.task.length > 0 && (
+            <div className="mt-0.5 truncate text-neutral-500" title={result.task}>
+              {result.task}
+            </div>
+          )}
+        </div>
+        {result.sessionId !== undefined && (
+          <button
+            onClick={() => onOpen(result.sessionId!)}
+            className="inline-flex shrink-0 items-center gap-1 rounded border border-neutral-700 px-2 py-1 text-[11px] text-neutral-300 hover:border-neutral-500 hover:text-neutral-100"
+            title={result.sessionFile ?? "Open sub-agent session"}
+          >
+            <ExternalLink size={11} />
+            Open
+          </button>
+        )}
+      </div>
+      {result.finalOutput !== undefined && (
+        <details className="mt-1.5">
+          <summary className="cursor-pointer text-[11px] text-neutral-500 hover:text-neutral-300">
+            output
+          </summary>
+          <pre className="mt-1 max-h-48 overflow-auto rounded bg-neutral-900 p-2 font-mono text-[11px] text-neutral-300">
+            {result.finalOutput}
+          </pre>
+        </details>
+      )}
+    </div>
   );
 }
 

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
 import {
   AtSign,
   Check,
@@ -21,7 +21,7 @@ import {
   type AgentMessageLike,
   type CompactionEvent,
 } from "../store/session-store";
-import { useActiveProject } from "../store/project-store";
+import { useActiveProject, useProjectStore } from "../store/project-store";
 import { ChatMarkdown } from "./ChatMarkdown";
 import { CompactionCard } from "./CompactionCard";
 import { DiffBlock } from "./DiffBlock";
@@ -1115,16 +1115,50 @@ function SubagentResultCard({
   isError: boolean;
 }) {
   const setActiveSession = useSessionStore((s) => s.setActiveSession);
+  const setActiveProject = useProjectStore((s) => s.setActive);
+  const byProject = useSessionStore((s) => s.byProject);
+  // Resolve a tool-result `sessionFile` (absolute path) back to its
+  // canonical sessionId by scanning the loaded session list. pi-subagents
+  // writes children as a literal `session.jsonl`, so the filename's
+  // stem is the string "session" — useless for navigation. Server-side
+  // discovery reads the JSONL header for the real id and surfaces both
+  // path AND sessionId on UnifiedSession; we look up by path here.
+  const sessionByPath = useMemo(() => {
+    const map = new Map<string, { sessionId: string; projectId: string }>();
+    for (const list of Object.values(byProject)) {
+      for (const s of list) {
+        if (typeof s.path === "string" && s.path.length > 0) {
+          map.set(s.path, { sessionId: s.sessionId, projectId: s.projectId });
+        }
+      }
+    }
+    return map;
+  }, [byProject]);
+  const openByFile = (sessionFile: string | undefined): void => {
+    if (sessionFile === undefined) {
+      console.warn("[subagent] Open clicked but result has no sessionFile");
+      return;
+    }
+    const match = sessionByPath.get(sessionFile);
+    console.info("[subagent] Open clicked", { sessionFile, match });
+    if (match === undefined) {
+      // The child wasn't in any project's session list — most likely
+      // because the project sidebar hasn't been refreshed since the
+      // sub-agent ran. Reload the active project's list and retry.
+      // For now: surface a console warning rather than silently doing
+      // nothing. (A future revision could trigger a refetch + retry.)
+      console.warn(
+        "[subagent] Open: sessionFile not found in any project's session list",
+        sessionFile,
+      );
+      return;
+    }
+    setActiveProject(match.projectId);
+    setActiveSession(match.sessionId);
+  };
   const parsed = parseSubagentDetails(message.details);
   const isManagement = parsed.mode === "management";
   const count = parsed.results.length;
-  // Single-result cards expose the Open button in the header for
-  // one-click navigation. Multi-result (parallel/chain) gets per-row
-  // Open buttons since there's no single sessionId to point at.
-  const singleSessionId =
-    count === 1 && parsed.results[0]!.sessionId !== undefined
-      ? parsed.results[0]!.sessionId
-      : undefined;
   const headline =
     count === 1
       ? `Sub-agent: ${parsed.results[0]!.agent}`
@@ -1162,21 +1196,11 @@ function SubagentResultCard({
             </span>
           )}
         </div>
-        {singleSessionId !== undefined && (
+        {parsed.results.length === 1 && parsed.results[0]!.sessionFile !== undefined && (
           <button
-            onClick={() => {
-              // Console breadcrumb so we can see in DevTools whether
-              // the click handler fires at all when "Open doesn't
-              // navigate" is reported. Strip when sub-agents UX
-              // stabilises.
-              console.info("[subagent] Open clicked", {
-                sessionId: singleSessionId,
-                sessionFile: parsed.results[0]!.sessionFile,
-              });
-              setActiveSession(singleSessionId);
-            }}
+            onClick={() => openByFile(parsed.results[0]!.sessionFile)}
             className="inline-flex shrink-0 items-center gap-1 rounded border border-sky-700/60 px-1.5 py-0.5 text-[10px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100"
-            title={`Open sub-agent session — ${singleSessionId}`}
+            title={`Open sub-agent session — ${parsed.results[0]!.sessionFile}`}
           >
             <ExternalLink size={10} />
             Open
@@ -1188,9 +1212,9 @@ function SubagentResultCard({
         <div className="space-y-1.5 border-t border-sky-900/30 px-2.5 py-2">
           {parsed.results.map((r, i) => (
             <SubagentResultRow
-              key={r.sessionId ?? `${i}-${r.agent}`}
+              key={r.sessionFile ?? `${i}-${r.agent}`}
               result={r}
-              onOpen={(sid) => setActiveSession(sid)}
+              onOpenFile={openByFile}
             />
           ))}
         </div>
@@ -1233,10 +1257,10 @@ function SubagentResultCard({
 
 function SubagentResultRow({
   result,
-  onOpen,
+  onOpenFile,
 }: {
   result: SubagentResult;
-  onOpen: (sessionId: string) => void;
+  onOpenFile: (sessionFile: string | undefined) => void;
 }) {
   const failed = result.exitCode !== 0;
   return (
@@ -1256,17 +1280,11 @@ function SubagentResultRow({
           </div>
         )}
       </div>
-      {result.sessionId !== undefined && (
+      {result.sessionFile !== undefined && (
         <button
-          onClick={() => {
-            console.info("[subagent] Open clicked (multi-row)", {
-              sessionId: result.sessionId,
-              sessionFile: result.sessionFile,
-            });
-            onOpen(result.sessionId!);
-          }}
+          onClick={() => onOpenFile(result.sessionFile)}
           className="inline-flex shrink-0 items-center gap-1 rounded border border-sky-700/60 px-1.5 py-0.5 text-[10px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100"
-          title={result.sessionFile ?? "Open sub-agent session"}
+          title={result.sessionFile}
         >
           <ExternalLink size={10} />
           Open

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -853,6 +853,7 @@ function ToolCallEntry({
   if (name === "subagent") {
     return (
       <SubagentInflightOrResult
+        argsText={argsText}
         input={argsObj}
         result={result}
         isError={isError}
@@ -1008,8 +1009,10 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
 
   // pi-subagents: replace the generic tool card with a richer surface
   // listing each spawned sub-agent + a "open session" affordance.
+  // Standalone (orphan) toolResult — no paired toolCall, so we have no
+  // input args to show. argsText="" and the Input section won't render.
   if (toolName === "subagent") {
-    return <SubagentResultCard message={message} fallbackText={text} isError={isError} />;
+    return <SubagentResultCard message={message} argsText="" outputText={text} isError={isError} />;
   }
 
   // Generic tool result fallback.
@@ -1035,30 +1038,35 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
  * back to a plain text block so we never lose information silently.
  */
 /**
- * Wrapper that picks the right sub-agent card variant based on
- * whether the tool has finished:
- *   - in-flight (no result yet) → "Sub-agent running…" card with the
- *     requested agent name + task pulled out of the input args
- *   - completed → the rich SubagentResultCard with per-result rows + Open buttons
- *
- * Used by ToolCallEntry (paired result) so the user sees a violet
- * sub-agent treatment for BOTH states — pre-result and post-result.
- * The standalone ToolResult branch reaches SubagentResultCard
- * directly since by the time it's rendered the result always exists.
+ * Wrapper that picks the right sub-agent card variant based on whether
+ * the tool has finished. In-flight (no result yet) renders a compact
+ * "Sub-agent running…" card; completed renders SubagentResultCard,
+ * which always carries Input + Output collapsibles so the user can
+ * inspect what was sent and what came back — same affordance the
+ * generic ToolCallEntry has.
  */
 function SubagentInflightOrResult({
+  argsText,
   input,
   result,
   isError,
   outputText,
 }: {
+  argsText: string;
   input: Record<string, unknown> | undefined;
   result: AgentMessageLike | undefined;
   isError: boolean;
   outputText: string;
 }) {
   if (result !== undefined) {
-    return <SubagentResultCard message={result} fallbackText={outputText} isError={isError} />;
+    return (
+      <SubagentResultCard
+        message={result}
+        argsText={argsText}
+        outputText={outputText}
+        isError={isError}
+      />
+    );
   }
   // In-flight: pull a friendly preview out of the SubagentParams shape
   // (single mode → input.agent / input.task; parallel/chain mode →
@@ -1079,13 +1087,13 @@ function SubagentInflightOrResult({
     else if (agent !== undefined) summary = agent;
   }
   return (
-    <div className="overflow-hidden rounded border border-amber-700/50 border-l-2 border-l-amber-400 bg-amber-950/15 text-xs">
+    <div className="overflow-hidden rounded border border-l-2 border-sky-700/50 border-l-sky-400 bg-sky-950/15 text-xs">
       <div className="flex items-center justify-between gap-2 px-2.5 py-1.5">
         <div className="flex min-w-0 items-center gap-1.5">
-          <Users size={11} className="shrink-0 text-amber-300" />
-          <span className="truncate font-medium text-amber-100">Sub-agent running…</span>
+          <Users size={11} className="shrink-0 text-sky-300" />
+          <span className="truncate font-medium text-sky-100">Sub-agent running…</span>
           {summary !== undefined && (
-            <span className="ml-1 truncate font-mono text-[11px] text-amber-200/70" title={summary}>
+            <span className="ml-1 truncate font-mono text-[11px] text-sky-200/70" title={summary}>
               {summary}
             </span>
           )}
@@ -1097,22 +1105,22 @@ function SubagentInflightOrResult({
 
 function SubagentResultCard({
   message,
-  fallbackText,
+  argsText,
+  outputText,
   isError,
 }: {
   message: AgentMessageLike;
-  fallbackText: string;
+  argsText: string;
+  outputText: string;
   isError: boolean;
 }) {
   const setActiveSession = useSessionStore((s) => s.setActiveSession);
   const parsed = parseSubagentDetails(message.details);
   const isManagement = parsed.mode === "management";
-  const isUnknown = parsed.mode === "unknown";
   const count = parsed.results.length;
-  // Single-result cards expose the Open button up in the header so the
-  // user can see-and-jump in one row of vertical space. Multi-result
-  // (parallel/chain) gets a per-result Open button down in the rows
-  // since there's no single sessionId to point at from the header.
+  // Single-result cards expose the Open button in the header for
+  // one-click navigation. Multi-result (parallel/chain) gets per-row
+  // Open buttons since there's no single sessionId to point at.
   const singleSessionId =
     count === 1 && parsed.results[0]!.sessionId !== undefined
       ? parsed.results[0]!.sessionId
@@ -1125,24 +1133,24 @@ function SubagentResultCard({
         : isManagement
           ? "Sub-agent management"
           : "Sub-agent";
-  // Compact orange/amber treatment — single-line header with optional
-  // body. Uses border-l-2 accent + amber-700 border for a subtle but
-  // distinctive treatment that doesn't dominate the chat stream.
+
+  // Light-blue (sky) color treatment per request — distinctive but
+  // soft. Failures get a red border but keep the rest of the card
+  // intact (so the input + output sections are still inspectable
+  // when the call errored).
+  const borderColors = isError
+    ? "border-red-700/50 border-l-red-400 bg-red-950/15"
+    : "border-sky-700/50 border-l-sky-400 bg-sky-950/15";
+
   return (
-    <div
-      className={`overflow-hidden rounded border border-l-2 ${
-        isError
-          ? "border-red-700/50 border-l-red-400 bg-red-950/15"
-          : "border-amber-700/50 border-l-amber-400 bg-amber-950/15"
-      } text-xs`}
-    >
+    <div className={`overflow-hidden rounded border border-l-2 ${borderColors} text-xs`}>
       <div className="flex items-center justify-between gap-2 px-2.5 py-1.5">
         <div className="flex min-w-0 items-center gap-1.5">
-          <Users size={11} className="shrink-0 text-amber-300" />
-          <span className="truncate font-medium text-amber-100">{headline}</span>
+          <Users size={11} className="shrink-0 text-sky-300" />
+          <span className="truncate font-medium text-sky-100">{headline}</span>
           {parsed.context !== undefined && (
             <span
-              className="shrink-0 rounded bg-amber-900/40 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-amber-200"
+              className="shrink-0 rounded bg-sky-900/40 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-sky-200"
               title={parsed.context === "fork" ? "Forked from parent context" : "Fresh context"}
             >
               {parsed.context}
@@ -1154,12 +1162,20 @@ function SubagentResultCard({
             </span>
           )}
         </div>
-        {/* Header-right Open button when there's a single child to
-            navigate to. Icon-only with title-tip so it stays small. */}
         {singleSessionId !== undefined && (
           <button
-            onClick={() => setActiveSession(singleSessionId)}
-            className="inline-flex shrink-0 items-center gap-1 rounded border border-amber-700/60 px-1.5 py-0.5 text-[10px] font-medium text-amber-200 hover:border-amber-500 hover:bg-amber-900/30 hover:text-amber-100"
+            onClick={() => {
+              // Console breadcrumb so we can see in DevTools whether
+              // the click handler fires at all when "Open doesn't
+              // navigate" is reported. Strip when sub-agents UX
+              // stabilises.
+              console.info("[subagent] Open clicked", {
+                sessionId: singleSessionId,
+                sessionFile: parsed.results[0]!.sessionFile,
+              });
+              setActiveSession(singleSessionId);
+            }}
+            className="inline-flex shrink-0 items-center gap-1 rounded border border-sky-700/60 px-1.5 py-0.5 text-[10px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100"
             title={`Open sub-agent session — ${singleSessionId}`}
           >
             <ExternalLink size={10} />
@@ -1167,13 +1183,9 @@ function SubagentResultCard({
           </button>
         )}
       </div>
-      {/* Body — only renders when there's something useful to show:
-          parallel/chain results (multiple), or management/unknown
-          mode's prose body. Single-result cards collapse fully to
-          the header-only treatment unless the result has a finalOutput
-          worth surfacing under a `<details>`. */}
+      {/* Multi-result body — one row per child with its own Open button. */}
       {count > 1 && (
-        <div className="space-y-1.5 border-t border-amber-900/30 px-2.5 py-2">
+        <div className="space-y-1.5 border-t border-sky-900/30 px-2.5 py-2">
           {parsed.results.map((r, i) => (
             <SubagentResultRow
               key={r.sessionId ?? `${i}-${r.agent}`}
@@ -1183,25 +1195,37 @@ function SubagentResultCard({
           ))}
         </div>
       )}
-      {count === 1 && parsed.results[0]!.finalOutput !== undefined && (
-        <details className="border-t border-amber-900/30 px-2.5 py-1.5">
-          <summary className="cursor-pointer text-[11px] text-neutral-500 hover:text-neutral-300">
-            output
+      {/* Input + Output collapsibles — same affordance the generic
+          ToolCallEntry has. Always present (when there's content),
+          collapsed by default, so the card stays compact but the user
+          can still see what was sent and what came back. Failures
+          surface here as Output content rather than disappearing. */}
+      {argsText.length > 0 && (
+        <details className="border-t border-sky-900/30">
+          <summary className="cursor-pointer px-2.5 py-1 text-[11px] text-neutral-500 hover:text-neutral-300">
+            Input
           </summary>
-          <pre className="mt-1 max-h-48 overflow-auto rounded bg-neutral-950 p-2 font-mono text-[11px] text-neutral-300">
-            {parsed.results[0]!.finalOutput}
+          <pre className="overflow-auto px-2.5 pb-2 font-mono text-[11px] text-neutral-400">
+            {argsText}
           </pre>
         </details>
       )}
-      {count === 0 && (isManagement || isUnknown) && fallbackText.length > 0 && (
-        // Management calls (`action: "list"` etc) and unrecognised
-        // payloads: render the raw text as readable body, NOT a
-        // monospace pre. The output is human-readable structured prose
-        // (e.g. "Executable agents:\n- name: description") and the pre
-        // treatment was making it disappear visually.
-        <div className="whitespace-pre-wrap border-t border-amber-900/30 px-2.5 py-2 text-[11px] leading-snug text-neutral-300">
-          {fallbackText}
-        </div>
+      {outputText.length > 0 && (
+        <details
+          // For management mode + errors the output IS the body, so open
+          // by default — otherwise a failed call or "list agents" call
+          // looks blank. Normal successful runs collapse the verbose
+          // sub-agent output by default so the chat stays scannable.
+          open={isError || (isManagement && count === 0)}
+          className="border-t border-sky-900/30"
+        >
+          <summary className="cursor-pointer px-2.5 py-1 text-[11px] text-neutral-500 hover:text-neutral-300">
+            Output
+          </summary>
+          <pre className="overflow-auto px-2.5 pb-2 font-mono text-[11px] text-neutral-300 whitespace-pre-wrap">
+            {outputText}
+          </pre>
+        </details>
       )}
     </div>
   );
@@ -1217,11 +1241,11 @@ function SubagentResultRow({
   const failed = result.exitCode !== 0;
   return (
     <div
-      className={`flex items-center justify-between gap-2 rounded border ${failed ? "border-red-700/40" : "border-amber-900/40"} bg-neutral-950/60 px-2 py-1.5`}
+      className={`flex items-center justify-between gap-2 rounded border ${failed ? "border-red-700/40" : "border-sky-900/40"} bg-neutral-950/60 px-2 py-1.5`}
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2">
-          <span className="font-mono text-[11px] font-medium text-amber-200">{result.agent}</span>
+          <span className="font-mono text-[11px] font-medium text-sky-200">{result.agent}</span>
           {failed && (
             <span className="text-[10px] font-medium text-red-400">exit {result.exitCode}</span>
           )}
@@ -1234,8 +1258,14 @@ function SubagentResultRow({
       </div>
       {result.sessionId !== undefined && (
         <button
-          onClick={() => onOpen(result.sessionId!)}
-          className="inline-flex shrink-0 items-center gap-1 rounded border border-amber-700/60 px-1.5 py-0.5 text-[10px] font-medium text-amber-200 hover:border-amber-500 hover:bg-amber-900/30 hover:text-amber-100"
+          onClick={() => {
+            console.info("[subagent] Open clicked (multi-row)", {
+              sessionId: result.sessionId,
+              sessionFile: result.sessionFile,
+            });
+            onOpen(result.sessionId!);
+          }}
+          className="inline-flex shrink-0 items-center gap-1 rounded border border-sky-700/60 px-1.5 py-0.5 text-[10px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100"
           title={result.sessionFile ?? "Open sub-agent session"}
         >
           <ExternalLink size={10} />

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1079,22 +1079,18 @@ function SubagentInflightOrResult({
     else if (agent !== undefined) summary = agent;
   }
   return (
-    <div className="overflow-hidden rounded-lg border border-violet-800/50 border-l-4 border-l-violet-500 bg-violet-950/20 shadow-sm">
-      <div className="flex items-center justify-between gap-2 border-b border-violet-900/40 bg-violet-950/30 px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <Users size={14} className="shrink-0 text-violet-300" />
-          <span className="truncate font-semibold text-violet-100">Sub-agent running…</span>
+    <div className="overflow-hidden rounded border border-amber-700/50 border-l-2 border-l-amber-400 bg-amber-950/15 text-xs">
+      <div className="flex items-center justify-between gap-2 px-2.5 py-1.5">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Users size={11} className="shrink-0 text-amber-300" />
+          <span className="truncate font-medium text-amber-100">Sub-agent running…</span>
+          {summary !== undefined && (
+            <span className="ml-1 truncate font-mono text-[11px] text-amber-200/70" title={summary}>
+              {summary}
+            </span>
+          )}
         </div>
-        <span className="shrink-0 rounded bg-violet-900/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-violet-200">
-          in-flight
-        </span>
       </div>
-      {summary !== undefined && (
-        <div className="px-3 py-2 text-xs text-neutral-300">
-          <span className="text-neutral-500">running:</span>{" "}
-          <span className="font-mono">{summary}</span>
-        </div>
-      )}
     </div>
   );
 }
@@ -1113,6 +1109,14 @@ function SubagentResultCard({
   const isManagement = parsed.mode === "management";
   const isUnknown = parsed.mode === "unknown";
   const count = parsed.results.length;
+  // Single-result cards expose the Open button up in the header so the
+  // user can see-and-jump in one row of vertical space. Multi-result
+  // (parallel/chain) gets a per-result Open button down in the rows
+  // since there's no single sessionId to point at from the header.
+  const singleSessionId =
+    count === 1 && parsed.results[0]!.sessionId !== undefined
+      ? parsed.results[0]!.sessionId
+      : undefined;
   const headline =
     count === 1
       ? `Sub-agent: ${parsed.results[0]!.agent}`
@@ -1121,54 +1125,84 @@ function SubagentResultCard({
         : isManagement
           ? "Sub-agent management"
           : "Sub-agent";
-  // Saturated violet treatment + thicker border so the card pops out
-  // of the chat stream — sub-agent runs are a different *kind* of
-  // event than a normal tool call, and the visual weight should
-  // reflect that. Border-l accent strip mirrors the gh PR-review
-  // surface for a "this matters" feel.
+  // Compact orange/amber treatment — single-line header with optional
+  // body. Uses border-l-2 accent + amber-700 border for a subtle but
+  // distinctive treatment that doesn't dominate the chat stream.
   return (
     <div
-      className={`overflow-hidden rounded-lg border-l-4 ${
+      className={`overflow-hidden rounded border border-l-2 ${
         isError
-          ? "border-l-red-500 border border-red-700/40 bg-red-950/10"
-          : "border-l-violet-500 border border-violet-800/50 bg-violet-950/20"
-      } shadow-sm`}
+          ? "border-red-700/50 border-l-red-400 bg-red-950/15"
+          : "border-amber-700/50 border-l-amber-400 bg-amber-950/15"
+      } text-xs`}
     >
-      <div className="flex items-center justify-between gap-2 border-b border-violet-900/40 bg-violet-950/30 px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <Users size={14} className="shrink-0 text-violet-300" />
-          <span className="truncate font-semibold text-violet-100">{headline}</span>
+      <div className="flex items-center justify-between gap-2 px-2.5 py-1.5">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Users size={11} className="shrink-0 text-amber-300" />
+          <span className="truncate font-medium text-amber-100">{headline}</span>
           {parsed.context !== undefined && (
             <span
-              className="shrink-0 rounded bg-violet-900/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-violet-200"
+              className="shrink-0 rounded bg-amber-900/40 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-amber-200"
               title={parsed.context === "fork" ? "Forked from parent context" : "Fresh context"}
             >
               {parsed.context}
             </span>
           )}
+          {isError && (
+            <span className="shrink-0 rounded bg-red-900/40 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-red-200">
+              error
+            </span>
+          )}
         </div>
-        {isError && (
-          <span className="shrink-0 rounded bg-red-900/40 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-red-200">
-            error
-          </span>
+        {/* Header-right Open button when there's a single child to
+            navigate to. Icon-only with title-tip so it stays small. */}
+        {singleSessionId !== undefined && (
+          <button
+            onClick={() => setActiveSession(singleSessionId)}
+            className="inline-flex shrink-0 items-center gap-1 rounded border border-amber-700/60 px-1.5 py-0.5 text-[10px] font-medium text-amber-200 hover:border-amber-500 hover:bg-amber-900/30 hover:text-amber-100"
+            title={`Open sub-agent session — ${singleSessionId}`}
+          >
+            <ExternalLink size={10} />
+            Open
+          </button>
         )}
       </div>
-      <div className="space-y-2 p-3">
-        {parsed.results.map((r, i) => (
-          <SubagentResultRow
-            key={r.sessionId ?? `${i}-${r.agent}`}
-            result={r}
-            onOpen={(sid) => setActiveSession(sid)}
-          />
-        ))}
-        {count === 0 && (isManagement || isUnknown) && (
-          // Management calls + unrecognised payloads: keep the raw text
-          // visible so the user / a future debugger can see the response.
-          <pre className="overflow-auto rounded bg-neutral-950 p-2 font-mono text-[11px] text-neutral-400">
-            {fallbackText}
+      {/* Body — only renders when there's something useful to show:
+          parallel/chain results (multiple), or management/unknown
+          mode's prose body. Single-result cards collapse fully to
+          the header-only treatment unless the result has a finalOutput
+          worth surfacing under a `<details>`. */}
+      {count > 1 && (
+        <div className="space-y-1.5 border-t border-amber-900/30 px-2.5 py-2">
+          {parsed.results.map((r, i) => (
+            <SubagentResultRow
+              key={r.sessionId ?? `${i}-${r.agent}`}
+              result={r}
+              onOpen={(sid) => setActiveSession(sid)}
+            />
+          ))}
+        </div>
+      )}
+      {count === 1 && parsed.results[0]!.finalOutput !== undefined && (
+        <details className="border-t border-amber-900/30 px-2.5 py-1.5">
+          <summary className="cursor-pointer text-[11px] text-neutral-500 hover:text-neutral-300">
+            output
+          </summary>
+          <pre className="mt-1 max-h-48 overflow-auto rounded bg-neutral-950 p-2 font-mono text-[11px] text-neutral-300">
+            {parsed.results[0]!.finalOutput}
           </pre>
-        )}
-      </div>
+        </details>
+      )}
+      {count === 0 && (isManagement || isUnknown) && fallbackText.length > 0 && (
+        // Management calls (`action: "list"` etc) and unrecognised
+        // payloads: render the raw text as readable body, NOT a
+        // monospace pre. The output is human-readable structured prose
+        // (e.g. "Executable agents:\n- name: description") and the pre
+        // treatment was making it disappear visually.
+        <div className="whitespace-pre-wrap border-t border-amber-900/30 px-2.5 py-2 text-[11px] leading-snug text-neutral-300">
+          {fallbackText}
+        </div>
+      )}
     </div>
   );
 }
@@ -1183,46 +1217,30 @@ function SubagentResultRow({
   const failed = result.exitCode !== 0;
   return (
     <div
-      className={`rounded border ${failed ? "border-red-700/40" : "border-violet-900/40"} bg-neutral-950/60 p-3`}
+      className={`flex items-center justify-between gap-2 rounded border ${failed ? "border-red-700/40" : "border-amber-900/40"} bg-neutral-950/60 px-2 py-1.5`}
     >
-      <div className="mb-2 flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-baseline gap-2">
-            <span className="font-mono text-sm font-medium text-violet-200">{result.agent}</span>
-            {failed && (
-              <span className="text-[11px] font-medium text-red-400">exit {result.exitCode}</span>
-            )}
-          </div>
-          {result.task.length > 0 && (
-            <div className="mt-1 line-clamp-2 text-xs text-neutral-300" title={result.task}>
-              {result.task}
-            </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="font-mono text-[11px] font-medium text-amber-200">{result.agent}</span>
+          {failed && (
+            <span className="text-[10px] font-medium text-red-400">exit {result.exitCode}</span>
           )}
         </div>
+        {result.task.length > 0 && (
+          <div className="mt-0.5 truncate text-[11px] text-neutral-400" title={result.task}>
+            {result.task}
+          </div>
+        )}
       </div>
-      {/* Primary CTA — full-width violet button so it reads as the
-          main action. Keyboard-accessible (button, not anchor) since
-          the navigation is purely client-side store mutation, not a
-          URL change. */}
       {result.sessionId !== undefined && (
         <button
           onClick={() => onOpen(result.sessionId!)}
-          className="mb-1 flex w-full items-center justify-center gap-1.5 rounded bg-violet-700 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-violet-600 focus:outline-none focus:ring-2 focus:ring-violet-400"
+          className="inline-flex shrink-0 items-center gap-1 rounded border border-amber-700/60 px-1.5 py-0.5 text-[10px] font-medium text-amber-200 hover:border-amber-500 hover:bg-amber-900/30 hover:text-amber-100"
           title={result.sessionFile ?? "Open sub-agent session"}
         >
-          <ExternalLink size={12} />
-          Open sub-agent session
+          <ExternalLink size={10} />
+          Open
         </button>
-      )}
-      {result.finalOutput !== undefined && (
-        <details className="mt-2">
-          <summary className="cursor-pointer text-[11px] text-neutral-400 hover:text-neutral-200">
-            output
-          </summary>
-          <pre className="mt-1 max-h-48 overflow-auto rounded bg-neutral-900 p-2 font-mono text-[11px] text-neutral-300">
-            {result.finalOutput}
-          </pre>
-        </details>
       )}
     </div>
   );

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -236,11 +236,11 @@ export function SessionList({ projectId }: Props) {
       */}
       {topLevel.flatMap((s) => {
         const children = childrenByParent.get(s.sessionId) ?? [];
-        // Default-expanded for parents with children — the typical
-        // user intent is "show me this run's sub-agents." User-toggled
-        // state (Map entry exists) overrides the default.
+        // Default-collapsed: most parents have zero children, and a
+        // sweeping "show every run's sub-agents" expansion adds noise
+        // to the sidebar. User toggle persists.
         const userToggle = expandedParents.get(s.sessionId);
-        const isExpanded = userToggle !== undefined ? userToggle : children.length > 0;
+        const isExpanded = userToggle === true;
         const rows: ReactNode[] = [
           <SessionRow
             key={s.sessionId}

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
+import { useEffect, useMemo, useState, type KeyboardEvent, type ReactNode } from "react";
 import { ChevronDown, ChevronRight, X } from "lucide-react";
 import { EMPTY_SESSIONS, useSessionStore } from "../store/session-store";
 import { useProjectStore } from "../store/project-store";
@@ -210,10 +210,17 @@ export function SessionList({ projectId }: Props) {
           </div>
         </div>
       )}
-      {topLevel.map((s) => {
+      {/*
+        Single-pass render: each parent row, immediately followed by
+        its children when the parent is expanded. flatMap returns
+        an array per parent — React unwraps it inline so the children
+        appear directly under their parent in DOM order, not as a
+        separate group at the bottom of the list.
+      */}
+      {topLevel.flatMap((s) => {
         const children = childrenByParent.get(s.sessionId) ?? [];
         const isExpanded = expandedParents.has(s.sessionId);
-        return (
+        const rows: ReactNode[] = [
           <SessionRow
             key={s.sessionId}
             session={s}
@@ -232,44 +239,34 @@ export function SessionList({ projectId }: Props) {
             onCommitRename={(id) => void commitRename(id)}
             onToggleExpanded={toggleExpanded}
             onAskDelete={(payload) => setDeleteDialog(payload)}
-          />
-        );
-        // Children render right below their parent when expanded. We
-        // can't return an array from inside the main map (React's key
-        // rules want flat children at the parent level), so the loop
-        // is split into two steps via a fragment-style flat-map below.
-      })}
-      {/*
-        Render children under each expanded parent. We do this in a
-        second pass so each parent + its children sit consecutively;
-        keeping the markup in a fragment instead of a nested
-        component preserves the same active/selected styling logic.
-      */}
-      {topLevel.flatMap((parent) => {
-        const children = childrenByParent.get(parent.sessionId);
-        if (children === undefined) return [];
-        if (!expandedParents.has(parent.sessionId)) return [];
-        return children.map((c) => (
-          <SessionRow
-            key={c.sessionId}
-            session={c}
-            isActive={c.sessionId === activeSessionId}
-            isSelected={selectedIds.has(c.sessionId)}
-            isRenaming={renamingId === c.sessionId}
-            renameDraft={renameDraft}
-            childCount={0}
-            isExpanded={false}
-            isChild={true}
-            onSelect={selectSession}
-            onToggleSelect={toggleSelected}
-            onStartRename={startRename}
-            onChangeRename={setRenameDraft}
-            onRenameKeyDown={onRenameKeyDown}
-            onCommitRename={(id) => void commitRename(id)}
-            onToggleExpanded={toggleExpanded}
-            onAskDelete={(payload) => setDeleteDialog(payload)}
-          />
-        ));
+          />,
+        ];
+        if (isExpanded) {
+          for (const c of children) {
+            rows.push(
+              <SessionRow
+                key={c.sessionId}
+                session={c}
+                isActive={c.sessionId === activeSessionId}
+                isSelected={selectedIds.has(c.sessionId)}
+                isRenaming={renamingId === c.sessionId}
+                renameDraft={renameDraft}
+                childCount={0}
+                isExpanded={false}
+                isChild={true}
+                onSelect={selectSession}
+                onToggleSelect={toggleSelected}
+                onStartRename={startRename}
+                onChangeRename={setRenameDraft}
+                onRenameKeyDown={onRenameKeyDown}
+                onCommitRename={(id) => void commitRename(id)}
+                onToggleExpanded={toggleExpanded}
+                onAskDelete={(payload) => setDeleteDialog(payload)}
+              />,
+            );
+          }
+        }
+        return rows;
       })}
       <ConfirmDialog
         open={deleteDialog !== undefined}

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, type KeyboardEvent } from "react";
-import { X } from "lucide-react";
+import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
+import { ChevronDown, ChevronRight, X } from "lucide-react";
 import { EMPTY_SESSIONS, useSessionStore } from "../store/session-store";
 import { useProjectStore } from "../store/project-store";
 import { ConfirmDialog } from "./Modal";
+import type { UnifiedSession } from "../lib/api-client";
 
 interface Props {
   projectId: string;
@@ -73,6 +74,50 @@ export function SessionList({ projectId }: Props) {
       return next;
     });
   };
+
+  /**
+   * Per-parent expansion state for the pi-subagents sub-agent dropdown.
+   * Children are spawned by the `subagent` extension tool — see
+   * `notes/MOBILE.md` and `CLAUDE.md` for context. Defaults to
+   * collapsed because most parents have zero children, and a default-
+   * expanded view would visually duplicate every existing top-level
+   * session row whenever a child happens to exist.
+   */
+  const [expandedParents, setExpandedParents] = useState<Set<string>>(new Set());
+  const toggleExpanded = (parentId: string): void => {
+    setExpandedParents((prev) => {
+      const next = new Set(prev);
+      if (next.has(parentId)) next.delete(parentId);
+      else next.add(parentId);
+      return next;
+    });
+  };
+
+  /**
+   * Bucket sessions into top-level rows and per-parent child arrays.
+   * Children are excluded from the top-level list (rendered nested
+   * under their parent's chevron); orphaned children — children
+   * whose parent isn't in this project's session list, e.g. because
+   * the parent was deleted — fall back to top-level rendering so they
+   * don't disappear from the sidebar entirely.
+   */
+  const { topLevel, childrenByParent } = useMemo(() => {
+    const childrenByParent = new Map<string, UnifiedSession[]>();
+    const topLevelIds = new Set(
+      sessions.filter((s) => s.parentSessionId === undefined).map((s) => s.sessionId),
+    );
+    for (const s of sessions) {
+      if (s.parentSessionId === undefined) continue;
+      if (!topLevelIds.has(s.parentSessionId)) continue; // orphan — keep at top level
+      const arr = childrenByParent.get(s.parentSessionId);
+      if (arr === undefined) childrenByParent.set(s.parentSessionId, [s]);
+      else arr.push(s);
+    }
+    const topLevel = sessions.filter(
+      (s) => s.parentSessionId === undefined || !topLevelIds.has(s.parentSessionId),
+    );
+    return { topLevel, childrenByParent };
+  }, [sessions]);
 
   const submitDelete = async (): Promise<void> => {
     if (deleteDialog === undefined) return;
@@ -165,79 +210,66 @@ export function SessionList({ projectId }: Props) {
           </div>
         </div>
       )}
-      {sessions.map((s) => {
-        const isActive = s.sessionId === activeSessionId;
-        const isSelected = selectedIds.has(s.sessionId);
-        const label =
-          s.name ??
-          (s.firstMessage.length > 0
-            ? s.firstMessage.slice(0, 40)
-            : `session ${s.sessionId.slice(0, 6)}`);
-        const isRenaming = renamingId === s.sessionId;
+      {topLevel.map((s) => {
+        const children = childrenByParent.get(s.sessionId) ?? [];
+        const isExpanded = expandedParents.has(s.sessionId);
         return (
-          <div
+          <SessionRow
             key={s.sessionId}
-            className={`group flex items-center gap-1 rounded px-2 py-0.5 text-xs ${
-              isSelected
-                ? "bg-emerald-900/20 text-neutral-100"
-                : isActive
-                  ? "bg-neutral-800 text-neutral-100"
-                  : "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
-            }`}
-          >
-            {isRenaming ? (
-              <input
-                autoFocus
-                value={renameDraft}
-                onChange={(e) => setRenameDraft(e.target.value)}
-                onKeyDown={(e) => onRenameKeyDown(e, s.sessionId)}
-                onBlur={() => void commitRename(s.sessionId)}
-                placeholder={label}
-                maxLength={200}
-                className="flex-1 rounded border border-neutral-700 bg-neutral-950 px-1.5 py-0.5 text-xs text-neutral-100 outline-none focus:border-neutral-500"
-              />
-            ) : (
-              <button
-                onClick={(e) => {
-                  // Cmd/Ctrl+click toggles selection without switching
-                  // the active session, so the user can build up a
-                  // selection for bulk delete without page churn.
-                  if (e.metaKey || e.ctrlKey) {
-                    toggleSelected(s.sessionId);
-                    return;
-                  }
-                  selectSession(s.sessionId);
-                }}
-                onDoubleClick={() => startRename(s.sessionId, s.name ?? "")}
-                className="flex-1 truncate text-left"
-                title={`${s.sessionId} — double-click to rename, Cmd/Ctrl+click to select for bulk delete`}
-              >
-                {s.isLive && <span className="mr-1 text-emerald-500">●</span>}
-                {label}
-              </button>
-            )}
-            {!isRenaming && (
-              <button
-                onClick={() =>
-                  setDeleteDialog({
-                    kind: "single",
-                    sessionId: s.sessionId,
-                    label,
-                    isLive: s.isLive,
-                  })
-                }
-                className="inline-flex items-center p-1 text-neutral-500 hover:text-red-400"
-                title={
-                  s.isLive
-                    ? "Delete session — also kills the live shell"
-                    : "Delete session JSONL from disk"
-                }
-              >
-                <X size={16} />
-              </button>
-            )}
-          </div>
+            session={s}
+            isActive={s.sessionId === activeSessionId}
+            isSelected={selectedIds.has(s.sessionId)}
+            isRenaming={renamingId === s.sessionId}
+            renameDraft={renameDraft}
+            childCount={children.length}
+            isExpanded={isExpanded}
+            isChild={false}
+            onSelect={selectSession}
+            onToggleSelect={toggleSelected}
+            onStartRename={startRename}
+            onChangeRename={setRenameDraft}
+            onRenameKeyDown={onRenameKeyDown}
+            onCommitRename={(id) => void commitRename(id)}
+            onToggleExpanded={toggleExpanded}
+            onAskDelete={(payload) => setDeleteDialog(payload)}
+          />
         );
+        // Children render right below their parent when expanded. We
+        // can't return an array from inside the main map (React's key
+        // rules want flat children at the parent level), so the loop
+        // is split into two steps via a fragment-style flat-map below.
+      })}
+      {/*
+        Render children under each expanded parent. We do this in a
+        second pass so each parent + its children sit consecutively;
+        keeping the markup in a fragment instead of a nested
+        component preserves the same active/selected styling logic.
+      */}
+      {topLevel.flatMap((parent) => {
+        const children = childrenByParent.get(parent.sessionId);
+        if (children === undefined) return [];
+        if (!expandedParents.has(parent.sessionId)) return [];
+        return children.map((c) => (
+          <SessionRow
+            key={c.sessionId}
+            session={c}
+            isActive={c.sessionId === activeSessionId}
+            isSelected={selectedIds.has(c.sessionId)}
+            isRenaming={renamingId === c.sessionId}
+            renameDraft={renameDraft}
+            childCount={0}
+            isExpanded={false}
+            isChild={true}
+            onSelect={selectSession}
+            onToggleSelect={toggleSelected}
+            onStartRename={startRename}
+            onChangeRename={setRenameDraft}
+            onRenameKeyDown={onRenameKeyDown}
+            onCommitRename={(id) => void commitRename(id)}
+            onToggleExpanded={toggleExpanded}
+            onAskDelete={(payload) => setDeleteDialog(payload)}
+          />
+        ));
       })}
       <ConfirmDialog
         open={deleteDialog !== undefined}
@@ -260,6 +292,140 @@ export function SessionList({ projectId }: Props) {
         primaryLabel={deleteDialog?.kind === "many" ? "Delete all" : "Delete"}
         tone="danger"
       />
+    </div>
+  );
+}
+
+interface DeletePayload {
+  kind: "single";
+  sessionId: string;
+  label: string;
+  isLive: boolean;
+}
+
+interface SessionRowProps {
+  session: UnifiedSession;
+  isActive: boolean;
+  isSelected: boolean;
+  isRenaming: boolean;
+  renameDraft: string;
+  /** Number of pi-subagents children for this session — drives chevron visibility. */
+  childCount: number;
+  isExpanded: boolean;
+  /** When true, render with extra left indent + nested-row treatment. */
+  isChild: boolean;
+  onSelect: (sessionId: string) => void;
+  onToggleSelect: (sessionId: string) => void;
+  onStartRename: (sessionId: string, current: string) => void;
+  onChangeRename: (next: string) => void;
+  onRenameKeyDown: (e: KeyboardEvent<HTMLInputElement>, sessionId: string) => void;
+  onCommitRename: (sessionId: string) => void;
+  onToggleExpanded: (parentId: string) => void;
+  onAskDelete: (payload: DeletePayload) => void;
+}
+
+function SessionRow(props: SessionRowProps) {
+  const {
+    session: s,
+    isActive,
+    isSelected,
+    isRenaming,
+    renameDraft,
+    childCount,
+    isExpanded,
+    isChild,
+    onSelect,
+    onToggleSelect,
+    onStartRename,
+    onChangeRename,
+    onRenameKeyDown,
+    onCommitRename,
+    onToggleExpanded,
+    onAskDelete,
+  } = props;
+  const label =
+    s.name ??
+    (s.firstMessage.length > 0
+      ? s.firstMessage.slice(0, 40)
+      : `session ${s.sessionId.slice(0, 6)}`);
+  return (
+    <div
+      className={`group flex items-center gap-1 rounded ${isChild ? "ml-4" : ""} px-2 py-0.5 text-xs ${
+        isSelected
+          ? "bg-emerald-900/20 text-neutral-100"
+          : isActive
+            ? "bg-neutral-800 text-neutral-100"
+            : "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
+      }`}
+    >
+      {/* Chevron column. Only parents with children get an interactive
+          chevron; everything else gets a fixed-width spacer so labels
+          line up across rows. */}
+      {childCount > 0 ? (
+        <button
+          onClick={() => onToggleExpanded(s.sessionId)}
+          className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-neutral-500 hover:text-neutral-200"
+          title={`${childCount} sub-agent session${childCount === 1 ? "" : "s"}`}
+          aria-label={isExpanded ? "Collapse sub-agents" : "Expand sub-agents"}
+        >
+          {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </button>
+      ) : (
+        <span className="inline-block h-4 w-4 shrink-0" aria-hidden="true" />
+      )}
+      {isRenaming ? (
+        <input
+          autoFocus
+          value={renameDraft}
+          onChange={(e) => onChangeRename(e.target.value)}
+          onKeyDown={(e) => onRenameKeyDown(e, s.sessionId)}
+          onBlur={() => onCommitRename(s.sessionId)}
+          placeholder={label}
+          maxLength={200}
+          className="flex-1 rounded border border-neutral-700 bg-neutral-950 px-1.5 py-0.5 text-xs text-neutral-100 outline-none focus:border-neutral-500"
+        />
+      ) : (
+        <button
+          onClick={(e) => {
+            if (e.metaKey || e.ctrlKey) {
+              onToggleSelect(s.sessionId);
+              return;
+            }
+            onSelect(s.sessionId);
+          }}
+          onDoubleClick={() => onStartRename(s.sessionId, s.name ?? "")}
+          className="flex-1 truncate text-left"
+          title={`${s.sessionId} — double-click to rename, Cmd/Ctrl+click to select for bulk delete`}
+        >
+          {s.isLive && <span className="mr-1 text-emerald-500">●</span>}
+          {isChild && (
+            <span className="mr-1 text-purple-400" title="sub-agent">
+              ↳
+            </span>
+          )}
+          {label}
+        </button>
+      )}
+      {!isRenaming && (
+        <button
+          onClick={() =>
+            onAskDelete({
+              kind: "single",
+              sessionId: s.sessionId,
+              label,
+              isLive: s.isLive,
+            })
+          }
+          className="inline-flex items-center p-1 text-neutral-500 hover:text-red-400"
+          title={
+            s.isLive
+              ? "Delete session — also kills the live shell"
+              : "Delete session JSONL from disk"
+          }
+        >
+          <X size={16} />
+        </button>
+      )}
     </div>
   );
 }

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -77,18 +77,18 @@ export function SessionList({ projectId }: Props) {
 
   /**
    * Per-parent expansion state for the pi-subagents sub-agent dropdown.
-   * Children are spawned by the `subagent` extension tool — see
-   * `notes/MOBILE.md` and `CLAUDE.md` for context. Defaults to
-   * collapsed because most parents have zero children, and a default-
-   * expanded view would visually duplicate every existing top-level
-   * session row whenever a child happens to exist.
+   * Tracks user TOGGLES — undefined entries inherit the default
+   * (auto-expanded when the parent has children). Storing toggles
+   * rather than absolute state means a freshly-discovered parent
+   * with children gets expanded by default without the user having
+   * to click the chevron, AND user-collapsed state survives across
+   * refetches.
    */
-  const [expandedParents, setExpandedParents] = useState<Set<string>>(new Set());
-  const toggleExpanded = (parentId: string): void => {
+  const [expandedParents, setExpandedParents] = useState<Map<string, boolean>>(new Map());
+  const toggleExpanded = (parentId: string, currentlyExpanded: boolean): void => {
     setExpandedParents((prev) => {
-      const next = new Set(prev);
-      if (next.has(parentId)) next.delete(parentId);
-      else next.add(parentId);
+      const next = new Map(prev);
+      next.set(parentId, !currentlyExpanded);
       return next;
     });
   };
@@ -116,8 +116,25 @@ export function SessionList({ projectId }: Props) {
     const topLevel = sessions.filter(
       (s) => s.parentSessionId === undefined || !topLevelIds.has(s.parentSessionId),
     );
+    // One-shot diagnostic so a still-broken grouping report can be
+    // triaged from the browser console: shows what parentSessionIds
+    // came in on the wire and which buckets they landed in. Strip
+    // when the sub-agent UX stabilises.
+    if (sessions.some((s) => s.parentSessionId !== undefined)) {
+      console.info("[subagent] SessionList grouping", {
+        projectId,
+        sessionCount: sessions.length,
+        topLevelCount: topLevel.length,
+        childCount: Array.from(childrenByParent.values()).reduce((n, a) => n + a.length, 0),
+        topLevelIds: Array.from(topLevelIds),
+        parentIdsOnChildren: sessions
+          .filter((s) => s.parentSessionId !== undefined)
+          .map((s) => s.parentSessionId),
+        bucketed: Array.from(childrenByParent.keys()),
+      });
+    }
     return { topLevel, childrenByParent };
-  }, [sessions]);
+  }, [sessions, projectId]);
 
   const submitDelete = async (): Promise<void> => {
     if (deleteDialog === undefined) return;
@@ -219,7 +236,11 @@ export function SessionList({ projectId }: Props) {
       */}
       {topLevel.flatMap((s) => {
         const children = childrenByParent.get(s.sessionId) ?? [];
-        const isExpanded = expandedParents.has(s.sessionId);
+        // Default-expanded for parents with children — the typical
+        // user intent is "show me this run's sub-agents." User-toggled
+        // state (Map entry exists) overrides the default.
+        const userToggle = expandedParents.get(s.sessionId);
+        const isExpanded = userToggle !== undefined ? userToggle : children.length > 0;
         const rows: ReactNode[] = [
           <SessionRow
             key={s.sessionId}
@@ -317,7 +338,7 @@ interface SessionRowProps {
   onChangeRename: (next: string) => void;
   onRenameKeyDown: (e: KeyboardEvent<HTMLInputElement>, sessionId: string) => void;
   onCommitRename: (sessionId: string) => void;
-  onToggleExpanded: (parentId: string) => void;
+  onToggleExpanded: (parentId: string, currentlyExpanded: boolean) => void;
   onAskDelete: (payload: DeletePayload) => void;
 }
 
@@ -360,7 +381,7 @@ function SessionRow(props: SessionRowProps) {
           line up across rows. */}
       {childCount > 0 ? (
         <button
-          onClick={() => onToggleExpanded(s.sessionId)}
+          onClick={() => onToggleExpanded(s.sessionId, isExpanded)}
           className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-neutral-500 hover:text-neutral-200"
           title={`${childCount} sub-agent session${childCount === 1 ? "" : "s"}`}
           aria-label={isExpanded ? "Collapse sub-agents" : "Expand sub-agents"}

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -245,6 +245,7 @@ function vUnifiedSession(value: unknown, status: number): UnifiedSession {
   if (typeof value.name === "string") out.name = value.name;
   if (typeof value.parentSessionId === "string") out.parentSessionId = value.parentSessionId;
   if (typeof value.runId === "string") out.runId = value.runId;
+  if (typeof value.path === "string") out.path = value.path;
   return out;
 }
 

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -243,6 +243,8 @@ function vUnifiedSession(value: unknown, status: number): UnifiedSession {
     firstMessage: value.firstMessage,
   };
   if (typeof value.name === "string") out.name = value.name;
+  if (typeof value.parentSessionId === "string") out.parentSessionId = value.parentSessionId;
+  if (typeof value.runId === "string") out.runId = value.runId;
   return out;
 }
 

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -143,6 +143,15 @@ export interface UnifiedSession {
   parentSessionId?: string;
   /** pi-subagents run id when this is a child session. */
   runId?: string;
+  /**
+   * Absolute disk path to the session JSONL. Set for disk-discovered
+   * sessions; undefined for live-only sessions that haven't flushed
+   * to disk yet. The SubagentResultCard uses this to resolve a
+   * `sessionFile` reference from a tool result back to the canonical
+   * sessionId — pi-subagents children are named `session.jsonl`, so
+   * deriving the id from the basename is unreliable.
+   */
+  path?: string;
 }
 
 export interface SessionSummary {

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -135,6 +135,14 @@ export interface UnifiedSession {
   createdAt: string;
   messageCount: number;
   firstMessage: string;
+  /**
+   * Set when this session was spawned by the pi-subagents extension —
+   * the parent session's id. The sidebar groups children under their
+   * parent in a chevron dropdown.
+   */
+  parentSessionId?: string;
+  /** pi-subagents run id when this is a child session. */
+  runId?: string;
 }
 
 export interface SessionSummary {

--- a/packages/client/src/lib/subagent-parser.ts
+++ b/packages/client/src/lib/subagent-parser.ts
@@ -1,0 +1,109 @@
+/**
+ * Parse the `details` payload of a `subagent` tool result message into
+ * the shape the SubagentResultCard renders. Pure function — defensive
+ * enough to handle malformed details (returns an empty array) so a
+ * future pi-subagents schema bump can't crash the chat view.
+ *
+ * Reference for the shape: pi-subagents `src/shared/types.ts` defines
+ * `Details { mode, runId?, context?, results: SingleResult[] }` where
+ * each `SingleResult` carries `agent`, `task`, `exitCode`, optional
+ * `sessionFile` (absolute path to the child JSONL — we extract the
+ * filename's UUID stem as the child sessionId), and optional
+ * `finalOutput`. Management-mode calls (`action: "list" | ...`) use the
+ * same tool name but have `mode: "management"` and no `results[].sessionFile`.
+ */
+
+export type SubagentMode = "single" | "parallel" | "chain" | "management" | "unknown";
+export type SubagentContext = "fresh" | "fork" | undefined;
+
+export interface SubagentResult {
+  agent: string;
+  task: string;
+  exitCode: number;
+  /** Best-effort sessionId derived from the basename of `sessionFile`. */
+  sessionId?: string;
+  /** Absolute path on the server's disk — surfaced for tooltips. */
+  sessionFile?: string;
+  finalOutput?: string;
+}
+
+export interface SubagentDetails {
+  mode: SubagentMode;
+  runId?: string;
+  context?: SubagentContext;
+  results: SubagentResult[];
+}
+
+const VALID_MODES: ReadonlySet<SubagentMode> = new Set([
+  "single",
+  "parallel",
+  "chain",
+  "management",
+]);
+
+/**
+ * Extract the child sessionId from an absolute JSONL path. pi-subagents
+ * names files `<uuid>.jsonl`, so we take the basename without the
+ * extension. Returns undefined if the path doesn't end in `.jsonl`.
+ */
+function sessionIdFromFile(file: string): string | undefined {
+  if (!file.endsWith(".jsonl")) return undefined;
+  // Use POSIX basename rules — pi-subagents writes paths in OS-native
+  // form, but on every platform the last separator is reliably `/` or `\`.
+  const lastSlash = Math.max(file.lastIndexOf("/"), file.lastIndexOf("\\"));
+  const base = lastSlash >= 0 ? file.slice(lastSlash + 1) : file;
+  const stem = base.slice(0, -".jsonl".length);
+  if (stem.length === 0) return undefined;
+  return stem;
+}
+
+export function parseSubagentDetails(details: unknown): SubagentDetails {
+  if (typeof details !== "object" || details === null) {
+    return { mode: "unknown", results: [] };
+  }
+  const d = details as { mode?: unknown; runId?: unknown; context?: unknown; results?: unknown };
+  const mode: SubagentMode = VALID_MODES.has(d.mode as SubagentMode)
+    ? (d.mode as SubagentMode)
+    : "unknown";
+  const runId = typeof d.runId === "string" && d.runId.length > 0 ? d.runId : undefined;
+  const context: SubagentContext =
+    d.context === "fresh" || d.context === "fork" ? d.context : undefined;
+  const results: SubagentResult[] = [];
+  if (Array.isArray(d.results)) {
+    for (const r of d.results) {
+      if (typeof r !== "object" || r === null) continue;
+      const o = r as {
+        agent?: unknown;
+        task?: unknown;
+        exitCode?: unknown;
+        sessionFile?: unknown;
+        finalOutput?: unknown;
+      };
+      const item: SubagentResult = {
+        agent: typeof o.agent === "string" ? o.agent : "agent",
+        task: typeof o.task === "string" ? o.task : "",
+        exitCode: typeof o.exitCode === "number" ? o.exitCode : 0,
+      };
+      if (typeof o.sessionFile === "string" && o.sessionFile.length > 0) {
+        item.sessionFile = o.sessionFile;
+        const id = sessionIdFromFile(o.sessionFile);
+        if (id !== undefined) item.sessionId = id;
+      }
+      if (typeof o.finalOutput === "string" && o.finalOutput.length > 0) {
+        item.finalOutput = o.finalOutput;
+      }
+      results.push(item);
+    }
+  }
+  // Canonical key order: mode, runId?, context?, results — matches the
+  // pi-subagents Details type declaration order so JSON.stringify
+  // output is stable across versions for tests + log readability.
+  // JS object literals preserve insertion order; the spreads below
+  // skip the optional keys cleanly when undefined.
+  return {
+    mode,
+    ...(runId !== undefined ? { runId } : {}),
+    ...(context !== undefined ? { context } : {}),
+    results,
+  };
+}

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -36,12 +36,21 @@ const unifiedSchema = {
     createdAt: { type: "string", format: "date-time" },
     messageCount: { type: "integer", minimum: 0 },
     firstMessage: { type: "string" },
+    /**
+     * Set on pi-subagents child sessions — the id of the session that
+     * spawned this sub-agent. Drives the sidebar's parent-row chevron
+     * grouping.
+     */
+    parentSessionId: { type: "string" },
+    /** pi-subagents run id when this is a child session. */
+    runId: { type: "string" },
   },
 } as const;
 
 function unifiedFromUnified(u: UnifiedSession): Record<string, unknown> {
   // Fastify's response serializer drops `undefined`-valued keys, but emit a
-  // stable shape: convert dates to ISO strings + only include `name` when set.
+  // stable shape: convert dates to ISO strings + only include optional
+  // fields (`name`, sub-agent linkage) when set.
   const out: Record<string, unknown> = {
     sessionId: u.sessionId,
     projectId: u.projectId,
@@ -53,6 +62,8 @@ function unifiedFromUnified(u: UnifiedSession): Record<string, unknown> {
     firstMessage: u.firstMessage,
   };
   if (u.name !== undefined) out.name = u.name;
+  if (u.parentSessionId !== undefined) out.parentSessionId = u.parentSessionId;
+  if (u.runId !== undefined) out.runId = u.runId;
   return out;
 }
 

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -44,6 +44,13 @@ const unifiedSchema = {
     parentSessionId: { type: "string" },
     /** pi-subagents run id when this is a child session. */
     runId: { type: "string" },
+    /**
+     * Absolute disk path to the session JSONL — used by the
+     * SubagentResultCard to resolve a result's `sessionFile` reference
+     * back to the canonical sessionId (since pi-subagents writes
+     * children as a literal `session.jsonl` filename, not `<uuid>.jsonl`).
+     */
+    path: { type: "string" },
   },
 } as const;
 
@@ -64,6 +71,7 @@ function unifiedFromUnified(u: UnifiedSession): Record<string, unknown> {
   if (u.name !== undefined) out.name = u.name;
   if (u.parentSessionId !== undefined) out.parentSessionId = u.parentSessionId;
   if (u.runId !== undefined) out.runId = u.runId;
+  if (u.path !== undefined) out.path = u.path;
   return out;
 }
 

--- a/packages/server/src/routes/stream.ts
+++ b/packages/server/src/routes/stream.ts
@@ -41,6 +41,18 @@ export const streamRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
+      // Diagnostic: stream-route entry. Pairs with subagent-discovery /
+      // resume-session-found logs in session-registry — seeing all
+      // three lines together for a click confirms the click reached
+      // the server, found the session, and attached the SSE.
+      process.stderr.write(
+        JSON.stringify({
+          level: "info",
+          time: new Date().toISOString(),
+          msg: "stream-route-hit",
+          sessionId: req.params.id,
+        }) + "\n",
+      );
       let live;
       try {
         live = await resumeSessionById(req.params.id);

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import {
   AgentSession,
@@ -74,6 +74,17 @@ export interface DiscoveredSession {
   messageCount: number;
   /** First user message text (truncated by the SDK). */
   firstMessage: string;
+  /**
+   * When this is a sub-agent session (i.e. its JSONL lives one level
+   * deeper than the project session dir), the parent session's id.
+   * pi-subagents writes child sessions to
+   * `<sessionDir>/<parentId>/<runId>/<childId>.jsonl` — we surface the
+   * `parentId` and `runId` segments so the client can group children
+   * under their parent in the sidebar.
+   */
+  parentSessionId?: string;
+  /** The pi-subagents run id (the directory between parent and child). */
+  runId?: string;
 }
 
 /**
@@ -96,6 +107,10 @@ export interface UnifiedSession {
   createdAt: Date;
   messageCount: number;
   firstMessage: string;
+  /** Parent session id when this is a pi-subagents child session. */
+  parentSessionId?: string;
+  /** pi-subagents run id when this is a child session. */
+  runId?: string;
 }
 
 export class SessionNotFoundError extends Error {
@@ -552,11 +567,21 @@ export async function resumeSession(
     if (raced) return raced;
 
     const dir = sessionDirFor(projectId);
-    const sessions = await SessionManager.list(workspacePath, dir);
-    const match = sessions.find((s) => s.id === sessionId);
+    // Use our own discovery (not SessionManager.list directly) so
+    // pi-subagents child sessions, which live one level deeper at
+    // `<dir>/<parentId>/<runId>/<childId>.jsonl`, are also resolvable
+    // by id. Top-level sessions are returned alongside children.
+    const discovered = await discoverSessionsOnDisk(projectId, workspacePath);
+    const match = discovered.find((s) => s.sessionId === sessionId);
     if (match === undefined) throw new SessionNotFoundError(sessionId);
 
-    const sessionManager = SessionManager.open(match.path, dir, workspacePath);
+    // For child sessions, hand SessionManager.open the *child's* run
+    // dir as the sessionDir so any subsequent file operations the SDK
+    // performs land alongside the existing JSONL rather than in the
+    // project's top-level dir. For top-level sessions, the run dir
+    // collapses to the project session dir.
+    const childSessionDir = match.parentSessionId !== undefined ? join(match.path, "..") : dir;
+    const sessionManager = SessionManager.open(match.path, childSessionDir, workspacePath);
     const customTools = await resolveMcpCustomTools(projectId, workspacePath);
     const settingsManager = await buildSessionSettingsManager(workspacePath, projectId);
     const resourceLoader = await buildForgeResourceLoader(
@@ -582,7 +607,7 @@ export async function resumeSession(
       projectId,
       workspacePath,
       clients: new Set(),
-      createdAt: match.created,
+      createdAt: match.createdAt,
       lastActivityAt: now,
       lastAgentStartIndex: undefined,
       unsubscribe: () => undefined,
@@ -609,10 +634,11 @@ export async function deleteColdSession(
   if (registry.has(sessionId)) return "live";
   const projects = await readProjects();
   for (const project of projects) {
-    const dir = sessionDirFor(project.id);
-    let infos: SessionInfo[];
+    let infos: DiscoveredSession[];
     try {
-      infos = await SessionManager.list(project.path, dir);
+      // Use our discovery (includes child sessions) so deleting a
+      // pi-subagents child by id also works.
+      infos = await discoverSessionsOnDisk(project.id, project.path);
     } catch {
       // Project's session dir errored out (perms, missing, malformed
       // JSONL). Skip this project and try the next one — the cold
@@ -622,7 +648,7 @@ export async function deleteColdSession(
       // not_found vs deleted clearly.)
       continue;
     }
-    const match = infos.find((s) => s.id === sessionId);
+    const match = infos.find((s) => s.sessionId === sessionId);
     if (match !== undefined) {
       try {
         await rm(match.path, { force: true });
@@ -719,6 +745,12 @@ export async function disposeSession(sessionId: string): Promise<boolean> {
  * registry. Used by the sidebar list. Backed by the SDK's SessionManager.list
  * which parses each file's first-line header and a few message previews.
  *
+ * In addition to the project's own top-level JSONLs, this also scans one
+ * level deeper for **pi-subagents child sessions**, which the plugin
+ * writes to `<sessionDir>/<parentId>/<runId>/*.jsonl`. Each child surfaces
+ * with `parentSessionId` and `runId` set, which the sidebar uses to group
+ * children under their parent in a chevron dropdown.
+ *
  * Returns an empty array (not throws) when the per-project dir doesn't exist
  * yet — e.g. a project that has never had a session.
  */
@@ -730,8 +762,8 @@ export async function discoverSessionsOnDisk(
   // SDK's list() guards `existsSync(dir)` and returns [] for missing dirs,
   // so we don't need an outer ENOENT catch.
   const infos: SessionInfo[] = await SessionManager.list(workspacePath, dir);
-  return infos.map((info) => {
-    const out: DiscoveredSession = {
+  const out: DiscoveredSession[] = infos.map((info) => {
+    const ds: DiscoveredSession = {
       sessionId: info.id,
       path: info.path,
       cwd: info.cwd,
@@ -740,9 +772,88 @@ export async function discoverSessionsOnDisk(
       messageCount: info.messageCount,
       firstMessage: info.firstMessage,
     };
-    if (info.name !== undefined) out.name = info.name;
-    return out;
+    if (info.name !== undefined) ds.name = info.name;
+    return ds;
   });
+  // Surface pi-subagents child sessions as first-class discovered
+  // sessions. The plugin writes children to
+  // `<sessionDir>/<parentId>/<runId>/*.jsonl`. We tag each with the
+  // parent id (the dir name above runId) and runId so the sidebar can
+  // group them.
+  const children = await discoverSubagentChildSessions(workspacePath, dir);
+  for (const child of children) out.push(child);
+  return out;
+}
+
+/**
+ * Walk one level deeper than the project's session dir to surface
+ * pi-subagents child sessions. Layout:
+ *
+ *   <dir>/<parentSessionId>/<runId>/<childSessionId>.jsonl
+ *
+ * pi-subagents creates `<parentSessionId>` as a sibling DIRECTORY to
+ * the parent's `.jsonl` (the plugin's `getSubagentSessionRoot` helper).
+ * So we list `<dir>` and treat any directory whose name matches the
+ * UUID-shape of an existing parent as a candidate child root, then
+ * descend into per-`runId` subdirs for the actual child JSONLs.
+ *
+ * Errors from individual subdirs are swallowed — a corrupted child
+ * session must not block the rest of the sidebar listing.
+ */
+async function discoverSubagentChildSessions(
+  workspacePath: string,
+  dir: string,
+): Promise<DiscoveredSession[]> {
+  const out: DiscoveredSession[] = [];
+  let topEntries: { name: string; isDirectory: boolean }[];
+  try {
+    const direntList = await readdir(dir, { withFileTypes: true });
+    topEntries = direntList.map((d) => ({ name: d.name, isDirectory: d.isDirectory() }));
+  } catch {
+    // dir missing or unreadable — caller already handles the empty case.
+    return out;
+  }
+  for (const top of topEntries) {
+    if (!top.isDirectory) continue;
+    const parentId = top.name;
+    const parentDir = join(dir, parentId);
+    let runDirs: string[];
+    try {
+      const runEntries = await readdir(parentDir, { withFileTypes: true });
+      runDirs = runEntries.filter((d) => d.isDirectory()).map((d) => d.name);
+    } catch {
+      continue;
+    }
+    for (const runId of runDirs) {
+      const runDir = join(parentDir, runId);
+      // SessionManager.list will read the JSONL headers. Pass the run
+      // dir so the SDK's existsSync guard is happy and so any future
+      // session files the manager creates inside this dir land in the
+      // right place.
+      let infos: SessionInfo[];
+      try {
+        infos = await SessionManager.list(workspacePath, runDir);
+      } catch {
+        continue;
+      }
+      for (const info of infos) {
+        const ds: DiscoveredSession = {
+          sessionId: info.id,
+          path: info.path,
+          cwd: info.cwd,
+          createdAt: info.created,
+          modifiedAt: info.modified,
+          messageCount: info.messageCount,
+          firstMessage: info.firstMessage,
+          parentSessionId: parentId,
+          runId,
+        };
+        if (info.name !== undefined) ds.name = info.name;
+        out.push(ds);
+      }
+    }
+  }
+  return out;
 }
 
 /**
@@ -791,12 +902,16 @@ export async function listSessionsForProject(
     const merged = liveById.get(d.sessionId);
     if (merged !== undefined) {
       // Disk wins for messageCount and firstMessage (see precedence in
-      // function doc); everything else stays as the live value.
+      // function doc); everything else stays as the live value. Sub-agent
+      // linkage fields are disk-side only — children are typically not
+      // live-resident.
       merged.messageCount = d.messageCount;
       merged.firstMessage = d.firstMessage;
+      if (d.parentSessionId !== undefined) merged.parentSessionId = d.parentSessionId;
+      if (d.runId !== undefined) merged.runId = d.runId;
       continue;
     }
-    liveById.set(d.sessionId, {
+    const u: UnifiedSession = {
       sessionId: d.sessionId,
       projectId,
       isLive: false,
@@ -806,7 +921,10 @@ export async function listSessionsForProject(
       createdAt: d.createdAt,
       messageCount: d.messageCount,
       firstMessage: d.firstMessage,
-    });
+    };
+    if (d.parentSessionId !== undefined) u.parentSessionId = d.parentSessionId;
+    if (d.runId !== undefined) u.runId = d.runId;
+    liveById.set(d.sessionId, u);
   }
   return Array.from(liveById.values()).sort(
     (a, b) => b.lastActivityAt.getTime() - a.lastActivityAt.getTime(),
@@ -832,10 +950,12 @@ export async function findSessionLocation(
   }
   const projects = await readProjects();
   for (const project of projects) {
-    const dir = sessionDirFor(project.id);
-    let infos: SessionInfo[];
+    let discovered: DiscoveredSession[];
     try {
-      infos = await SessionManager.list(project.path, dir);
+      // discoverSessionsOnDisk includes pi-subagents child sessions, so
+      // a child's UUID resolves to its parent project the same as a
+      // top-level session.
+      discovered = await discoverSessionsOnDisk(project.id, project.path);
     } catch (err) {
       // Don't fail the whole search just because one project's session
       // dir is corrupted, but DO log so the operator can see when a
@@ -844,14 +964,14 @@ export async function findSessionLocation(
       process.stderr.write(
         JSON.stringify({
           level: "warn",
-          msg: "findSessionLocation: skipping project due to SessionManager.list error",
+          msg: "findSessionLocation: skipping project due to discoverSessionsOnDisk error",
           projectId: project.id,
           err: err instanceof Error ? err.message : String(err),
         }) + "\n",
       );
       continue;
     }
-    if (infos.some((s) => s.id === sessionId)) {
+    if (discovered.some((s) => s.sessionId === sessionId)) {
       return { projectId: project.id, workspacePath: project.path };
     }
   }

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -746,10 +746,12 @@ export async function disposeSession(sessionId: string): Promise<boolean> {
  * which parses each file's first-line header and a few message previews.
  *
  * In addition to the project's own top-level JSONLs, this also scans one
- * level deeper for **pi-subagents child sessions**, which the plugin
- * writes to `<sessionDir>/<parentId>/<runId>/*.jsonl`. Each child surfaces
- * with `parentSessionId` and `runId` set, which the sidebar uses to group
- * children under their parent in a chevron dropdown.
+ * level deeper for **pi-subagents child sessions**. The plugin's
+ * `getSubagentSessionRoot` helper names the child dir after the parent
+ * file's full basename (timestamp + id), so we look up the basename
+ * against the top-level session list to recover the actual parent
+ * sessionId — without that mapping the child would inherit the dir name
+ * verbatim and grouping in the sidebar would silently fail.
  *
  * Returns an empty array (not throws) when the per-project dir doesn't exist
  * yet — e.g. a project that has never had a session.
@@ -775,27 +777,51 @@ export async function discoverSessionsOnDisk(
     if (info.name !== undefined) ds.name = info.name;
     return ds;
   });
-  // Surface pi-subagents child sessions as first-class discovered
-  // sessions. The plugin writes children to
-  // `<sessionDir>/<parentId>/<runId>/*.jsonl`. We tag each with the
-  // parent id (the dir name above runId) and runId so the sidebar can
-  // group them.
-  const children = await discoverSubagentChildSessions(workspacePath, dir);
+  // Build a basename → sessionId map from the top-level scan so the
+  // child-discovery pass can resolve dir names like
+  // `2026-05-07T12-34-56-000Z_abc123` back to the parent's actual
+  // sessionId `abc123`. Without this, child grouping in the SessionList
+  // never matches because the dir name and the parent's sessionId differ.
+  const basenameToParentId = new Map<string, string>();
+  for (const info of infos) {
+    const base = basenameNoExt(info.path);
+    if (base !== undefined) basenameToParentId.set(base, info.id);
+  }
+  const children = await discoverSubagentChildSessions(workspacePath, dir, basenameToParentId);
   for (const child of children) out.push(child);
   return out;
 }
 
+/** `/path/to/2026-05-07_abc.jsonl` → `2026-05-07_abc`; undefined for any non-jsonl. */
+function basenameNoExt(filePath: string): string | undefined {
+  const lastSlash = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  const base = lastSlash >= 0 ? filePath.slice(lastSlash + 1) : filePath;
+  if (!base.endsWith(".jsonl")) return undefined;
+  return base.slice(0, -".jsonl".length);
+}
+
 /**
  * Walk one level deeper than the project's session dir to surface
- * pi-subagents child sessions. Layout:
+ * pi-subagents child sessions.
  *
- *   <dir>/<parentSessionId>/<runId>/<childSessionId>.jsonl
+ * Two layouts to support:
  *
- * pi-subagents creates `<parentSessionId>` as a sibling DIRECTORY to
- * the parent's `.jsonl` (the plugin's `getSubagentSessionRoot` helper).
- * So we list `<dir>` and treat any directory whose name matches the
- * UUID-shape of an existing parent as a candidate child root, then
- * descend into per-`runId` subdirs for the actual child JSONLs.
+ *   1. Nested with runId:    <dir>/<parentBasename>/<runId>/<child>.jsonl
+ *   2. Flat under parent:    <dir>/<parentBasename>/<child>.jsonl
+ *
+ * The plugin's `getSubagentSessionRoot(parentSessionFile)` returns
+ * `<dirname(parentSessionFile)>/<basename(parentSessionFile, ".jsonl")>`,
+ * which collides with neither (it's a directory NAMED after the parent
+ * basename). Whether a runId subdir exists depends on the plugin's run
+ * mode — both shapes are observed in the wild.
+ *
+ * `basenameToParentId` maps the directory name back to the parent's
+ * actual sessionId (since the dir name is the parent's full basename
+ * including timestamp prefix, NOT the bare sessionId). When the dir
+ * name doesn't map to a known parent (e.g. the parent JSONL was
+ * deleted), we fall back to using the dir name verbatim so the
+ * children still appear (the SessionList will treat them as orphans
+ * and render them at top level).
  *
  * Errors from individual subdirs are swallowed — a corrupted child
  * session must not block the rest of the sidebar listing.
@@ -803,6 +829,7 @@ export async function discoverSessionsOnDisk(
 async function discoverSubagentChildSessions(
   workspacePath: string,
   dir: string,
+  basenameToParentId: Map<string, string>,
 ): Promise<DiscoveredSession[]> {
   const out: DiscoveredSession[] = [];
   let topEntries: { name: string; isDirectory: boolean }[];
@@ -815,21 +842,55 @@ async function discoverSubagentChildSessions(
   }
   for (const top of topEntries) {
     if (!top.isDirectory) continue;
-    const parentId = top.name;
-    const parentDir = join(dir, parentId);
-    let runDirs: string[];
+    const dirName = top.name;
+    // Resolve the dir name to the parent's actual sessionId via the
+    // basename map. Fall back to the dir name when no match (the
+    // SessionList will render unmatched children as orphans at top
+    // level — never silently lost).
+    const parentSessionId = basenameToParentId.get(dirName) ?? dirName;
+    const parentDir = join(dir, dirName);
+
+    // Layout 2 (flat): collect any .jsonl files directly under the
+    // parent dir before descending into runId subdirs.
+    let parentDirEntries: { name: string; isDirectory: boolean }[];
     try {
-      const runEntries = await readdir(parentDir, { withFileTypes: true });
-      runDirs = runEntries.filter((d) => d.isDirectory()).map((d) => d.name);
+      const entries = await readdir(parentDir, { withFileTypes: true });
+      parentDirEntries = entries.map((d) => ({ name: d.name, isDirectory: d.isDirectory() }));
     } catch {
       continue;
     }
-    for (const runId of runDirs) {
+
+    const hasFlatJsonls = parentDirEntries.some((e) => !e.isDirectory && e.name.endsWith(".jsonl"));
+    if (hasFlatJsonls) {
+      // Flat layout: SessionManager.list reads .jsonl files directly
+      // in parentDir. No runId.
+      let infos: SessionInfo[];
+      try {
+        infos = await SessionManager.list(workspacePath, parentDir);
+      } catch {
+        infos = [];
+      }
+      for (const info of infos) {
+        const ds: DiscoveredSession = {
+          sessionId: info.id,
+          path: info.path,
+          cwd: info.cwd,
+          createdAt: info.created,
+          modifiedAt: info.modified,
+          messageCount: info.messageCount,
+          firstMessage: info.firstMessage,
+          parentSessionId,
+        };
+        if (info.name !== undefined) ds.name = info.name;
+        out.push(ds);
+      }
+    }
+
+    // Layout 1 (nested with runId): each subdirectory of parentDir is
+    // a runId, holding the actual child JSONLs.
+    const runDirNames = parentDirEntries.filter((e) => e.isDirectory).map((e) => e.name);
+    for (const runId of runDirNames) {
       const runDir = join(parentDir, runId);
-      // SessionManager.list will read the JSONL headers. Pass the run
-      // dir so the SDK's existsSync guard is happy and so any future
-      // session files the manager creates inside this dir land in the
-      // right place.
       let infos: SessionInfo[];
       try {
         infos = await SessionManager.list(workspacePath, runDir);
@@ -845,7 +906,7 @@ async function discoverSubagentChildSessions(
           modifiedAt: info.modified,
           messageCount: info.messageCount,
           firstMessage: info.firstMessage,
-          parentSessionId: parentId,
+          parentSessionId,
           runId,
         };
         if (info.name !== undefined) ds.name = info.name;

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -111,6 +111,16 @@ export interface UnifiedSession {
   parentSessionId?: string;
   /** pi-subagents run id when this is a child session. */
   runId?: string;
+  /**
+   * Absolute path to the session JSONL on disk. Surfaced so the
+   * client can resolve a `sessionFile` reference (e.g. from a
+   * pi-subagents tool result) back to the canonical sessionId — the
+   * filename alone is unreliable since pi-subagents writes its
+   * children as a literal `session.jsonl` rather than `<uuid>.jsonl`.
+   * Only set for disk-discovered sessions; undefined for live-only
+   * sessions that haven't flushed to disk yet.
+   */
+  path?: string;
 }
 
 export class SessionNotFoundError extends Error {
@@ -1023,6 +1033,7 @@ export async function listSessionsForProject(
       merged.firstMessage = d.firstMessage;
       if (d.parentSessionId !== undefined) merged.parentSessionId = d.parentSessionId;
       if (d.runId !== undefined) merged.runId = d.runId;
+      merged.path = d.path;
       continue;
     }
     const u: UnifiedSession = {
@@ -1035,6 +1046,7 @@ export async function listSessionsForProject(
       createdAt: d.createdAt,
       messageCount: d.messageCount,
       firstMessage: d.firstMessage,
+      path: d.path,
     };
     if (d.parentSessionId !== undefined) u.parentSessionId = d.parentSessionId;
     if (d.runId !== undefined) u.runId = d.runId;

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -1,5 +1,5 @@
 import { mkdir, readdir, rm } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
   AgentSession,
   type AgentSessionEvent,
@@ -698,6 +698,30 @@ export async function deleteColdSession(
         const code = (err as NodeJS.ErrnoException).code;
         if (code === "ENOENT") return "deleted";
         throw err;
+      }
+      // Cascade-delete the pi-subagents sibling directory if this was
+      // a top-level parent session. The plugin's
+      // `getSubagentSessionRoot(parentSessionFile)` lays children at
+      // `<dirname(parentFile)>/<basename(parentFile, ".jsonl")>/...`,
+      // so we mirror that path and `rm -rf` it. Without this, deleting
+      // a parent leaves its child sub-agent JSONLs behind as
+      // sidebar orphans.
+      //
+      // Skipped for sub-agent CHILDREN — they don't have a sibling
+      // dir of their own (they live UNDER one). The project-scoped
+      // `subagent-artifacts/` dir is intentionally untouched: it's
+      // shared across every parent session in the project, not
+      // per-session, so blowing it away on single-session delete
+      // would clobber unrelated sessions' artifacts.
+      if (match.parentSessionId === undefined) {
+        const stem = basename(match.path, ".jsonl");
+        const siblingDir = join(dirname(match.path), stem);
+        // force: true makes ENOENT silent; recursive: true clears the
+        // run/runId/run-N tree the plugin nests under there. Failures
+        // for any other reason (perms, EBUSY) are swallowed — the
+        // primary delete already succeeded and the user-facing op is
+        // "session is gone."
+        await rm(siblingDir, { recursive: true, force: true }).catch(() => undefined);
       }
       return "deleted";
     }

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -573,7 +573,33 @@ export async function resumeSession(
     // by id. Top-level sessions are returned alongside children.
     const discovered = await discoverSessionsOnDisk(projectId, workspacePath);
     const match = discovered.find((s) => s.sessionId === sessionId);
-    if (match === undefined) throw new SessionNotFoundError(sessionId);
+    if (match === undefined) {
+      // Diagnostic log so a missing-session resume failure is
+      // explicit in stderr (the client just sees a 404 SSE
+      // disconnect, which doesn't tell us WHICH discovery missed).
+      process.stderr.write(
+        JSON.stringify({
+          level: "warn",
+          time: new Date().toISOString(),
+          msg: "resume-session-not-found",
+          projectId,
+          sessionId,
+          discoveredIds: discovered.map((s) => s.sessionId),
+        }) + "\n",
+      );
+      throw new SessionNotFoundError(sessionId);
+    }
+    process.stderr.write(
+      JSON.stringify({
+        level: "info",
+        time: new Date().toISOString(),
+        msg: "resume-session-found",
+        projectId,
+        sessionId,
+        path: match.path,
+        parentSessionId: match.parentSessionId,
+      }) + "\n",
+    );
 
     // For child sessions, hand SessionManager.open the *child's* run
     // dir as the sessionDir so any subsequent file operations the SDK
@@ -789,6 +815,29 @@ export async function discoverSessionsOnDisk(
   }
   const children = await discoverSubagentChildSessions(workspacePath, dir, basenameToParentId);
   for (const child of children) out.push(child);
+  // Diagnostic log when sub-agent discovery fires — keep this so
+  // future reports of "children aren't grouped" can be triaged from
+  // server stderr alone (no client-side debugging needed). One line
+  // per call, JSON-shaped for log shippers.
+  if (children.length > 0 || basenameToParentId.size > 0) {
+    process.stderr.write(
+      JSON.stringify({
+        level: "info",
+        time: new Date().toISOString(),
+        msg: "subagent-discovery",
+        projectId,
+        topLevelSessions: infos.length,
+        basenameMapSize: basenameToParentId.size,
+        childrenFound: children.length,
+        children: children.map((c) => ({
+          childId: c.sessionId,
+          parentSessionId: c.parentSessionId,
+          runId: c.runId,
+          path: c.path,
+        })),
+      }) + "\n",
+    );
+  }
   return out;
 }
 

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -801,27 +801,29 @@ function basenameNoExt(filePath: string): string | undefined {
 }
 
 /**
- * Walk one level deeper than the project's session dir to surface
- * pi-subagents child sessions.
+ * Walk under each `<projectId>/<parentBasename>/` to surface
+ * pi-subagents child sessions, regardless of how deep the plugin
+ * nests them.
  *
- * Two layouts to support:
+ * The plugin's `getSubagentSessionRoot(parentSessionFile)` always
+ * returns `<dirname(parentSessionFile)>/<basename(parentSessionFile, ".jsonl")>`
+ * — a directory NAMED after the parent's full basename. WHAT goes
+ * underneath varies by plugin run mode; observed in the wild:
  *
- *   1. Nested with runId:    <dir>/<parentBasename>/<runId>/<child>.jsonl
- *   2. Flat under parent:    <dir>/<parentBasename>/<child>.jsonl
+ *   - <basename>/<child>.jsonl                       (flat — rare)
+ *   - <basename>/<runId>/<child>.jsonl               (single-mode)
+ *   - <basename>/<runId>/run-<N>/session.jsonl       (parallel/chain)
  *
- * The plugin's `getSubagentSessionRoot(parentSessionFile)` returns
- * `<dirname(parentSessionFile)>/<basename(parentSessionFile, ".jsonl")>`,
- * which collides with neither (it's a directory NAMED after the parent
- * basename). Whether a runId subdir exists depends on the plugin's run
- * mode — both shapes are observed in the wild.
+ * Rather than enumerating every layout, we recursively walk under
+ * `<basename>/` (capped at depth 4 for safety) and treat any
+ * directory containing `.jsonl` files as a candidate sessions dir.
+ * `runId` is reconstructed from the path segments between
+ * `<basename>` and the JSONL's containing dir.
  *
- * `basenameToParentId` maps the directory name back to the parent's
- * actual sessionId (since the dir name is the parent's full basename
- * including timestamp prefix, NOT the bare sessionId). When the dir
- * name doesn't map to a known parent (e.g. the parent JSONL was
- * deleted), we fall back to using the dir name verbatim so the
- * children still appear (the SessionList will treat them as orphans
- * and render them at top level).
+ * `basenameToParentId` maps the basename dir back to the parent's
+ * actual sessionId (since the dir name includes the timestamp prefix,
+ * NOT the bare sessionId). Without this mapping the sidebar grouping
+ * silently fails because the dir name and sessionId never compare equal.
  *
  * Errors from individual subdirs are swallowed — a corrupted child
  * session must not block the rest of the sidebar listing.
@@ -843,60 +845,34 @@ async function discoverSubagentChildSessions(
   for (const top of topEntries) {
     if (!top.isDirectory) continue;
     const dirName = top.name;
-    // Resolve the dir name to the parent's actual sessionId via the
-    // basename map. Fall back to the dir name when no match (the
-    // SessionList will render unmatched children as orphans at top
-    // level — never silently lost).
+    // Skip well-known sibling dirs the plugin creates at the same
+    // level for unrelated reasons (artifacts, etc.) — these aren't
+    // parent-named child roots.
+    if (dirName === "subagent-artifacts") continue;
+
     const parentSessionId = basenameToParentId.get(dirName) ?? dirName;
     const parentDir = join(dir, dirName);
 
-    // Layout 2 (flat): collect any .jsonl files directly under the
-    // parent dir before descending into runId subdirs.
-    let parentDirEntries: { name: string; isDirectory: boolean }[];
-    try {
-      const entries = await readdir(parentDir, { withFileTypes: true });
-      parentDirEntries = entries.map((d) => ({ name: d.name, isDirectory: d.isDirectory() }));
-    } catch {
-      continue;
-    }
-
-    const hasFlatJsonls = parentDirEntries.some((e) => !e.isDirectory && e.name.endsWith(".jsonl"));
-    if (hasFlatJsonls) {
-      // Flat layout: SessionManager.list reads .jsonl files directly
-      // in parentDir. No runId.
+    // Recursively find every dir containing .jsonl files under
+    // <parentDir>, capped at depth 4 (the deepest layout observed
+    // is <basename>/<runId>/run-N/session.jsonl, which is depth 3 —
+    // depth 4 leaves headroom for one more level the plugin might
+    // add in future versions). Depth cap also protects against
+    // symlink loops without needing a visited-set.
+    const sessionDirs = await collectJsonlDirs(parentDir, 0, 4);
+    for (const sd of sessionDirs) {
       let infos: SessionInfo[];
       try {
-        infos = await SessionManager.list(workspacePath, parentDir);
-      } catch {
-        infos = [];
-      }
-      for (const info of infos) {
-        const ds: DiscoveredSession = {
-          sessionId: info.id,
-          path: info.path,
-          cwd: info.cwd,
-          createdAt: info.created,
-          modifiedAt: info.modified,
-          messageCount: info.messageCount,
-          firstMessage: info.firstMessage,
-          parentSessionId,
-        };
-        if (info.name !== undefined) ds.name = info.name;
-        out.push(ds);
-      }
-    }
-
-    // Layout 1 (nested with runId): each subdirectory of parentDir is
-    // a runId, holding the actual child JSONLs.
-    const runDirNames = parentDirEntries.filter((e) => e.isDirectory).map((e) => e.name);
-    for (const runId of runDirNames) {
-      const runDir = join(parentDir, runId);
-      let infos: SessionInfo[];
-      try {
-        infos = await SessionManager.list(workspacePath, runDir);
+        infos = await SessionManager.list(workspacePath, sd);
       } catch {
         continue;
       }
+      // Reconstruct runId from path segments between parentDir and sd.
+      // Single segment → that's the runId. Multiple segments
+      // (e.g. <runId>/run-0) → join with '/' so the sidebar can show
+      // the full run identity in its title attribute.
+      const rel = sd.slice(parentDir.length).replace(/^[/\\]+/, "");
+      const runId = rel.length > 0 ? rel : undefined;
       for (const info of infos) {
         const ds: DiscoveredSession = {
           sessionId: info.id,
@@ -907,12 +883,40 @@ async function discoverSubagentChildSessions(
           messageCount: info.messageCount,
           firstMessage: info.firstMessage,
           parentSessionId,
-          runId,
         };
         if (info.name !== undefined) ds.name = info.name;
+        if (runId !== undefined) ds.runId = runId;
         out.push(ds);
       }
     }
+  }
+  return out;
+}
+
+/**
+ * Recursively find every directory under `root` (inclusive) that
+ * contains at least one `.jsonl` file. Bounded by `maxDepth` to
+ * cap the worst case and defend against symlink loops.
+ */
+async function collectJsonlDirs(root: string, depth: number, maxDepth: number): Promise<string[]> {
+  if (depth > maxDepth) return [];
+  let entries: { name: string; isDirectory: boolean; isFile: boolean }[];
+  try {
+    const list = await readdir(root, { withFileTypes: true });
+    entries = list.map((d) => ({
+      name: d.name,
+      isDirectory: d.isDirectory(),
+      isFile: d.isFile(),
+    }));
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  if (entries.some((e) => e.isFile && e.name.endsWith(".jsonl"))) out.push(root);
+  for (const e of entries) {
+    if (!e.isDirectory) continue;
+    const child = join(root, e.name);
+    out.push(...(await collectJsonlDirs(child, depth + 1, maxDepth)));
   }
   return out;
 }

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -200,6 +200,65 @@ async function main(): Promise<void> {
       resumed.sessionId === childA,
       `got ${resumed.sessionId}`,
     );
+
+    // 6. REALISTIC pi-subagents layout: the plugin's
+    // `getSubagentSessionRoot` names the child dir using the parent
+    // FILE's full basename (timestamp + id), not the bare parent id.
+    // The discovery has to map basename → parent's actual sessionId
+    // via the top-level scan, otherwise the child's `parentSessionId`
+    // ends up as the timestamped string and SessionList grouping
+    // silently fails. This is the regression that motivated the
+    // basenameToParentId map; without it, this assertion would tag
+    // the child with `2026-...-realistic-parent` instead of
+    // `realistic-parent`.
+    const realisticParentId = "realistic-parent-" + randomUUID().slice(0, 6);
+    const realisticBasename = "2026-05-07T12-34-56-000Z_" + realisticParentId;
+    const realisticParentPath = join(projectSessionDir, `${realisticBasename}.jsonl`);
+    await writeChildSessionFile(realisticParentPath, realisticParentId, project.path);
+    const realisticRunId = "run-" + randomUUID().slice(0, 6);
+    const realisticChildId = randomUUID();
+    const realisticChildPath = join(
+      projectSessionDir,
+      realisticBasename, // dir named after parent's full basename, NOT just the id
+      realisticRunId,
+      `${realisticChildId}.jsonl`,
+    );
+    await writeChildSessionFile(realisticChildPath, realisticChildId, project.path);
+    const rediscovered = await registry.discoverSessionsOnDisk(project.id, project.path);
+    const realisticChildEntry = rediscovered.find((d) => d.sessionId === realisticChildId);
+    assert(
+      "realistic-layout child was discovered",
+      realisticChildEntry !== undefined,
+      `child id=${realisticChildId} not in ${rediscovered.map((d) => d.sessionId).join(",")}`,
+    );
+    assert(
+      "realistic-layout child's parentSessionId resolves via basename map",
+      realisticChildEntry?.parentSessionId === realisticParentId,
+      `got parentSessionId=${realisticChildEntry?.parentSessionId} expected=${realisticParentId}`,
+    );
+
+    // 7. FLAT layout (no runId subdir): some pi-subagents run modes
+    // write children directly under <parentBasename>/, not under
+    // <parentBasename>/<runId>/. Discovery must surface these too.
+    const flatParentId = "flat-parent-" + randomUUID().slice(0, 6);
+    const flatBasename = "2026-05-07T13-00-00-000Z_" + flatParentId;
+    const flatParentPath = join(projectSessionDir, `${flatBasename}.jsonl`);
+    await writeChildSessionFile(flatParentPath, flatParentId, project.path);
+    const flatChildId = randomUUID();
+    const flatChildPath = join(projectSessionDir, flatBasename, `${flatChildId}.jsonl`);
+    await writeChildSessionFile(flatChildPath, flatChildId, project.path);
+    const reFlat = await registry.discoverSessionsOnDisk(project.id, project.path);
+    const flatChildEntry = reFlat.find((d) => d.sessionId === flatChildId);
+    assert(
+      "flat-layout child (no runId subdir) was discovered",
+      flatChildEntry !== undefined,
+      `child id=${flatChildId} not in ${reFlat.map((d) => d.sessionId).join(",")}`,
+    );
+    assert(
+      "flat-layout child's parentSessionId resolves and runId is undefined",
+      flatChildEntry?.parentSessionId === flatParentId && flatChildEntry?.runId === undefined,
+      `parentSessionId=${flatChildEntry?.parentSessionId} runId=${flatChildEntry?.runId}`,
+    );
   } finally {
     await registry.disposeAllSessions();
     // Clean every temp dir we created. Safe to ignore failures —

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -237,7 +237,45 @@ async function main(): Promise<void> {
       `got parentSessionId=${realisticChildEntry?.parentSessionId} expected=${realisticParentId}`,
     );
 
-    // 7. FLAT layout (no runId subdir): some pi-subagents run modes
+    // 7a. DEEP layout (parallel/chain mode):
+    //     <basename>/<runId>/run-N/session.jsonl. Three dir levels
+    //     under the parent — observed in the wild on real
+    //     pi-subagents installs. Discovery has to walk past the runId
+    //     dir to find the actual session.jsonl.
+    const deepParentId = "deep-parent-" + randomUUID().slice(0, 6);
+    const deepBasename = "2026-05-07T14-00-00-000Z_" + deepParentId;
+    const deepParentPath = join(projectSessionDir, `${deepBasename}.jsonl`);
+    await writeChildSessionFile(deepParentPath, deepParentId, project.path);
+    const deepRunId = randomUUID().slice(0, 8);
+    const deepChildId = randomUUID();
+    const deepChildPath = join(
+      projectSessionDir,
+      deepBasename,
+      deepRunId,
+      "run-0",
+      `${deepChildId}.jsonl`,
+    );
+    await writeChildSessionFile(deepChildPath, deepChildId, project.path);
+    const reDeep = await registry.discoverSessionsOnDisk(project.id, project.path);
+    const deepChildEntry = reDeep.find((d) => d.sessionId === deepChildId);
+    assert(
+      "deep-layout child (basename/runId/run-N/session.jsonl) was discovered",
+      deepChildEntry !== undefined,
+      `child id=${deepChildId} not in ${reDeep.map((d) => d.sessionId).join(",")}`,
+    );
+    assert(
+      "deep-layout child's parentSessionId resolves via basename map",
+      deepChildEntry?.parentSessionId === deepParentId,
+      `got parentSessionId=${deepChildEntry?.parentSessionId} expected=${deepParentId}`,
+    );
+    assert(
+      "deep-layout child's runId reflects the full intermediate path",
+      deepChildEntry?.runId === `${deepRunId}/run-0` ||
+        deepChildEntry?.runId === `${deepRunId}\\run-0`,
+      `got runId=${deepChildEntry?.runId}`,
+    );
+
+    // 7b. FLAT layout (no runId subdir): some pi-subagents run modes
     // write children directly under <parentBasename>/, not under
     // <parentBasename>/<runId>/. Discovery must surface these too.
     const flatParentId = "flat-parent-" + randomUUID().slice(0, 6);

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -97,6 +97,7 @@ interface TestRegistry {
   findSessionLocation: (
     id: string,
   ) => Promise<{ projectId: string; workspacePath: string } | undefined>;
+  deleteColdSession: (id: string) => Promise<"deleted" | "live" | "not_found">;
 }
 interface TestProjectManager {
   createProject: (name: string, path: string) => Promise<{ id: string; path: string }>;
@@ -296,6 +297,25 @@ async function main(): Promise<void> {
       "flat-layout child's parentSessionId resolves and runId is undefined",
       flatChildEntry?.parentSessionId === flatParentId && flatChildEntry?.runId === undefined,
       `parentSessionId=${flatChildEntry?.parentSessionId} runId=${flatChildEntry?.runId}`,
+    );
+
+    // 8. Cascade-delete: deleting a parent session also wipes its
+    // pi-subagents sibling directory and any nested children, so the
+    // sidebar doesn't accumulate orphan child sessions whose parent
+    // is gone. We use the deep-layout fixture because it exercises
+    // the full <basename>/<runId>/run-N/<child>.jsonl tree the
+    // recursive rm has to clear.
+    const cascadeStatus = await registry.deleteColdSession(deepParentId);
+    assert("deleteColdSession on the deep parent returns 'deleted'", cascadeStatus === "deleted");
+    const reAfterCascade = await registry.discoverSessionsOnDisk(project.id, project.path);
+    assert(
+      "deep-layout child is gone after parent delete (cascade)",
+      reAfterCascade.find((d) => d.sessionId === deepChildId) === undefined,
+      `child still discovered: ${reAfterCascade.map((d) => d.sessionId).join(",")}`,
+    );
+    assert(
+      "deep-layout parent is gone after parent delete",
+      reAfterCascade.find((d) => d.sessionId === deepParentId) === undefined,
     );
   } finally {
     await registry.disposeAllSessions();

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -1,0 +1,220 @@
+/**
+ * Integration test for pi-subagents child-session discovery in the
+ * server's session-registry.
+ *
+ * pi-subagents writes child sessions to
+ * `<sessionDir>/<parentSessionId>/<runId>/<childId>.jsonl`. The
+ * registry has to:
+ *   1. Surface those children via `discoverSessionsOnDisk` with
+ *      `parentSessionId` + `runId` set (so the sidebar can render
+ *      a chevron dropdown grouping children under their parent).
+ *   2. Resolve a child by its UUID via `findSessionLocation` (so
+ *      cross-project resume-by-id works).
+ *   3. Resume a child as a normal LiveSession via `resumeSession`
+ *      (so clicking a SubagentResultCard's "Open" button hydrates the
+ *      child's chat view).
+ *   4. Continue to surface top-level (non-child) sessions alongside
+ *      children — no regression on the existing happy path.
+ *
+ * The test fakes a child JSONL by hand with a minimal SDK-shaped
+ * header. We don't need the pi-subagents plugin actually installed;
+ * the registry treats any JSONL nested one level deeper than the
+ * project session dir as a child.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+async function setupEnv(): Promise<{
+  workspacePath: string;
+  configDir: string;
+  dataDir: string;
+  sessionDir: string;
+}> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-data-"));
+  const sessionDir = join(workspacePath, ".pi", "sessions");
+  process.env.WORKSPACE_PATH = workspacePath;
+  process.env.PI_CONFIG_DIR = configDir;
+  process.env.FORGE_DATA_DIR = dataDir;
+  process.env.SESSION_DIR = sessionDir;
+  process.env.NODE_ENV = "test";
+  delete process.env.UI_PASSWORD;
+  delete process.env.JWT_SECRET;
+  delete process.env.API_KEY;
+  return { workspacePath, configDir, dataDir, sessionDir };
+}
+
+/** Write a minimal SDK-shaped session JSONL header file at `path`. */
+async function writeChildSessionFile(path: string, sessionId: string, cwd: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const header = {
+    type: "session",
+    version: 1,
+    id: sessionId,
+    timestamp: new Date().toISOString(),
+    cwd,
+  };
+  await writeFile(path, JSON.stringify(header) + "\n", "utf8");
+}
+
+interface TestLive {
+  session: {
+    sessionId: string;
+    sessionFile?: string;
+    sessionManager: { appendMessage: (msg: unknown) => string };
+  };
+  sessionId: string;
+}
+interface TestDiscovered {
+  sessionId: string;
+  path: string;
+  parentSessionId?: string;
+  runId?: string;
+}
+interface TestRegistry {
+  createSession: (projectId: string, workspacePath: string) => Promise<TestLive>;
+  disposeSession: (id: string) => Promise<boolean>;
+  disposeAllSessions: () => Promise<void>;
+  resumeSession: (id: string, projectId: string, workspacePath: string) => Promise<TestLive>;
+  discoverSessionsOnDisk: (projectId: string, workspacePath: string) => Promise<TestDiscovered[]>;
+  findSessionLocation: (
+    id: string,
+  ) => Promise<{ projectId: string; workspacePath: string } | undefined>;
+}
+interface TestProjectManager {
+  createProject: (name: string, path: string) => Promise<{ id: string; path: string }>;
+}
+
+async function main(): Promise<void> {
+  const { workspacePath, sessionDir } = await setupEnv();
+  console.log(`[test-subagent-discovery] WORKSPACE_PATH=${workspacePath}`);
+  console.log(`[test-subagent-discovery] SESSION_DIR=${sessionDir}`);
+
+  const registry = (await import(
+    resolve(repoRoot, "packages/server/dist/session-registry.js")
+  )) as unknown as TestRegistry;
+  const pm = (await import(
+    resolve(repoRoot, "packages/server/dist/project-manager.js")
+  )) as unknown as TestProjectManager;
+
+  // Register the project so findSessionLocation can locate children.
+  const project = await pm.createProject("test-subagent-project", workspacePath);
+
+  try {
+    // 1. Parent session — created via the registry like any normal session.
+    const parent = await registry.createSession(project.id, project.path);
+    assert(
+      "createSession returns a parent session with a sessionId",
+      typeof parent.sessionId === "string" && parent.sessionId.length > 0,
+    );
+    // The SDK only flushes JSONL once a message is appended (matches
+    // the live-test pattern in tests/test-session.ts). Inject a
+    // minimal assistant message so the parent's JSONL header lands on
+    // disk and `discoverSessionsOnDisk` can see it.
+    parent.session.sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "test fixture", id: "stub-1" }],
+      api: "messages",
+      provider: "anthropic",
+      model: "test-fixture",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+
+    // 2. Fake a pi-subagents child JSONL nested under the parent's id.
+    //    Layout: <sessionDir>/<projectId>/<parentId>/<runId>/<childId>.jsonl
+    const runId = "run-" + randomUUID().slice(0, 8);
+    const childA = randomUUID();
+    const childB = randomUUID();
+    const projectSessionDir = join(sessionDir, project.id);
+    const childAPath = join(projectSessionDir, parent.sessionId, runId, `${childA}.jsonl`);
+    const childBPath = join(projectSessionDir, parent.sessionId, runId, `${childB}.jsonl`);
+    await writeChildSessionFile(childAPath, childA, project.path);
+    await writeChildSessionFile(childBPath, childB, project.path);
+
+    // 3. discoverSessionsOnDisk surfaces the parent AND both children.
+    const discovered = await registry.discoverSessionsOnDisk(project.id, project.path);
+    const ids = discovered.map((d) => d.sessionId).sort();
+    const expectedIds = [parent.sessionId, childA, childB].sort();
+    assert(
+      "discoverSessionsOnDisk includes parent + 2 children",
+      JSON.stringify(ids) === JSON.stringify(expectedIds),
+      `got ${ids.join(",")} expected ${expectedIds.join(",")}`,
+    );
+
+    const childAEntry = discovered.find((d) => d.sessionId === childA);
+    assert(
+      "child A is tagged with parentSessionId",
+      childAEntry?.parentSessionId === parent.sessionId,
+      `parentSessionId=${childAEntry?.parentSessionId}`,
+    );
+    assert(
+      "child A is tagged with the runId",
+      childAEntry?.runId === runId,
+      `runId=${childAEntry?.runId}`,
+    );
+
+    const parentEntry = discovered.find((d) => d.sessionId === parent.sessionId);
+    assert(
+      "parent session has no parentSessionId / runId tagging",
+      parentEntry?.parentSessionId === undefined && parentEntry?.runId === undefined,
+    );
+
+    // 4. findSessionLocation resolves the child to its project.
+    const loc = await registry.findSessionLocation(childA);
+    assert(
+      "findSessionLocation finds the child's project",
+      loc?.projectId === project.id && loc?.workspacePath === project.path,
+      `loc=${JSON.stringify(loc)}`,
+    );
+
+    // 5. resumeSession opens the child as a LiveSession (registry hit).
+    const resumed = await registry.resumeSession(childA, project.id, project.path);
+    assert(
+      "resumeSession returns a LiveSession for the child",
+      resumed.sessionId === childA,
+      `got ${resumed.sessionId}`,
+    );
+  } finally {
+    await registry.disposeAllSessions();
+    // Clean every temp dir we created. Safe to ignore failures —
+    // mkdtemp dirs are isolated per test run.
+    await rm(workspacePath, { recursive: true, force: true }).catch(() => undefined);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-subagent-discovery] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-subagent-discovery] PASS");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/test-subagent-parser.ts
+++ b/tests/test-subagent-parser.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for `parseSubagentDetails` — the pure-function input to the
+ * SubagentResultCard. Pure parser, no DOM, no async — runs in <50ms.
+ *
+ * Coverage targets:
+ *   - SINGLE / PARALLEL / CHAIN / MANAGEMENT mode tagging
+ *   - Per-result sessionId derived from sessionFile basename
+ *   - Posix and Windows-style separators in sessionFile paths
+ *   - Missing optional fields (no sessionFile, no finalOutput)
+ *   - Malformed payloads (null, non-object, non-array results) → safe default
+ *   - Unrecognised mode strings → "unknown"
+ *
+ * The pi-subagents source of truth is `src/shared/types.ts` in
+ * https://github.com/nicobailon/pi-subagents — see also the integration
+ * report captured in `notes/MOBILE.md` for the full schema.
+ */
+import { parseSubagentDetails } from "../packages/client/src/lib/subagent-parser";
+
+let failures = 0;
+
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`  PASS  ${label}`);
+  } else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail !== undefined ? ` — ${detail}` : ""}`);
+  }
+}
+
+function assertEqual<T>(label: string, actual: T, expected: T): void {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  assert(label, a === e, `\n    expected: ${e}\n    actual:   ${a}`);
+}
+
+// --- Malformed inputs ------------------------------------------------
+
+assertEqual("null details → empty unknown", parseSubagentDetails(null), {
+  mode: "unknown",
+  results: [],
+});
+assertEqual("undefined details → empty unknown", parseSubagentDetails(undefined), {
+  mode: "unknown",
+  results: [],
+});
+assertEqual("string details → empty unknown", parseSubagentDetails("oops"), {
+  mode: "unknown",
+  results: [],
+});
+assertEqual(
+  "unrecognised mode → unknown but results still parse",
+  parseSubagentDetails({
+    mode: "sideways",
+    results: [{ agent: "a", task: "t", exitCode: 0 }],
+  }),
+  {
+    mode: "unknown",
+    results: [{ agent: "a", task: "t", exitCode: 0 }],
+  },
+);
+assertEqual(
+  "non-array results coerce to empty",
+  parseSubagentDetails({ mode: "single", results: "nope" }),
+  { mode: "single", results: [] },
+);
+
+// --- SINGLE mode -----------------------------------------------------
+
+assertEqual(
+  "single mode with sessionFile yields a sessionId from the basename",
+  parseSubagentDetails({
+    mode: "single",
+    runId: "run-abc",
+    context: "fresh",
+    results: [
+      {
+        agent: "researcher",
+        task: "investigate auth",
+        exitCode: 0,
+        sessionFile:
+          "/Users/devin/.pi/agent/sessions/parent-id/run-abc/00000000-1111-2222-3333-444444444444.jsonl",
+        finalOutput: "All good.",
+      },
+    ],
+  }),
+  {
+    mode: "single",
+    runId: "run-abc",
+    context: "fresh",
+    results: [
+      {
+        agent: "researcher",
+        task: "investigate auth",
+        exitCode: 0,
+        sessionFile:
+          "/Users/devin/.pi/agent/sessions/parent-id/run-abc/00000000-1111-2222-3333-444444444444.jsonl",
+        sessionId: "00000000-1111-2222-3333-444444444444",
+        finalOutput: "All good.",
+      },
+    ],
+  },
+);
+
+assertEqual(
+  "single mode without sessionFile leaves sessionId undefined",
+  parseSubagentDetails({
+    mode: "single",
+    results: [{ agent: "writer", task: "draft summary", exitCode: 0 }],
+  }),
+  {
+    mode: "single",
+    results: [{ agent: "writer", task: "draft summary", exitCode: 0 }],
+  },
+);
+
+// --- PARALLEL mode (multiple results) --------------------------------
+
+assertEqual(
+  "parallel mode with two results, mixed exit codes",
+  parseSubagentDetails({
+    mode: "parallel",
+    runId: "p-1",
+    results: [
+      {
+        agent: "tester",
+        task: "run unit",
+        exitCode: 0,
+        sessionFile: "/abs/parent/p-1/aaa.jsonl",
+      },
+      {
+        agent: "tester",
+        task: "run integration",
+        exitCode: 1,
+        sessionFile: "/abs/parent/p-1/bbb.jsonl",
+      },
+    ],
+  }),
+  {
+    mode: "parallel",
+    runId: "p-1",
+    results: [
+      {
+        agent: "tester",
+        task: "run unit",
+        exitCode: 0,
+        sessionFile: "/abs/parent/p-1/aaa.jsonl",
+        sessionId: "aaa",
+      },
+      {
+        agent: "tester",
+        task: "run integration",
+        exitCode: 1,
+        sessionFile: "/abs/parent/p-1/bbb.jsonl",
+        sessionId: "bbb",
+      },
+    ],
+  },
+);
+
+// --- CHAIN mode ------------------------------------------------------
+
+assertEqual(
+  "chain mode tags as chain",
+  parseSubagentDetails({
+    mode: "chain",
+    runId: "c-1",
+    context: "fork",
+    results: [
+      { agent: "step1", task: "do A", exitCode: 0, sessionFile: "/x/y/c-1/step1.jsonl" },
+      { agent: "step2", task: "do B", exitCode: 0, sessionFile: "/x/y/c-1/step2.jsonl" },
+    ],
+  }),
+  {
+    mode: "chain",
+    runId: "c-1",
+    context: "fork",
+    results: [
+      {
+        agent: "step1",
+        task: "do A",
+        exitCode: 0,
+        sessionFile: "/x/y/c-1/step1.jsonl",
+        sessionId: "step1",
+      },
+      {
+        agent: "step2",
+        task: "do B",
+        exitCode: 0,
+        sessionFile: "/x/y/c-1/step2.jsonl",
+        sessionId: "step2",
+      },
+    ],
+  },
+);
+
+// --- MANAGEMENT mode (no results.sessionFile) ------------------------
+
+assertEqual(
+  "management mode tags correctly even with empty results",
+  parseSubagentDetails({ mode: "management", results: [] }),
+  { mode: "management", results: [] },
+);
+
+// --- Path separator handling ----------------------------------------
+
+assertEqual(
+  "windows-style backslashes in sessionFile still extract sessionId",
+  parseSubagentDetails({
+    mode: "single",
+    results: [
+      {
+        agent: "win",
+        task: "t",
+        exitCode: 0,
+        sessionFile: "C:\\Users\\u\\.pi\\agent\\sessions\\p\\r\\child-id.jsonl",
+      },
+    ],
+  }),
+  {
+    mode: "single",
+    results: [
+      {
+        agent: "win",
+        task: "t",
+        exitCode: 0,
+        sessionFile: "C:\\Users\\u\\.pi\\agent\\sessions\\p\\r\\child-id.jsonl",
+        sessionId: "child-id",
+      },
+    ],
+  },
+);
+
+assertEqual(
+  "non-jsonl extension means no sessionId is extracted",
+  parseSubagentDetails({
+    mode: "single",
+    results: [{ agent: "x", task: "t", exitCode: 0, sessionFile: "/var/tmp/run/something.json" }],
+  }),
+  {
+    mode: "single",
+    results: [{ agent: "x", task: "t", exitCode: 0, sessionFile: "/var/tmp/run/something.json" }],
+  },
+);
+
+// --- Final tally -----------------------------------------------------
+
+if (failures > 0) {
+  console.log(`\n[test-subagent-parser] FAIL — ${failures} assertion(s) failed`);
+  process.exit(1);
+}
+console.log("\n[test-subagent-parser] PASS");


### PR DESCRIPTION
## Summary

When the [`pi-subagents`](https://github.com/nicobailon/pi-subagents) plugin is installed (`pi install npm:pi-subagents`), pi-forge now treats spawned sub-agents as first-class sessions — discoverable, navigable, and cleanly grouped under their parent in the sidebar.

Three pieces, two surfaces:

- **Server: nested session discovery.** `discoverSessionsOnDisk` now walks one level deeper into `<sessionDir>/<parentId>/<runId>/*.jsonl` (the path layout pi-subagents writes children to) and tags each child with `parentSessionId` + `runId`. `findSessionLocation`, `resumeSession`, and `deleteColdSession` all use the unified discovery so a child UUID resolves like any top-level session.
- **Client: SubagentResultCard.** Tool-call cards in the chat for `toolName === "subagent"` are replaced with a richer card listing each spawned agent's name + task + exit code, plus an **Open** button that switches the active session to the child's JSONL. Management-mode calls and unparsable payloads fall back to a plain text block so nothing is lost silently.
- **Client: SessionList chevron.** Top-level sessions with sub-agent children get an expandable chevron; children render indented underneath. Orphaned children (parent missing from this project's list) fall back to top-level rendering so they don't disappear.

Detection is free — `/config/tools` already exposes the `extension` family with `packageSource`, so any future "is pi-subagents installed?" gate can query that endpoint without a new route.

## Test plan

- [ ] `npm run test:ci` green (locally: 23/23 incl. two new tests)
- [ ] Install pi-subagents (`pi install npm:pi-subagents`), spawn a sub-agent from a chat in pi-forge, verify the SubagentResultCard renders with agent name + task + exit code + Open button
- [ ] Click **Open** on a sub-agent result row — active session switches to the child JSONL, chat hydrates from snapshot, sidebar shows child highlighted
- [ ] Sidebar: parent session row shows a chevron (▶); click expands, children render indented with the `↳` prefix; click again collapses
- [ ] Spawn a parallel-mode subagent (multiple children in one tool result) — card lists all of them, sidebar shows all under the parent
- [ ] Delete a child session via the sidebar X — file gets removed, parent + sibling children unaffected
- [ ] Refresh the page — all of the above still works (cold-start discovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)