### PR TITLE
chore(gitignore): ignore .worktrees/ for in-tree git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ Desktop.ini
 tmp/
 .tmp/
 
+# Git worktrees (in-tree convention: `git worktree add .worktrees/<branch>`)
+.worktrees/
+
 # Local working notes (not committed)
 notes/
 pi-webui-dev-plan.md


### PR DESCRIPTION
## Summary

- Adopt the `git worktree add .worktrees/<branch>` convention for short-lived feature worktrees living inside the repo.
- Ignore the `.worktrees/` directory so worktree contents stay out of `git status` while IDEs / search tools still treat each worktree as a normal project root.

## Test plan

- [x] `git check-ignore .worktrees/<anything>` matches the new rule
- [x] Existing checked-in files unaffected