### PR TITLE
feat(ui): bump unsaved-file indicator + show folder name on project rows

### DIFF
--- a/packages/client/src/components/EditorPanel.tsx
+++ b/packages/client/src/components/EditorPanel.tsx
@@ -242,7 +242,14 @@ function Tabs({
                 {extChanged ? (
                   <AlertTriangle size={11} className="mr-1 inline text-amber-400" />
                 ) : f.dirty ? (
-                  <span className="mr-1 text-amber-400">•</span>
+                  // Filled 10-px circle (was a 12-px bullet character that
+                  // mostly disappeared into the surrounding text). aria-
+                  // label so screen readers announce the unsaved state.
+                  <span
+                    className="mr-1.5 inline-block h-2.5 w-2.5 rounded-full bg-amber-400 align-middle"
+                    aria-label="Unsaved changes"
+                    title="Unsaved changes"
+                  />
                 ) : null}
                 {name}
               </button>

--- a/packages/client/src/components/ProjectSidebar.tsx
+++ b/packages/client/src/components/ProjectSidebar.tsx
@@ -143,10 +143,21 @@ export function ProjectSidebar() {
                       setRenamingId(p.id);
                       setRenameValue(p.name);
                     }}
-                    className="flex-1 truncate text-left"
+                    className="flex min-w-0 flex-1 flex-col items-start text-left leading-tight"
                     title={p.path}
                   >
-                    {p.name}
+                    <span className="w-full truncate">{p.name}</span>
+                    {/* Folder basename below the display name. Distinct
+                        font (mono) and tone (neutral-500) so it reads as
+                        metadata, not part of the name. Useful when the
+                        display name doesn't match the on-disk folder
+                        (e.g. user renamed the project to something
+                        memorable but is debugging which checkout it
+                        points at). Hover the row to see the full path
+                        — that's still in the title attribute above. */}
+                    <span className="w-full truncate font-mono text-[10px] text-neutral-500">
+                      {folderName(p.path)}
+                    </span>
                   </button>
                 )}
                 <button
@@ -233,4 +244,19 @@ export function ProjectSidebar() {
       </Modal>
     </aside>
   );
+}
+
+/**
+ * Strip everything but the last path segment so the project row can
+ * show "the folder name" as a sub-label under the display name. Both
+ * `/` and `\` are accepted so Windows-form paths (which the project
+ * store could in principle produce) don't fall through to showing the
+ * whole absolute path. Trailing-separator and empty-string defenses
+ * are belt-and-suspenders — `project-manager` realpaths every project
+ * path before storage, so the result should always have at least one
+ * segment.
+ */
+function folderName(absPath: string): string {
+  const parts = absPath.split(/[/\\]/).filter((s) => s.length > 0);
+  return parts[parts.length - 1] ?? absPath;
 }


### PR DESCRIPTION
## Summary

Two small UX fixes:

### Unsaved file indicator (bigger)
The dirty-state dot on editor tabs was a 12 px bullet character (`•`) at the surrounding text size — visually it just disappeared into the filename. Replaced with an explicit **10 px filled circle** (`h-2.5 w-2.5 rounded-full bg-amber-400`) sized independently of the surrounding text. Added `aria-label`/`title="Unsaved changes"` for accessibility + tooltip confirmation.

### Folder name on project rows
Project rows in the sidebar now show the folder basename as a smaller mono-font sub-label beneath the display name. Useful when the user has renamed a project to something memorable and is debugging which on-disk checkout it points at. Mono font + `neutral-500` tone reads as metadata, not as part of the name. Full path stays in the title-attribute tooltip for the rare deep-disambiguation case.

```
my-project
~/path/to/checkout       ← new folder-name sub-label (basename only)
```

New `folderName()` helper at the bottom of `ProjectSidebar.tsx` strips to the last path segment, accepting both `/` and `\` for Windows-path defensive parsing.

## Test plan
- [x] `npm run check` clean (typecheck + lint + format)
- [x] `npm run build` clean
- [x] `npm run test:ci` — 24/24 PASS
- [x] Visual: edit a file in the editor, confirm the new amber circle is clearly visible on the dirty tab and survives switching tabs
- [x] Visual: rename a project so its display name diverges from the on-disk folder, confirm the folder name shows up beneath the display name