### PR TITLE
fix(routes): return reply after resolveProject's 404 to avoid FST_ERR_REP_ALREADY_SENT

### DIFF
--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -195,10 +195,12 @@ function mapError(reply: FastifyReply, err: unknown): FastifyReply {
  *
  * Contract: returns the project on success. On miss, sends a 404
  * via `reply` AND returns undefined — caller MUST `if (project ===
- * undefined) return;` immediately to avoid double-send. The 404
- * response is intentionally awaited (Fastify reply.send returns the
- * reply object; awaiting it ensures any onSend hooks have run before
- * the route handler proceeds).
+ * undefined) return reply;` immediately. Returning bare `undefined`
+ * trips Fastify's `FST_ERR_REP_ALREADY_SENT` because the handler's
+ * resolved value is interpreted as "send this," racing the 404 the
+ * helper already sent. The 404 response is intentionally awaited
+ * (Fastify reply.send returns the reply object; awaiting it ensures
+ * any onSend hooks have run before the route handler proceeds).
  */
 async function resolveProject(
   projectId: string,
@@ -323,7 +325,7 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         // Clamp client-supplied maxDepth to a sane window. The schema
         // already gates on `^[0-9]+$`, so parseInt is safe; we cap at
@@ -373,7 +375,7 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       const target = req.query.path ?? project.path;
       try {
         const result = await downloadStream(target, project.path);
@@ -431,7 +433,7 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         const result = await readFile(req.query.path, project.path);
         return result;
@@ -471,7 +473,7 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         await writeFile(req.body.path, project.path, req.body.content);
         return { path: req.body.path };
@@ -509,7 +511,7 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         const created = await makeDirectory(req.body.parentPath, project.path, req.body.name);
         return { path: created };
@@ -549,7 +551,7 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         const renamed = await renameEntry(req.body.path, project.path, req.body.name);
         return { path: renamed };
@@ -590,7 +592,7 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         const moved = await moveEntry(req.body.src, req.body.dest, project.path);
         return { path: moved };
@@ -632,7 +634,7 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         const recursive = req.query.recursive === "true";
         await deleteEntry(req.query.path, project.path, { recursive });
@@ -718,7 +720,7 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       const { q } = req.query;
       const regex = req.query.regex === "1" || req.query.regex === "true";
       const caseSensitive = req.query.caseSensitive === "1" || req.query.caseSensitive === "true";

--- a/packages/server/src/routes/git.ts
+++ b/packages/server/src/routes/git.ts
@@ -166,8 +166,11 @@ function mapError(reply: FastifyReply, err: unknown): FastifyReply {
 
 /**
  * Resolve the project for a request. On miss, sends 404 + returns
- * undefined; caller MUST `return` immediately. See files.ts:resolveProject
- * for the same contract.
+ * undefined; caller MUST `return reply` immediately. Returning bare
+ * `undefined` trips Fastify's `FST_ERR_REP_ALREADY_SENT` because the
+ * route handler's resolved `undefined` is interpreted as "send this,"
+ * which races the 404 the helper already sent. See
+ * files.ts:resolveProject for the same contract.
  */
 async function resolveProject(
   projectId: string,
@@ -201,7 +204,10 @@ async function withProject<T>(
   fn: (project: { id: string; path: string }) => Promise<T>,
 ): Promise<T | FastifyReply | undefined> {
   const project = await resolveProject(projectId, reply);
-  if (project === undefined) return undefined;
+  // resolveProject already called reply.send for the 404 path —
+  // returning the reply here tells Fastify the response was handled,
+  // avoiding the FST_ERR_REP_ALREADY_SENT double-send error.
+  if (project === undefined) return reply;
   try {
     return await fn(project);
   } catch (err) {
@@ -245,7 +251,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         if (await isGitRepo(project.path)) {
           return { alreadyInitialised: true, isGitRepo: true };
@@ -284,7 +290,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         return await getStatus(project.path);
       } catch (err) {
@@ -448,7 +454,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         await addRemote(project.path, req.body.name, req.body.url);
         return { ok: true };
@@ -486,7 +492,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         await removeRemote(project.path, req.params.name);
         return { ok: true };
@@ -525,7 +531,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         await checkoutBranch(project.path, req.body.branch);
         return { ok: true };
@@ -567,7 +573,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         const opts: { startPoint?: string; checkout?: boolean } = {};
         if (req.body.startPoint !== undefined) opts.startPoint = req.body.startPoint;
@@ -612,7 +618,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         const force = req.query.force === "1" || req.query.force === "true";
         await deleteBranch(project.path, req.params.name, { force });
@@ -658,7 +664,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         await stagePaths(project.path, req.body.paths);
         return { ok: true };
@@ -703,7 +709,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         await unstagePaths(project.path, req.body.paths);
         return { ok: true };
@@ -754,7 +760,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         await revertPaths(project.path, req.body.paths);
         return { ok: true };
@@ -796,7 +802,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       const message = req.body.message.trim();
       if (message.length === 0) {
         return reply.code(400).send({ error: "empty_message" });
@@ -838,7 +844,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         const opts: { remote?: string; prune?: boolean } = {};
         if (req.body.remote !== undefined) opts.remote = req.body.remote;
@@ -884,7 +890,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         const opts: { remote?: string; branch?: string; rebase?: boolean } = {};
         if (req.body.remote !== undefined) opts.remote = req.body.remote;
@@ -943,7 +949,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return;
+      if (project === undefined) return reply;
       try {
         const opts: { remote?: string; branch?: string; setUpstream?: boolean } = {};
         if (req.body.remote !== undefined) opts.remote = req.body.remote;


### PR DESCRIPTION
## Summary

Every git.ts and files.ts handler that calls `resolveProject` was ending with `if (project === undefined) return;` after the helper already called `reply.send(404)`. Fastify interprets the handler's resolved `undefined` as "send this," racing the 404 the helper just sent — tripping `FST_ERR_REP_ALREADY_SENT` and surfacing as a noisy 500 in the request log even though the client got the 404 fine.

Repro: hit `GET /api/v1/git/status?projectId=<unknown-id>`. Client sees 404 (correct). Server log shows:
```
{"err":{"type":"FastifyError","message":"Reply was already sent, did you forget to \"return reply\" in \"/api/v1/git/status...\"","code":"FST_ERR_REP_ALREADY_SENT","statusCode":500}}
```

Fixed:
- Every `if (project === undefined) return;` call site (14 in `git.ts`, 9 in `files.ts`) now returns `reply` so Fastify knows the response was handled.
- The shared `withProject` helper in `git.ts` does the same — was returning bare `undefined`.
- Doc-comment on both `resolveProject` helpers updated so the contract is explicit: callers MUST `return reply`, not bare `return`. Future-me / future-anyone won't re-introduce the bug.

Surfaced while testing pi-subagents (separate branch). Unrelated to that feature; this fix lives off `main` so it can ship independently.

## Test plan

- [ ] After merge, hitting any git or files route with a non-existent `projectId` query returns 404 cleanly with no `FST_ERR_REP_ALREADY_SENT` log entry. Easiest manual repro: `curl -H "Authorization: Bearer \$API_KEY" "http://localhost:3000/api/v1/git/status?projectId=does-not-exist"` → 404, no 500 in `npm run dev` output.
- [ ] `npm run test:ci` green (no behavioral regressions to existing route tests; this is purely an error-path noise fix).
- [ ] Affected routes still 404 correctly when project exists check fails (manual: try `/api/v1/files/tree`, `/api/v1/git/branches`, etc with a junk projectId).

🤖 Generated with [Claude Code](https://claude.com/claude-code)