### PR TITLE
feat(chat): support folder @-references with aggregate-byte budget

### DIFF
--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -365,13 +365,27 @@ export async function listAllFiles(rootPath: string): Promise<string[]> {
   return out;
 }
 
+/**
+ * Recursive walk that emits BOTH files and directories. Directories
+ * are emitted with a trailing `/` so the chat input's `@` autocomplete
+ * (and any other consumer) can tell them apart at a glance — same
+ * convention as `ls -F`. Files have no trailing slash. The
+ * skip-list (`node_modules`, `.git`, etc.) still applies — those
+ * dirs aren't emitted nor descended into.
+ */
 async function walkFlat(dir: string, root: string, relPath: string, out: string[]): Promise<void> {
   const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
   for (const entry of entries) {
     const name = entry.name;
     if (entry.isDirectory()) {
       if (TREE_SKIP_DIRS.has(name)) continue;
-      await walkFlat(join(dir, name), root, relPath === "" ? name : `${relPath}/${name}`, out);
+      const dirRel = relPath === "" ? name : `${relPath}/${name}`;
+      // Emit the directory itself (with trailing `/`) so chat
+      // `@`-autocomplete can offer folder references that the LLM
+      // explores via its read/grep/find tools — see
+      // `expandFileReferences` for the directory-marker handling.
+      out.push(`${dirRel}/`);
+      await walkFlat(join(dir, name), root, dirRel, out);
     } else if (entry.isFile()) {
       out.push(relPath === "" ? name : `${relPath}/${name}`);
     }
@@ -414,22 +428,27 @@ function looksBinary(buf: Buffer): boolean {
 /**
  * Lightweight existence + safety + binary-sniff for `@<path>` chat
  * references. Doesn't read the whole file — just verifies the path is
- * safe, stats it, and peeks the first 8 KB for the binary heuristic.
+ * safe, stats it, and (for files) peeks the first 8 KB for the binary
+ * heuristic.
  *
  * Used by `expandFileReferences` so we can leave a literal `@<path>`
  * marker in the prompt (the model handles loading content via its
- * read tool) without burning the read on attestable text files of
- * any size.
+ * read/ls/find tools) without burning the read on attestable text
+ * files of any size.
  *
- * Throws the same error classes as `readFile` (PathOutsideRootError,
- * NotFoundError, NotAFileError) so the caller's existing error
- * handling applies.
+ * Returns a discriminated kind so `expandFileReferences` can branch
+ * on file-vs-directory. Directories no longer throw — they were
+ * previously rejected (`NotAFileError` → "path is a directory"
+ * error message), but the model already has tools for exploring
+ * directory contents, so passing the path through as a literal
+ * marker is more useful.
+ *
+ * Still throws PathOutsideRootError / NotFoundError for anything
+ * that isn't a regular file or directory under the root.
  */
-export interface ReferenceCheckResult {
-  path: string;
-  size: number;
-  binary: boolean;
-}
+export type ReferenceCheckResult =
+  | { kind: "file"; path: string; size: number; binary: boolean }
+  | { kind: "directory"; path: string };
 
 export async function checkFileReference(
   absPath: string,
@@ -438,6 +457,9 @@ export async function checkFileReference(
   const resolved = await verifyPathSafe(absPath, root);
   const st = await stat(resolved).catch(() => undefined);
   if (st === undefined) throw new NotFoundError(resolved);
+  if (st.isDirectory()) {
+    return { kind: "directory", path: resolved };
+  }
   if (!st.isFile()) throw new NotAFileError(resolved);
   // Real partial read — open the file and read just the first 8 KB
   // for the NUL-byte heuristic. Avoids slurping the whole file just
@@ -447,6 +469,7 @@ export async function checkFileReference(
     const buf = Buffer.alloc(8000);
     const { bytesRead } = await fh.read(buf, 0, 8000, 0);
     return {
+      kind: "file",
       path: resolved,
       size: st.size,
       binary: looksBinary(buf.subarray(0, bytesRead)),

--- a/packages/server/src/file-references.ts
+++ b/packages/server/src/file-references.ts
@@ -40,17 +40,39 @@ import { checkFileReference, readFile } from "./file-manager.js";
  *                  with `[@<path> not included: <reason>]` so neither
  *                  user nor model is left guessing.
  *
- * Multiple markers in one prompt all process independently.
+ * Multiple markers in one prompt are classified independently, then
+ * inline candidates compete for a shared aggregate budget. See
+ * `AGGREGATE_INLINE_BUDGET_BYTES` for the cap and the smallest-first
+ * walk that keeps the degradation graceful.
  */
 
 /**
- * Inlining cutoff. Files at or under this byte count are inlined as
- * fenced blocks; larger files are left as `@<path>` for the model to
- * fetch. 128 KB is roughly 32K tokens — small enough to be safe in a
- * 200K-token context window and large enough to cover most real
- * source files (a 1k-line TS file is typically ~50 KB).
+ * Per-file inlining cutoff. Files at or under this byte count are
+ * eligible for inlining; larger files are left as `@<path>` for the
+ * model to fetch. 128 KB is roughly 32K tokens — small enough to be
+ * safe in a 200K-token context window and large enough to cover most
+ * real source files (a 1k-line TS file is typically ~50 KB).
  */
 const INLINE_THRESHOLD_BYTES = 128 * 1024;
+
+/**
+ * Aggregate cap on TOTAL bytes inlined across every `@<path>` in a
+ * single prompt. Without this, a user `@`-ing 50 mid-sized files
+ * (each well under the per-file cap) could push 5+ MB into a single
+ * prompt and blow the model's context window. 512 KB ≈ 128K tokens,
+ * which leaves comfortable headroom for the user's prose, the system
+ * prompt, the model's response, and tool round-trips inside a 200K
+ * context window.
+ *
+ * Files that would push the running total over this cap fall back to
+ * `defer` (the model can still load them via its read tool on demand).
+ * We process candidates in ascending size order so the smallest /
+ * cheapest files inline first — graceful degradation: a 2 KB
+ * package.json + a 90 KB README both inline, and the 50th mid-sized
+ * file is the one that defers, not whichever happened to be parsed
+ * first in the user's text.
+ */
+const AGGREGATE_INLINE_BUDGET_BYTES = 512 * 1024;
 
 /**
  * Regex shared by `findRefs` and `parseFileReferences`. Match `@` at
@@ -104,37 +126,32 @@ export async function expandFileReferences(text: string, workspacePath: string):
   const matches = findRefs(text);
   if (matches.length === 0) return text;
 
-  type Outcome =
-    | { kind: "inline"; text: string }
-    | { kind: "defer" }
+  /**
+   * Per-marker decision after the cheap path-safety + stat + binary
+   * sniff. `inlineCandidate` is the only kind whose outcome depends on
+   * the aggregate budget; the other kinds are fixed at this stage.
+   */
+  type Classification =
+    | { kind: "inlineCandidate"; size: number; abs: string }
+    | { kind: "deferLarge" }
     | { kind: "directory" }
     | { kind: "error"; reason: string };
 
-  const outcomes: Outcome[] = await Promise.all(
-    matches.map(async (mm): Promise<Outcome> => {
+  // Phase 1: classify every marker in parallel. Cheap — `checkFileReference`
+  // does a path-safety check + a stat + an 8 KB binary sniff. No content
+  // reads here, so there's no point doing the budget walk later if all
+  // we've spent is a few stats.
+  const classifications: Classification[] = await Promise.all(
+    matches.map(async (mm): Promise<Classification> => {
       try {
         const abs = join(workspacePath, mm.path);
-        // Cheap up-front check (path safety + stat + 8 KB sniff for
-        // files) so we can decide outcome without reading large files.
         const check = await checkFileReference(abs, workspacePath);
         if (check.kind === "directory") return { kind: "directory" };
         if (check.binary) return { kind: "error", reason: "binary file" };
-        if (check.size > INLINE_THRESHOLD_BYTES) return { kind: "defer" };
-        // Small enough to inline — read the whole file and emit a
-        // fenced block.
-        const result = await readFile(abs, workspacePath);
-        if (result.binary) return { kind: "error", reason: "binary file" };
-        return { kind: "inline", text: formatExpansion(mm.path, result.content) };
+        if (check.size > INLINE_THRESHOLD_BYTES) return { kind: "deferLarge" };
+        return { kind: "inlineCandidate", size: check.size, abs };
       } catch (err) {
         const e = err as Error & { code?: string };
-        if (e.name === "FileTooLargeError") {
-          // readFile's own 5 MB cap fired — defer to model tool use.
-          // Shouldn't normally hit this since the size-check above
-          // catches anything bigger than INLINE_THRESHOLD_BYTES, but
-          // belt-and-suspenders for cases where the file grew between
-          // check and read.
-          return { kind: "defer" };
-        }
         if (e.name === "NotFoundError" || e.code === "ENOENT") {
           return { kind: "error", reason: "file not found" };
         }
@@ -146,6 +163,72 @@ export async function expandFileReferences(text: string, workspacePath: string):
         // explicitly via the directory outcome above.
         if (e.name === "NotAFileError") {
           return { kind: "error", reason: "path is not a regular file or directory" };
+        }
+        return { kind: "error", reason: "unreadable" };
+      }
+    }),
+  );
+
+  // Phase 2: aggregate-budget walk. Sort inline candidates ascending by
+  // size and walk until the budget runs out. Survivors get marked for
+  // inlining; the rest fall back to defer. Walking smallest-first
+  // maximises the number of useful inlines before the budget exhausts —
+  // a 2 KB `package.json` + 90 KB README both fit, and the 50th
+  // mid-sized file is the one that defers, not whichever happened to
+  // be parsed first in the user's text.
+  const inlineSet = new Set<number>();
+  const candidateIndices: { i: number; size: number }[] = [];
+  for (let i = 0; i < classifications.length; i += 1) {
+    const c = classifications[i];
+    if (c?.kind === "inlineCandidate") candidateIndices.push({ i, size: c.size });
+  }
+  candidateIndices.sort((a, b) => a.size - b.size);
+  let remaining = AGGREGATE_INLINE_BUDGET_BYTES;
+  for (const { i, size } of candidateIndices) {
+    if (size <= remaining) {
+      inlineSet.add(i);
+      remaining -= size;
+    }
+    // Else: this index falls back to defer in phase 3. We DON'T break
+    // here — a single oversized candidate still leaves room for
+    // smaller ones later in the (size-sorted) walk.
+  }
+
+  type Outcome =
+    | { kind: "inline"; text: string }
+    | { kind: "defer" }
+    | { kind: "directory" }
+    | { kind: "error"; reason: string };
+
+  // Phase 3: read content for the budget survivors, materialise the
+  // final outcomes for everything else. Index order preserved so the
+  // splice loop below can apply each outcome at its original marker
+  // position in the user's text.
+  const outcomes: Outcome[] = await Promise.all(
+    classifications.map(async (c, i): Promise<Outcome> => {
+      if (c.kind === "directory") return { kind: "directory" };
+      if (c.kind === "error") return { kind: "error", reason: c.reason };
+      if (c.kind === "deferLarge") return { kind: "defer" };
+      // c.kind === "inlineCandidate"
+      if (!inlineSet.has(i)) return { kind: "defer" };
+      try {
+        const result = await readFile(c.abs, workspacePath);
+        if (result.binary) return { kind: "error", reason: "binary file" };
+        const mm = matches[i];
+        if (mm === undefined) return { kind: "defer" };
+        return { kind: "inline", text: formatExpansion(mm.path, result.content) };
+      } catch (err) {
+        const e = err as Error & { code?: string };
+        if (e.name === "FileTooLargeError") {
+          // readFile's own 5 MB cap fired — defer to model tool use.
+          // Shouldn't normally hit this since classification already
+          // catches anything > INLINE_THRESHOLD_BYTES, but
+          // belt-and-suspenders for cases where the file grew between
+          // check and read.
+          return { kind: "defer" };
+        }
+        if (e.name === "NotFoundError" || e.code === "ENOENT") {
+          return { kind: "error", reason: "file not found" };
         }
         return { kind: "error", reason: "unreadable" };
       }

--- a/packages/server/src/file-references.ts
+++ b/packages/server/src/file-references.ts
@@ -24,14 +24,21 @@ import { checkFileReference, readFile } from "./file-manager.js";
  *     `@<path>`               — greedy non-whitespace; common case.
  *     `@"<path with spaces>"` — anything that isn't a `"` or newline.
  * - Resolved against the project's workspace root via file-manager's
- *   path-traversal-safe `checkFileReference`. Three outcomes:
- *     inline  → file ≤ INLINE_THRESHOLD; replace marker with a fenced
- *                code block. Language hint derived from extension.
- *     defer   → file > INLINE_THRESHOLD; leave the literal `@<path>`
- *                reference for the model to load on demand.
- *     error   → missing / outside root / directory / binary. Replace
- *                marker with `[@<path> not included: <reason>]` so
- *                neither user nor model is left guessing.
+ *   path-traversal-safe `checkFileReference`. Four outcomes:
+ *     inline    → file ≤ INLINE_THRESHOLD; replace marker with a
+ *                  fenced code block. Language hint derived from
+ *                  extension.
+ *     defer     → file > INLINE_THRESHOLD; leave the literal `@<path>`
+ *                  reference for the model to load on demand.
+ *     directory → path is a directory; preserve the marker normalized
+ *                  with a trailing `/` (e.g. `@src/components/`) so
+ *                  the model can ls/find/grep it via its tools. We
+ *                  intentionally do NOT bulk-embed directory contents
+ *                  — large dirs would blow the context window, and
+ *                  the model has cheap tools to explore on demand.
+ *     error     → missing / outside root / binary. Replace marker
+ *                  with `[@<path> not included: <reason>]` so neither
+ *                  user nor model is left guessing.
  *
  * Multiple markers in one prompt all process independently.
  */
@@ -100,15 +107,17 @@ export async function expandFileReferences(text: string, workspacePath: string):
   type Outcome =
     | { kind: "inline"; text: string }
     | { kind: "defer" }
+    | { kind: "directory" }
     | { kind: "error"; reason: string };
 
   const outcomes: Outcome[] = await Promise.all(
     matches.map(async (mm): Promise<Outcome> => {
       try {
         const abs = join(workspacePath, mm.path);
-        // Cheap up-front check (path safety + stat + 8 KB sniff) so we
-        // can decide inline-vs-defer without reading large files.
+        // Cheap up-front check (path safety + stat + 8 KB sniff for
+        // files) so we can decide outcome without reading large files.
         const check = await checkFileReference(abs, workspacePath);
+        if (check.kind === "directory") return { kind: "directory" };
         if (check.binary) return { kind: "error", reason: "binary file" };
         if (check.size > INLINE_THRESHOLD_BYTES) return { kind: "defer" };
         // Small enough to inline — read the whole file and emit a
@@ -132,8 +141,11 @@ export async function expandFileReferences(text: string, workspacePath: string):
         if (e.name === "PathOutsideRootError") {
           return { kind: "error", reason: "path is outside the project root" };
         }
+        // NotAFileError now only fires for non-regular non-directory
+        // entries (sockets, devices, etc.) — directories are handled
+        // explicitly via the directory outcome above.
         if (e.name === "NotAFileError") {
-          return { kind: "error", reason: "path is a directory, not a file" };
+          return { kind: "error", reason: "path is not a regular file or directory" };
         }
         return { kind: "error", reason: "unreadable" };
       }
@@ -158,6 +170,14 @@ export async function expandFileReferences(text: string, workspacePath: string):
       out = `${before}${marker}\n${outcome.text}\n${after}`;
     } else if (outcome.kind === "defer") {
       out = `${before}${marker}${after}`;
+    } else if (outcome.kind === "directory") {
+      // Normalize the directory marker to end with `/` so the model
+      // can tell file vs folder at a glance — same convention as
+      // `ls -F`. If the user already typed the trailing slash we
+      // keep their form; otherwise we append one.
+      const dirPath = mm.path.endsWith("/") ? mm.path : `${mm.path}/`;
+      const dirMarker = /\s/.test(dirPath) ? `@"${dirPath}"` : `@${dirPath}`;
+      out = `${before}${dirMarker}${after}`;
     } else {
       out = `${before}[${marker} not included: ${outcome.reason}]${after}`;
     }

--- a/tests/test-folder-references.ts
+++ b/tests/test-folder-references.ts
@@ -1,0 +1,178 @@
+/**
+ * Folder-reference expansion test.
+ *
+ * Verifies that `@<path>` markers resolving to a directory are
+ * preserved in the prompt as `@<path>/` (defer to model tool use)
+ * rather than rejected as errors. Covers:
+ *
+ *   - Directory marker preserved with trailing `/` appended
+ *   - Existing trailing `/` from user input is kept (not doubled)
+ *   - Quoted form `@"path with spaces"` works for directories too
+ *   - Non-existent path still becomes `[@<path> not included: ...]`
+ *   - File markers (small + large + binary) keep their existing
+ *     behaviour — regression guard
+ *   - listAllFiles output now includes directories with trailing `/`
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`  PASS  ${label}`);
+  } else {
+    console.log(`  FAIL  ${label}${detail !== undefined ? `  (${detail})` : ""}`);
+    failures++;
+  }
+}
+
+interface FileRefs {
+  expandFileReferences: (text: string, workspacePath: string) => Promise<string>;
+}
+
+interface FileMgr {
+  listAllFiles: (rootPath: string) => Promise<string[]>;
+}
+
+async function main(): Promise<void> {
+  const workspace = await mkdtemp(join(tmpdir(), "pi-forge-folderref-"));
+
+  // Set up a workspace tree:
+  //   src/
+  //     components/
+  //       Button.tsx       (small, will inline)
+  //     index.ts           (small, will inline)
+  //   docs with spaces/    (directory with whitespace in name)
+  //     readme.md
+  //   big.txt              (>128 KB, will defer)
+  await mkdir(join(workspace, "src", "components"), { recursive: true });
+  await mkdir(join(workspace, "docs with spaces"), { recursive: true });
+  await writeFile(join(workspace, "src", "index.ts"), "export const x = 1;\n");
+  await writeFile(
+    join(workspace, "src", "components", "Button.tsx"),
+    "export const Button = () => null;\n",
+  );
+  await writeFile(join(workspace, "docs with spaces", "readme.md"), "# Readme\n");
+  await writeFile(join(workspace, "big.txt"), "x".repeat(150 * 1024));
+
+  const fr = (await import(
+    resolve(REPO_ROOT, "packages/server/dist/file-references.js")
+  )) as unknown as FileRefs;
+  const fm = (await import(
+    resolve(REPO_ROOT, "packages/server/dist/file-manager.js")
+  )) as unknown as FileMgr;
+
+  try {
+    // ---- expandFileReferences with directory markers ----
+
+    // 1. Bare directory reference — should normalize to `@src/`
+    {
+      const out = await fr.expandFileReferences("review @src for cleanups", workspace);
+      assert(
+        "bare directory `@src` is preserved with trailing slash appended",
+        out === "review @src/ for cleanups",
+        `got: ${JSON.stringify(out)}`,
+      );
+    }
+
+    // 2. User-typed trailing slash — should NOT double it
+    {
+      const out = await fr.expandFileReferences("review @src/ for cleanups", workspace);
+      assert(
+        "directory `@src/` (user-typed slash) is preserved as-is",
+        out === "review @src/ for cleanups",
+        `got: ${JSON.stringify(out)}`,
+      );
+    }
+
+    // 3. Nested directory
+    {
+      const out = await fr.expandFileReferences("look at @src/components closely", workspace);
+      assert(
+        "nested directory `@src/components` becomes `@src/components/`",
+        out === "look at @src/components/ closely",
+        `got: ${JSON.stringify(out)}`,
+      );
+    }
+
+    // 4. Quoted path with spaces resolving to a directory
+    {
+      const out = await fr.expandFileReferences(`peek at @"docs with spaces" please`, workspace);
+      assert(
+        "quoted directory marker preserved + slash appended",
+        out === `peek at @"docs with spaces/" please`,
+        `got: ${JSON.stringify(out)}`,
+      );
+    }
+
+    // 5. Non-existent path still errors out cleanly
+    {
+      const out = await fr.expandFileReferences("missing @nope", workspace);
+      assert(
+        "missing path produces `[@nope not included: ...]`",
+        out.includes("[@nope not included") && out.includes("not found"),
+        `got: ${JSON.stringify(out)}`,
+      );
+    }
+
+    // ---- regression: file behaviour unchanged ----
+
+    // 6. Small file still inlines as fenced block + preserves marker
+    {
+      const out = await fr.expandFileReferences("ts: @src/index.ts", workspace);
+      assert(
+        "small file marker preserved + content inlined as fenced block",
+        out.includes("@src/index.ts\n```") && out.includes("export const x = 1;"),
+        `got: ${JSON.stringify(out)}`,
+      );
+    }
+
+    // 7. Big file defers (marker preserved, no inline content)
+    {
+      const out = await fr.expandFileReferences("see @big.txt", workspace);
+      assert(
+        "big file marker is preserved without inlining",
+        out === "see @big.txt",
+        `got: ${JSON.stringify(out)}`,
+      );
+    }
+
+    // ---- listAllFiles emits dirs with trailing `/` ----
+
+    {
+      const all = await fm.listAllFiles(workspace);
+      assert(
+        "listAllFiles includes directory entries with trailing `/`",
+        all.includes("src/") && all.includes("src/components/"),
+        `got: ${all.join(",")}`,
+      );
+      assert(
+        "listAllFiles still includes file entries without trailing `/`",
+        all.includes("src/index.ts") && all.includes("src/components/Button.tsx"),
+        `got: ${all.join(",")}`,
+      );
+      assert(
+        "listAllFiles emits the directory-with-spaces entry",
+        all.includes("docs with spaces/"),
+        `got: ${all.join(",")}`,
+      );
+    }
+  } finally {
+    await rm(workspace, { recursive: true, force: true }).catch(() => undefined);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-folder-references] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-folder-references] PASS");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/test-folder-references.ts
+++ b/tests/test-folder-references.ts
@@ -161,6 +161,78 @@ async function main(): Promise<void> {
         `got: ${all.join(",")}`,
       );
     }
+
+    // ---- aggregate-inline budget ----
+    //
+    // Six files at 100 KB each — every file is individually under the
+    // 128 KB per-file cap, but together they're 600 KB > 512 KB
+    // aggregate budget. Walk should inline the first 5 (smallest-first;
+    // identical sizes here so any 5 win) and defer the 6th.
+    {
+      const budgetWorkspace = await mkdtemp(join(tmpdir(), "pi-forge-budget-"));
+      try {
+        const oneHundredK = "x".repeat(100 * 1024);
+        for (let i = 1; i <= 6; i += 1) {
+          await writeFile(join(budgetWorkspace, `f${i}.txt`), oneHundredK);
+        }
+        const out = await fr.expandFileReferences(
+          "review @f1.txt @f2.txt @f3.txt @f4.txt @f5.txt @f6.txt please",
+          budgetWorkspace,
+        );
+        // Count how many fenced "file: fN.txt" headers appear — that's
+        // the count of inlined files. Bare markers (no fenced block)
+        // are deferred.
+        const inlinedCount = (out.match(/file: f\d\.txt/g) ?? []).length;
+        assert(
+          "5 of 6 100 KB files inline (sums to 500 KB ≤ 512 KB budget)",
+          inlinedCount === 5,
+          `got ${inlinedCount} inlined`,
+        );
+        // The deferred file appears as a bare `@fN.txt` marker without
+        // a following fenced block.
+        assert(
+          "1 of 6 100 KB files defers (running budget exhausted)",
+          // Six markers in the input. Five became `@fN.txt\n```...```\n`
+          // (marker + fence). One stayed as the bare marker. Total bare
+          // markers in output should be 1 — count by matching the
+          // marker NOT followed by a fence.
+          (out.match(/@f\d\.txt(?!\n```)/g) ?? []).length === 1,
+          `got: ${JSON.stringify(out.slice(0, 200))}…`,
+        );
+      } finally {
+        await rm(budgetWorkspace, { recursive: true, force: true }).catch(() => undefined);
+      }
+    }
+
+    // Smallest-first ordering: in a mixed-size prompt that exceeds the
+    // budget, the SMALLEST files should be the ones that inline. Three
+    // files: 1 KB, 1 KB, 600 KB. Per-file cap is 128 KB so the 600 KB
+    // file ALREADY defers (deferLarge, not budget-driven). Both 1 KB
+    // files fit comfortably and inline.
+    {
+      const orderWorkspace = await mkdtemp(join(tmpdir(), "pi-forge-budget-order-"));
+      try {
+        await writeFile(join(orderWorkspace, "tiny1.txt"), "x".repeat(1024));
+        await writeFile(join(orderWorkspace, "tiny2.txt"), "x".repeat(1024));
+        await writeFile(join(orderWorkspace, "huge.txt"), "x".repeat(600 * 1024));
+        const out = await fr.expandFileReferences(
+          "see @huge.txt @tiny1.txt @tiny2.txt",
+          orderWorkspace,
+        );
+        assert(
+          "tiny files inline regardless of position in the prompt",
+          out.includes("file: tiny1.txt") && out.includes("file: tiny2.txt"),
+          `got: ${JSON.stringify(out.slice(0, 200))}…`,
+        );
+        assert(
+          "huge file (>per-file cap) defers — bare marker, no fenced block",
+          /@huge\.txt(?!\n```)/.test(out),
+          `got: ${JSON.stringify(out.slice(0, 200))}…`,
+        );
+      } finally {
+        await rm(orderWorkspace, { recursive: true, force: true }).catch(() => undefined);
+      }
+    }
   } finally {
     await rm(workspace, { recursive: true, force: true }).catch(() => undefined);
   }


### PR DESCRIPTION
## Summary

Two commits:

1. **`feat(chat): support folder references in @-mentions`** — `@<path>` markers resolving to a directory now preserve the literal marker (with `/` appended) so the model can `ls`/`grep` the folder via its tools, instead of getting rejected as `[@<path> not included: path is a directory]`. `checkFileReference` returns a discriminated kind (file | directory) instead of throwing on directories. `listAllFiles` emits directories with trailing `/` so the chat-input `@`-autocomplete surfaces folders automatically. New `tests/test-folder-references.ts` (10 assertions).
2. **`feat(chat): aggregate-byte budget on @-reference inlining`** — Today, every `@<path>` gets a per-file decision (inline if ≤128 KB, defer otherwise) with **no aggregate cap**. A user `@`-ing 50 files at 100 KB each pushes ~5 MB / 1.25M tokens into one prompt and blows the context window. Restructure `expandFileReferences` into three phases: classify → budget walk (sort ascending by size, walk a 512 KB running budget; smallest-first maximises useful inlines) → read content for survivors only. +4 test assertions covering the budget threshold, smallest-first ordering, and the per-file vs aggregate distinction.

## Test plan
- [ ] `npx tsx tests/test-folder-references.ts` — 14/14 PASS (10 from commit 1, 4 from commit 2).
- [ ] `npm run test:ci` — all 24 tests pass.
- [ ] Live: `@<dir>` autocomplete surfaces folders in the popover.
- [ ] Live: type `@src/` in the chat input, hit send, confirm the agent receives `@src/` (preserved) and uses its `ls`/`grep` tools to inspect.
- [ ] Live: `@`-mention 6 files at ~100 KB each, hit send, confirm 5 inline + 1 defers (visible in the message bubble's expansion).