### PR TITLE
revert(deps): downgrade @xterm/xterm 6.0.0 → 5.5.0 + suppress major-bumps until addons stable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,25 @@ updates:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
       include: "scope"
+    ignore:
+      # Suppress @xterm/xterm major bumps until the satellite addon
+      # ecosystem catches up. As of writing, `@xterm/xterm@6` is
+      # stable but `@xterm/addon-fit` and `@xterm/addon-web-links`
+      # only have `0.12.0-beta.X` releases that match v6 — their
+      # current stable lines (0.10 / 0.11) peer-dep `@xterm/xterm@^5`.
+      # Auto-bumping xterm alone (as #49 did) leaves a peer-dep
+      # mismatch that soft-passes on existing lockfiles but breaks
+      # `npm ci` / Docker rebuilds with strict resolution.
+      #
+      # Re-evaluate periodically with:
+      #   npm view @xterm/addon-fit versions --json     | jq '. | map(select(test("^0\\.12\\.[0-9]+$")))'
+      #   npm view @xterm/addon-web-links versions --json | jq '. | map(select(test("^0\\.13\\.[0-9]+$")))'
+      # When both have a non-beta release, drop this rule and cut a
+      # coordinated `@xterm/*` upgrade PR (xterm + both addons in
+      # lockstep).
+      - dependency-name: "@xterm/xterm"
+        update-types:
+          - "version-update:semver-major"
 
   # ----- GitHub Actions (.github/workflows/*.yml) -----
   - package-ecosystem: "github-actions"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16939,7 +16939,7 @@
         "@codemirror/theme-one-dark": "^6.1.2",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",
-        "@xterm/xterm": "^6.0.0",
+        "@xterm/xterm": "^5.5.0",
         "codemirror": "^6.0.1",
         "hash-wasm": "^4.12.0",
         "lucide-react": "^1.14.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -23,7 +23,7 @@
     "@codemirror/theme-one-dark": "^6.1.2",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
-    "@xterm/xterm": "^6.0.0",
+    "@xterm/xterm": "^5.5.0",
     "codemirror": "^6.0.1",
     "hash-wasm": "^4.12.0",
     "lucide-react": "^1.14.0",


### PR DESCRIPTION
## Summary

Two atomic commits:

1. **Reverts `@xterm/xterm` 6.0.0 → 5.5.0** (the bump from #49). xterm v6 is stable but the satellite addon suite hasn't caught up — `@xterm/addon-fit` and `@xterm/addon-web-links` peer-dep `@xterm/xterm@^5` on their current stable lines (0.10 / 0.11). Their next major (0.12) only has `0.12.0-beta.X` releases that match v6.
2. **Adds a `dependabot.yml` ignore rule** so Dependabot's next weekly run doesn't re-open the same broken bump. Same shape as the Node major ignore (#61).

## Why

xterm v6 install soft-passed on existing lockfiles (npm logs the peer-dep mismatch as a warning when the lockfile already pinned everything through). But:

- Fresh `npm ci` in CI / Docker rebuilds / new clones fails strict peer-dep resolution without `--legacy-peer-deps`.
- Runtime contract between xterm core and its addons isn't guaranteed across the major boundary; we'd be running addon-fit@0.10 (built against xterm 5) inside an xterm 6 host.

## Re-evaluation

Periodic check whenever you remember:
```sh
npm view @xterm/addon-fit versions --json     | jq '. | map(select(test("^0\\.12\\.[0-9]+$")))'
npm view @xterm/addon-web-links versions --json | jq '. | map(select(test("^0\\.13\\.[0-9]+$")))'
```
When both arrays have a non-beta result, drop the ignore rule and cut a coordinated `@xterm/*` upgrade PR that bumps all three in lockstep.

## Test plan

- [x] `npm install` clean, no peer-dep warnings on xterm
- [x] `npm run check` clean
- [x] `npm run build` clean
- [x] `npm run test:ci` — all 23 tests pass (`test-pty-reattach` flaked once under parallel load but passes when run isolated; pre-existing, unrelated to xterm version)
- [ ] Reviewer confirms terminal still renders + functions in browser after pulling

Pairs with #68 — both are reverts of #45/#49 npm-major bumps that broke peer-dep / dev-mode contracts. After both land, run the new dev-server boot-and-fetch verification on main to confirm the toolchain is fully restored.