### PR TITLE
fix(server): resolve correct version for npm-published flat layout + add npm install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ diffs, all from one tab.
 
 ## Quick start
 
+Two install paths depending on how you want to run it.
+
+### Docker (recommended for ongoing use)
+
 ```bash
 git clone https://github.com/Devin-Marks/pi-forge.git
 cd pi-forge
@@ -56,12 +60,30 @@ cp docker/.env.example docker/.env       # edit auth + paths if you want
 cd docker && docker compose up -d --build
 ```
 
-Open <http://localhost:3000>. Add a project (point at a folder under
-`WORKSPACE_PATH`), drop a provider API key into Settings, and start a
-session.
+### npm (no Docker, runs from your shell)
 
-For non-Docker workflows, production deploys, Kubernetes, and configuration
-details, follow the links in [Documentation](#documentation) below.
+```bash
+# One-shot, ephemeral — npx caches and you can wipe with `rm -rf ~/.npm/_npx`:
+npx pi-forge
+
+# Or install globally:
+npm install -g pi-forge
+pi-forge
+```
+
+By default pi-forge listens on `http://localhost:3000`, reads provider config
+from `~/.pi/agent/` (shared with the host `pi` CLI if you have one), and
+stores its own state in `~/.pi-forge/`. Override with `PORT`, `PI_CONFIG_DIR`,
+`FORGE_DATA_DIR`, `WORKSPACE_PATH` env vars — see
+[`docs/configuration.md`](./docs/configuration.md).
+
+Either way: open the listed URL, add a project (point at a folder under
+`WORKSPACE_PATH`), drop a provider API key into Settings, and start a session.
+
+For source builds and a development setup, see
+[`CONTRIBUTING.md`](./CONTRIBUTING.md). For production deploys, Kubernetes,
+and the rest of the docs, follow the links in
+[Documentation](#documentation) below.
 
 ## Features
 

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -9,21 +9,45 @@ import { config, passwordAuthEnabled } from "../config.js";
 /**
  * Read the server's own package.json once at module load. Used by the
  * /ui-config response so the browser can render an "About" footer
- * with the deployed version. Resolves relative to the compiled
- * server file (`packages/server/dist/routes/health.js`) — three
- * `../` to reach the package root regardless of whether this runs
- * from `dist/` (production) or `src/` (tsx watch dev mode).
+ * with the deployed version.
+ *
+ * The published artifact layouts to handle:
+ *   - In-repo dev (tsx watch from src/): code lives at
+ *     `packages/server/src/routes/health.ts`. Up-two = `packages/server/`.
+ *   - In-repo built (dist/): code lives at
+ *     `packages/server/dist/routes/health.js`. Up-two = `packages/server/`.
+ *   - Docker image (built): code lives at
+ *     `/app/packages/server/dist/routes/health.js`. Up-two =
+ *     `/app/packages/server/`.
+ *   - npm publish (flat): the synthetic publish dir flattens both
+ *     workspaces under `dist/`, so code lives at
+ *     `<install>/dist/server/routes/health.js`. Up-two would be
+ *     `<install>/dist/` — which has NO package.json. Up-three is
+ *     `<install>/` which has the synthetic `package.json` carrying
+ *     the right version.
+ *
+ * v1.1.4 shipped with only the up-two probe and surfaced "0.0.0" in
+ * the About panel for npm-installed users. We now try up-two first
+ * (preserves the workspace package.json's authority for in-repo and
+ * Docker), then up-three (catches the published flat layout). First
+ * resolvable hit wins; if neither hits, fall back to "0.0.0".
  */
 const SERVER_VERSION: string = (() => {
-  try {
-    const here = dirname(fileURLToPath(import.meta.url));
-    const pkgPath = join(here, "..", "..", "package.json");
-    const raw = readFileSync(pkgPath, "utf8");
-    const parsed = JSON.parse(raw) as { version?: unknown };
-    return typeof parsed.version === "string" ? parsed.version : "0.0.0";
-  } catch {
-    return "0.0.0";
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, "..", "..", "package.json"), // workspace / Docker
+    join(here, "..", "..", "..", "package.json"), // npm publish (flat layout)
+  ];
+  for (const pkgPath of candidates) {
+    try {
+      const raw = readFileSync(pkgPath, "utf8");
+      const parsed = JSON.parse(raw) as { version?: unknown };
+      if (typeof parsed.version === "string") return parsed.version;
+    } catch {
+      // Try the next candidate.
+    }
   }
+  return "0.0.0";
 })();
 
 export const healthRoutes: FastifyPluginAsync = async (fastify) => {


### PR DESCRIPTION
## Summary
- About panel and `/api/v1/ui-config` showed `0.0.0` on freshly-installed `pi-forge@1.1.4`. `health.ts`'s `SERVER_VERSION` walks up exactly two levels from `routes/health.js` to find package.json — works for in-repo + Docker layouts, but the npm-publish synthetic flat layout puts the code at `<install>/dist/server/routes/health.js` where up-two has no package.json. Fix: try up-two first (workspace + Docker authority), then up-three (publish flat layout). First resolvable hit wins.
- README's Quick start only documented Docker. Added `npx pi-forge` / `npm i -g pi-forge` paths alongside Docker, plus a cross-link to `docs/configuration.md` for env var overrides. Source-build instructions stay in `CONTRIBUTING.md`.

## Test plan
- [ ] Probe both layouts in isolation (workspace `1.2.3-workspace` + npm flat `9.8.7-npm` + orphan `0.0.0` fallback).
- [ ] Live `npx tsx packages/server/src/index.ts` + `curl /ui-config` returns `"version":"1.1.4"` (workspace-layout regression).
- [ ] Build the npm tarball, install in tmpdir, confirm `/ui-config` returns the package's actual version.
- [ ] Render README on GitHub, confirm the npm install path is visible in Quick start.