### PR TITLE
chore(release): v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,22 +16,65 @@ the README for the support window policy.
 
 ### Added
 
-- **pi-subagents integration.** When the `pi-subagents` package is
-  installed (`pi install npm:pi-subagents`), three things turn on:
-  (1) the existing tool/extension surface already enables the plugin's
-  `subagent` tool — sessions get it via the regular allowlist; (2) tool
-  call cards in the chat for `subagent` are replaced with a richer
-  `SubagentResultCard` that lists each spawned sub-agent's name + task
-  + exit code and exposes an "Open" button that switches the active
-  session to the child JSONL; (3) the session sidebar now groups
-  sub-agent sessions under a chevron dropdown on their parent row.
-  Server-side, `discoverSessionsOnDisk` now walks one level deeper
-  into `<sessionDir>/<parentId>/<runId>/*.jsonl` (the path layout
-  pi-subagents writes to) and tags each child with `parentSessionId`
-  and `runId`; `findSessionLocation` and `resumeSession` resolve child
-  UUIDs the same as top-level sessions. Coverage in
-  `tests/test-subagent-discovery.ts` (registry-level) and
-  `tests/test-subagent-parser.ts` (pure parser).
+- **VS Code-style git diff gutter in the file viewer.** CodeMirror
+  editor now renders a 3px colored gutter strip per changed line —
+  green for additions, blue for modified, red triangle for the line
+  below a deletion — plus a proportional overview overlay on the right
+  scrollbar so changes are visible at a glance in long files. Diff
+  data flows in via a `setDiffEffect` StateEffect so swaps don't
+  require rebuilding EditorState (cursor / undo / scroll all
+  preserved). Pure-function `parseUnifiedDiff` parses git diff output
+  into per-line decorations keyed by new-file line numbers; full unit
+  coverage in `tests/test-diff-parser.ts`.
+- **Dependabot enabled.** `.github/dependabot.yml` configures weekly
+  version updates across three ecosystems: `npm` (root + every
+  workspace under `packages/*` via auto-discovery), `github-actions`
+  (workflow YAMLs), and `docker` (`docker/Dockerfile` base image).
+  Each stream tags PRs with `dependencies` plus an ecosystem label
+  and uses a conventional-commit prefix (`chore(deps)`, `chore(ci)`,
+  `chore(docker)`). The pi SDK trio is intentionally NOT ignored —
+  Dependabot still surfaces those bumps as PRs even though the
+  policy is "review carefully, never auto-merge" per `CLAUDE.md`.
+- **pi-subagents integration.** When the `pi-subagents` plugin is
+  installed (`pi install npm:pi-subagents`), spawned sub-agents are
+  now first-class sessions in pi-forge: discoverable, navigable,
+  cleanly grouped under their parent in the sidebar. Specifically:
+  - The `subagent` tool's result message is rendered as a richer
+    light-blue card in the chat (replaces the generic tool card),
+    with collapsible Input + Output sections and a small Open button
+    in the header that switches the active session to the spawned
+    child's JSONL.
+  - Server-side discovery walks the deeply-nested
+    `<sessionDir>/<projectId>/<basename>/<runId>/run-N/session.jsonl`
+    layout pi-subagents writes to, and tags each child with
+    `parentSessionId` + `runId` for sidebar grouping. Recursive
+    walker handles every layout variant the plugin emits without
+    enumerating each by hand.
+  - Sidebar shows children indented under their parent's row when
+    the chevron is expanded. True orphans (parent JSONL deleted but
+    child dir survived) fall back to top-level rendering.
+  - Open click resolves `sessionFile` → canonical `sessionId` via
+    a path lookup against the loaded session list (pi-subagents
+    names children `session.jsonl`, not `<uuid>.jsonl`, so deriving
+    the id from the basename is unreliable). Uses the JSONL header's
+    real id instead.
+  - Deleting a parent session cascades the entire pi-subagents
+    sibling directory so orphan children don't accumulate. The
+    project-scoped `subagent-artifacts/` dir is intentionally
+    untouched.
+
+### Fixed
+
+- **`FST_ERR_REP_ALREADY_SENT` 500s on git/files routes.** Every
+  handler that called `resolveProject` was ending with
+  `if (project === undefined) return;` after the helper already
+  called `reply.send(404)`. Fastify interpreted the resolved
+  `undefined` as "send this," racing the helper's 404 — surfacing
+  as a noisy 500 in the request log even though the client got
+  the 404 fine. All call sites in `git.ts` (14) and `files.ts` (9)
+  plus the shared `withProject` helper now `return reply` so
+  Fastify knows the response was handled. Doc-comments on both
+  helpers updated to make the contract explicit.
 
 ## [1.1.2] — 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.1.3] — 2026-05-07
+
 ### Added
 
 - **VS Code-style git diff gutter in the file viewer.** CodeMirror

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "workspaces": [
         "packages/*"
       ],
@@ -17268,7 +17268,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17311,7 +17311,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts v1.1.3. Three pieces ship together — the diff gutter and Dependabot are already on main, the sub-agents integration and Fastify fix are merging in alongside this release PR.

### Added

- **VS Code-style git diff gutter in the file viewer** (#33). Per-line green/blue/red strip in the editor gutter plus a proportional overview overlay on the right scrollbar.
- **Dependabot enabled** (#35). Weekly version updates across npm, github-actions, and docker. Pi SDK trio surfaces as PRs but is policy-gated as "review carefully, never auto-merge."
- **pi-subagents integration** (#34). When `pi-subagents` is installed, spawned sub-agents are first-class sessions: rich light-blue card in the chat (with collapsible Input/Output and an Open button), recursive discovery of children at any pi-subagents layout depth, sidebar grouping under the parent's chevron, and cascade-delete that removes the child tree when the parent is deleted.

### Fixed

- **`FST_ERR_REP_ALREADY_SENT` 500s on git/files routes** (#55). Every handler that called `resolveProject` was returning `undefined` after the helper sent its 404, racing the helper's reply. All call sites now `return reply` so Fastify knows the response was handled.

### Sequencing

This release PR must merge AFTER #34 and #55 land on main — otherwise the changelog references features that aren't actually shipping. Suggested order:

1. Merge #55 (fastify fix — small, safe, independent)
2. Merge #34 (sub-agents)
3. Merge this PR
4. Tag from main:
   ```
   git checkout main && git pull --ff-only
   git tag v1.1.3 && git push origin v1.1.3
   ```

The release workflow handles the multi-arch image, GitHub Release, and npm publish via OIDC.

## Test plan

- [ ] `npm run test:ci` green
- [ ] All three `package.json` files pinned to `1.1.3` (root + workspaces)
- [ ] `package-lock.json` reflects the bump
- [ ] `[Unreleased]` is empty under the new `[1.1.3] — 2026-05-07` stanza
- [ ] After merge + tag, the release workflow succeeds end-to-end (multi-arch image on GHCR, GitHub Release, npm publish via Trusted Publisher OIDC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)