### PR TITLE
chore(scripts): add npm run dev:remote for LAN-accessible dev server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ pi-forge/
 npm install          # Install all workspace deps (run from root)
 npm run build        # Compile server TS + Vite client build
 npm run dev          # Start both: server (tsx watch) + client (vite dev server)
+npm run dev:remote   # Same as `dev` but binds both to 0.0.0.0 (LAN-accessible).
+                     # Set UI_PASSWORD or API_KEY before exposing — auth is OFF
+                     # by default in dev. macOS will prompt to allow incoming
+                     # connections on first run.
 npm run check        # tsc typecheck + eslint + prettier (requires npm run build first)
 npm run test:ci      # Loop every tests/test-*.ts (skips test-docker; ~40 s)
 npm run test         # Same loop, no skip list (run before tagging a release)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "dev": "concurrently \"npm run dev -w packages/server\" \"npm run dev -w packages/client\"",
+    "dev:remote": "HOST=0.0.0.0 concurrently \"npm run dev -w packages/server\" \"npm run dev -w packages/client -- --host\"",
     "typecheck": "npm run check --workspaces --if-present && tsc -p tests/tsconfig.json",
     "lint": "eslint .",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary

New `npm run dev:remote` script — same as `npm run dev` but binds both halves (Fastify server on :3000 + Vite dev server on :5173) to `0.0.0.0` so other devices on the same network can reach the dev workbench. Useful for testing on a phone, pair-debugging from another laptop, demo'ing in a room, etc.

```jsonc
"dev:remote": "HOST=0.0.0.0 concurrently \"npm run dev -w packages/server\" \"npm run dev -w packages/client -- --host\""
```

The server side has supported `HOST=0.0.0.0` since v1.0 (`config.ts:144` honours the env). The vite side just needed the `--host` flag — vite defaults to `127.0.0.1` in dev. The new script wires both at once so there's nothing to remember.

`CLAUDE.md`'s "Build & Dev Commands" table gains a one-line entry calling out:
- The auth posture: dev mode runs auth-OFF by default — operators MUST set `UI_PASSWORD` or `API_KEY` before exposing anything beyond localhost. The script doesn't enforce this (no nanny-state), but the doc-comment makes it discoverable.
- The macOS firewall prompt that fires on first run.

## Test plan

- [x] `PORT=3993 npm run dev:remote` boots both, binds both to `*`, both reachable from the Mac's LAN IP (not just localhost) — verified with `lsof -nP -iTCP -sTCP:LISTEN` and a `curl` against the Mac's LAN IP.
- [x] Existing `npm run dev` still binds to `127.0.0.1` (no regression — the new script just adds a second entry).
- [x] `npm run check` clean.
- [x] Live: `npm run dev:remote` on the Mac, hit `http://<mac-lan-ip>:5173` from a second device on the same wifi, confirm the chat UI loads + the `/api/*` proxy works (server-side proxy on the Mac, so works regardless of what the second device can resolve).
- [x] If using outside the LAN: prefer Tailscale or `ngrok http 5173` over poking the router — both inherit the auth gate above.

## Closes

n/a — DX improvement.