### PR TITLE
feat(prompts): full pi prompt-templates surface (list / invoke / per-project overrides)

### DIFF
--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -364,6 +364,59 @@ export function ChatInput({ sessionId }: Props) {
   const slashOpen = text.startsWith("/") && !text.includes("\n");
   const slashQuery = slashOpen ? (text.slice(1).split(/\s/)[0] ?? "") : "";
 
+  /**
+   * Pi prompt templates available for the active project, surfaced in
+   * the slash-command palette as `/<promptname>` entries. The pi SDK's
+   * `session.prompt()` expands the template at send time (defaults to
+   * `expandPromptTemplates: true`), so we don't expand client-side or
+   * server-side — the palette is purely a discovery + filling-in
+   * affordance. Selecting a prompt entry inserts `/<promptname> ` into
+   * the input (with trailing space) so the user can append args
+   * before pressing Enter.
+   *
+   * Refetched on project change. Errors silently swallow — a
+   * prompts-fetch failure shouldn't block the input from working;
+   * the user just sees the standard slash-command catalog without
+   * project prompts.
+   */
+  const [availablePrompts, setAvailablePrompts] = useState<
+    { name: string; description: string; argumentHint?: string }[]
+  >([]);
+  useEffect(() => {
+    if (project === undefined) {
+      setAvailablePrompts([]);
+      return;
+    }
+    let cancelled = false;
+    void api
+      .listPrompts(project.id)
+      .then((res) => {
+        if (cancelled) return;
+        // Only surface prompts that are actually enabled for this
+        // project — matches what `session.prompt()` will be able to
+        // expand at send time.
+        setAvailablePrompts(
+          res.prompts
+            .filter((p) => p.effective)
+            .map((p) => {
+              const out: { name: string; description: string; argumentHint?: string } = {
+                name: p.name,
+                description: p.description,
+              };
+              if (p.argumentHint !== undefined) out.argumentHint = p.argumentHint;
+              return out;
+            }),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setAvailablePrompts([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [project?.id]);
+
   // Bang-prefix mode for the visual treatment around the textarea.
   // `!!` runs bash local-only (output stays out of LLM context); `!`
   // runs bash AND feeds the output into the next turn. Both only fire
@@ -467,8 +520,43 @@ export function ChatInput({ sessionId }: Props) {
         },
       },
     ];
+    // Append pi prompt templates after the built-in commands. The
+    // SDK's `session.prompt()` expands `/<promptname> args` to the
+    // template body at send time (`expandPromptTemplates: true` by
+    // default in pi). Selecting one here just inserts the `/<name> `
+    // into the input; the user fills in args, presses Enter, and pi
+    // expands before forwarding to the model.
+    for (const p of availablePrompts) {
+      const description =
+        p.argumentHint !== undefined ? `${p.description} — args: ${p.argumentHint}` : p.description;
+      commands.push({
+        name: `/${p.name}`,
+        description,
+        available: !isStreaming,
+        run: () => {
+          // Insert `/<name> ` (trailing space) into the input — user
+          // appends arg(s) and presses Enter.
+          const insert = `/${p.name} `;
+          setText(insert);
+          requestAnimationFrame(() => {
+            const ta = textareaRef.current;
+            if (ta === null) return;
+            ta.focus();
+            ta.setSelectionRange(insert.length, insert.length);
+          });
+        },
+      });
+    }
     return commands;
-  }, [isStreaming, sessionId, abortSession, reloadMessages, openSettings, minimalUi]);
+  }, [
+    isStreaming,
+    sessionId,
+    abortSession,
+    reloadMessages,
+    openSettings,
+    minimalUi,
+    availablePrompts,
+  ]);
 
   const slashFiltered = useMemo(() => {
     const q = slashQuery.toLowerCase();

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -564,6 +564,26 @@ export function ChatInput({ sessionId }: Props) {
     return slashCatalog.filter((c) => c.name.slice(1).toLowerCase().startsWith(q));
   }, [slashCatalog, slashQuery]);
 
+  /**
+   * True when the input text is in `/<knownpromptname>` or
+   * `/<knownpromptname> ...args` form. In those cases Enter should
+   * BYPASS slash-command dispatch and fall through to a normal submit
+   * — pi's `session.prompt()` will expand the template at send time.
+   * Without this bypass, Enter on `/<name> foo` re-fires the prompt
+   * entry's `run()` which re-inserts `/<name> ` and clobbers the args.
+   *
+   * Distinguishes from the still-typing-the-name case (e.g. text is
+   * `/sum` while a prompt is named `summarize`) — that DOES go through
+   * normal slash dispatch so Enter Tab-completes the name.
+   */
+  const isPromptInvocation = useMemo(() => {
+    if (!slashOpen) return false;
+    const firstWord = text.slice(1).split(/\s/)[0] ?? "";
+    if (firstWord.length === 0) return false;
+    if (!availablePrompts.some((p) => p.name === firstWord)) return false;
+    return text === `/${firstWord}` || text.startsWith(`/${firstWord} `);
+  }, [slashOpen, text, availablePrompts]);
+
   const slashRunSelected = (): void => {
     const cmd = slashFiltered[slashSelectedIdx];
     if (cmd === undefined || !cmd.available) return;
@@ -929,7 +949,10 @@ export function ChatInput({ sessionId }: Props) {
     // /-command dispatch — the keyboard path (Enter) handles this
     // first, but a click on Send also lands here and a `/foo` typed
     // input shouldn't slip through to the LLM as a regular prompt.
-    if (slashOpen) {
+    // Exception: pi prompt templates in `/<name> ...args` form bypass
+    // dispatch — the SDK's `session.prompt()` expands them at send
+    // time. See `isPromptInvocation` for the predicate.
+    if (slashOpen && !isPromptInvocation) {
       if (slashFiltered.length > 0) {
         slashRunSelected();
       } else {
@@ -1032,9 +1055,19 @@ export function ChatInput({ sessionId }: Props) {
           return;
         }
         if (e.key === "Enter" || e.key === "Tab") {
-          e.preventDefault();
-          slashRunSelected();
-          return;
+          // Pi-prompt invocation form (`/<knownname>` or
+          // `/<knownname> ...args`) — fall through to the normal
+          // Enter-submits path. Without this branch the Enter key
+          // would re-fire the prompt entry's `run()` and clobber
+          // any args the user typed.
+          if (isPromptInvocation && e.key === "Enter" && !e.shiftKey) {
+            // Don't preventDefault — let the regular Enter handler
+            // below pick it up. (Tab still discovers / fills in.)
+          } else {
+            e.preventDefault();
+            slashRunSelected();
+            return;
+          }
         }
       } else if (e.key === "Enter" && !e.shiftKey) {
         // Open palette + no matches + Enter: refuse rather than

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -359,6 +359,10 @@ export function ChatInput({ sessionId }: Props) {
   const openSettings = useUiStore((s) => s.openSettings);
   const chatInsertRequest = useUiStore((s) => s.chatInsertRequest);
   const clearChatInsertRequest = useUiStore((s) => s.clearChatInsertRequest);
+  // Bumped by Settings → Prompts after every toggle so the slash
+  // palette refetches without requiring a project switch or full
+  // reload. Included in the prompts-fetch effect's deps.
+  const promptsRefreshTrigger = useUiStore((s) => s.promptsRefreshTrigger);
   const lastChatInsertSeqRef = useRef(0);
   const [slashSelectedIdx, setSlashSelectedIdx] = useState(0);
   const slashOpen = text.startsWith("/") && !text.includes("\n");
@@ -415,7 +419,7 @@ export function ChatInput({ sessionId }: Props) {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [project?.id]);
+  }, [project?.id, promptsRefreshTrigger]);
 
   // Bang-prefix mode for the visual treatment around the textarea.
   // `!!` runs bash local-only (output stays out of LLM context); `!`

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -111,7 +111,12 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="flex h-full max-h-[640px] w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950 shadow-2xl"
+        // Width bumped from max-w-3xl (768px) to max-w-4xl (896px) when
+        // the Prompts tab brought the count to 9 and the bar started
+        // crowding the "API Docs ↗" button on the right. Settings is
+        // a modal, so the extra width doesn't compete with the chat
+        // for screen real estate.
+        className="flex h-full max-h-[640px] w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950 shadow-2xl"
       >
         <header className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
           <div className="flex items-center gap-1">

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -8,6 +8,7 @@ import {
   type McpServerStatus,
   type McpTransport,
   type ProvidersListing,
+  type PromptSummary,
   type SkillDiagnostic,
   type SkillSummary,
   type ToolListing,
@@ -19,7 +20,16 @@ import { THEME_DEFS, useThemeStore, type ThemeId } from "../lib/theme";
 import { getStoredToken } from "../lib/auth-client";
 import { useAuthStore } from "../store/auth-store";
 
-type Tab = "providers" | "agent" | "mcp" | "tools" | "skills" | "appearance" | "backup" | "general";
+type Tab =
+  | "providers"
+  | "agent"
+  | "mcp"
+  | "tools"
+  | "skills"
+  | "prompts"
+  | "appearance"
+  | "backup"
+  | "general";
 
 interface Props {
   onClose: () => void;
@@ -63,13 +73,14 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           // deployments often want to disable bash/edit/write at the
           // tool level, regardless of what providers / agent settings
           // are exposed.
-          (["skills", "tools", "appearance", "backup", "general"] as const)
+          (["skills", "prompts", "tools", "appearance", "backup", "general"] as const)
         : ([
             "providers",
             "agent",
             "mcp",
             "tools",
             "skills",
+            "prompts",
             "appearance",
             "backup",
             "general",
@@ -124,11 +135,13 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
                         ? "Tools"
                         : t === "skills"
                           ? "Skills"
-                          : t === "appearance"
-                            ? "Appearance"
-                            : t === "backup"
-                              ? "Backup"
-                              : "General"}
+                          : t === "prompts"
+                            ? "Prompts"
+                            : t === "appearance"
+                              ? "Appearance"
+                              : t === "backup"
+                                ? "Backup"
+                                : "General"}
               </button>
             ))}
           </div>
@@ -177,6 +190,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           {tab === "mcp" && <McpTab onError={setError} />}
           {tab === "tools" && <ToolsTab onError={setError} />}
           {tab === "skills" && <SkillsTab onError={setError} />}
+          {tab === "prompts" && <PromptsTab onError={setError} />}
           {tab === "appearance" && <AppearanceTab />}
           {tab === "backup" && <BackupTab onError={setError} />}
           {tab === "general" && <GeneralTab />}
@@ -993,6 +1007,242 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
                     disabled={busy}
                     onAdd={(targetProjectId, state) =>
                       void setProjectOverride(targetProjectId, s.name, state)
+                    }
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------- Prompts tab ----------------
+
+/**
+ * Settings → Prompts. Mirrors `SkillsTab` end-to-end (see that for
+ * detailed comments on the override / cascade pattern). Differences:
+ *
+ * - No "extension" source kind — pi prompts have no package-contributed
+ *   path today, so every prompt is `global` or `project`.
+ * - Surfaces the optional `argumentHint` from the prompt's frontmatter
+ *   so users know what `/<promptname>` expects.
+ * - Same diagnostics envelope (always empty server-side today, but
+ *   plumbed for future SDK changes).
+ *
+ * Toggling enabled/disabled here doesn't INVOKE the prompt — that's
+ * driven from the chat input's `/<promptname>` slash-command palette.
+ * This tab is the management surface (which prompts exist on disk,
+ * which are turned on for which projects).
+ */
+function PromptsTab({ onError }: { onError: (msg: string | undefined) => void }) {
+  const project = useActiveProject();
+  const projects = useProjectStore((s) => s.projects);
+  const [prompts, setPrompts] = useState<PromptSummary[] | undefined>(undefined);
+  const [diagnostics, setDiagnostics] = useState<SkillDiagnostic[]>([]);
+  const [allOverrides, setAllOverrides] = useState<
+    Record<string, { enable: string[]; disable: string[] }>
+  >({});
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [busy, setBusy] = useState(false);
+
+  const refresh = async (): Promise<void> => {
+    if (project === undefined) return;
+    onError(undefined);
+    try {
+      const [{ prompts: list, diagnostics: diags }, overrides] = await Promise.all([
+        api.listPrompts(project.id),
+        api.listPromptOverrides(),
+      ]);
+      setPrompts(list);
+      setDiagnostics(diags);
+      setAllOverrides(overrides.projects);
+    } catch (err) {
+      onError(`Failed to load prompts: ${errorCode(err)}`);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [project?.id]);
+
+  if (project === undefined) {
+    return (
+      <p className="text-xs italic text-neutral-500">
+        Pick a project from the header to manage its prompts.
+      </p>
+    );
+  }
+
+  if (prompts === undefined) {
+    return <p className="text-xs italic text-neutral-500">Loading prompts for {project.name}…</p>;
+  }
+
+  const toggleGlobal = async (name: string, next: boolean): Promise<void> => {
+    setBusy(true);
+    try {
+      const { prompts: updated } = await api.setPromptEnabled(project.id, name, next, "global");
+      setPrompts(updated);
+    } catch (err) {
+      onError(`Toggle failed: ${errorCode(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const setProjectOverride = async (
+    targetProjectId: string,
+    name: string,
+    state: "enabled" | "disabled" | undefined,
+  ): Promise<void> => {
+    setBusy(true);
+    try {
+      if (state === undefined) {
+        await api.clearPromptProjectOverride(targetProjectId, name);
+      } else {
+        await api.setPromptEnabled(targetProjectId, name, state === "enabled", "project");
+      }
+      await refresh();
+    } catch (err) {
+      onError(`Override write failed: ${errorCode(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const overrideStateFor = (
+    targetProjectId: string,
+    promptName: string,
+  ): "enabled" | "disabled" | undefined => {
+    const entry = allOverrides[targetProjectId];
+    if (entry === undefined) return undefined;
+    if (entry.enable.includes(promptName)) return "enabled";
+    if (entry.disable.includes(promptName)) return "disabled";
+    return undefined;
+  };
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-neutral-500">
+        Pi prompt templates discovered in <code className="font-mono">~/.pi/agent/prompts/</code>{" "}
+        and <code className="font-mono">{project.path}/.pi/prompts/</code>. Invoke from the chat
+        input via <code className="font-mono">/&lt;name&gt;</code>; the global toggle writes to
+        pi&apos;s <code className="font-mono">settings.prompts</code>; per-project overrides write
+        to <code className="font-mono">{`\${FORGE_DATA_DIR}/prompts-overrides.json`}</code>.
+      </p>
+      <div className="rounded border border-amber-700/40 bg-amber-900/10 px-3 py-2 text-[11px] text-amber-200">
+        Prompt changes apply to the <strong>next session</strong> you start in the affected project.
+        Live sessions keep the prompt set they booted with — start a new session to use a freshly
+        enabled prompt.
+      </div>
+      {diagnostics.length > 0 && <SkillDiagnosticsBanner diagnostics={diagnostics} />}
+      {prompts.length === 0 && (
+        <p className="text-xs italic text-neutral-500">No prompts found for this project.</p>
+      )}
+      {prompts.map((p) => {
+        const key = `${p.source}:${p.name}`;
+        const isExpanded = expanded[key] === true;
+        const overrideRows = projects
+          .map((proj) => ({ project: proj, state: overrideStateFor(proj.id, p.name) }))
+          .filter((r) => r.state !== undefined);
+        const projectsWithoutOverride = projects.filter(
+          (proj) => overrideStateFor(proj.id, p.name) === undefined,
+        );
+        return (
+          <div key={key} className="rounded border border-neutral-800 bg-neutral-900/40">
+            <div className="flex items-start gap-3 p-3">
+              <span
+                className={`mt-1.5 inline-block h-2.5 w-2.5 rounded-full ${
+                  p.effective ? "bg-emerald-500" : "bg-neutral-700"
+                }`}
+                title={`Effective for ${project.name}: ${p.effective ? "enabled" : "disabled"}`}
+              />
+              <div className="flex-1 space-y-0.5">
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="font-mono text-neutral-100">/{p.name}</span>
+                  <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400">
+                    {p.source}
+                  </span>
+                  {p.argumentHint !== undefined && (
+                    <span
+                      className="rounded bg-neutral-800/60 px-1.5 py-0.5 font-mono text-[10px] text-neutral-300"
+                      title="Argument hint from the prompt's frontmatter"
+                    >
+                      {p.argumentHint}
+                    </span>
+                  )}
+                  {p.projectOverride !== undefined && (
+                    <span
+                      className={`rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${
+                        p.projectOverride === "enabled"
+                          ? "bg-emerald-900/40 text-emerald-300"
+                          : "bg-red-900/40 text-red-300"
+                      }`}
+                      title={`Active project ('${project.name}') has an override`}
+                    >
+                      Project: {p.projectOverride}
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-neutral-400">{p.description || "(no description)"}</p>
+                <p className="font-mono text-[10px] text-neutral-600">{p.filePath}</p>
+              </div>
+              <div className="flex shrink-0 items-center gap-1 text-xs">
+                <button
+                  onClick={() => void toggleGlobal(p.name, !p.enabled)}
+                  disabled={busy}
+                  className={`rounded border px-2 py-0.5 ${
+                    p.enabled
+                      ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300"
+                      : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
+                  }`}
+                  title="Global enable in pi's settings.prompts"
+                >
+                  Global: {p.enabled ? "enabled" : "disabled"}
+                </button>
+                <button
+                  onClick={() => setExpanded((e) => ({ ...e, [key]: !isExpanded }))}
+                  className="rounded border border-neutral-700 px-2 py-0.5 text-neutral-300 hover:border-neutral-500"
+                  title="Show per-project overrides"
+                >
+                  {isExpanded ? "▾ Overrides" : `▸ Overrides (${overrideRows.length})`}
+                </button>
+              </div>
+            </div>
+            {isExpanded && (
+              <div className="border-t border-neutral-800 px-3 py-2">
+                {overrideRows.length === 0 ? (
+                  <p className="mb-2 text-[11px] italic text-neutral-500">
+                    No project overrides yet — every project inherits the global state.
+                  </p>
+                ) : (
+                  <div className="mb-2 space-y-1">
+                    {overrideRows.map(({ project: proj, state }) => (
+                      <div
+                        key={proj.id}
+                        className="flex items-center justify-between gap-2 rounded bg-neutral-900/60 px-2 py-1 text-xs"
+                      >
+                        <span className="truncate text-neutral-200" title={proj.path}>
+                          {proj.name}
+                        </span>
+                        <TriStatePicker
+                          value={state}
+                          disabled={busy}
+                          onChange={(next) => void setProjectOverride(proj.id, p.name, next)}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {projectsWithoutOverride.length > 0 && (
+                  <AddOverrideDropdown
+                    projects={projectsWithoutOverride}
+                    disabled={busy}
+                    onAdd={(targetProjectId, state) =>
+                      void setProjectOverride(targetProjectId, p.name, state)
                     }
                   />
                 )}

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from "../lib/api-client";
 import { useActiveProject, useProjectStore } from "../store/project-store";
 import { useUiConfigStore } from "../store/ui-config-store";
+import { useUiStore } from "../store/ui-store";
 import { EMPTY_STATUS, useMcpStore } from "../store/mcp-store";
 import { THEME_DEFS, useThemeStore, type ThemeId } from "../lib/theme";
 import { getStoredToken } from "../lib/auth-client";
@@ -1045,6 +1046,7 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
 function PromptsTab({ onError }: { onError: (msg: string | undefined) => void }) {
   const project = useActiveProject();
   const projects = useProjectStore((s) => s.projects);
+  const bumpPromptsRefresh = useUiStore((s) => s.bumpPromptsRefresh);
   const [prompts, setPrompts] = useState<PromptSummary[] | undefined>(undefined);
   const [diagnostics, setDiagnostics] = useState<SkillDiagnostic[]>([]);
   const [allOverrides, setAllOverrides] = useState<
@@ -1091,6 +1093,9 @@ function PromptsTab({ onError }: { onError: (msg: string | undefined) => void })
     try {
       const { prompts: updated } = await api.setPromptEnabled(project.id, name, next, "global");
       setPrompts(updated);
+      // Tell the chat input to refetch its slash-palette so the
+      // toggled prompt appears / disappears without a project switch.
+      bumpPromptsRefresh();
     } catch (err) {
       onError(`Toggle failed: ${errorCode(err)}`);
     } finally {
@@ -1111,6 +1116,7 @@ function PromptsTab({ onError }: { onError: (msg: string | undefined) => void })
         await api.setPromptEnabled(targetProjectId, name, state === "enabled", "project");
       }
       await refresh();
+      bumpPromptsRefresh();
     } catch (err) {
       onError(`Override write failed: ${errorCode(err)}`);
     } finally {

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -18,6 +18,7 @@ import {
   type UiConfigResponse,
   type UnifiedSession,
   type SessionSummary,
+  type PromptSummary,
   type SkillDiagnostic,
   type SkillSummary,
   type ToolListing,
@@ -391,6 +392,88 @@ function vSkillOverrides(
   }
   return { projects: out };
 }
+
+function vPromptSummary(p: unknown, status: number): PromptSummary {
+  if (
+    !isObject(p) ||
+    typeof p.name !== "string" ||
+    typeof p.description !== "string" ||
+    (p.source !== "global" && p.source !== "project") ||
+    typeof p.filePath !== "string" ||
+    typeof p.enabled !== "boolean" ||
+    typeof p.effective !== "boolean"
+  ) {
+    fail(status, "expected PromptSummary");
+  }
+  const summary: PromptSummary = {
+    name: p.name,
+    description: p.description,
+    source: p.source,
+    filePath: p.filePath,
+    enabled: p.enabled,
+    effective: p.effective,
+  };
+  if (typeof p.argumentHint === "string") summary.argumentHint = p.argumentHint;
+  if (p.projectOverride === "enabled" || p.projectOverride === "disabled") {
+    summary.projectOverride = p.projectOverride;
+  }
+  return summary;
+}
+
+function vPromptsList(value: unknown, status: number): { prompts: PromptSummary[] } {
+  if (!isObject(value) || !Array.isArray(value.prompts)) {
+    fail(status, "expected { prompts: PromptSummary[] }");
+  }
+  return { prompts: value.prompts.map((p) => vPromptSummary(p, status)) };
+}
+
+function vPromptsListWithDiagnostics(
+  value: unknown,
+  status: number,
+): { prompts: PromptSummary[]; diagnostics: SkillDiagnostic[] } {
+  if (!isObject(value) || !Array.isArray(value.prompts) || !Array.isArray(value.diagnostics)) {
+    fail(status, "expected { prompts: PromptSummary[], diagnostics: SkillDiagnostic[] }");
+  }
+  // Same diagnostic shape as skills — see vSkillsListWithDiagnostics
+  // for the per-entry tolerance rationale.
+  const diagnostics: SkillDiagnostic[] = [];
+  for (const d of value.diagnostics) {
+    if (
+      !isObject(d) ||
+      (d.type !== "warning" && d.type !== "error" && d.type !== "collision") ||
+      typeof d.message !== "string"
+    ) {
+      continue;
+    }
+    const out: SkillDiagnostic = { type: d.type, message: d.message };
+    if (typeof d.path === "string") out.path = d.path;
+    if (
+      isObject(d.collision) &&
+      typeof d.collision.resourceType === "string" &&
+      typeof d.collision.name === "string" &&
+      typeof d.collision.winnerPath === "string" &&
+      typeof d.collision.loserPath === "string"
+    ) {
+      out.collision = {
+        resourceType: d.collision.resourceType,
+        name: d.collision.name,
+        winnerPath: d.collision.winnerPath,
+        loserPath: d.collision.loserPath,
+      };
+    }
+    diagnostics.push(out);
+  }
+  return {
+    prompts: value.prompts.map((p) => vPromptSummary(p, status)),
+    diagnostics,
+  };
+}
+
+// `vPromptOverrides` shape is identical to `vSkillOverrides` (same
+// `{ projects: { <pid>: { enable, disable } } }` envelope), so reuse
+// the existing validator. Aliased as a separate name in the api object
+// below for clarity at call sites.
+const vPromptOverrides = vSkillOverrides;
 
 function vProvidersListing(value: unknown, status: number): ProvidersListing {
   if (!isObject(value) || !Array.isArray(value.providers)) {
@@ -1257,6 +1340,35 @@ export const api = {
     request(
       `/api/v1/config/skills/${encodeURIComponent(name)}/enabled?projectId=${encodeURIComponent(projectId)}`,
       vSkillsList,
+      { method: "DELETE" },
+    ),
+
+  // ---------------- prompts ----------------
+  // Mirror of the skills surface above — see those for parameter
+  // semantics and the tri-state `scope` rationale. Today the slash-
+  // command palette in ChatInput drives invocation; the Settings →
+  // Prompts tab uses these to render the management UI.
+  listPrompts: (projectId: string) =>
+    request(
+      `/api/v1/config/prompts?projectId=${encodeURIComponent(projectId)}`,
+      vPromptsListWithDiagnostics,
+    ),
+  listPromptOverrides: () => request(`/api/v1/config/prompts/overrides`, vPromptOverrides),
+  setPromptEnabled: (
+    projectId: string,
+    name: string,
+    enabled: boolean,
+    scope: "global" | "project" = "global",
+  ) =>
+    request(
+      `/api/v1/config/prompts/${encodeURIComponent(name)}/enabled?projectId=${encodeURIComponent(projectId)}`,
+      vPromptsList,
+      { method: "PUT", body: { enabled, scope } },
+    ),
+  clearPromptProjectOverride: (projectId: string, name: string) =>
+    request(
+      `/api/v1/config/prompts/${encodeURIComponent(name)}/enabled?projectId=${encodeURIComponent(projectId)}`,
+      vPromptsList,
       { method: "DELETE" },
     ),
 

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -214,6 +214,39 @@ export interface SkillsListResponse {
   diagnostics: SkillDiagnostic[];
 }
 
+// ---------------- Prompts ----------------
+//
+// Mirrors the Skills shapes above. Pi prompts have no
+// package-contributed source today — every prompt is global or
+// project — so `source` enum is narrower than skills' (no
+// "extension"). `argumentHint` carries the optional bash-style
+// usage hint from the prompt's frontmatter so the slash-command
+// palette can render it.
+
+export type PromptOverrideState = "enabled" | "disabled";
+
+export interface PromptSummary {
+  name: string;
+  description: string;
+  argumentHint?: string;
+  source: "global" | "project";
+  filePath: string;
+  enabled: boolean;
+  projectOverride?: PromptOverrideState;
+  effective: boolean;
+}
+
+export interface PromptOverridesResponse {
+  projects: Record<string, { enable: string[]; disable: string[] }>;
+}
+
+export interface PromptsListResponse {
+  prompts: PromptSummary[];
+  /** Always `[]` from the server today (prompts SDK doesn't surface
+   *  collisions); kept on the shape for parallelism with skills. */
+  diagnostics: SkillDiagnostic[];
+}
+
 /**
  * Unified tool listing returned by `GET /api/v1/config/tools`.
  * Two families:

--- a/packages/client/src/store/ui-store.ts
+++ b/packages/client/src/store/ui-store.ts
@@ -14,7 +14,7 @@ import { create } from "zustand";
  * state belongs here too.
  */
 
-export type SettingsTab = "providers" | "agent" | "mcp" | "skills" | "appearance";
+export type SettingsTab = "providers" | "agent" | "mcp" | "skills" | "prompts" | "appearance";
 
 interface SettingsRequest {
   /** Optional tab to switch to on open. Undefined = leave the

--- a/packages/client/src/store/ui-store.ts
+++ b/packages/client/src/store/ui-store.ts
@@ -52,6 +52,23 @@ interface UiState {
   requestChatInsert: (text: string) => void;
   clearChatInsertRequest: () => void;
   /**
+   * Monotonic refresh trigger for the chat input's per-project prompt
+   * list. Bumped by the Settings → Prompts tab on every toggle so the
+   * chat input re-fetches `availablePrompts` and the slash-command
+   * palette reflects the new effective state without a project switch
+   * or full reload.
+   *
+   * Why a counter and not a callback: the chat input is mounted by
+   * App, not by SettingsPanel — there's no parent/child relationship
+   * to thread a callback through. Same pattern as `_chatInsertSeq` on
+   * the producer side; consumers (chat input) just include this in
+   * their useEffect deps.
+   */
+  promptsRefreshTrigger: number;
+  /** Bump `promptsRefreshTrigger`. Called from PromptsTab after every
+   *  global / project-scope toggle. */
+  bumpPromptsRefresh: () => void;
+  /**
    * Monotonic counters feeding the `seq` field on cross-component
    * requests. These NEVER reset on `clear*` — that's the whole point.
    *
@@ -92,5 +109,9 @@ export const useUiStore = create<UiState>((set, get) => ({
   },
   clearChatInsertRequest: () => {
     set({ chatInsertRequest: undefined });
+  },
+  promptsRefreshTrigger: 0,
+  bumpPromptsRefresh: () => {
+    set((s) => ({ promptsRefreshTrigger: s.promptsRefreshTrigger + 1 }));
   },
 }));

--- a/packages/server/src/agent-resource-loader.ts
+++ b/packages/server/src/agent-resource-loader.ts
@@ -47,6 +47,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { config } from "./config.js";
 import { getProjectDisabledSkillNames } from "./skill-overrides.js";
+import { getProjectDisabledPromptNames } from "./prompt-overrides.js";
 
 /**
  * Plain string (not a backtick template) so what's stored is exactly
@@ -96,24 +97,43 @@ export async function buildForgeResourceLoader(
   projectId?: string,
 ): Promise<ResourceLoader> {
   const appendSystemPrompt = config.agentSecretHygieneRule ? [FORGE_SECRET_HYGIENE_RULE] : [];
-  const disabledSkills =
-    projectId !== undefined ? await getProjectDisabledSkillNames(projectId) : new Set<string>();
+  const [disabledSkills, disabledPrompts] =
+    projectId !== undefined
+      ? await Promise.all([
+          getProjectDisabledSkillNames(projectId),
+          getProjectDisabledPromptNames(projectId),
+        ])
+      : [new Set<string>(), new Set<string>()];
   const baseOptions = {
     cwd,
     agentDir,
     settingsManager,
     appendSystemPrompt,
   };
-  const loader =
-    disabledSkills.size > 0
-      ? new DefaultResourceLoader({
-          ...baseOptions,
-          skillsOverride: ({ skills, diagnostics }) => ({
-            skills: skills.filter((s) => !disabledSkills.has(s.name)),
-            diagnostics,
-          }),
-        })
-      : new DefaultResourceLoader(baseOptions);
+  // Both override hooks are installed conditionally on whether the
+  // active project has any explicit disables. Pi's pattern system
+  // covers auto-discovered resources via `effectiveSkillsForProject` /
+  // `effectivePromptsForProject` (injected through the SettingsManager
+  // monkey-patch in session-registry.ts); these `*sOverride` callbacks
+  // backstop everything the SDK loaded — including the (currently
+  // hypothetical for prompts) package-contributed entries that
+  // `DefaultPackageManager` registers as `enabled: true` regardless of
+  // patterns. Same rationale as the original skills-only code path —
+  // see `skill-overrides.getProjectDisabledSkillNames` doc-comment.
+  const loaderOptions: ConstructorParameters<typeof DefaultResourceLoader>[0] = baseOptions;
+  if (disabledSkills.size > 0) {
+    loaderOptions.skillsOverride = ({ skills, diagnostics }) => ({
+      skills: skills.filter((s) => !disabledSkills.has(s.name)),
+      diagnostics,
+    });
+  }
+  if (disabledPrompts.size > 0) {
+    loaderOptions.promptsOverride = ({ prompts, diagnostics }) => ({
+      prompts: prompts.filter((p) => !disabledPrompts.has(p.name)),
+      diagnostics,
+    });
+  }
+  const loader = new DefaultResourceLoader(loaderOptions);
   await loader.reload();
   return loader;
 }

--- a/packages/server/src/config-manager.ts
+++ b/packages/server/src/config-manager.ts
@@ -3,8 +3,11 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import {
   AuthStorage,
+  DefaultResourceLoader,
   ModelRegistry,
+  type PromptTemplate,
   type ResourceDiagnostic,
+  SettingsManager,
   type Skill,
   loadSkills,
 } from "@earendil-works/pi-coding-agent";
@@ -19,6 +22,13 @@ import {
   type SkillOverrides,
   type SkillOverrideState,
 } from "./skill-overrides.js";
+import {
+  getProjectPromptState,
+  readPromptOverrides,
+  setProjectPromptOverride,
+  type PromptOverrides,
+  type PromptOverrideState,
+} from "./prompt-overrides.js";
 
 const MODELS_FILE = (): string => join(config.piConfigDir, "models.json");
 const AUTH_FILE = (): string => join(config.piConfigDir, "auth.json");
@@ -59,6 +69,8 @@ export interface SettingsJson {
   steeringMode?: "all" | "one-at-a-time";
   followUpMode?: "all" | "one-at-a-time";
   skills?: string[];
+  /** Pi's prompt-pattern overrides — same `!name`/`+name`/`-name` grammar as `skills`. */
+  prompts?: string[];
   enableSkillCommands?: boolean;
   [k: string]: unknown;
 }
@@ -680,4 +692,193 @@ export async function effectiveSkillsForProject(projectId: string): Promise<stri
     for (const name of entry.enable) result.add(forceIncludePattern(name));
   }
   return Array.from(result);
+}
+
+// ---------------------------------------------------------------------------
+// prompts — pi prompt templates (`.md` files under `<dir>/prompts/`).
+// Mirrors the skills section's shape end-to-end: list summaries with
+// global + per-project effective state, tri-state per-project toggle,
+// pattern-list injection at session-create. Pi exposes prompts via
+// `loadPromptTemplates(...)` (returns `PromptTemplate[]` directly — no
+// `diagnostics` like loadSkills, which is why `PromptsListResult.diagnostics`
+// is always `[]`; kept on the shape for parallelism with the SkillsTab UI
+// so the client validator and panel layout can mirror SkillsTab structurally).
+//
+// Pi prompts have NO package-contributed source today (`extensions-discovery`
+// only surfaces tools + skillPaths) — every prompt is either global
+// (`<piConfigDir>/prompts/`) or project (`<workspacePath>/.pi/prompts/`).
+// If pi adds package-contributed prompts later, plumb them through the
+// same way `extensionSkillPaths` flows for skills.
+
+export interface PromptSummary {
+  name: string;
+  description: string;
+  /** Optional argument hint from the prompt's frontmatter (e.g. `<file>`). */
+  argumentHint?: string;
+  source: "global" | "project";
+  filePath: string;
+  /** Whether the prompt is enabled in pi's GLOBAL settings.prompts list. */
+  enabled: boolean;
+  /** Tri-state per-project override; absent = inherit from global. */
+  projectOverride?: PromptOverrideState;
+  /**
+   * Resolved state for the project the request asked about —
+   * `(global ∪ project.enabled) − project.disabled`. Equals `enabled`
+   * when no project context is supplied.
+   */
+  effective: boolean;
+}
+
+/**
+ * Mirrors `SkillsListResult`. `diagnostics` is always `[]` for prompts
+ * (the SDK's `loadPromptTemplates` doesn't surface collision warnings
+ * the way `loadSkills` does); it's kept on the shape so the client
+ * SkillDiagnosticsBanner / PromptDiagnosticsBanner pattern stays
+ * uniform.
+ */
+export interface PromptsListResult {
+  prompts: PromptSummary[];
+  diagnostics: ResourceDiagnostic[];
+}
+
+export async function listPrompts(
+  workspacePath: string,
+  projectId?: string,
+): Promise<PromptsListResult> {
+  // Use a one-off DefaultResourceLoader for discovery — the SDK's
+  // standalone `loadPromptTemplates` isn't exported from the package
+  // index, so we go through the loader's `getPrompts()` instead. This
+  // also gives us SDK-emitted diagnostics for free if/when the SDK
+  // starts surfacing them for prompts (today the array is always empty).
+  const loader = new DefaultResourceLoader({
+    cwd: workspacePath,
+    agentDir: config.piConfigDir,
+    settingsManager: SettingsManager.create(workspacePath, config.piConfigDir),
+  });
+  await loader.reload();
+  const { prompts: templates, diagnostics } = loader.getPrompts();
+  const settings = await readSettings();
+  const globalDisabled = disabledNamesFromPatterns(settings.prompts ?? []);
+  const overrides = await readPromptOverrides();
+  return {
+    prompts: templates.map((t) =>
+      promptSummary(t, workspacePath, globalDisabled, overrides, projectId),
+    ),
+    diagnostics,
+  };
+}
+
+function promptSummary(
+  t: PromptTemplate,
+  workspacePath: string,
+  globalDisabled: Set<string>,
+  overrides: PromptOverrides,
+  projectId: string | undefined,
+): PromptSummary {
+  // The SDK returns sourceInfo with a `scope` of "user" / "project" /
+  // undefined; we fall back to a path-based heuristic when the SDK
+  // didn't tag (e.g. explicit promptPaths from a third-party caller).
+  const isProject =
+    t.sourceInfo.scope === "project" ||
+    (t.sourceInfo.scope === undefined && t.filePath.startsWith(workspacePath));
+  const source: PromptSummary["source"] = isProject ? "project" : "global";
+  const isEnabledGlobal = !globalDisabled.has(t.name);
+  const projectOverride =
+    projectId !== undefined ? getProjectPromptState(overrides, projectId, t.name) : undefined;
+  const effective =
+    projectOverride === "enabled" ? true : projectOverride === "disabled" ? false : isEnabledGlobal;
+  const summary: PromptSummary = {
+    name: t.name,
+    description: t.description,
+    source,
+    filePath: t.filePath,
+    enabled: isEnabledGlobal,
+    effective,
+  };
+  if (t.argumentHint !== undefined) summary.argumentHint = t.argumentHint;
+  if (projectOverride !== undefined) summary.projectOverride = projectOverride;
+  return summary;
+}
+
+export class PromptNotFoundError extends Error {
+  constructor(name: string) {
+    super(`prompt not found: ${name}`);
+    this.name = "PromptNotFoundError";
+  }
+}
+
+/**
+ * Toggle a prompt's enabled state at either the global scope (writes
+ * pi's `settings.prompts` patterns) or the project scope (writes
+ * pi-forge-private prompt-overrides.json). Mirrors `setSkillEnabled`
+ * end-to-end — same tri-state semantics for project scope, same
+ * pattern-rewrite for global scope.
+ */
+export async function setPromptEnabled(
+  name: string,
+  enabled: boolean | undefined,
+  workspacePath: string,
+  opts?: { scope?: "global" | "project"; projectId?: string },
+): Promise<PromptSummary[]> {
+  const all = await listPrompts(workspacePath, opts?.projectId);
+  if (!all.prompts.some((p) => p.name === name)) throw new PromptNotFoundError(name);
+  const scope = opts?.scope ?? "global";
+  if (scope === "project") {
+    if (opts?.projectId === undefined) {
+      throw new Error("setPromptEnabled: scope=project requires a projectId");
+    }
+    const state: PromptOverrideState | undefined =
+      enabled === true ? "enabled" : enabled === false ? "disabled" : undefined;
+    await setProjectPromptOverride(opts.projectId, name, state);
+    return (await listPrompts(workspacePath, opts.projectId)).prompts;
+  }
+  if (enabled === undefined) {
+    throw new Error("setPromptEnabled: scope=global requires enabled to be true or false");
+  }
+  // Same lock + read-modify-write + pattern-rewrite as setSkillEnabled.
+  // Pi auto-discovers every prompt and enables them by default; to
+  // disable one we push `!<name>`. Drop any prior pattern targeting the
+  // same name plus any inert bare entries on every rewrite.
+  await withSettingsLock(async () => {
+    const settings = await readSettings();
+    const existing = settings.prompts ?? [];
+    const filtered = existing.filter((p) => {
+      if (!p.startsWith("!") && !p.startsWith("+") && !p.startsWith("-")) return false;
+      if (p.slice(1) === name) return false;
+      return true;
+    });
+    if (!enabled) filtered.push(excludePattern(name));
+    const next: SettingsJson = { ...settings, prompts: filtered };
+    await atomicWriteJson(SETTINGS_FILE(), next);
+  });
+  return (await listPrompts(workspacePath, opts?.projectId)).prompts;
+}
+
+/**
+ * Compute the prompt-pattern list a session in `projectId` should see.
+ * Same merge semantics as `effectiveSkillsForProject` — global patterns
+ * are the floor; per-project enable/disable patterns layer on top
+ * via `+name`/`!name`. Pushed into the SettingsManager monkey-patch in
+ * `session-registry.buildSessionSettingsManager` so pi's package-manager
+ * applies them when discovering prompts.
+ */
+export async function effectivePromptsForProject(projectId: string): Promise<string[]> {
+  const settings = await readSettings();
+  const overrides = await readPromptOverrides();
+  const globalPatterns = (settings.prompts ?? []).filter(
+    (p) => p.startsWith("!") || p.startsWith("+") || p.startsWith("-"),
+  );
+  const result = new Set<string>(globalPatterns);
+  const entry = overrides.projects[projectId];
+  if (entry !== undefined) {
+    for (const name of entry.disable) result.add(excludePattern(name));
+    for (const name of entry.enable) result.add(forceIncludePattern(name));
+  }
+  return Array.from(result);
+}
+
+/** Cascade-view counterpart to `getAllSkillOverrides`, for the Settings
+ *  UI's per-prompt expand-and-show-all-projects affordance. */
+export async function getAllPromptOverrides(): Promise<PromptOverrides> {
+  return readPromptOverrides();
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -201,6 +201,17 @@ export const config = Object.freeze({
    */
   toolOverridesFile: join(FORGE_DATA_DIR, "tool-overrides.json"),
   /**
+   * Path to the forge-private per-project prompt overrides file.
+   * Same shape + rationale as `skillOverridesFile` but for pi prompt
+   * templates (markdown files under `<dir>/prompts/`). Pi's
+   * `settings.prompts` is a flat global override-pattern list; we
+   * inject project-scoped patterns at session create through the
+   * SettingsManager monkey-patch in session-registry.ts (mirrors the
+   * skills code path). Lives in the data dir for the same reasons
+   * skill overrides do — install-private, not team-shared.
+   */
+  promptOverridesFile: join(FORGE_DATA_DIR, "prompts-overrides.json"),
+  /**
    * Whether `/api/docs` (Swagger UI + OpenAPI JSON spec) is reachable.
    * Defaults to true so Docker / production deploys keep working without
    * extra config (the README quickstart documents `/api/docs`). When

--- a/packages/server/src/project-manager.ts
+++ b/packages/server/src/project-manager.ts
@@ -13,6 +13,7 @@ import { dirname, join, relative, resolve, sep } from "node:path";
 import { randomUUID } from "node:crypto";
 import { config } from "./config.js";
 import { clearProjectOverrides as clearProjectSkillOverrides } from "./skill-overrides.js";
+import { clearProjectPromptOverrides } from "./prompt-overrides.js";
 
 /**
  * Project ids are always `randomUUID()` output. Mirrors the same
@@ -258,6 +259,9 @@ export async function deleteProject(
   // cascade view; it's harmless to read but pointless to keep.
   await clearProjectSkillOverrides(id).catch((err: unknown) => {
     warn({ err, id }, "skill-overrides cleanup failed");
+  });
+  await clearProjectPromptOverrides(id).catch((err: unknown) => {
+    warn({ err, id }, "prompt-overrides cleanup failed");
   });
   if (opts.cascadeSessionDir === true) {
     // Wipe the project's session directory. Best-effort — a missing

--- a/packages/server/src/prompt-overrides.ts
+++ b/packages/server/src/prompt-overrides.ts
@@ -1,0 +1,161 @@
+import { chmodSync } from "node:fs";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+import { config } from "./config.js";
+
+/**
+ * pi-forge-private per-project prompt overrides at
+ * `${FORGE_DATA_DIR}/prompts-overrides.json`. Mirrors the
+ * skill-overrides shape and rationale: each project keeps a tri-state
+ * position on every prompt (enabled / disabled / inherit), the
+ * effective list a session sees is `(global ∪ project.enabled) −
+ * project.disabled`, file lives outside `${PI_CONFIG_DIR}` because pi's
+ * `settings.prompts` is a single global pattern list, single file (vs
+ * per-project) so the cascade view across all projects is one read.
+ *
+ * The pi SDK's prompt patterns share the same prefix grammar as skills:
+ * `!name` excludes, `+name` force-includes. See `effectivePromptsForProject`
+ * for the merge semantics.
+ */
+
+export type PromptOverrideState = "enabled" | "disabled";
+
+interface ProjectOverrides {
+  /** Prompt names this project actively wants ON, regardless of global. */
+  enable: string[];
+  /** Prompt names this project actively wants OFF, regardless of global. */
+  disable: string[];
+}
+
+export interface PromptOverrides {
+  /** Map from projectId → that project's per-prompt overrides. */
+  projects: Record<string, ProjectOverrides>;
+}
+
+const EMPTY: PromptOverrides = { projects: {} };
+
+async function ensureDir(): Promise<void> {
+  await mkdir(dirname(config.promptOverridesFile), { recursive: true });
+}
+
+async function atomicWrite(data: PromptOverrides): Promise<void> {
+  await ensureDir();
+  const path = config.promptOverridesFile;
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+  try {
+    chmodSync(tmp, 0o600);
+  } catch {
+    // best-effort
+  }
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
+}
+
+export async function readPromptOverrides(): Promise<PromptOverrides> {
+  try {
+    const raw = await readFile(config.promptOverridesFile, "utf8");
+    if (raw.trim().length === 0) return { projects: {} };
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null || !("projects" in parsed)) {
+      return { projects: {} };
+    }
+    const projects = (parsed as { projects?: unknown }).projects;
+    if (typeof projects !== "object" || projects === null) return { projects: {} };
+    // Normalize each project entry — stale/malformed entries silently
+    // become empty rather than throwing.
+    const out: PromptOverrides = { projects: {} };
+    for (const [pid, val] of Object.entries(projects as Record<string, unknown>)) {
+      if (typeof val !== "object" || val === null) continue;
+      const enable = Array.isArray((val as ProjectOverrides).enable)
+        ? (val as ProjectOverrides).enable.filter((s) => typeof s === "string")
+        : [];
+      const disable = Array.isArray((val as ProjectOverrides).disable)
+        ? (val as ProjectOverrides).disable.filter((s) => typeof s === "string")
+        : [];
+      out.projects[pid] = { enable, disable };
+    }
+    return out;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return { projects: {} };
+    throw err;
+  }
+}
+
+/**
+ * Tri-state set: pass `state = undefined` to clear (inherit). Empty
+ * project entries are pruned so the file doesn't grow with stale
+ * keys after a series of toggles back to inherit.
+ */
+export async function setProjectPromptOverride(
+  projectId: string,
+  promptName: string,
+  state: PromptOverrideState | undefined,
+): Promise<void> {
+  const cur = await readPromptOverrides();
+  const entry = cur.projects[projectId] ?? { enable: [], disable: [] };
+  // Always remove from both lists first — flipping enabled→disabled
+  // or vice versa is just remove + maybe add.
+  entry.enable = entry.enable.filter((n) => n !== promptName);
+  entry.disable = entry.disable.filter((n) => n !== promptName);
+  if (state === "enabled") entry.enable.push(promptName);
+  else if (state === "disabled") entry.disable.push(promptName);
+  if (entry.enable.length === 0 && entry.disable.length === 0) {
+    delete cur.projects[projectId];
+  } else {
+    cur.projects[projectId] = entry;
+  }
+  await atomicWrite(cur);
+}
+
+/**
+ * Lookup helper used by the UI. Returns `undefined` when the project
+ * has no opinion on this prompt (= inherit from global).
+ */
+export function getProjectPromptState(
+  overrides: PromptOverrides,
+  projectId: string,
+  promptName: string,
+): PromptOverrideState | undefined {
+  const entry = overrides.projects[projectId];
+  if (entry === undefined) return undefined;
+  if (entry.enable.includes(promptName)) return "enabled";
+  if (entry.disable.includes(promptName)) return "disabled";
+  return undefined;
+}
+
+/**
+ * Return the set of prompt names this project has explicitly
+ * disabled. Used by the resource-loader's `promptsOverride` hook to
+ * filter out prompts that pi's pattern system can't reach (parallel
+ * to `getProjectDisabledSkillNames`). Today the SDK has no
+ * package-contributed prompts, but the hook is plumbed for symmetry
+ * with skills + future-proofing.
+ */
+export async function getProjectDisabledPromptNames(projectId: string): Promise<Set<string>> {
+  const cur = await readPromptOverrides();
+  const entry = cur.projects[projectId];
+  if (entry === undefined) return new Set();
+  return new Set(entry.disable);
+}
+
+/**
+ * Drop every override mention of a deleted project so the file
+ * doesn't accumulate orphaned entries. Called from project-manager
+ * on project delete (parallel to the skill-overrides version).
+ */
+export async function clearProjectPromptOverrides(projectId: string): Promise<void> {
+  const cur = await readPromptOverrides();
+  if (cur.projects[projectId] === undefined) return;
+  delete cur.projects[projectId];
+  await atomicWrite(cur);
+}
+
+/** Suppress an unused-export warning if EMPTY isn't referenced
+ *  by the importing module — the constant is exported for tests. */
+export const _EMPTY_FOR_TESTS = EMPTY;

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -1,13 +1,17 @@
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import {
   AuthProviderNotFoundError,
-  liveProvidersListing,
+  getAllPromptOverrides,
   getAllSkillOverrides,
+  liveProvidersListing,
+  listPrompts,
   listSkills,
+  PromptNotFoundError,
   readAuthSummary,
   readModelsJsonRedacted,
   readSettings,
   removeApiKey,
+  setPromptEnabled,
   setSkillEnabled,
   SkillNotFoundError,
   updateSettings,
@@ -184,6 +188,28 @@ const skillDiagnosticSchema = {
         loserPath: { type: "string" },
       },
     },
+  },
+} as const;
+
+/**
+ * Mirrors `skillSchema`. No `extensionPath` (no package-contributed
+ * prompts source today; see `listPrompts` doc-comment) and no
+ * `disableModelInvocation` (skills-only concept). `argumentHint`
+ * surfaces the optional bash-style usage hint from the prompt's
+ * frontmatter so the slash-command palette can render it.
+ */
+const promptSchema = {
+  type: "object",
+  required: ["name", "description", "source", "filePath", "enabled", "effective"],
+  properties: {
+    name: { type: "string" },
+    description: { type: "string" },
+    argumentHint: { type: "string" },
+    source: { type: "string", enum: ["global", "project"] },
+    filePath: { type: "string" },
+    enabled: { type: "boolean" },
+    projectOverride: { type: "string", enum: ["enabled", "disabled"] },
+    effective: { type: "boolean" },
   },
 } as const;
 
@@ -601,6 +627,221 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
       } catch (err) {
         if (err instanceof SkillNotFoundError) {
           return reply.code(404).send({ error: "skill_not_found" });
+        }
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  // ---------------------- prompts ----------------------
+  // Mirrors the skills routes end-to-end (list / overrides cascade /
+  // PUT enabled / DELETE override). Same tri-state per-project
+  // semantics; see the skills section above for the shape rationale.
+  // The pi SDK exposes prompts via `DefaultResourceLoader.getPrompts()`
+  // — see `listPrompts` in `config-manager.ts` for how we discover them
+  // and inject pattern overrides through the SettingsManager.
+  fastify.get<{ Querystring: { projectId: string } }>(
+    "/config/prompts",
+    {
+      schema: {
+        description:
+          "List prompt templates discovered for a project. Sources: global " +
+          "`~/.pi/agent/prompts/` and project-local `.pi/prompts/`. Each " +
+          "prompt carries `enabled` reflecting whether it's listed in " +
+          "`settings.prompts`. `diagnostics` mirrors the skills shape " +
+          "(currently always empty — the SDK doesn't surface prompt " +
+          "collisions today). Required: `?projectId=`.",
+        tags: ["config"],
+        querystring: {
+          type: "object",
+          required: ["projectId"],
+          properties: { projectId: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["prompts", "diagnostics"],
+            properties: {
+              prompts: { type: "array", items: promptSchema },
+              diagnostics: { type: "array", items: skillDiagnosticSchema },
+            },
+          },
+          404: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const project = await getProject(req.query.projectId);
+      if (project === undefined) {
+        return reply.code(404).send({ error: "project_not_found" });
+      }
+      try {
+        const { prompts, diagnostics } = await listPrompts(project.path, project.id);
+        return { prompts, diagnostics };
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  fastify.get(
+    "/config/prompts/overrides",
+    {
+      schema: {
+        description:
+          "All per-project prompt overrides across all projects. Same " +
+          "shape as `/config/skills/overrides`. Returns " +
+          "`{ projects: { <projectId>: { enable: [...], disable: [...] } } }`. " +
+          "Absent project keys mean 'no overrides defined' (the project " +
+          "inherits everything from global).",
+        tags: ["config"],
+        response: {
+          200: {
+            type: "object",
+            required: ["projects"],
+            properties: {
+              projects: {
+                type: "object",
+                additionalProperties: {
+                  type: "object",
+                  required: ["enable", "disable"],
+                  properties: {
+                    enable: { type: "array", items: { type: "string" } },
+                    disable: { type: "array", items: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+          500: errorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      try {
+        return await getAllPromptOverrides();
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  fastify.put<{
+    Params: { name: string };
+    Querystring: { projectId: string };
+    Body: { enabled: boolean; scope?: "global" | "project" };
+  }>(
+    "/config/prompts/:name/enabled",
+    {
+      schema: {
+        description:
+          "Toggle a prompt's enabled state. Default scope=`global` mutates " +
+          "pi's `settings.prompts`. scope=`project` writes to the pi-forge-" +
+          "private overrides file at `${FORGE_DATA_DIR}/prompts-overrides.json` " +
+          "for the project named in `?projectId=`. Same tri-state semantics " +
+          "as `/config/skills/:name/enabled`. Prompt changes apply on the " +
+          "NEXT session created in the affected project — live sessions " +
+          "keep the prompt set they booted with.",
+        tags: ["config"],
+        params: {
+          type: "object",
+          required: ["name"],
+          properties: { name: { type: "string", minLength: 1 } },
+        },
+        querystring: {
+          type: "object",
+          required: ["projectId"],
+          properties: { projectId: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          required: ["enabled"],
+          additionalProperties: false,
+          properties: {
+            enabled: { type: "boolean" },
+            scope: { type: "string", enum: ["global", "project"] },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["prompts"],
+            properties: { prompts: { type: "array", items: promptSchema } },
+          },
+          404: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const project = await getProject(req.query.projectId);
+      if (project === undefined) {
+        return reply.code(404).send({ error: "project_not_found" });
+      }
+      try {
+        const scope = req.body.scope ?? "global";
+        const prompts = await setPromptEnabled(req.params.name, req.body.enabled, project.path, {
+          scope,
+          projectId: project.id,
+        });
+        return { prompts };
+      } catch (err) {
+        if (err instanceof PromptNotFoundError) {
+          return reply.code(404).send({ error: "prompt_not_found" });
+        }
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  fastify.delete<{
+    Params: { name: string };
+    Querystring: { projectId: string };
+  }>(
+    "/config/prompts/:name/enabled",
+    {
+      schema: {
+        description:
+          "Clear a prompt's PROJECT override (= return it to inherit from " +
+          "global). Does not affect pi's settings.prompts. Use the PUT " +
+          "endpoint to change global state.",
+        tags: ["config"],
+        params: {
+          type: "object",
+          required: ["name"],
+          properties: { name: { type: "string", minLength: 1 } },
+        },
+        querystring: {
+          type: "object",
+          required: ["projectId"],
+          properties: { projectId: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["prompts"],
+            properties: { prompts: { type: "array", items: promptSchema } },
+          },
+          404: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const project = await getProject(req.query.projectId);
+      if (project === undefined) {
+        return reply.code(404).send({ error: "project_not_found" });
+      }
+      try {
+        const prompts = await setPromptEnabled(req.params.name, undefined, project.path, {
+          scope: "project",
+          projectId: project.id,
+        });
+        return { prompts };
+      } catch (err) {
+        if (err instanceof PromptNotFoundError) {
+          return reply.code(404).send({ error: "prompt_not_found" });
         }
         return internalError(reply, err);
       }

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -11,7 +11,7 @@ import {
 import { buildForgeResourceLoader } from "./agent-resource-loader.js";
 import { config } from "./config.js";
 import { makeDedupe, makeLock } from "./concurrency.js";
-import { effectiveSkillsForProject } from "./config-manager.js";
+import { effectivePromptsForProject, effectiveSkillsForProject } from "./config-manager.js";
 import { readProjects } from "./project-manager.js";
 import { filterEnabledTools, readToolOverrides } from "./tool-overrides.js";
 import { discoverExtensionResources } from "./extensions-discovery.js";
@@ -1399,19 +1399,28 @@ async function buildSessionSettingsManager(
   projectId: string,
 ): Promise<SettingsManager> {
   const sm = SettingsManager.create(workspacePath, config.piConfigDir);
-  const patterns = await effectiveSkillsForProject(projectId);
-  if (patterns.length === 0) return sm;
+  const [skillPatterns, promptPatterns] = await Promise.all([
+    effectiveSkillsForProject(projectId),
+    effectivePromptsForProject(projectId),
+  ]);
+  if (skillPatterns.length === 0 && promptPatterns.length === 0) return sm;
   const origGlobal = sm.getGlobalSettings.bind(sm);
   const origProject = sm.getProjectSettings.bind(sm);
-  const merge = (existing: string[] | undefined): string[] =>
-    Array.from(new Set([...(existing ?? []), ...patterns]));
+  const mergeSkills = (existing: string[] | undefined): string[] =>
+    skillPatterns.length === 0
+      ? (existing ?? [])
+      : Array.from(new Set([...(existing ?? []), ...skillPatterns]));
+  const mergePrompts = (existing: string[] | undefined): string[] =>
+    promptPatterns.length === 0
+      ? (existing ?? [])
+      : Array.from(new Set([...(existing ?? []), ...promptPatterns]));
   sm.getGlobalSettings = (): ReturnType<typeof origGlobal> => {
     const s = origGlobal();
-    return { ...s, skills: merge(s.skills) };
+    return { ...s, skills: mergeSkills(s.skills), prompts: mergePrompts(s.prompts) };
   };
   sm.getProjectSettings = (): ReturnType<typeof origProject> => {
     const s = origProject();
-    return { ...s, skills: merge(s.skills) };
+    return { ...s, skills: mergeSkills(s.skills), prompts: mergePrompts(s.prompts) };
   };
   return sm;
 }

--- a/tests/test-prompts.ts
+++ b/tests/test-prompts.ts
@@ -1,0 +1,272 @@
+/**
+ * Pi prompts surface integration test.
+ *
+ * Mirrors the skills coverage in test-config.ts but for the `/config/prompts`
+ * endpoints + per-project overrides + cascade view. Also exercises the
+ * SettingsManager monkey-patch via `effectivePromptsForProject` indirectly
+ * (via project-scope PUT/DELETE behaviour visible through GET).
+ *
+ * What this test does NOT cover:
+ *   - Actual prompt expansion at session.prompt() time. That's pi SDK
+ *     behaviour, gated by `expandPromptTemplates: true` in the SDK
+ *     itself; we don't re-test the SDK contract.
+ *   - The chat-input slash-command palette. UI behaviour, no server
+ *     surface to assert against.
+ */
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+interface JsonResponse {
+  status: number;
+  body: unknown;
+}
+
+async function jget(base: string, path: string): Promise<JsonResponse> {
+  const res = await fetch(`${base}${path}`);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function jsend(
+  base: string,
+  method: "POST" | "PUT" | "PATCH" | "DELETE",
+  path: string,
+  body?: unknown,
+): Promise<JsonResponse> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(`${base}${path}`, init);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function main(): Promise<void> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-prompts-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-prompts-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-prompts-data-"));
+  process.env.WORKSPACE_PATH = workspacePath;
+  process.env.PI_CONFIG_DIR = configDir;
+  process.env.FORGE_DATA_DIR = dataDir;
+  process.env.SESSION_DIR = join(workspacePath, ".pi", "sessions");
+  process.env.NODE_ENV = "test";
+  delete process.env.UI_PASSWORD;
+  delete process.env.JWT_SECRET;
+  delete process.env.API_KEY;
+
+  console.log(`[test-prompts] WORKSPACE_PATH=${workspacePath}`);
+  console.log(`[test-prompts] PI_CONFIG_DIR=${configDir}`);
+  console.log(`[test-prompts] FORGE_DATA_DIR=${dataDir}`);
+
+  // Seed a project-local prompt template under the workspace's
+  // `.pi/prompts/` directory. The pi SDK's prompt loader picks up
+  // top-level `.md` files there.
+  await mkdir(join(workspacePath, ".pi", "prompts"), { recursive: true });
+  await writeFile(
+    join(workspacePath, ".pi", "prompts", "summarize.md"),
+    [
+      "---",
+      "name: summarize",
+      "description: Summarize the given file at a high level.",
+      "argument-hint: <path>",
+      "---",
+      "Read $1 and produce a 3-bullet executive summary.",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  // And a global one so we exercise both source kinds.
+  await mkdir(join(configDir, "prompts"), { recursive: true });
+  await writeFile(
+    join(configDir, "prompts", "review.md"),
+    [
+      "---",
+      "name: review",
+      "description: Review the diff of the current branch and suggest improvements.",
+      "---",
+      "Run git diff main..HEAD and review the changes for correctness and style.",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const buildModule = (await import(
+    resolve(repoRoot, "packages/server/dist/index.js")
+  )) as unknown as {
+    buildServer: () => Promise<{
+      listen: (opts: { port: number; host: string }) => Promise<string>;
+      close: () => Promise<void>;
+    }>;
+  };
+
+  const fastify = await buildModule.buildServer();
+  const base = await fastify.listen({ port: 0, host: "127.0.0.1" });
+
+  try {
+    // 1. Create a project so the prompt routes can scope to it.
+    const proj = await jsend(base, "POST", "/api/v1/projects", {
+      name: "test-prompts",
+      path: workspacePath,
+    });
+    assert("create project → 201", proj.status === 201);
+    const projectId = (proj.body as { id: string }).id;
+
+    // 2. GET /config/prompts — should list both global + project-local.
+    {
+      const list = await jget(base, `/api/v1/config/prompts?projectId=${projectId}`);
+      assert("GET /config/prompts → 200", list.status === 200);
+      const body = list.body as {
+        prompts: { name: string; source: string; enabled: boolean; effective: boolean; argumentHint?: string }[];
+        diagnostics: unknown[];
+      };
+      const summarize = body.prompts.find((p) => p.name === "summarize");
+      const review = body.prompts.find((p) => p.name === "review");
+      assert("  project-local 'summarize' present", summarize !== undefined);
+      assert("  global 'review' present", review !== undefined);
+      assert("  source classification correct", summarize?.source === "project" && review?.source === "global");
+      assert("  argumentHint surfaced", summarize?.argumentHint === "<path>");
+      assert("  both default to enabled (no global !patterns)", summarize?.enabled === true && review?.enabled === true);
+      assert("  diagnostics is empty array (SDK doesn't surface prompt collisions yet)", Array.isArray(body.diagnostics) && body.diagnostics.length === 0);
+    }
+
+    // 3. PUT global enabled=false on `summarize` — writes pi's settings.prompts pattern.
+    {
+      const r = await jsend(
+        base,
+        "PUT",
+        `/api/v1/config/prompts/summarize/enabled?projectId=${projectId}`,
+        { enabled: false, scope: "global" },
+      );
+      assert("PUT /config/prompts/summarize/enabled false (global) → 200", r.status === 200);
+      const updated = (r.body as { prompts: { name: string; enabled: boolean }[] }).prompts.find(
+        (p) => p.name === "summarize",
+      );
+      assert("  summarize.enabled === false after disable", updated?.enabled === false);
+
+      const onDisk = JSON.parse(await readFile(join(configDir, "settings.json"), "utf8")) as {
+        prompts?: string[];
+      };
+      assert(
+        "  settings.json contains `!summarize` exclude pattern",
+        onDisk.prompts?.includes("!summarize") === true,
+        JSON.stringify(onDisk.prompts),
+      );
+    }
+
+    // 4. PUT project enabled=true on `summarize` — project enable beats global disable.
+    {
+      const r = await jsend(
+        base,
+        "PUT",
+        `/api/v1/config/prompts/summarize/enabled?projectId=${projectId}`,
+        { enabled: true, scope: "project" },
+      );
+      assert("PUT /config/prompts/summarize/enabled true (project) → 200", r.status === 200);
+      const updated = (
+        r.body as { prompts: { name: string; enabled: boolean; effective: boolean; projectOverride?: string }[] }
+      ).prompts.find((p) => p.name === "summarize");
+      assert(
+        "  global remains disabled",
+        updated?.enabled === false,
+        JSON.stringify(updated),
+      );
+      assert("  projectOverride === 'enabled'", updated?.projectOverride === "enabled");
+      assert(
+        "  effective is true (project enable wins)",
+        updated?.effective === true,
+        JSON.stringify(updated),
+      );
+    }
+
+    // 5. GET /config/prompts/overrides — cascade view returns the file contents.
+    {
+      const r = await jget(base, "/api/v1/config/prompts/overrides");
+      assert("GET /config/prompts/overrides → 200", r.status === 200);
+      const body = r.body as {
+        projects: Record<string, { enable: string[]; disable: string[] }>;
+      };
+      assert(
+        "  override file lists this project's enable",
+        body.projects[projectId]?.enable.includes("summarize") === true,
+        JSON.stringify(body),
+      );
+    }
+
+    // 6. DELETE the project override — effective falls back to (still-disabled) global.
+    {
+      const r = await jsend(
+        base,
+        "DELETE",
+        `/api/v1/config/prompts/summarize/enabled?projectId=${projectId}`,
+      );
+      assert("DELETE /config/prompts/summarize/enabled → 200", r.status === 200);
+      const updated = (
+        r.body as { prompts: { name: string; effective: boolean; projectOverride?: string }[] }
+      ).prompts.find((p) => p.name === "summarize");
+      assert("  projectOverride absent after clear", updated?.projectOverride === undefined);
+      assert(
+        "  effective falls back to global (false)",
+        updated?.effective === false,
+        JSON.stringify(updated),
+      );
+    }
+
+    // 7. Unknown prompt → 404.
+    {
+      const r = await jsend(
+        base,
+        "PUT",
+        `/api/v1/config/prompts/no-such-prompt/enabled?projectId=${projectId}`,
+        { enabled: true },
+      );
+      assert(
+        "PUT toggle on unknown prompt → 404",
+        r.status === 404,
+        JSON.stringify(r.body),
+      );
+    }
+
+    // 8. Unknown projectId → 404.
+    {
+      const r = await jget(
+        base,
+        `/api/v1/config/prompts?projectId=00000000-0000-0000-0000-000000000000`,
+      );
+      assert("GET /config/prompts with unknown projectId → 404", r.status === 404);
+    }
+  } finally {
+    await fastify.close();
+    await rm(workspacePath, { recursive: true, force: true }).catch(() => undefined);
+    await rm(configDir, { recursive: true, force: true }).catch(() => undefined);
+    await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-prompts] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-prompts] PASS");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/test-prompts.ts
+++ b/tests/test-prompts.ts
@@ -134,17 +134,32 @@ async function main(): Promise<void> {
       const list = await jget(base, `/api/v1/config/prompts?projectId=${projectId}`);
       assert("GET /config/prompts → 200", list.status === 200);
       const body = list.body as {
-        prompts: { name: string; source: string; enabled: boolean; effective: boolean; argumentHint?: string }[];
+        prompts: {
+          name: string;
+          source: string;
+          enabled: boolean;
+          effective: boolean;
+          argumentHint?: string;
+        }[];
         diagnostics: unknown[];
       };
       const summarize = body.prompts.find((p) => p.name === "summarize");
       const review = body.prompts.find((p) => p.name === "review");
       assert("  project-local 'summarize' present", summarize !== undefined);
       assert("  global 'review' present", review !== undefined);
-      assert("  source classification correct", summarize?.source === "project" && review?.source === "global");
+      assert(
+        "  source classification correct",
+        summarize?.source === "project" && review?.source === "global",
+      );
       assert("  argumentHint surfaced", summarize?.argumentHint === "<path>");
-      assert("  both default to enabled (no global !patterns)", summarize?.enabled === true && review?.enabled === true);
-      assert("  diagnostics is empty array (SDK doesn't surface prompt collisions yet)", Array.isArray(body.diagnostics) && body.diagnostics.length === 0);
+      assert(
+        "  both default to enabled (no global !patterns)",
+        summarize?.enabled === true && review?.enabled === true,
+      );
+      assert(
+        "  diagnostics is empty array (SDK doesn't surface prompt collisions yet)",
+        Array.isArray(body.diagnostics) && body.diagnostics.length === 0,
+      );
     }
 
     // 3. PUT global enabled=false on `summarize` — writes pi's settings.prompts pattern.
@@ -181,13 +196,16 @@ async function main(): Promise<void> {
       );
       assert("PUT /config/prompts/summarize/enabled true (project) → 200", r.status === 200);
       const updated = (
-        r.body as { prompts: { name: string; enabled: boolean; effective: boolean; projectOverride?: string }[] }
+        r.body as {
+          prompts: {
+            name: string;
+            enabled: boolean;
+            effective: boolean;
+            projectOverride?: string;
+          }[];
+        }
       ).prompts.find((p) => p.name === "summarize");
-      assert(
-        "  global remains disabled",
-        updated?.enabled === false,
-        JSON.stringify(updated),
-      );
+      assert("  global remains disabled", updated?.enabled === false, JSON.stringify(updated));
       assert("  projectOverride === 'enabled'", updated?.projectOverride === "enabled");
       assert(
         "  effective is true (project enable wins)",
@@ -237,11 +255,7 @@ async function main(): Promise<void> {
         `/api/v1/config/prompts/no-such-prompt/enabled?projectId=${projectId}`,
         { enabled: true },
       );
-      assert(
-        "PUT toggle on unknown prompt → 404",
-        r.status === 404,
-        JSON.stringify(r.body),
-      );
+      assert("PUT toggle on unknown prompt → 404", r.status === 404, JSON.stringify(r.body));
     }
 
     // 8. Unknown projectId → 404.


### PR DESCRIPTION
## Summary

Brings pi-forge's prompts surface to **feature parity with skills** — list, invoke from chat, Settings → Prompts management tab, per-project enable/disable overrides, cascade view across projects.

Pi prompts are markdown templates under `<dir>/prompts/` (mirrors the skills layout). The pi SDK loads them via the resource loader and `session.prompt()` already expands `/<promptname> args` to the template body before sending to the model (`expandPromptTemplates: true` is the SDK default — pi-forge does NOT need to expand server-side; the integration is purely **discovery + management**).

## What lands

### Server
- **`prompt-overrides.ts`** (new) — pi-forge-private per-project tri-state store at `${FORGE_DATA_DIR}/prompts-overrides.json`. Mirrors `skill-overrides.ts` byte-for-byte (atomic writes, tri-state semantics, cascade-clear on project delete).
- **`config-manager.ts`** — `listPrompts` + `setPromptEnabled` + `effectivePromptsForProject` + `getAllPromptOverrides` + `PromptNotFoundError` + `PromptSummary` + `PromptsListResult`. Uses `DefaultResourceLoader.getPrompts()` for discovery (the standalone `loadPromptTemplates` isn't exported from the SDK package index).
- **`session-registry.ts buildSessionSettingsManager`** — extended to inject BOTH skill AND prompt patterns into the SettingsManager monkey-patch.
- **`agent-resource-loader.ts buildForgeResourceLoader`** — adds the `promptsOverride` callback (parallel to existing `skillsOverride`).
- **`routes/config.ts`** — four new routes: `GET /config/prompts`, `GET /config/prompts/overrides`, `PUT /config/prompts/:name/enabled`, `DELETE /config/prompts/:name/enabled`. Same shape as the corresponding skills routes.

### Client
- **`api-client/`** — `PromptSummary`, `PromptOverridesResponse`, `PromptsListResponse`, `PromptOverrideState` types + matching validators + `listPrompts` / `listPromptOverrides` / `setPromptEnabled` / `clearPromptProjectOverride` api methods.
- **`SettingsPanel.tsx`** — new "Prompts" tab + `PromptsTab` component (mirrors `SkillsTab` with the extension/`disableModelInvocation` columns dropped, `argumentHint` chip added when present).
- **`ChatInput.tsx`** — fetches the active project's enabled prompts and appends them to the slash-command catalog as `/<promptname>` entries with description + argument hint. Selecting one inserts `/<name> ` into the input so the user can append args before pressing Enter; the SDK expands the template at send time.

## Differences from skills

| | Skills | Prompts |
|---|---|---|
| Source kinds | `global` / `project` / `extension` | `global` / `project` (no package source today) |
| `disableModelInvocation` field | Yes | No (not a prompts concept) |
| Argument hint | No | Yes (`argument-hint` frontmatter) |
| Diagnostics | SDK surfaces collisions | SDK doesn't surface today (always `[]`) |
| File location | `<dir>/skills/` | `<dir>/prompts/` |

## Test plan
- [x] `npm run check` clean (typecheck + lint + format)
- [x] `npm run build` clean
- [x] `npx tsx tests/test-prompts.ts` — 22/22 PASS (new file, mirrors skills coverage in test-config.ts)
- [x] `npm run test:ci` — 25/25 PASS (was 24)
- [ ] Live: drop a `summarize.md` with `name:` + `description:` + `argument-hint:` frontmatter into `<project>/.pi/prompts/`, confirm it appears in:
  - Settings → Prompts (with the argument-hint chip)
  - the chat-input slash-command palette as `/summarize`
- [ ] Live: type `/summarize foo.ts` in the chat, hit send, confirm the agent receives the EXPANDED template body (with `$1` substituted) — that's pi SDK behaviour we're trusting; the chat input shouldn't echo the literal `/summarize foo.ts`.
- [ ] Live: toggle the prompt off in Settings → Prompts, confirm it disappears from the slash palette on next session.
- [ ] Live: per-project override (Settings → Prompts → Overrides) — toggle on for one project, off for another; verify each session sees its own state.