### PR TITLE
fix(ci): pin Node 22.22.1 to dodge 22.22.2's broken bundled npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,9 +241,19 @@ jobs:
         # the registry-aware mode required for OIDC. Without this,
         # `npm publish` would silently use the default user-level
         # config and fail authentication.
+        #
+        # node-version is pinned (not `22`) because Node 22.22.2 ships
+        # with a broken bundled npm tree — `promise-retry` is missing
+        # from `@npmcli/arborist`'s node_modules, so any
+        # `npm install -g npm@<anything>` crashes with MODULE_NOT_FOUND
+        # before it can do the upgrade. Confirmed regression vs 22.22.1:
+        #   - https://github.com/nodejs/node/issues/62425
+        #   - https://github.com/actions/runner-images/issues/13883
+        # 22.22.1 is the last known-good 22.x. Drop the pin (back to
+        # `22`) once 22.22.3 ships with the fix from nodejs/node#62463.
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.22.1
           cache: npm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
## Summary

- Node 22.22.2's hostedtoolcache image ships with a corrupted bundled npm — `promise-retry` is missing from `@npmcli/arborist`'s `node_modules`, so any `npm install -g npm@<anything>` crashes with `MODULE_NOT_FOUND` before the upgrade can run.
- This blocked `release.yml`'s `npm install -g npm@latest` step (added in v1.1.2 to get Trusted Publisher OIDC support, npm ≥ 11.5.1).
- Pinning `node-version: 22.22.1` forces `actions/setup-node` to download a clean Node + npm pair from nodejs.org instead of using the broken cached image.

Confirmed regression vs 22.22.1:
- https://github.com/nodejs/node/issues/62425
- https://github.com/actions/runner-images/issues/13883

Drop the pin (back to plain `22`) once 22.22.3 ships with the fix from nodejs/node#62463.

## Test plan

- [ ] Tag a non-production rc (e.g. `v1.1.3-rc1`) and confirm `release.yml`'s `check-version` + `npm-publish` jobs both run to completion
- [ ] Inspect the `npm-publish` job log to confirm it prints a Node 22.22.1 version line