### PR TITLE
fix(subagents): pi-subagents container PATH + cascade-dispose live children + sidebar refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,44 @@ the README for the support window policy.
 
 ## [Unreleased]
 
+### Fixed
+
+- **pi-subagents now works inside the Docker image.** The plugin
+  shells out via `child_process.spawn("pi", ...)` and on Linux has no
+  fallback resolution — the container previously failed every subagent
+  call with `spawn pi ENOENT`. The runtime image now prepends
+  `/app/node_modules/.bin` to `PATH`, exposing the `pi` bin shim
+  shipped by `@mariozechner/pi-coding-agent` (already a server
+  dependency, so no extra install). Verifiable with
+  `docker compose exec pi-forge sh -c 'which pi && pi --version'`.
+- **Session sidebar refreshes around sub-agents.** The list now
+  refetches when (a) a parent session finishes a `subagent` tool call
+  (so newly-spawned children appear without a manual refresh), and
+  (b) a parent session is deleted (so the server's cascade-removed
+  child JSONLs disappear from `byProject` instead of lingering as
+  sidebar orphans). Cross-tab `session_deleted` receivers refetch on
+  the same paths.
+- **Cascade-delete now disposes LIVE sub-agent children before
+  removing their JSONLs.** Previously, opening a sub-agent session in
+  the UI promoted it to a `LiveSession` in the in-memory registry,
+  and deleting the parent's JSONL would `rm -rf` the sibling subagent
+  dir but leave the live child entry pointing at the now-deleted
+  file. Any SSE clients still attached to the zombie kept emitting
+  events that couldn't be persisted. `deleteColdSession` now disposes
+  every registered child of the deleted parent (in parallel — each
+  dispose can wait up to 5 s on its own LLM-call abort) before
+  unlinking. Test coverage added in `tests/test-subagent-discovery.ts`
+  via a resume-then-cascade fixture.
+
+### Documentation
+
+- README's "Tools & MCP" feature list now includes pi-subagents.
+  `docs/configuration.md` gains a "Pi plugins" section documenting
+  the `pi install npm:<package>` install path and the pi-subagents
+  surface specifically. CLAUDE.md drops the "sub-agent dropdown"
+  deferred entry and rewrites the Pi-SDK-key-fact line to point at
+  the actual integration code.
+
 ## [1.1.3] — 2026-05-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,8 +366,16 @@ These are facts about the pi SDK that are easy to get wrong:
   directly. Extract it with `event.details?.diff` or similar — check the actual
   type definition in `node_modules/@mariozechner/pi-coding-agent/dist/` for the
   exact field name before using it.
-- Pi does NOT have native sub-agent support in the SDK. Do not try to implement
-  sub-agent session tracking — it is explicitly deferred.
+- Pi does NOT have native sub-agent support in the SDK — there is no
+  "child session created" event. Sub-agent integration is provided by the
+  community [`pi-subagents`](https://github.com/nicobailon/pi-subagents)
+  plugin and surfaced in pi-forge by: (a) discovering child JSONLs at
+  `<sessionDir>/<projectId>/<basename>/<runId>/run-N/session.jsonl` in
+  `discoverSessionsOnDisk`, (b) refetching the project session list on
+  `tool_execution_end` for `toolName === "subagent"` and on parent dispose
+  (`session-store.ts`), (c) cascade-deleting the parent's sibling subagent
+  dir in `deleteColdSession`. The plugin shells out to the `pi` CLI; the
+  Docker image puts it on PATH via `/app/node_modules/.bin`.
 - `session.fork()` creates a new session FILE. The new session ID is returned.
   The registry must then load this new session before it can be used.
 - `session.navigateTree()` operates IN-PLACE on the current session file. It does
@@ -690,9 +698,6 @@ test-terminal     PTY WebSocket + idle-reap
 
 ## Known Limitations & Deferred Work
 
-- **Sub-agent session dropdown** — pi does not natively expose sub-agent sessions
-  via the SDK. The `pi-subagents` community package exists but requires scraping
-  temp files rather than subscribing to SDK events. Deferred indefinitely.
 - **GitHub integration** — GitHub OAuth, PR creation, issue context. Deferred.
 - **Multi-agent parallel worktrees** — parallel agent runs against git worktrees.
   Not feasible with current pi SDK without significant custom work. Deferred.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ details, follow the links in [Documentation](#documentation) below.
   scrubbed environment (no `JWT_SECRET`, `API_KEY`, provider keys) so a stuck
   agent can't `printenv` pi-forge secrets back into the transcript. Same
   posture as the integrated terminal and the `!` exec route.
+- **pi-subagents plugin support** — install the community
+  [`pi-subagents`](https://github.com/nicobailon/pi-subagents) plugin
+  (`pi install npm:pi-subagents`) and the agent gains a `subagent` tool for
+  delegating work to spawned child sessions, sequentially or in parallel.
+  pi-forge groups the children under their parent in the sidebar, renders the
+  tool result as a rich card with one-click jump into each child, refreshes the
+  list when new children appear, and cascade-deletes children when the parent
+  is removed. Works in the Docker image out of the box.
 
 ### Sessions & chat
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,9 +114,17 @@ USER pi
 # SHELL=/bin/bash so node-pty spawns bash for the integrated terminal
 # (pty-manager.ts uses `process.env.SHELL || '/bin/sh'`). TERM hint
 # helps line-editing programs pick a sane terminfo entry inside xterm.
+#
+# PATH prepends /app/node_modules/.bin so the `pi` CLI shipped by
+# @mariozechner/pi-coding-agent (already a server dep) is on PATH for
+# the running server and any process it spawns. The pi-subagents
+# plugin shells out via `child_process.spawn("pi", ...)` with no
+# fallback resolution on Linux — without this, the subagent tool
+# fails with `spawn pi ENOENT` inside the container.
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
     PORT=3000 \
+    PATH=/app/node_modules/.bin:$PATH \
     WORKSPACE_PATH=/workspace \
     PI_CONFIG_DIR=/home/pi/.pi/agent \
     FORGE_DATA_DIR=/home/pi/.pi-forge \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,6 +267,40 @@ and `<projectPath>/.mcp.json` (project-scoped). Manage them from the
 [`mcp.md`](./mcp.md) for the field reference, transport options,
 auth model, and troubleshooting.
 
+## Pi plugins
+
+The pi CLI supports community plugins installed via
+`pi install npm:<package>`. Plugin sources land under
+`${PI_CONFIG_DIR}/packages/<name>` and register additional tools at
+session-creation time. Because `PI_CONFIG_DIR` (default `~/.pi/agent`)
+is bind-mounted into the container, host-side `pi install` automatically
+exposes the plugin to the container as well.
+
+### pi-subagents
+
+[`pi-subagents`](https://github.com/nicobailon/pi-subagents) adds a
+`subagent` tool that lets the agent delegate work to spawned child
+sessions, sequentially or in parallel. pi-forge surfaces it without
+extra config:
+
+- Child sessions are discovered on disk under the parent's directory
+  (`<sessionDir>/<projectId>/<basenameOfParentJsonl>/<runId>/run-N/session.jsonl`)
+  and rendered nested under their parent in the session sidebar.
+- The `subagent` tool result renders as a rich card with one row per
+  child + a one-click jump into each child session.
+- The project's session list refetches on every `subagent`
+  `tool_execution_end` so newly spawned children appear without a
+  manual refresh, and on parent dispose so cascade-deleted children
+  disappear.
+- Container-side, the plugin's `spawn("pi", ...)` works because
+  `/app/node_modules/.bin` is on PATH (the `pi` CLI ships as a bin
+  shim of `@mariozechner/pi-coding-agent`, which pi-forge already
+  depends on).
+
+To install: `pi install npm:pi-subagents` on the host. The plugin
+files travel into the container via the mounted `~/.pi/agent`; no
+in-container install step is needed.
+
 ## See also
 
 - [`README.md`](../README.md) — pi-forge env vars + Docker quickstart

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -161,6 +161,13 @@ function revokeOptimisticBlobUrls(messages: readonly AgentMessageLike[]): void {
  * Revokes blob URLs in the soon-to-be-discarded messages so optimistic
  * image attachments that never got refetched don't leak.
  */
+function findProjectIdForSession(state: SessionState, sessionId: string): string | undefined {
+  for (const [pid, list] of Object.entries(state.byProject)) {
+    if (list.some((u) => u.sessionId === sessionId)) return pid;
+  }
+  return undefined;
+}
+
 function removeSessionFromState(current: SessionState, sessionId: string): Partial<SessionState> {
   const stale = current.messagesBySession[sessionId];
   if (stale !== undefined) revokeOptimisticBlobUrls(stale);
@@ -634,12 +641,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       // Capture projectId before we wipe the entry — cross-tab
       // listeners only need the id, but we may want to filter by
       // project later.
-      const priorProjectId = (() => {
-        for (const [pid, list] of Object.entries(get().byProject)) {
-          if (list.some((u) => u.sessionId === sessionId)) return pid;
-        }
-        return undefined;
-      })();
+      const priorProjectId = findProjectIdForSession(get(), sessionId);
       await api.disposeSession(sessionId, opts);
       set((s) => removeSessionFromState(s, sessionId));
       if (get().activeSessionId === undefined) {
@@ -652,6 +654,14 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       // JSONL cleanup, etc.).
       if (priorProjectId !== undefined) {
         postCrossTab({ type: "session_deleted", projectId: priorProjectId, sessionId });
+        // Cascade refetch: the server hard-delete also rm -rf's any
+        // pi-subagents child session JSONLs sitting under the
+        // parent's directory (see deleteColdSession in
+        // session-registry.ts). The local removeSessionFromState
+        // above only knows about the parent id — without a refetch,
+        // those children linger in byProject as sidebar orphans
+        // pointing at deleted files.
+        void get().loadSessionsForProject(priorProjectId);
       }
     } catch (err) {
       set({ error: err instanceof ApiError ? err.code : (err as Error).message });
@@ -832,6 +842,15 @@ function applyEvent(
     // bubble) shows up before the next tool fires. Without this the
     // user sees a stretch of "running …" badges with no output.
     scheduleMessagesRefetch(set, sessionId);
+    // pi-subagents: a `subagent` tool call just finished, which
+    // means one or more child session JSONLs were written to disk
+    // under the parent's directory. Refetch the project's session
+    // list so the sidebar picks them up — pi has no native
+    // "child session created" SDK event we can hook into.
+    if (event.toolName === "subagent") {
+      const projectId = findProjectIdForSession(get(), sessionId);
+      if (projectId !== undefined) void get().loadSessionsForProject(projectId);
+    }
     return;
   }
 
@@ -1130,6 +1149,13 @@ if (!globalThis.__piForgeSessionCrossTabRegistered) {
           // private-mode storage failure — fine
         }
       }
+      // Cross-tab counterpart to the cascade refetch in
+      // disposeSession: the server has rm -rf'd any pi-subagents
+      // child JSONLs under the deleted parent. The local
+      // removeSessionFromState above only knows about the parent
+      // id — without this, children stay in byProject in the
+      // receiving tab until its next mount.
+      void useSessionStore.getState().loadSessionsForProject(msg.projectId);
       return;
     }
     if (msg.type === "session_renamed") {

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -716,6 +716,23 @@ export async function deleteColdSession(
       if (match.parentSessionId === undefined) {
         const stem = basename(match.path, ".jsonl");
         const siblingDir = join(dirname(match.path), stem);
+        // Dispose any LIVE children before removing their JSONLs.
+        // `discoverSessionsOnDisk` populated `infos` with every child
+        // under this parent (their `parentSessionId` matches our
+        // `sessionId`). If a child was opened in the UI it now has a
+        // LiveSession entry in the registry; rm-ing its JSONL out from
+        // under it leaves a zombie session pointing at a deleted file
+        // and any SSE clients attached to it keep firing events that
+        // can't be persisted. Dispose in parallel — `disposeSession`
+        // awaits a per-session abort with a 5-second ceiling, so a
+        // sequential loop on N live children would block the delete
+        // request for up to 5N seconds.
+        const liveChildIds = infos
+          .filter((s) => s.parentSessionId === sessionId && registry.has(s.sessionId))
+          .map((s) => s.sessionId);
+        if (liveChildIds.length > 0) {
+          await Promise.all(liveChildIds.map((id) => disposeSession(id)));
+        }
         // force: true makes ENOENT silent; recursive: true clears the
         // run/runId/run-N tree the plugin nests under there. Failures
         // for any other reason (perms, EBUSY) are swallowed — the

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -98,6 +98,7 @@ interface TestRegistry {
     id: string,
   ) => Promise<{ projectId: string; workspacePath: string } | undefined>;
   deleteColdSession: (id: string) => Promise<"deleted" | "live" | "not_found">;
+  getSession: (id: string) => TestLive | undefined;
 }
 interface TestProjectManager {
   createProject: (name: string, path: string) => Promise<{ id: string; path: string }>;
@@ -305,8 +306,25 @@ async function main(): Promise<void> {
     // is gone. We use the deep-layout fixture because it exercises
     // the full <basename>/<runId>/run-N/<child>.jsonl tree the
     // recursive rm has to clear.
+    //
+    // We ALSO resume the deep child first so it's a live registry
+    // entry (matching the bug case: user opened a sub-agent session
+    // in the UI, then deleted its parent). The cascade has to dispose
+    // the live LiveSession AND remove the JSONL — without the
+    // dispose, the registry holds a zombie pointing at a deleted
+    // file and any attached SSE clients keep emitting events that
+    // can't be persisted.
+    await registry.resumeSession(deepChildId, project.id, project.path);
+    assert(
+      "deep child is live in the registry before cascade",
+      registry.getSession(deepChildId) !== undefined,
+    );
     const cascadeStatus = await registry.deleteColdSession(deepParentId);
     assert("deleteColdSession on the deep parent returns 'deleted'", cascadeStatus === "deleted");
+    assert(
+      "deep child's LiveSession was disposed by the cascade",
+      registry.getSession(deepChildId) === undefined,
+    );
     const reAfterCascade = await registry.discoverSessionsOnDisk(project.id, project.path);
     assert(
       "deep-layout child is gone after parent delete (cascade)",


### PR DESCRIPTION
## Summary

Three independent pi-subagents follow-ups from the v1.1.3 integration, plus the docs update that v1.1.3 didn't have time for:

1. **Docker**: prepend `/app/node_modules/.bin` to `PATH` so the `pi` CLI shipped by `@mariozechner/pi-coding-agent` (already a server dep) resolves on `child_process.spawn("pi", ...)`. Without this, every subagent call inside the container died with `spawn pi ENOENT`.
2. **Server**: `deleteColdSession` now disposes any LIVE sub-agent children before the cascade `rm -rf` of the parent's sibling directory. Previously, opening a sub-agent in the UI promoted it to a `LiveSession` in the registry — and deleting the parent left a zombie session pointing at a deleted JSONL, with attached SSE clients still emitting events that couldn't be persisted. Children disposed in parallel because each `disposeSession` waits up to 5 s on its own LLM-call abort.
3. **Client**: the session sidebar now refetches the project's session list on `tool_execution_end` for `toolName === "subagent"` (so freshly-spawned children appear without a manual reload — pi has no native "child session created" SDK event) and after `disposeSession` resolves (so cascade-removed children disappear from `byProject` instead of lingering as sidebar orphans). Cross-tab `session_deleted` receivers do the same.
4. **Docs**: README "Tools & MCP" gains a pi-subagents bullet; `docs/configuration.md` gets a "Pi plugins" section; CLAUDE.md's "Pi has no native sub-agent support" SDK fact is rewritten to point at the actual integration code; the "Sub-agent session dropdown" entry leaves Known Limitations.

## Test plan

- [x] `tests/test-subagent-discovery.ts` passes — extended with a resume-then-cascade fixture verifying live children are disposed by `deleteColdSession`
- [x] `npm run check` clean (typecheck + lint + format)
- [ ] Build the Docker image and confirm `docker compose exec pi-forge sh -c 'which pi && pi --version'` prints a real version
- [ ] In the browser: spawn a subagent from the agent, confirm the new child appears in the sidebar without a refresh
- [ ] In the browser: open a child session, then delete its parent, confirm the child vanishes from the sidebar AND its chat view doesn't error out with stale state
- [ ] In two tabs: same scenario across tabs to confirm the cross-tab refetch path