### PR TITLE
chore(deps): suppress Docker Node major bumps that cross to non-LTS lines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,23 @@ updates:
     commit-message:
       prefix: "chore(docker)"
       include: "scope"
+    ignore:
+      # Pin the Docker base image to the current LTS major. Dependabot
+      # still surfaces patch / minor bumps within the LTS line (which
+      # we want — security fixes), but suppresses cross-major bumps
+      # that would jump to an odd-numbered "current" Node line (23,
+      # 25, 27, ...) before it stabilizes as the next LTS.
+      #
+      # Node's release cadence ships odd-numbered current lines that
+      # aren't supported long-term, plus even-numbered LTS lines (22,
+      # 24, 26, ...). Auto-bumping to a current line trades one
+      # known-good Node for an unsupported one, and we hit exactly
+      # that class of pain with the 22.22.2 bundled-npm regression
+      # (release.yml had to pin 22.22.1 mid-flight).
+      #
+      # Re-evaluate when 24 reaches Active LTS (April 2027) and we're
+      # ready to migrate. Update this rule + cut a manual upgrade PR
+      # rather than letting Dependabot drive the bump.
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Summary

- Pin the Docker base image to the current LTS major (Node 22) by ignoring `version-update:semver-major` for the `node` dependency under the docker package-manager.
- Dependabot keeps surfacing patch / minor bumps within the LTS line (still want those for security fixes); it just stops opening PRs that jump to odd-numbered current lines (23, 25, 27, ...) which aren't supported long-term.
- Closes #41 (Node 22 → 26 bump). Re-open manually when Node 24 reaches Active LTS in April 2027.

## Why

Node's release cadence interleaves even-numbered LTS lines (22, 24, 26, ...) with odd-numbered current lines (23, 25, 27, ...). Auto-bumping to a current line trades one known-good Node for an unsupported one. We hit exactly that class of breakage with the 22.22.2 bundled-npm regression — `release.yml` had to pin 22.22.1 mid-flight (#58, nodejs/node#62425, actions/runner-images#13883). The same risk applies to the runtime image.

## Test plan

- [ ] Confirm dependabot.yml passes `dependabot-fetcher`'s schema validation (Dependabot will silently log a parse error if it doesn't, surfaced in the repo's Insights → Dependency graph → Dependabot tab)
- [ ] After merge, close #41 with a comment pointing here
- [ ] Confirm Dependabot doesn't re-open the Node 22→26 bump on its next weekly run