### PR TITLE
fix(deps): dedupe @xterm/xterm to drop stale workspace-local v6 install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6762,8 +6762,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -17158,15 +17157,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "packages/client/node_modules/@xterm/xterm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
-      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
-      "license": "MIT",
-      "workspaces": [
-        "addons/*"
-      ]
     },
     "packages/client/node_modules/esbuild": {
       "version": "0.25.12",


### PR DESCRIPTION
## Summary

Follow-up to #69. The xterm package.json revert landed correctly, but the lockfile retained a stale `packages/client/node_modules/@xterm/xterm@6.0.0` entry from the pre-revert state. npm install respected both lockfile entries, so two copies of xterm ended up on disk simultaneously:

```
./node_modules/@xterm/xterm                  → 5.5.0  (root, hoisted)
./packages/client/node_modules/@xterm/xterm  → 6.0.0  (workspace-local)
```

Node's module resolution walks up from the importer, so the client's `import { Terminal } from "@xterm/xterm"` resolved to the **closer** v6 — while the addons (`addon-fit@0.10`, `addon-web-links@0.11`) were still v5-shaped.

This produced a runtime crash on terminal mount in dev:

```
pi-forge: render crash
can't access property "scrollBarWidth", e2.viewport is undefined
```

`addon-fit`'s `proposeDimensions` reaches into xterm's internal `_viewport.scrollBarWidth` — which xterm v6 renamed/restructured.

## Fix

Single command: `npm install @xterm/xterm@^5.5.0 -w @pi-forge/client`. That forces npm to reconcile the two lockfile entries against `package.json`'s `^5.5.0` constraint, collapsing the workspace-local copy. Result:

- Lockfile has one xterm entry: `node_modules/@xterm/xterm@5.5.0`
- Disk has one xterm copy at the root, hoisted
- Client resolves to it (no closer copy to override)

## Test plan

- [x] `npm ls @xterm/xterm` shows a single entry
- [x] `find . -name "package.json" | xargs grep "@xterm/xterm"` confirms one on-disk copy
- [x] `npm run check` clean
- [x] `npm run build` clean
- [x] `npm run test:ci` — 23/23 (`test-pty-reattach` flakes occasionally under parallel load; passes when run isolated; pre-existing)
- [x] `npx vite` boots clean, `/src/main.tsx` returns 200, no vite errors
- [ ] Reviewer confirms terminal panel renders without the `scrollBarWidth` crash after pulling

## Why not just delete the lockfile?

A full `rm -rf node_modules package-lock.json && npm install` would fix this but produces a thousand-line lockfile diff that's hard to review. The workspace-targeted reinstall makes the surgical change npm needed (drop the stale duplicate) without touching anything else.

## Why this happened

`#69` was made via package.json edit + `npm install` (not `npm uninstall + install`). For workspace deps with stale lockfile entries, that pattern can leave the lockfile in a half-reconciled state. **Going forward, the verification protocol in `notes/DEPENDABOT.md` should add a `npm ls <pkg>` step after any version revert** to confirm the lockfile fully cascaded — I'll add that as a separate note.