### PR TITLE
chore(release): v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.1.6] — 2026-05-09
+
 ### Added
 
 - **Pi prompt templates as a first-class surface.** Markdown templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,55 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Added
+
+- **Pi prompt templates as a first-class surface.** Markdown templates
+  under `<dir>/prompts/` (mirrors `<dir>/skills/`) now appear in the
+  chat-input slash-command palette as `/<promptname>` entries with
+  description + argument hint, and in a new **Settings → Prompts**
+  management tab modeled on Settings → Skills (per-project tri-state
+  toggles, cascade view across projects). Pi's `session.prompt()`
+  already expands `/<name> args` to the template body via
+  `expandPromptTemplates: true`, so pi-forge's role is purely
+  discovery + management — no server-side expansion. Per-project
+  state lives in `${FORGE_DATA_DIR}/prompts-overrides.json`. Toggling
+  in Settings → Prompts immediately drops/adds the prompt in the
+  chat-input palette without a project switch (cross-component
+  refresh trigger via ui-store).
+- **Settings → Backup now bundles per-project override files.** Export
+  tarball gains `skills-overrides.json`, `tool-overrides.json`, and
+  `prompts-overrides.json` alongside the existing `mcp.json` /
+  `settings.json` / `models.json`. Pairs the global state with the
+  per-project tool/skill/prompt toggles so a backup → restore cycle
+  preserves both. `projectId` keys in the override files are local
+  UUIDs — importing onto a different installation leaves orphan
+  entries that are silently ignored at session-create (deliberate
+  trade-off; the alternative would defeat the point of carrying
+  per-project config across installs that share workspaces).
+- **`npm run dev:remote`** — same as `npm run dev` but binds both
+  halves (Fastify + Vite dev server) to `0.0.0.0` so other devices
+  on the LAN can reach the dev workbench. Useful for testing on a
+  phone, pair-debugging from another laptop, or demoing in a room.
+  Set `UI_PASSWORD` or `API_KEY` first — auth is OFF by default in
+  dev. macOS will prompt to allow incoming connections on first run.
+- **Folder name on project sidebar rows.** Each project row now shows
+  the on-disk folder basename below the display name in a smaller
+  mono font. Useful when the display name has been renamed away from
+  the folder name and you're debugging which checkout the project
+  points at.
+
+### Changed
+
+- **Settings panel widened from `max-w-3xl` (768 px) to `max-w-4xl`
+  (896 px)** to give the now-9-tab bar (Providers, Agent, MCP, Tools,
+  Skills, Prompts, Appearance, Backup, General) breathing room. The
+  panel is a modal so the extra width doesn't compete with the chat.
+- **Unsaved file indicator on editor tabs is now a 10 px filled
+  amber circle.** Was a 12 px bullet character (`•`) at the
+  surrounding text size which mostly disappeared into the filename.
+  Sized independently of the text so the dirty cue is unmissable;
+  `aria-label="Unsaved changes"` for screen readers.
+
 ## [1.1.5] — 2026-05-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "workspaces": [
         "packages/*"
       ],
@@ -17041,7 +17041,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17120,7 +17120,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.74.0",
         "@earendil-works/pi-ai": "0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts v1.1.6 — bumps the three workspace package.json files in lockstep and renames `[Unreleased]` → `[1.1.6] — 2026-05-09`. Four PRs since v1.1.5:

**Added** (4) — pi prompt-templates surface (Settings → Prompts + slash palette + per-project overrides) (#93), per-project override files in config backup (skills/tool/prompts) (#92), `npm run dev:remote` for LAN-accessible dev server (#94), folder name on project sidebar rows (#91).

**Changed** (2) — Settings panel max-width 3xl → 4xl to fit the 9-tab bar (#93 follow-on), unsaved-file editor-tab indicator bumped from `•` to a 10 px filled amber circle (#91).

## Notable for operators

- **Backup tarball shape changed.** Now includes `skills-overrides.json`, `tool-overrides.json`, and `prompts-overrides.json` alongside the existing three. Old v1.1.5 tarballs still import cleanly (the new files are simply absent → no per-project overrides applied). New tarballs imported on a v1.1.5 install will warn-and-skip the unknown filenames.
- **`npm run dev:remote`** is the new way to expose the dev workbench on the LAN. Set `UI_PASSWORD` or `API_KEY` first — auth is OFF by default in dev.

## Test plan

- [x] `npm run check` clean (typecheck + lint + format) on the bumped tree
- [x] `npm run test:ci` — 25/25 PASS
- [x] Tag from main after merge: `git checkout main && git pull --ff-only && git tag v1.1.6 && git push origin v1.1.6`
- [x] Release workflow runs and produces: GHCR multi-arch image (`ghcr.io/devin-marks/pi-forge:v1.1.6`), npm tarball published as `pi-forge@1.1.6`, GitHub Release with notes derived from the CHANGELOG entry
- [x] Smoke-test the npm install: `npx pi-forge@1.1.6` boots and `/api/v1/ui-config` reports version `1.1.6`
- [x] Run `scripts/run-tests.sh --only docker` locally before tagging to confirm the production image still builds (CI-skipped per repo policy)