### PR TITLE
feat: file-tree create scoping + LaTeX math + resizable composer + skill diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6261,6 +6261,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -8259,6 +8265,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
@@ -9844,6 +9862,100 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
@@ -9878,6 +9990,22 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10952,6 +11080,31 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11805,6 +11958,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -12149,6 +12321,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -13788,6 +13979,25 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-breaks": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
@@ -13814,6 +14024,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -15462,6 +15688,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -15482,6 +15722,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -15691,6 +15945,20 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -16314,6 +16582,16 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -17090,6 +17368,7 @@
         "@xterm/xterm": "^5.5.0",
         "codemirror": "^6.0.1",
         "hash-wasm": "^4.12.0",
+        "katex": "^0.16.45",
         "lucide-react": "^1.14.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^19.2.6",
@@ -17097,8 +17376,10 @@
         "react-dom": "^19.2.6",
         "react-markdown": "^10.1.0",
         "refractor": "^5.0.0",
+        "rehype-katex": "^7.0.1",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
         "zustand": "^5.0.3"
       },
       "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -26,6 +26,7 @@
     "@xterm/xterm": "^5.5.0",
     "codemirror": "^6.0.1",
     "hash-wasm": "^4.12.0",
+    "katex": "^0.16.45",
     "lucide-react": "^1.14.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.6",
@@ -33,8 +34,10 @@
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",
     "refractor": "^5.0.0",
+    "rehype-katex": "^7.0.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
-import { AtSign, Image as ImageIcon, Paperclip, X } from "lucide-react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import { AtSign, Image as ImageIcon, Paperclip, RotateCcw, X } from "lucide-react";
 import { api, ApiError, type ProvidersListing } from "../lib/api-client";
 import { EMPTY_MESSAGES, useSessionStore, type AgentMessageLike } from "../store/session-store";
 import { useActiveProject } from "../store/project-store";
@@ -241,6 +248,95 @@ export function ChatInput({ sessionId }: Props) {
   // block at send time — see file-references.ts).
   const project = useActiveProject();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  /**
+   * User-chosen textarea height in pixels, driven by the drag handle
+   * that lives where the composer's top border used to be. `undefined`
+   * means "use the default `rows={3}` layout"; once the user drags,
+   * it becomes a concrete number that overrides via inline style.
+   *
+   * Persisted under a window-scoped localStorage key — per-session
+   * heights would just confuse (one preferred draft size beats N
+   * session-scoped sizes the user has to re-discover on every
+   * switch). Clamp on read so a stale absurd value gets corrected
+   * silently. Bounds: min 60 px (~2 rows), max 60 % viewport.
+   */
+  const HEIGHT_KEY = "pi-forge:chat-input-height";
+  const heightBounds = (): { min: number; max: number } => ({
+    min: 60,
+    max: Math.floor(window.innerHeight * 0.6),
+  });
+  const [textareaHeight, setTextareaHeight] = useState<number | undefined>(() => {
+    if (typeof window === "undefined") return undefined;
+    const raw = window.localStorage.getItem(HEIGHT_KEY);
+    if (raw === null) return undefined;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) return undefined;
+    const { min, max } = heightBounds();
+    return Math.max(min, Math.min(max, parsed));
+  });
+
+  /**
+   * Pointer-driven drag handler for the divider above the composer.
+   * Drag UP = textarea grows; drag DOWN = shrinks. Persistence and
+   * pointer release happen at pointerup. We capture the pointer so
+   * the drag survives even if the cursor leaves the slim handle
+   * during a fast move.
+   *
+   * Why pointer events (not mousedown/mousemove): pointer capture +
+   * unified handling for touch/pen/mouse + we don't have to wire up
+   * a window-scoped move listener manually.
+   */
+  const startDividerDrag = (e: ReactPointerEvent<HTMLDivElement>): void => {
+    e.preventDefault();
+    const target = e.currentTarget;
+    target.setPointerCapture(e.pointerId);
+    const startY = e.clientY;
+    const startHeight = textareaRef.current?.getBoundingClientRect().height ?? 60;
+    const { min, max } = heightBounds();
+
+    const onMove = (ev: PointerEvent): void => {
+      // Inverted: dragging UP (clientY decreases) should grow the
+      // textarea, since the handle sits ABOVE the composer.
+      const delta = startY - ev.clientY;
+      const next = Math.max(min, Math.min(max, startHeight + delta));
+      setTextareaHeight(next);
+    };
+    const onUp = (ev: PointerEvent): void => {
+      target.removeEventListener("pointermove", onMove);
+      target.removeEventListener("pointerup", onUp);
+      target.removeEventListener("pointercancel", onUp);
+      try {
+        target.releasePointerCapture(ev.pointerId);
+      } catch {
+        // capture may already be released; ignore
+      }
+      // Persist whatever height the textarea actually has now —
+      // reads from the live element, not from React state, so a
+      // mid-drag re-render won't desync the saved value.
+      const live = textareaRef.current?.getBoundingClientRect().height;
+      if (live !== undefined && Number.isFinite(live)) {
+        window.localStorage.setItem(HEIGHT_KEY, String(Math.round(live)));
+      }
+    };
+    target.addEventListener("pointermove", onMove);
+    target.addEventListener("pointerup", onUp);
+    target.addEventListener("pointercancel", onUp);
+  };
+
+  /**
+   * Reset the composer to its default `rows={3}` size. Drops the
+   * inline-style override so the textarea picks up its CSS-derived
+   * default, and clears the persisted height so the next mount
+   * doesn't restore the old value. The button rendering this is
+   * conditional on `textareaHeight !== undefined`, so the affordance
+   * disappears once it's done its job — no clutter for the common
+   * "I never resized" case.
+   */
+  const resetTextareaHeight = (): void => {
+    setTextareaHeight(undefined);
+    window.localStorage.removeItem(HEIGHT_KEY);
+  };
   interface AcToken {
     /** index of the `@` in `text`. */
     start: number;
@@ -1077,8 +1173,27 @@ export function ChatInput({ sessionId }: Props) {
   };
 
   return (
-    <div className="border-t border-neutral-800 bg-neutral-950 px-6 py-3">
-      <div className="mx-auto max-w-3xl space-y-2">
+    <div className="bg-neutral-950">
+      {/*
+        Drag handle that lives where the composer's top border used to
+        be. Plain visual: a 1-px hairline matching the rest of the
+        chrome's border-neutral-800. On hover/active it brightens and
+        the cursor flips to row-resize so the affordance is
+        discoverable without taking up extra vertical space at rest.
+        The 5-px hit area extends above the visual line so users don't
+        have to pixel-hunt; `-translate-y` shifts the click region up
+        without growing the layout box.
+      */}
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize chat input"
+        onPointerDown={startDividerDrag}
+        className="group relative h-px cursor-row-resize bg-neutral-800 hover:bg-neutral-600 active:bg-neutral-500"
+      >
+        <div className="absolute inset-x-0 -top-1 h-2" />
+      </div>
+      <div className="mx-auto max-w-3xl space-y-2 px-6 py-3">
         <div className="flex flex-wrap items-center gap-2">
           <ModelPicker
             providers={providers}
@@ -1108,8 +1223,23 @@ export function ChatInput({ sessionId }: Props) {
               ))}
             </div>
           )}
-          {modelError !== undefined && (
-            <span className="ml-auto text-[11px] text-red-400">{modelError}</span>
+          {(modelError !== undefined || textareaHeight !== undefined) && (
+            <div className="ml-auto flex items-center gap-2">
+              {modelError !== undefined && (
+                <span className="text-[11px] text-red-400">{modelError}</span>
+              )}
+              {textareaHeight !== undefined && (
+                <button
+                  type="button"
+                  onClick={resetTextareaHeight}
+                  className="rounded p-1 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
+                  title="Reset chat input height to default"
+                  aria-label="Reset chat input height to default"
+                >
+                  <RotateCcw size={12} />
+                </button>
+              )}
+            </div>
           )}
         </div>
         {error !== undefined && <p className="text-xs text-red-400">Error: {error}</p>}
@@ -1257,6 +1387,7 @@ export function ChatInput({ sessionId }: Props) {
                   : undefined
               }
               rows={3}
+              style={textareaHeight !== undefined ? { height: `${textareaHeight}px` } : undefined}
               className={`w-full resize-none rounded-md border bg-neutral-900 px-3 py-2 text-sm text-neutral-100 outline-none ${
                 bangMode === "local"
                   ? "border-amber-500 focus:border-amber-400"

--- a/packages/client/src/components/ChatMarkdown.tsx
+++ b/packages/client/src/components/ChatMarkdown.tsx
@@ -41,8 +41,14 @@ import { Highlight, themes as prismThemes } from "prism-react-renderer";
 import { useState, type HTMLAttributes, type ReactNode } from "react";
 import { Check, Copy } from "lucide-react";
 import ReactMarkdown, { type Components } from "react-markdown";
+import rehypeKatex from "rehype-katex";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+// KaTeX styles — pulled into the bundle by Vite. Without this, the math
+// nodes that rehype-katex emits land in the DOM with no fonts/spacing
+// applied and look like raw HTML.
+import "katex/dist/katex.min.css";
 
 /**
  * Small copy-to-clipboard control rendered in the top-right corner of
@@ -271,10 +277,15 @@ export function ChatMarkdown({ text, size = "sm", chatStyleBreaks = false }: Pro
   // pasted lists. See the prop docstring for the trade-off and why
   // it's user-only.
   const sizeClass = size === "xs" ? "text-xs" : "text-sm";
-  const plugins = chatStyleBreaks ? [remarkGfm, remarkBreaks] : [remarkGfm];
+  // remark-math parses `$inline$` and `$$block$$`; rehype-katex turns
+  // those nodes into rendered MathML+HTML using KaTeX. Order matters —
+  // remark-math must run before remark-breaks so a `$\rightarrow$` token
+  // lands as a math node rather than text containing a literal `\n` →
+  // `<br>` rewrite around the dollar signs.
+  const plugins = chatStyleBreaks ? [remarkGfm, remarkMath, remarkBreaks] : [remarkGfm, remarkMath];
   return (
     <div className={`${sizeClass} break-words [overflow-wrap:anywhere]`}>
-      <ReactMarkdown remarkPlugins={plugins} components={components}>
+      <ReactMarkdown remarkPlugins={plugins} rehypePlugins={[rehypeKatex]} components={components}>
         {text}
       </ReactMarkdown>
     </div>

--- a/packages/client/src/components/FileBrowserPanel.tsx
+++ b/packages/client/src/components/FileBrowserPanel.tsx
@@ -136,10 +136,9 @@ export function FileBrowserPanel() {
   };
 
   // Open the create dialog scoped to a specific folder. Used by the
-  // context-menu "Add file" / "Add folder" entries on a folder row, so
-  // the new entry lands inside the right-clicked directory rather
-  // than at the project root. Auto-expands the parent so the new
-  // entry is visible after `loadTree` refreshes the tree.
+  // per-row + buttons so the new file/folder lands inside the hovered
+  // directory rather than at the project root. Auto-expands the parent
+  // so the new entry becomes visible after loadTree refreshes the tree.
   const requestCreateInFolder = (
     parentAbsPath: string,
     parentRelPath: string,
@@ -521,6 +520,9 @@ export function FileBrowserPanel() {
             onRenameCommit={(absPath) => void commitRename(absPath)}
             onRenameStart={startRename}
             onDelete={(absPath, name, isDir) => requestDelete(absPath, name, isDir)}
+            onCreate={(parentAbsPath, parentRelPath, entryKind) =>
+              requestCreateInFolder(parentAbsPath, parentRelPath, entryKind)
+            }
             onUpload={(absPath) => onPickUpload(absPath)}
             onDownload={(absPath) => void downloadEntry(absPath)}
             dropTarget={dropTarget}
@@ -790,6 +792,13 @@ interface TreeProps {
   onRenameCommit: (absPath: string) => void;
   onRenameStart: (absPath: string, name: string) => void;
   onDelete: (absPath: string, name: string, isDir: boolean) => void;
+  /**
+   * Open the create-entry dialog scoped to this directory. parentRelPath
+   * is the tree-relative key (used to auto-expand the folder so the new
+   * entry materializes in view); parentAbsPath is what the file store
+   * needs to resolve the destination on the server.
+   */
+  onCreate: (parentAbsPath: string, parentRelPath: string, entryKind: "file" | "folder") => void;
   /** Click-to-upload into this directory; click-fired from a hover icon. */
   onUpload: (absPath: string) => void;
   /** Click-to-download (file: verbatim; directory: tar.gz). */
@@ -957,16 +966,38 @@ function Tree(props: TreeProps) {
         {!isRenaming && (
           <div className="hidden items-center gap-0.5 group-hover:flex">
             {isDir && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  props.onUpload(absPath);
-                }}
-                className="rounded p-0.5 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
-                title="Upload into this folder"
-              >
-                <Upload size={11} />
-              </button>
+              <>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    props.onCreate(absPath, node.path, "file");
+                  }}
+                  className="rounded p-0.5 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
+                  title="New file in this folder"
+                >
+                  <FilePlus2 size={11} />
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    props.onCreate(absPath, node.path, "folder");
+                  }}
+                  className="rounded p-0.5 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
+                  title="New subfolder in this folder"
+                >
+                  <FolderPlus size={11} />
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    props.onUpload(absPath);
+                  }}
+                  className="rounded p-0.5 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
+                  title="Upload into this folder"
+                >
+                  <Upload size={11} />
+                </button>
+              </>
             )}
             <button
               onClick={(e) => {
@@ -1027,9 +1058,9 @@ function joinPath(root: string, rel: string): string {
 /**
  * Derive the parent's display path for the create-dialog title/label.
  * Toolbar-triggered creates have parentAbsPath === project root and
- * read as "(relative to project root)"; context-menu creates on a
- * folder get the project-relative form so users see exactly where
- * the new entry will land.
+ * read as "(relative to project root)"; per-folder + buttons get the
+ * project-relative form so users see exactly where the new entry will
+ * land.
  */
 function parentDisplay(parentAbsPath: string, projectPath: string): string | undefined {
   if (parentAbsPath === projectPath) return undefined;

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -8,6 +8,7 @@ import {
   type McpServerStatus,
   type McpTransport,
   type ProvidersListing,
+  type SkillDiagnostic,
   type SkillSummary,
   type ToolListing,
 } from "../lib/api-client";
@@ -775,6 +776,15 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
   const project = useActiveProject();
   const projects = useProjectStore((s) => s.projects);
   const [skills, setSkills] = useState<SkillSummary[] | undefined>(undefined);
+  /**
+   * SDK-emitted warnings about skill files the loader rejected. The
+   * most common case is a name collision when a top-level
+   * `<dir>/foo.md` skill lacks `name:` frontmatter and falls back to
+   * the parent dir name "skills" — silently colliding with another
+   * file's identical fallback name. Without surfacing these the user
+   * sees an authored skill go missing with no clue why.
+   */
+  const [diagnostics, setDiagnostics] = useState<SkillDiagnostic[]>([]);
   /** All per-project overrides, keyed by projectId. Used for the
    *  cascade view inside each expanded skill row. */
   const [allOverrides, setAllOverrides] = useState<
@@ -787,11 +797,12 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
     if (project === undefined) return;
     onError(undefined);
     try {
-      const [{ skills: list }, overrides] = await Promise.all([
+      const [{ skills: list, diagnostics: diags }, overrides] = await Promise.all([
         api.listSkills(project.id),
         api.listSkillOverrides(),
       ]);
       setSkills(list);
+      setDiagnostics(diags);
       setAllOverrides(overrides.projects);
     } catch (err) {
       onError(`Failed to load skills: ${errorCode(err)}`);
@@ -877,6 +888,7 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
         Live sessions keep the skill set they booted with — start a new session to use a freshly
         enabled skill.
       </div>
+      {diagnostics.length > 0 && <SkillDiagnosticsBanner diagnostics={diagnostics} />}
       {skills.length === 0 && (
         <p className="text-xs italic text-neutral-500">No skills found for this project.</p>
       )}
@@ -989,6 +1001,56 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
           </div>
         );
       })}
+    </div>
+  );
+}
+
+/**
+ * Renders SDK-emitted diagnostics — the loader's "I tried to load this
+ * file but rejected it" warnings. Most user-actionable case is a name
+ * collision: pi falls back to the parent dir name when no `name:` is
+ * in the file's frontmatter, so multiple top-level `<dir>/*.md` skills
+ * collide on the parent dir name and only the first one is loaded.
+ * Surface enough context for the user to find and fix the offending
+ * file without grepping through pi-mono source.
+ */
+function SkillDiagnosticsBanner({ diagnostics }: { diagnostics: SkillDiagnostic[] }) {
+  return (
+    <div className="space-y-1 rounded border border-red-700/40 bg-red-900/10 px-3 py-2 text-[11px] text-red-200">
+      <p className="font-medium">
+        {diagnostics.length} skill {diagnostics.length === 1 ? "file" : "files"} were not loaded:
+      </p>
+      <ul className="space-y-1.5">
+        {diagnostics.map((d, i) => (
+          <li key={i} className="border-l-2 border-red-700/60 pl-2">
+            <div className="text-red-100">
+              <span className="rounded bg-red-900/40 px-1 py-0.5 text-[10px] uppercase tracking-wider text-red-300">
+                {d.type}
+              </span>{" "}
+              {d.message}
+            </div>
+            {d.collision !== undefined && (
+              <div className="mt-0.5 font-mono text-[10px] text-red-300/80">
+                <div>
+                  loser:&nbsp;&nbsp;<span className="text-red-200">{d.collision.loserPath}</span>
+                </div>
+                <div>
+                  winner:&nbsp;<span className="text-red-200">{d.collision.winnerPath}</span>
+                </div>
+                <div className="mt-1 text-red-300/70">
+                  Add <code className="rounded bg-red-900/40 px-1">name: {`<unique>`}</code> to the
+                  loser&apos;s frontmatter, or move it to{" "}
+                  <code className="rounded bg-red-900/40 px-1">{`<unique>/SKILL.md`}</code> so the
+                  parent dir name disambiguates.
+                </div>
+              </div>
+            )}
+            {d.collision === undefined && d.path !== undefined && (
+              <div className="mt-0.5 font-mono text-[10px] text-red-300/80">{d.path}</div>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -18,6 +18,7 @@ import {
   type UiConfigResponse,
   type UnifiedSession,
   type SessionSummary,
+  type SkillDiagnostic,
   type SkillSummary,
   type ToolListing,
   type ToolOverridesResponse,
@@ -289,41 +290,84 @@ function vAccepted(value: unknown, status: number): { accepted: true } {
   return { accepted: true };
 }
 
+function vSkillSummary(s: unknown, status: number): SkillSummary {
+  if (
+    !isObject(s) ||
+    typeof s.name !== "string" ||
+    typeof s.description !== "string" ||
+    (s.source !== "global" && s.source !== "project" && s.source !== "extension") ||
+    typeof s.filePath !== "string" ||
+    typeof s.enabled !== "boolean" ||
+    typeof s.effective !== "boolean" ||
+    typeof s.disableModelInvocation !== "boolean"
+  ) {
+    fail(status, "expected SkillSummary");
+  }
+  const summary: SkillSummary = {
+    name: s.name,
+    description: s.description,
+    source: s.source,
+    filePath: s.filePath,
+    enabled: s.enabled,
+    effective: s.effective,
+    disableModelInvocation: s.disableModelInvocation,
+  };
+  if (typeof s.extensionPath === "string") {
+    summary.extensionPath = s.extensionPath;
+  }
+  if (s.projectOverride === "enabled" || s.projectOverride === "disabled") {
+    summary.projectOverride = s.projectOverride;
+  }
+  return summary;
+}
+
 function vSkillsList(value: unknown, status: number): { skills: SkillSummary[] } {
   if (!isObject(value) || !Array.isArray(value.skills)) {
     fail(status, "expected { skills: SkillSummary[] }");
   }
-  return {
-    skills: value.skills.map((s): SkillSummary => {
-      if (
-        !isObject(s) ||
-        typeof s.name !== "string" ||
-        typeof s.description !== "string" ||
-        (s.source !== "global" && s.source !== "project" && s.source !== "extension") ||
-        typeof s.filePath !== "string" ||
-        typeof s.enabled !== "boolean" ||
-        typeof s.effective !== "boolean" ||
-        typeof s.disableModelInvocation !== "boolean"
-      ) {
-        fail(status, "expected SkillSummary");
-      }
-      const summary: SkillSummary = {
-        name: s.name,
-        description: s.description,
-        source: s.source,
-        filePath: s.filePath,
-        enabled: s.enabled,
-        effective: s.effective,
-        disableModelInvocation: s.disableModelInvocation,
+  return { skills: value.skills.map((s) => vSkillSummary(s, status)) };
+}
+
+function vSkillsListWithDiagnostics(
+  value: unknown,
+  status: number,
+): { skills: SkillSummary[]; diagnostics: SkillDiagnostic[] } {
+  if (!isObject(value) || !Array.isArray(value.skills) || !Array.isArray(value.diagnostics)) {
+    fail(status, "expected { skills: SkillSummary[], diagnostics: SkillDiagnostic[] }");
+  }
+  const diagnostics: SkillDiagnostic[] = [];
+  for (const d of value.diagnostics) {
+    if (
+      !isObject(d) ||
+      (d.type !== "warning" && d.type !== "error" && d.type !== "collision") ||
+      typeof d.message !== "string"
+    ) {
+      // Tolerate malformed entries — drop rather than reject the whole
+      // response; a stale skill diagnostic shape shouldn't break the
+      // SkillsTab from rendering the (correct) skills list.
+      continue;
+    }
+    const out: SkillDiagnostic = { type: d.type, message: d.message };
+    if (typeof d.path === "string") out.path = d.path;
+    if (
+      isObject(d.collision) &&
+      typeof d.collision.resourceType === "string" &&
+      typeof d.collision.name === "string" &&
+      typeof d.collision.winnerPath === "string" &&
+      typeof d.collision.loserPath === "string"
+    ) {
+      out.collision = {
+        resourceType: d.collision.resourceType,
+        name: d.collision.name,
+        winnerPath: d.collision.winnerPath,
+        loserPath: d.collision.loserPath,
       };
-      if (typeof s.extensionPath === "string") {
-        summary.extensionPath = s.extensionPath;
-      }
-      if (s.projectOverride === "enabled" || s.projectOverride === "disabled") {
-        summary.projectOverride = s.projectOverride;
-      }
-      return summary;
-    }),
+    }
+    diagnostics.push(out);
+  }
+  return {
+    skills: value.skills.map((s) => vSkillSummary(s, status)),
+    diagnostics,
   };
 }
 
@@ -1185,7 +1229,10 @@ export const api = {
   listMcpTools: (projectId: string) =>
     request(`/api/v1/mcp/tools?projectId=${encodeURIComponent(projectId)}`, vMcpTools),
   listSkills: (projectId: string) =>
-    request(`/api/v1/config/skills?projectId=${encodeURIComponent(projectId)}`, vSkillsList),
+    request(
+      `/api/v1/config/skills?projectId=${encodeURIComponent(projectId)}`,
+      vSkillsListWithDiagnostics,
+    ),
   /** Cascade view: every per-project override across every project. */
   listSkillOverrides: () => request(`/api/v1/config/skills/overrides`, vSkillOverrides),
   /**

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -190,6 +190,31 @@ export interface SkillOverridesResponse {
 }
 
 /**
+ * SDK-emitted diagnostic for a skill file the loader rejected.
+ * Surfaced through `GET /config/skills` so the SkillsTab can show
+ * the user *why* a file under `.pi/skills/` didn't load. The most
+ * common case is `type: "collision"` when a top-level `<dir>/foo.md`
+ * lacks `name:` frontmatter and falls back to the parent dir name,
+ * colliding with another file's identical fallback.
+ */
+export interface SkillDiagnostic {
+  type: "warning" | "error" | "collision";
+  message: string;
+  path?: string;
+  collision?: {
+    resourceType: string;
+    name: string;
+    winnerPath: string;
+    loserPath: string;
+  };
+}
+
+export interface SkillsListResponse {
+  skills: SkillSummary[];
+  diagnostics: SkillDiagnostic[];
+}
+
+/**
  * Unified tool listing returned by `GET /api/v1/config/tools`.
  * Two families:
  *   - `builtin` — pi's seven shipped coding tools (read, bash, edit,

--- a/packages/server/src/config-manager.ts
+++ b/packages/server/src/config-manager.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import {
   AuthStorage,
   ModelRegistry,
+  type ResourceDiagnostic,
   type Skill,
   loadSkills,
 } from "@earendil-works/pi-coding-agent";
@@ -414,10 +415,24 @@ export interface SkillSummary {
   disableModelInvocation: boolean;
 }
 
+/**
+ * Skills + the diagnostics the SDK emitted while discovering them.
+ * Diagnostics surface the cases where a skill file exists on disk but
+ * didn't make it into `skills` — most commonly a name collision between
+ * a top-level `<dir>/foo.md` skill (which falls back to the parent dir
+ * name "skills" if it has no `name:` frontmatter) and another file with
+ * the same fallback name. Without surfacing these, the user sees a
+ * missing skill with no clue why; the loader silently dropped it.
+ */
+export interface SkillsListResult {
+  skills: SkillSummary[];
+  diagnostics: ResourceDiagnostic[];
+}
+
 export async function listSkills(
   workspacePath: string,
   projectId?: string,
-): Promise<SkillSummary[]> {
+): Promise<SkillsListResult> {
   // Pi packages can contribute skill directories or files via
   // `package.json#pi.skills`, resolved by DefaultPackageManager.
   // discoverExtensionResources returns those resolved paths so
@@ -445,9 +460,12 @@ export async function listSkills(
   for (const s of extResources.skillPaths) {
     skillPathToPackage.set(s.skillPath, s.packageSource);
   }
-  return result.skills.map((s) =>
-    skillSummary(s, workspacePath, globalDisabled, overrides, projectId, skillPathToPackage),
-  );
+  return {
+    skills: result.skills.map((s) =>
+      skillSummary(s, workspacePath, globalDisabled, overrides, projectId, skillPathToPackage),
+    ),
+    diagnostics: result.diagnostics,
+  };
 }
 
 function skillSummary(
@@ -551,7 +569,7 @@ export async function setSkillEnabled(
   opts?: { scope?: "global" | "project"; projectId?: string },
 ): Promise<SkillSummary[]> {
   const all = await listSkills(workspacePath, opts?.projectId);
-  if (!all.some((s) => s.name === name)) throw new SkillNotFoundError(name);
+  if (!all.skills.some((s) => s.name === name)) throw new SkillNotFoundError(name);
   const scope = opts?.scope ?? "global";
   if (scope === "project") {
     if (opts?.projectId === undefined) {
@@ -564,7 +582,7 @@ export async function setSkillEnabled(
     const state: SkillOverrideState | undefined =
       enabled === true ? "enabled" : enabled === false ? "disabled" : undefined;
     await setProjectSkillOverride(opts.projectId, name, state);
-    return listSkills(workspacePath, opts.projectId);
+    return (await listSkills(workspacePath, opts.projectId)).skills;
   }
   // global scope (existing behaviour)
   if (enabled === undefined) {
@@ -599,7 +617,7 @@ export async function setSkillEnabled(
     const next: SettingsJson = { ...settings, skills: filtered };
     await atomicWriteJson(SETTINGS_FILE(), next);
   });
-  return listSkills(workspacePath, opts?.projectId);
+  return (await listSkills(workspacePath, opts?.projectId)).skills;
 }
 
 /**

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -159,6 +159,34 @@ const skillSchema = {
   },
 } as const;
 
+/**
+ * Surfaced verbatim from the SDK's `loadSkills` so the SkillsTab can
+ * tell the user *why* a file under `.pi/skills/` didn't load — most
+ * commonly a name collision when a top-level `<dir>/foo.md` skill
+ * lacks `name:` frontmatter and falls back to the parent dir name.
+ * Without this, those skills disappear silently and the user has no
+ * way to debug the authoring.
+ */
+const skillDiagnosticSchema = {
+  type: "object",
+  required: ["type", "message"],
+  properties: {
+    type: { type: "string", enum: ["warning", "error", "collision"] },
+    message: { type: "string" },
+    path: { type: "string" },
+    collision: {
+      type: "object",
+      required: ["resourceType", "name", "winnerPath", "loserPath"],
+      properties: {
+        resourceType: { type: "string" },
+        name: { type: "string" },
+        winnerPath: { type: "string" },
+        loserPath: { type: "string" },
+      },
+    },
+  },
+} as const;
+
 function internalError(reply: FastifyReply, err: unknown): FastifyReply {
   reply.log.error({ err }, "config route error");
   return reply.code(500).send({ error: "internal_error" });
@@ -374,7 +402,9 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
           "List skills discovered for a project. Skills come from two sources: " +
           "the global `~/.pi/agent/skills/` and the project-local `.pi/skills/`. " +
           "Each skill carries `enabled` reflecting whether it's listed in " +
-          "`settings.skills`. Required: `?projectId=`.",
+          "`settings.skills`. `diagnostics` surfaces SDK warnings for files " +
+          "the loader rejected (missing description, name collision, etc.) " +
+          "so the UI can render actionable errors. Required: `?projectId=`.",
         tags: ["config"],
         querystring: {
           type: "object",
@@ -384,8 +414,11 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
         response: {
           200: {
             type: "object",
-            required: ["skills"],
-            properties: { skills: { type: "array", items: skillSchema } },
+            required: ["skills", "diagnostics"],
+            properties: {
+              skills: { type: "array", items: skillSchema },
+              diagnostics: { type: "array", items: skillDiagnosticSchema },
+            },
           },
           404: errorSchema,
           500: errorSchema,
@@ -398,8 +431,8 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
         return reply.code(404).send({ error: "project_not_found" });
       }
       try {
-        const skills = await listSkills(project.path, project.id);
-        return { skills };
+        const { skills, diagnostics } = await listSkills(project.path, project.id);
+        return { skills, diagnostics };
       } catch (err) {
         return internalError(reply, err);
       }

--- a/tests/test-config.ts
+++ b/tests/test-config.ts
@@ -27,7 +27,7 @@
  *     `settings.skills`.
  *   - GET /config/skills?projectId=<unknown> → 404 (project_not_found).
  */
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -279,11 +279,19 @@ async function main(): Promise<void> {
 
       const list = await jget(base, `/api/v1/config/skills?projectId=${projectId}`);
       assert("GET /config/skills → 200", list.status === 200);
-      const skills = (list.body as { skills: { name: string; enabled: boolean; source: string }[] })
-        .skills;
+      const listBody = list.body as {
+        skills: { name: string; enabled: boolean; source: string }[];
+        diagnostics: unknown[];
+      };
+      const skills = listBody.skills;
       const hello = skills.find((s) => s.name === "hello");
       assert("project-local 'hello' skill discovered", hello !== undefined);
       assert("  source is 'project'", hello?.source === "project");
+      assert(
+        "  diagnostics array is present (well-formed fixture → empty)",
+        Array.isArray(listBody.diagnostics) && listBody.diagnostics.length === 0,
+        JSON.stringify(listBody.diagnostics),
+      );
       // Skills are now ENABLED by default in the global state (the
       // model is "exclude by `!name` pattern"; absence of the pattern
       // means enabled). Disable the skill first so the subsequent
@@ -492,6 +500,53 @@ async function main(): Promise<void> {
         `/api/v1/config/skills?projectId=00000000-0000-0000-0000-000000000000`,
       );
       assert("GET /config/skills with unknown projectId → 404", unknownProject.status === 404);
+
+      // 7b. Diagnostics: a top-level `<dir>/foo.md` skill without `name:`
+      //     in its frontmatter falls back to the parent dir name "skills"
+      //     (per pi's loadSkillFromFile). When two skill files collide on
+      //     that fallback, the SDK silently drops the second one and emits
+      //     a "collision" diagnostic. Without surfacing diagnostics through
+      //     /config/skills, the user has no way to learn why their
+      //     project-local skill went missing — this assertion locks in the
+      //     diagnostic flow so the SkillsTab can show the error banner.
+      {
+        // Drop a top-level `.md` global skill (no `name:` → falls back to "skills").
+        await mkdir(join(configDir, "skills"), { recursive: true });
+        await writeFile(
+          join(configDir, "skills", "globalonly.md"),
+          "---\ndescription: Global skill that takes the 'skills' fallback name first.\n---\nbody\n",
+          "utf8",
+        );
+        // Drop a colliding top-level `.md` project skill.
+        await writeFile(
+          join(workspacePath, ".pi", "skills", "projectonly.md"),
+          "---\ndescription: Project skill that should win once authoring is fixed.\n---\nbody\n",
+          "utf8",
+        );
+
+        const withCollision = await jget(base, `/api/v1/config/skills?projectId=${projectId}`);
+        assert("GET /config/skills with collision fixture → 200", withCollision.status === 200);
+        const body = withCollision.body as {
+          diagnostics?: { type: string; collision?: { winnerPath: string; loserPath: string } }[];
+        };
+        const collision = body.diagnostics?.find((d) => d.type === "collision");
+        assert(
+          "  diagnostics surfaces the collision",
+          collision !== undefined,
+          JSON.stringify(body.diagnostics),
+        );
+        assert(
+          "  collision names both winner and loser file paths",
+          typeof collision?.collision?.winnerPath === "string" &&
+            typeof collision?.collision?.loserPath === "string",
+          JSON.stringify(collision?.collision),
+        );
+
+        // Tidy up so unrelated assertions later in the suite (e.g. the
+        // export/import test downstream) don't see these stray files.
+        await unlink(join(configDir, "skills", "globalonly.md"));
+        await unlink(join(workspacePath, ".pi", "skills", "projectonly.md"));
+      }
     }
 
     // 8. atomic write proof: models.json updated mid-test should produce a


### PR DESCRIPTION
## Summary

Four atomic commits in this PR:

1. **`feat(file-tree): + buttons for file/folder creation on folder rows`** — Today file/folder creation is anchored to the project root. Adds discoverable per-folder + buttons in each folder row's hover group; the dialog scopes to the hovered directory. Toolbar buttons keep their existing project-root behaviour. Auto-expands the parent so the new entry is visible after `loadTree` refreshes.
2. **`feat(chat): render LaTeX math via remark-math + rehype-katex`** — `$\rightarrow$` used to render as literal text. Wires KaTeX in (remark-math + rehype-katex + katex CSS). Both `$inline$` and `$$block$$` math now render. Bundle grew ~280 KB (KaTeX fonts).
3. **`feat(chat): drag-divider above composer to resize chat input pane`** — Replaces the static hairline above the composer with a real drag handle (pointer-capture-driven, persisted to localStorage, clamped to `[60px, 60% of viewport]`). Reset button (`RotateCcw` icon) appears in the model-picker chip row only when the height has been customized.
4. **`fix(skills): surface SDK loader diagnostics so collisions are visible`** — Real bug fix for "project skills aren't loading." Root cause: pi's loader falls back to **parent dir name** (not file basename) when `name:` is missing from frontmatter, so multiple top-level `<dir>/*.md` skills silently collide and only one wins. pi-forge was discarding `result.diagnostics` from `loadSkills`. Now surfaced through `/config/skills` and rendered in `SkillsTab` with winner/loser file paths and an actionable hint. +3 test assertions in `test-config.ts`.

## Test plan
- [ ] `npm run check` clean.
- [ ] `npm run build` clean.
- [ ] `npm run test:ci` — 23/23 (test-config.ts has 3 new assertions covering skill diagnostics).
- [ ] Live: right-click a folder in the file tree → confirm a `+ file` button appears in the hover group; clicking it opens a dialog scoped to that folder.
- [ ] Live: send a chat message containing `When $x \to \infty$, the result is $\rightarrow 0$.` and confirm the math renders.
- [ ] Live: drag the divider above the composer up/down; reload the page and confirm the height persists. Confirm the reset button appears only after a drag.
- [ ] Live: create `<project>/.pi/skills/foo.md` and `<project>/.pi/skills/bar.md` (both top-level `.md` without `name:` frontmatter). Open Settings → Skills and confirm the red diagnostics banner shows the collision with both file paths.