### PR TITLE
fix(editor): pin diff scrollbar marks by making .cm-scroller the real scroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Diff scrollbar marks now stay pinned to the scrollbar.** The
+  CodeMirror file viewer's container had `overflow-auto` while the
+  editor itself had no forced height, so `.cm-editor` grew to the
+  document's full content height and the parent div became the actual
+  scroll container instead of CM6's `.cm-scroller`. The diff overview
+  overlay (mounted on `view.dom` / `.cm-editor`) translated along with
+  the editor on every scroll, making the colored marks "follow" the
+  text instead of staying anchored to the scrollbar. Forcing
+  `.cm-editor { height: 100% }` and switching the wrapper to
+  `flex-1 min-h-0` puts the scroll back where CM6 expects it — marks
+  are pinned, and viewport virtualization works again so large files
+  no longer render every line into the DOM.
+
 ## [1.1.3] — 2026-05-07
 
 ### Added

--- a/packages/client/src/components/CodeMirrorEditor.tsx
+++ b/packages/client/src/components/CodeMirrorEditor.tsx
@@ -52,6 +52,25 @@ import { nginx } from "@codemirror/legacy-modes/mode/nginx";
 import type { OpenFile } from "../store/file-store";
 
 /**
+ * Force the editor to fill its container so CodeMirror's own
+ * `.cm-scroller` is the actual scroller — not the parent div.
+ *
+ * Without this, `.cm-editor` grows to the document's natural content
+ * height, the parent's `overflow-auto` becomes the scroll container,
+ * and two things break: (1) the diff scrollbar overview overlay (which
+ * is mounted on `view.dom` / `.cm-editor`) gets translated along with
+ * the editor on every scroll, so the marks "move with" the content
+ * instead of staying pinned to the scrollbar; (2) CM6's viewport
+ * virtualization no longer triggers — every line in the file is in the
+ * DOM, killing performance on large files. With `height: 100%` here
+ * the wrapper div constrains the editor and `.cm-scroller` does its
+ * job.
+ */
+const editorFillContainerTheme = EditorView.theme({
+  "&": { height: "100%" },
+});
+
+/**
  * CodeMirror host. Lives in its own module so EditorPanel can pull it
  * in via `React.lazy()` — the CM bundle is ~700 KB minified and the
  * user might never open a file in a given session, so it shouldn't
@@ -129,6 +148,7 @@ export function CodeMirrorEditor({
     const langExt = languageExtension(file.language);
     const exts: Extension[] = [
       basicSetup,
+      editorFillContainerTheme,
       // Initial theme matches the user's currently-applied app
       // theme. Swapped at runtime via the compartment below; no
       // light-themed CodeMirror pack is bundled, so light mode
@@ -246,7 +266,12 @@ export function CodeMirrorEditor({
     return () => window.clearTimeout(id);
   }, [file.pendingNav, file.path]);
 
-  return <div ref={containerRef} className="flex-1 overflow-auto" />;
+  // `min-h-0` on the flex child so it shrinks rather than growing to
+  // its content's intrinsic height; combined with the editor theme
+  // above (`.cm-editor { height: 100% }`) this makes `.cm-scroller`
+  // the scroller. Removing the parent's `overflow-auto` is the whole
+  // point — see editorFillContainerTheme's doc-comment.
+  return <div ref={containerRef} className="flex-1 min-h-0 min-w-0" />;
 }
 
 function languageExtension(language: string): Extension | undefined {


### PR DESCRIPTION
## Summary

- The CodeMirror file viewer's wrapper had `overflow-auto` while the editor itself had no forced height, so `.cm-editor` grew to the full document content height and the **parent div** ended up being the actual scroll container instead of CM6's `.cm-scroller`.
- The diff overview overlay (mounted on `view.dom` / `.cm-editor`) translated along with the editor on every scroll, so the colored marks "followed" the text instead of staying anchored to the scrollbar.
- Forcing `.cm-editor { height: 100% }` and switching the wrapper to `flex-1 min-h-0` puts the scroll back where CM6 expects it. Marks are pinned, and CM6's viewport virtualization re-engages so large files no longer render every line into the DOM.

## Test plan

- [ ] Open a long file (1000+ lines) with active git diff in the file viewer
- [ ] Scroll up/down — verify the colored marks on the right edge stay anchored to the scrollbar position
- [ ] Confirm the gutter strip still renders correctly in the left margin
- [ ] Confirm the line-wrap toggle still works (off = horizontal scroll inside `.cm-scroller`)
- [ ] Confirm Cmd/Ctrl+S save still fires and pendingNav (search-result jump) still scrolls the cursor into view