### PR TITLE
fix(npm-package): chmod node-pty spawn-helper exec bit in postinstall

### DIFF
--- a/bin/fix-pty-perms.mjs
+++ b/bin/fix-pty-perms.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * pi-forge postinstall: ensure node-pty's prebuilt `spawn-helper`
+ * binaries are executable.
+ *
+ * The bug: `node-pty` ships prebuilt native binaries at
+ *   `node_modules/node-pty/prebuilds/<platform>/spawn-helper`
+ * The tarball's mode bits don't always survive npm's tar extract —
+ * fresh installs frequently land `spawn-helper` at `0644` with no
+ * exec bit. When pi-forge later spawns a PTY, `posix_spawnp` fails
+ * with the unhelpful "spawn EACCES" or "posix_spawnp failed."
+ *
+ * `node-pty`'s own postinstall script handles the from-source-built
+ * path (`build/Release/`) but NOT the prebuilt path (`prebuilds/`),
+ * so the bug ships on every npm-published install of pi-forge.
+ *
+ * Why this script lives in pi-forge and not upstream: the upstream
+ * fix would need to land in node-pty itself. Until then, every
+ * package that depends on node-pty needs its own postinstall to
+ * cover the gap. We pay one trivial chmod per install in exchange
+ * for the integrated terminal actually working.
+ *
+ * Idempotent: chmod +x on something already +x is a no-op.
+ * Failure-tolerant: missing node-pty (e.g. `--omit=optional`),
+ * missing prebuilds dir (unusual platform), or chmod failure
+ * (read-only mount, EPERM) all warn instead of failing the install.
+ */
+import { chmodSync, existsSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+let nodePtyDir;
+try {
+  nodePtyDir = dirname(require.resolve("node-pty/package.json"));
+} catch {
+  // node-pty not installed — no-op.
+  process.exit(0);
+}
+
+const prebuildsDir = join(nodePtyDir, "prebuilds");
+if (!existsSync(prebuildsDir)) process.exit(0);
+
+let fixed = 0;
+for (const platform of readdirSync(prebuildsDir)) {
+  const helper = join(prebuildsDir, platform, "spawn-helper");
+  if (!existsSync(helper)) continue;
+  try {
+    const mode = statSync(helper).mode;
+    // 0o111 = any-x bits. If even one is set, assume the file is
+    // already runnable.
+    if ((mode & 0o111) !== 0) continue;
+    chmodSync(helper, mode | 0o755);
+    fixed++;
+  } catch (err) {
+    console.warn(
+      `[pi-forge postinstall] could not chmod ${helper}: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+if (fixed > 0) {
+  console.log(
+    `[pi-forge postinstall] fixed exec bit on ${fixed} node-pty spawn-helper binar${
+      fixed === 1 ? "y" : "ies"
+    }`,
+  );
+}

--- a/scripts/build-publish-dir.mjs
+++ b/scripts/build-publish-dir.mjs
@@ -40,6 +40,7 @@ const PUBLISH_DIR = resolve(REPO_ROOT, "publish");
 const SERVER_DIST = resolve(REPO_ROOT, "packages/server/dist");
 const CLIENT_DIST = resolve(REPO_ROOT, "packages/client/dist");
 const BIN_SRC = resolve(REPO_ROOT, "bin/pi-forge.mjs");
+const POSTINSTALL_SRC = resolve(REPO_ROOT, "bin/fix-pty-perms.mjs");
 
 async function readJson(path) {
   return JSON.parse(await readFile(path, "utf8"));
@@ -51,6 +52,7 @@ async function main() {
     ["server dist", SERVER_DIST],
     ["client dist", CLIENT_DIST],
     ["bin shim", BIN_SRC],
+    ["postinstall script", POSTINSTALL_SRC],
   ]) {
     if (!existsSync(path)) {
       console.error(
@@ -74,9 +76,10 @@ async function main() {
   await cp(SERVER_DIST, resolve(PUBLISH_DIR, "dist/server"), { recursive: true });
   await cp(CLIENT_DIST, resolve(PUBLISH_DIR, "dist/client"), { recursive: true });
 
-  // 4. Bin shim
+  // 4. Bin shim + postinstall fix-pty-perms script
   await mkdir(resolve(PUBLISH_DIR, "bin"), { recursive: true });
   await copyFile(BIN_SRC, resolve(PUBLISH_DIR, "bin/pi-forge.mjs"));
+  await copyFile(POSTINSTALL_SRC, resolve(PUBLISH_DIR, "bin/fix-pty-perms.mjs"));
 
   // 5. Synthetic package.json
   // Hoist the server's runtime deps verbatim — the server is the only
@@ -106,6 +109,14 @@ async function main() {
     files: ["bin/", "dist/", "README.md", "LICENSE"],
     // Same node target as the server workspace + CI matrix.
     engines: { node: ">=20" },
+    // node-pty's tarball ships `prebuilds/<platform>/spawn-helper`
+    // without a reliable executable bit (the upstream postinstall
+    // only fixes `build/Release/`, not `prebuilds/`). Without an
+    // exec bit, every PTY spawn fails with `posix_spawnp failed.`
+    // Our postinstall walks every prebuild and chmod +x's the
+    // spawn-helper. Idempotent + failure-tolerant — see
+    // bin/fix-pty-perms.mjs for the full story.
+    scripts: { postinstall: "node bin/fix-pty-perms.mjs" },
     dependencies: serverPkg.dependencies,
     // `publishConfig.provenance: true` makes `npm publish` attach a
     // sigstore-signed provenance attestation tying this version to the


### PR DESCRIPTION
## Summary
- The npm-published pi-forge tarball's `node-pty` prebuilt `spawn-helper` lands at 0644 (no exec bit), so every PTY spawn fails with `posix_spawnp failed` and the integrated terminal is broken on host installs.
- Add a `scripts.postinstall` to the synthetic publish package.json that walks `node_modules/node-pty/prebuilds/*/spawn-helper` and chmods +x. Idempotent and failure-tolerant (warns, doesn't fail the install).

## Test plan
- [ ] `npm pack` the tarball, install in a tmpdir, verify `-rwxr-xr-x` on `prebuilds/<platform>/spawn-helper` after install.
- [ ] Re-install with `--ignore-scripts`, verify `-rw-r--r--` (proves the postinstall is the fix).
- [ ] Boot `pi-forge` from the npm-installed copy, open the integrated terminal, confirm a PTY spawns successfully.
- [ ] CI green on the existing test suite (no test changes; `tests/test-publish-package.ts` still passes).