### PR TITLE
feat(backup): include skills-overrides.json + tool-overrides.json in config backup

### DIFF
--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -1550,8 +1550,9 @@ function ThemeSwatch({ id }: { id: ThemeId }) {
 /**
  * Export / import the pi-forge's portable config as a `.tar.gz`.
  *
- * Export bundles `mcp.json` + `settings.json` + `models.json`. Auth
- * is deliberately excluded (provider keys / OAuth tokens), and the
+ * Export bundles `mcp.json` + `settings.json` + `models.json` +
+ * `skills-overrides.json` + `tool-overrides.json`. Auth is
+ * deliberately excluded (provider keys / OAuth tokens), and the
  * UI calls that out so a user planning a migration knows to re-auth
  * providers afterwards.
  *
@@ -1693,8 +1694,10 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
         <p className="mb-3 text-xs text-neutral-400">
           Downloads a <code className="font-mono">.tar.gz</code> with{" "}
           <code className="font-mono">mcp.json</code>,{" "}
-          <code className="font-mono">settings.json</code>, and{" "}
-          <code className="font-mono">models.json</code>. Provider auth (
+          <code className="font-mono">settings.json</code>,{" "}
+          <code className="font-mono">models.json</code>,{" "}
+          <code className="font-mono">skills-overrides.json</code>, and{" "}
+          <code className="font-mono">tool-overrides.json</code>. Provider auth (
           <code className="font-mono">auth.json</code> — API keys, OAuth tokens) is{" "}
           <strong>not</strong> included; re-authenticate providers after restoring on a new install.
         </p>

--- a/packages/server/src/config-export.ts
+++ b/packages/server/src/config-export.ts
@@ -2,9 +2,24 @@
  * Config export / import as a flat `.tar.gz`.
  *
  * What's included (and why):
- *   - `mcp.json`       — pi-forge-owned MCP server registry
- *   - `settings.json`  — pi-owned defaults (model, thinking level, skills patterns)
- *   - `models.json`    — pi-owned custom providers
+ *   - `mcp.json`              — pi-forge-owned MCP server registry
+ *   - `settings.json`         — pi-owned defaults (model, thinking level, skills patterns)
+ *   - `models.json`           — pi-owned custom providers
+ *   - `skills-overrides.json` — pi-forge-private per-project skill enable/disable state
+ *   - `tool-overrides.json`   — pi-forge-private per-project tool enable/disable state
+ *
+ * The two `*-overrides.json` files live in `${FORGE_DATA_DIR}` (not
+ * `${PI_CONFIG_DIR}` like the other three). They're included because
+ * the user's per-project tool/skill toggle decisions are part of "the
+ * pi-forge config a power-user wants to carry across installations" —
+ * pairing a backup of `settings.json` (global skill patterns) without
+ * also backing up the per-project overrides loses information.
+ * `projectId`s in the overrides files are local UUIDs — re-importing
+ * onto an installation with a different `projects.json` will leave
+ * orphan entries that are silently ignored at session-create time.
+ * Acceptable trade-off; the alternative (refusing to import overrides
+ * when project IDs don't match) would defeat the point of carrying
+ * per-project config across installs that share workspaces.
  *
  * What's deliberately EXCLUDED:
  *   - `auth.json` — provider API keys + OAuth tokens. OAuth tokens are
@@ -14,12 +29,14 @@
  *     (Slack, Drive, ticket attachment) outweighs the convenience. The
  *     import flow tells the user to re-authenticate providers
  *     afterwards.
+ *   - `projects.json` — installation-bound (project paths reference
+ *     local disk locations that won't exist on the target machine).
  *   - The auto-generated `jwt-secret` and `password-hash` files —
  *     installation-bound, intentionally not portable.
  *
- * Archive layout: a flat tar with the three files at the top level (no
+ * Archive layout: a flat tar with the files at the top level (no
  * leading directory). Importing rejects any entry that isn't one of
- * those three exact names — this is the only validation that matters
+ * the allow-listed names — this is the only validation that matters
  * for safety, since the names map deterministically to disk targets.
  *
  * Atomic writes: each imported file lands in `<dst>.import.tmp` first,
@@ -41,19 +58,30 @@ import { config } from "./config.js";
  * entry and we can't accidentally accept a near-miss like
  * `Settings.json` on a case-sensitive filesystem.
  */
-const ALLOWED_FILES = ["mcp.json", "settings.json", "models.json"] as const;
+const ALLOWED_FILES = [
+  "mcp.json",
+  "settings.json",
+  "models.json",
+  "skills-overrides.json",
+  "tool-overrides.json",
+] as const;
 type AllowedFile = (typeof ALLOWED_FILES)[number];
 const ALLOWED_SET: ReadonlySet<string> = new Set<string>(ALLOWED_FILES);
 
 /**
  * Map each allowed name to its on-disk target. Functions (not
- * constants) so changes to `config.piConfigDir` /
- * `config.mcpConfigFile` at test time take effect.
+ * constants) so changes to `config.piConfigDir` / `config.forgeDataDir`
+ * / `config.mcpConfigFile` at test time take effect. The two
+ * `*-overrides.json` files live under FORGE_DATA_DIR, NOT PI_CONFIG_DIR
+ * — pi-forge-private state, intentionally not commingled with the
+ * SDK's directory.
  */
 const TARGETS: Record<AllowedFile, () => string> = {
   "mcp.json": () => config.mcpConfigFile,
   "settings.json": () => join(config.piConfigDir, "settings.json"),
   "models.json": () => join(config.piConfigDir, "models.json"),
+  "skills-overrides.json": () => config.skillOverridesFile,
+  "tool-overrides.json": () => config.toolOverridesFile,
 };
 
 export interface ExportResult {

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -609,20 +609,23 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
 
   // ---------------------- export / import ----------------------
   // Two routes that round-trip the pi-forge's portable config
-  // (mcp.json + settings.json + models.json — see config-export.ts
-  // header for what's in and what's out).
+  // (mcp.json + settings.json + models.json + skills-overrides.json +
+  // tool-overrides.json — see config-export.ts header for what's in
+  // and what's out).
   fastify.get(
     "/config/export",
     {
       schema: {
         description:
           "Stream a `.tar.gz` of the portable pi-forge config: " +
-          "`mcp.json`, `settings.json`, and `models.json`. Excludes " +
-          "`auth.json` (provider keys / OAuth tokens) and any " +
-          "installation-bound files (jwt-secret, password-hash). " +
-          "The header `X-Pi-Forge-Files` lists the names actually " +
-          "included so a client can warn when a file was missing on " +
-          "disk and therefore omitted from the export.",
+          "`mcp.json`, `settings.json`, `models.json`, " +
+          "`skills-overrides.json`, and `tool-overrides.json`. Excludes " +
+          "`auth.json` (provider keys / OAuth tokens), `projects.json` " +
+          "(installation-bound paths), and the auto-generated " +
+          "`jwt-secret`/`password-hash` files. The header " +
+          "`X-Pi-Forge-Files` lists the names actually included so a " +
+          "client can warn when a file was missing on disk and " +
+          "therefore omitted from the export.",
         tags: ["config"],
         response: {
           200: {
@@ -655,13 +658,18 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
       schema: {
         description:
           "Restore a `.tar.gz` previously produced by `/config/export`. " +
-          "The archive must contain only the three top-level files " +
-          "`mcp.json`, `settings.json`, `models.json` — anything else " +
-          "is reported in `skipped`. Each accepted file is parsed as " +
-          "JSON; ALL files must validate before ANY are written. " +
+          "The archive must contain only the allow-listed top-level " +
+          "files (`mcp.json`, `settings.json`, `models.json`, " +
+          "`skills-overrides.json`, `tool-overrides.json`) — anything " +
+          "else is reported in `skipped`. Each accepted file is parsed " +
+          "as JSON; ALL files must validate before ANY are written. " +
           "Imported files land atomically (`.tmp` + rename). " +
           "**Provider auth is NOT included in exports** — re-authenticate " +
-          "providers via the Auth settings page after import.",
+          "providers via the Auth settings page after import. Note that " +
+          "`*-overrides.json` `projectId` keys are local UUIDs; importing " +
+          "onto an installation with a different `projects.json` will " +
+          "leave orphan entries that are silently ignored at session-" +
+          "create time.",
         tags: ["config"],
         consumes: ["multipart/form-data"],
         response: {

--- a/tests/test-config-export.ts
+++ b/tests/test-config-export.ts
@@ -142,8 +142,10 @@ async function main(): Promise<void> {
   console.log(`[test-config-export] PI_CONFIG_DIR=${configDir}`);
   console.log(`[test-config-export] FORGE_DATA_DIR=${dataDir}`);
 
-  // Seed the three exportable files PLUS auth.json (which we expect
-  // the export to deliberately exclude).
+  // Seed the five exportable files PLUS auth.json (which we expect
+  // the export to deliberately exclude). The two `*-overrides.json`
+  // files live under FORGE_DATA_DIR (dataDir), not PI_CONFIG_DIR
+  // (configDir) — pi-forge-private state.
   await mkdir(configDir, { recursive: true });
   await mkdir(dataDir, { recursive: true });
   const seedSettings = { defaultProvider: "anthropic", defaultThinkingLevel: "high" };
@@ -153,11 +155,31 @@ async function main(): Promise<void> {
   const seedMcp = {
     servers: { example: { url: "http://localhost:9000/sse" } },
   };
+  const seedSkillsOverrides = {
+    projects: {
+      "00000000-0000-0000-0000-000000000001": { enable: ["foo-skill"], disable: ["bar-skill"] },
+    },
+  };
+  const seedToolOverrides = {
+    projects: {
+      "00000000-0000-0000-0000-000000000001": {
+        builtin: { enable: [], disable: ["bash"] },
+        mcp: {},
+        extension: {},
+      },
+    },
+  };
   const seedAuth = { providers: { anthropic: { apiKey: "sk-ant-secret-do-not-export" } } };
   await writeFile(join(configDir, "settings.json"), JSON.stringify(seedSettings), "utf8");
   await writeFile(join(configDir, "models.json"), JSON.stringify(seedModels), "utf8");
   await writeFile(join(configDir, "auth.json"), JSON.stringify(seedAuth), "utf8");
   await writeFile(join(dataDir, "mcp.json"), JSON.stringify(seedMcp), "utf8");
+  await writeFile(
+    join(dataDir, "skills-overrides.json"),
+    JSON.stringify(seedSkillsOverrides),
+    "utf8",
+  );
+  await writeFile(join(dataDir, "tool-overrides.json"), JSON.stringify(seedToolOverrides), "utf8");
 
   const buildModule = (await import(
     resolve(repoRoot, "packages/server/dist/index.js")
@@ -187,8 +209,15 @@ async function main(): Promise<void> {
         .filter((s) => s.length > 0)
         .sort();
       assert(
-        "  X-Pi-Forge-Files lists all three files",
-        JSON.stringify(filesList) === JSON.stringify(["mcp.json", "models.json", "settings.json"]),
+        "  X-Pi-Forge-Files lists all five files",
+        JSON.stringify(filesList) ===
+          JSON.stringify([
+            "mcp.json",
+            "models.json",
+            "settings.json",
+            "skills-overrides.json",
+            "tool-overrides.json",
+          ]),
         filesHeader,
       );
       assert(
@@ -206,8 +235,15 @@ async function main(): Promise<void> {
 
       const entries = (await listTarEntries(exportedBuf)).sort();
       assert(
-        "  tar contents match the three exportable files",
-        JSON.stringify(entries) === JSON.stringify(["mcp.json", "models.json", "settings.json"]),
+        "  tar contents match the five exportable files",
+        JSON.stringify(entries) ===
+          JSON.stringify([
+            "mcp.json",
+            "models.json",
+            "settings.json",
+            "skills-overrides.json",
+            "tool-overrides.json",
+          ]),
         JSON.stringify(entries),
       );
       assert(
@@ -223,6 +259,8 @@ async function main(): Promise<void> {
       await rm(join(configDir, "settings.json"));
       await rm(join(configDir, "models.json"));
       await rm(join(dataDir, "mcp.json"));
+      await rm(join(dataDir, "skills-overrides.json"));
+      await rm(join(dataDir, "tool-overrides.json"));
 
       const r = await postMultipart(
         base,
@@ -235,8 +273,9 @@ async function main(): Promise<void> {
       assert("POST /config/import → 200", r.status === 200, JSON.stringify(r.body));
       const summary = r.body as { imported: string[]; skipped: string[]; errors: unknown[] };
       assert(
-        "  imported lists all three",
-        summary.imported.sort().join(",") === "mcp.json,models.json,settings.json",
+        "  imported lists all five",
+        summary.imported.sort().join(",") ===
+          "mcp.json,models.json,settings.json,skills-overrides.json,tool-overrides.json",
         JSON.stringify(summary),
       );
       assert("  no skipped entries", summary.skipped.length === 0, JSON.stringify(summary.skipped));
@@ -256,6 +295,22 @@ async function main(): Promise<void> {
       );
       const mcpBack = JSON.parse(await readFile(join(dataDir, "mcp.json"), "utf8"));
       assert("  mcp.json content round-trips", JSON.stringify(mcpBack) === JSON.stringify(seedMcp));
+      const skillsOverridesBack = JSON.parse(
+        await readFile(join(dataDir, "skills-overrides.json"), "utf8"),
+      );
+      assert(
+        "  skills-overrides.json content round-trips",
+        JSON.stringify(skillsOverridesBack) === JSON.stringify(seedSkillsOverrides),
+        JSON.stringify(skillsOverridesBack),
+      );
+      const toolOverridesBack = JSON.parse(
+        await readFile(join(dataDir, "tool-overrides.json"), "utf8"),
+      );
+      assert(
+        "  tool-overrides.json content round-trips",
+        JSON.stringify(toolOverridesBack) === JSON.stringify(seedToolOverrides),
+        JSON.stringify(toolOverridesBack),
+      );
 
       // auth.json was NEVER touched by the import path.
       const authBack = JSON.parse(await readFile(join(configDir, "auth.json"), "utf8"));
@@ -407,15 +462,30 @@ async function main(): Promise<void> {
         .split(",")
         .filter((s) => s.length > 0)
         .sort();
+      // The two `*-overrides.json` files were re-imported in step 2
+      // and again touched by step 3, so they're still on disk and
+      // included in this missing-mcp.json export.
       assert(
         "  X-Pi-Forge-Files omits missing mcp.json",
-        JSON.stringify(filesList) === JSON.stringify(["models.json", "settings.json"]),
+        JSON.stringify(filesList) ===
+          JSON.stringify([
+            "models.json",
+            "settings.json",
+            "skills-overrides.json",
+            "tool-overrides.json",
+          ]),
         JSON.stringify(filesList),
       );
       const entries = (await listTarEntries(r.buf)).sort();
       assert(
         "  tar contents omit missing mcp.json",
-        JSON.stringify(entries) === JSON.stringify(["models.json", "settings.json"]),
+        JSON.stringify(entries) ===
+          JSON.stringify([
+            "models.json",
+            "settings.json",
+            "skills-overrides.json",
+            "tool-overrides.json",
+          ]),
         JSON.stringify(entries),
       );
     }


### PR DESCRIPTION
## Summary

Pairing a backup of `settings.json` (global skill patterns) with no backup of the **per-project** skill/tool toggles loses information for any user who's set per-project preferences. Adds both override files to the export tarball + import allow-list.

| Was (3 files) | Now (5 files) |
|---|---|
| `mcp.json` | `mcp.json` |
| `settings.json` | `settings.json` |
| `models.json` | `models.json` |
| | **`skills-overrides.json`** ← new |
| | **`tool-overrides.json`** ← new |

The two override files live under `${FORGE_DATA_DIR}` (not `${PI_CONFIG_DIR}` like the other three) — pi-forge-private state, intentionally separated from the SDK's directory.

## Caveat called out in the docs

`projectId` keys in the override files are local UUIDs. Importing onto an installation with a different `projects.json` will leave orphan entries that are silently ignored at session-create time. The alternative (refusing to import overrides when project IDs don't match) would defeat the point of carrying per-project config across installs that share workspaces. Documented in both the file header + the import route's OpenAPI description.

## What's still excluded (unchanged)

- `auth.json` — provider keys + OAuth tokens (sensitive enough that bundling into a download the user might forward by accident is the wrong default)
- `projects.json` — installation-bound paths
- `jwt-secret` / `password-hash` — auto-generated, installation-bound

## Test plan
- [x] `npm run check` clean (typecheck + lint + format)
- [x] `npm run build` clean
- [x] `npx tsx tests/test-config-export.ts` — all 26 assertions pass (was 21; +5 new for the two files)
- [x] `npm run test:ci` — 24/24 PASS
- [x] Live: open Settings → Backup, click Export, untar the download, confirm `skills-overrides.json` + `tool-overrides.json` are present
- [x] Live: wipe the two override files, click Import on the same tarball, confirm they're restored