### PR TITLE
feat(cli): expose env vars as flags + tighten safer defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,13 @@ serves the built Vite output as static files — single port, no CORS needed.
 All reads are centralized in `packages/server/src/config.ts`. Never read
 `process.env` directly in any other file — always import from config.
 
+Every operationally-relevant env var also has an equivalent CLI flag on
+the `pi-forge` command, surfaced via the bin shim
+(`bin/pi-forge.mjs` → `packages/server/src/cli.ts`). The flag table in
+`cli.ts` is the single source of truth for the env↔flag mapping —
+adding a new env var means adding one row there so it's reachable
+without an env wrapper. Run `pi-forge --help` for the grouped list.
+
 | Variable | Default | Description |
 |---|---|---|
 | `PORT` | `3000` | Fastify listen port |

--- a/README.md
+++ b/README.md
@@ -73,9 +73,19 @@ pi-forge
 
 By default pi-forge listens on `http://localhost:3000`, reads provider config
 from `~/.pi/agent/` (shared with the host `pi` CLI if you have one), and
-stores its own state in `~/.pi-forge/`. Override with `PORT`, `PI_CONFIG_DIR`,
-`FORGE_DATA_DIR`, `WORKSPACE_PATH` env vars — see
-[`docs/configuration.md`](./docs/configuration.md).
+stores its own state in `~/.pi-forge/`. Override paths, port, auth, and the
+rest with `--flags` or environment variables — every server env var has an
+equivalent flag, so you don't need a wrapper script just to set a port:
+
+```bash
+pi-forge --port 4000 --workspace-path ~/Code
+pi-forge --api-key @/run/secrets/api-key --no-expose-docs
+pi-forge --help            # full flag table grouped by category
+```
+
+Flags win when both a flag and the matching env var are set. See
+[`docs/configuration.md`](./docs/configuration.md) for the full
+flag ↔ env mapping.
 
 Either way: open the listed URL, add a project (point at a folder under
 `WORKSPACE_PATH`), drop a provider API key into Settings, and start a session.

--- a/bin/pi-forge.mjs
+++ b/bin/pi-forge.mjs
@@ -17,12 +17,14 @@
  * package. We override `CLIENT_DIST_PATH` here so the same server entry
  * works in all three deployment shapes without touching server code.
  *
- * Everything else (workspace path, pi config dir, forge data dir, port,
- * auth) is read from env vars and uses the server's existing defaults
- * (`~/.pi-forge/workspace`, `~/.pi/agent`, `~/.pi-forge`, port 3000) —
- * users who installed via `npm i -g pi-forge` get sensible per-user
- * paths under their home directory without any setup.
+ * Flag parsing: `cli.js` translates argv into env-var writes BEFORE
+ * `index.js` is imported, because config.js reads `process.env` at
+ * module-load time. Every server env var has an equivalent --flag —
+ * see `pi-forge --help` or `packages/server/src/cli.ts` for the
+ * complete table. Env vars still work as fallbacks for users who
+ * already have them set; flag values win when both are present.
  */
+import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -31,6 +33,33 @@ const packageRoot = resolve(here, "..");
 
 process.env.CLIENT_DIST_PATH ??= resolve(packageRoot, "dist", "client");
 process.env.NODE_ENV ??= "production";
+
+const cliEntry = resolve(packageRoot, "dist", "server", "cli.js");
+const { parseCliArgs, applyCliEnv, buildHelpText } = await import(pathToFileURL(cliEntry).href);
+
+const parsed = parseCliArgs(process.argv.slice(2));
+
+if (parsed.errors.length > 0) {
+  for (const err of parsed.errors) {
+    process.stderr.write(`pi-forge: ${err}\n`);
+  }
+  process.stderr.write(`pi-forge: run with --help for usage.\n`);
+  process.exit(2);
+}
+
+if (parsed.helpRequested) {
+  const pkg = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
+  process.stdout.write(buildHelpText(pkg.version));
+  process.exit(0);
+}
+
+if (parsed.versionRequested) {
+  const pkg = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
+  process.stdout.write(`pi-forge ${pkg.version}\n`);
+  process.exit(0);
+}
+
+applyCliEnv(parsed);
 
 const serverEntry = resolve(packageRoot, "dist", "server", "index.js");
 const { start } = await import(pathToFileURL(serverEntry).href);

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -46,13 +46,16 @@ FORGE_DATA_HOST_PATH=~/.pi-forge-docker
 # Delete the password-hash file (and unset/rotate UI_PASSWORD if you
 # want a different initial value) to reset.
 UI_PASSWORD=
-# When `true` (default) and the user logs in with the env-supplied
-# UI_PASSWORD AND no on-disk hash exists yet, the issued JWT is
-# scoped to POST /auth/change-password — the UI forces the user to
-# pick a new password before any other API call works. Set to
-# `false` to skip the prompt and keep UI_PASSWORD as-is (useful when
-# the value is sourced from a sealed secret you rotate out-of-band).
-REQUIRE_PASSWORD_CHANGE=true
+# When `true` and the user logs in with the env-supplied UI_PASSWORD
+# AND no on-disk hash exists yet, the issued JWT is scoped to
+# POST /auth/change-password — the UI forces the user to pick a new
+# password before any other API call works. Defaults to `false`:
+# pi-forge is single-tenant and a user setting their own UI_PASSWORD
+# does so deliberately, so forcing a change is friction without a
+# real win. Set to `true` for deployments where UI_PASSWORD comes
+# from a sealed secret (helm, vault, sealed-secrets) and the operator
+# should rotate it on first login.
+REQUIRE_PASSWORD_CHANGE=false
 # JWT signing key. OPTIONAL — if UI_PASSWORD is set and JWT_SECRET is
 # empty, the server auto-generates one and persists it to
 # ${FORGE_DATA_DIR}/jwt-secret (mode 0600). The data dir is already

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -56,10 +56,11 @@ services:
       # UI_PASSWORD is the INITIAL password; once changed via the UI
       # the scrypt hash at ${FORGE_DATA_DIR}/password-hash takes
       # over and this env value is ignored. REQUIRE_PASSWORD_CHANGE
-      # (default true) forces the user to pick a new password on
-      # first login when only UI_PASSWORD is set.
+      # (default false) opt-in flag for sealed-secret deployments —
+      # set to true when UI_PASSWORD comes from helm/vault and the
+      # operator should rotate it on first login.
       - UI_PASSWORD=${UI_PASSWORD:-}
-      - REQUIRE_PASSWORD_CHANGE=${REQUIRE_PASSWORD_CHANGE:-true}
+      - REQUIRE_PASSWORD_CHANGE=${REQUIRE_PASSWORD_CHANGE:-false}
       - JWT_SECRET=${JWT_SECRET:-}
       - API_KEY=${API_KEY:-}
       # Logging + reverse-proxy hint.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,12 +11,43 @@ pi-forge's runtime behavior is shaped by **two** layers of configuration:
    `/api/v1/config/*` routes. See [Pi SDK config files](#pi-sdk-config-files)
    below.
 
+## CLI flags
+
+Every server env var below has an equivalent kebab-case flag on the
+`pi-forge` command. **Flags win when both are set** — `pi-forge --port
+4000` overrides `PORT=3000` in the environment. When no flag is given,
+the existing env value persists. The flag table is exhaustive — anything
+you'd set with `FOO_BAR=value` you can pass as `--foo-bar value`.
+
+```bash
+pi-forge --help              # full grouped flag list
+pi-forge --port 4000 --workspace-path ~/Code
+pi-forge --no-expose-docs --minimal-ui
+```
+
+**Sensitive flags** (`--ui-password`, `--api-key`, `--jwt-secret`)
+accept `@<path>` to read the value from a file instead of argv (avoids
+shell history / `ps` leakage):
+
+```bash
+pi-forge --api-key @/run/secrets/api-key
+```
+
+**Boolean flags** accept `true|false|on|off|1|0|yes|no`. Bare `--flag`
+means `true`; `--no-flag` means `false`.
+
+The single source of truth is
+[`packages/server/src/cli.ts`](../packages/server/src/cli.ts) — adding a
+new env var means adding one row to the `FLAGS` table there, which
+auto-derives the parser, the `process.env` writes, and the `--help`
+output.
+
 ## Environment variables
 
 | Variable | Default | Notes |
 |---|---|---|
 | `PORT` | `3000` | Fastify listen port. |
-| `HOST` | `0.0.0.0` | Bind address. |
+| `HOST` | `127.0.0.1` | Bind address. Defaults to loopback so a fresh install can't accidentally expose the agent's `bash`/`edit` tools to anyone on the same network. Set to `0.0.0.0` to expose to the LAN or to make Docker port-forwarding work (the shipped Dockerfile already does this). |
 | `LOG_LEVEL` | `info` | Pino log level. |
 | `WORKSPACE_PATH` | `~/.pi-forge/workspace` | Where project code lives. Docker image overrides to `/workspace` (mounted from host). Point at an existing dir (e.g. `~/Code`) to reuse code you already have on disk. |
 | `PI_CONFIG_DIR` | `~/.pi/agent` | Pi SDK config dir (auth.json, models.json, settings.json — owned by the SDK). The Docker image overrides this to `/home/pi/.pi/agent` (mounted from the host's `~/.pi/agent`). |
@@ -25,7 +56,7 @@ pi-forge's runtime behavior is shaped by **two** layers of configuration:
 | `SERVE_CLIENT` | `true` | Set to `false` to skip static-serving (useful when running the dev Vite server in front of the API). |
 | `SESSION_DIR` | `${WORKSPACE_PATH}/.pi/sessions` | JSONL session storage. |
 | `UI_PASSWORD` | (unset) | If set, enables browser JWT auth. `JWT_SECRET` is auto-generated on first boot if not supplied. After the user changes it via the UI, a scrypt hash is persisted to `${FORGE_DATA_DIR}/password-hash` and this env var is ignored on subsequent logins. |
-| `REQUIRE_PASSWORD_CHANGE` | `true` | When the user logs in with the env-supplied `UI_PASSWORD` and no on-disk hash exists yet, the issued token is scoped to `POST /auth/change-password` and the UI forces the user to pick a new password before continuing. Set to `false` to keep the env-supplied password as-is (useful when `UI_PASSWORD` is itself sourced from a sealed secret you rotate out-of-band). |
+| `REQUIRE_PASSWORD_CHANGE` | `false` | When `true` and the user logs in with the env-supplied `UI_PASSWORD` and no on-disk hash exists yet, the issued token is scoped to `POST /auth/change-password` and the UI forces the user to pick a new password before continuing. Defaults to `false` because pi-forge is single-tenant and a user setting their own `--ui-password` does so deliberately — forcing them to change it is friction without a real win. Set to `true` for deployments where `UI_PASSWORD` comes from a sealed secret (helm, docker-compose `.env`, vault) and should be rotated by the operator on first login. |
 | `JWT_SECRET` | (unset, auto-generated) | HS256 signing key. **Optional** — when `UI_PASSWORD` is set and `JWT_SECRET` is not, the server generates one and persists it to `${FORGE_DATA_DIR}/jwt-secret` (mode 0600). The data dir is already a PVC / bind-mount in K8s and Docker, so tokens survive restarts with no extra wiring. Set this env var to override (e.g. `openssl rand -hex 32`). Delete the file to rotate. |
 | `API_KEY` | (unset) | Static bearer token for programmatic access. |
 | `JWT_EXPIRES_IN_SECONDS` | `604800` | JWT lifetime (default 7 d). |

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,0 +1,569 @@
+/**
+ * pi-forge CLI argument parser.
+ *
+ * Pure module — does NOT import from `./config.js` or any other server
+ * module so it can run in the bin shim BEFORE the server module loads.
+ * Config reads `process.env` at import time, so flag → env writes must
+ * happen before that import.
+ *
+ * Single source of truth: the `FLAGS` table below drives:
+ *   1. argument parsing (via Node's built-in `node:util` parseArgs)
+ *   2. process.env mutation (each flag maps to its env-var equivalent)
+ *   3. `--help` rendering
+ *
+ * Adding a new env var → add one row here. Don't fork the table.
+ *
+ * Conventions:
+ *   - Flag names: kebab-case, long-form only (no single-char shortcuts).
+ *   - Boolean flags: `--foo true|false|on|off|1|0|yes|no`. Bare `--foo`
+ *     is treated as `--foo=true`. `--no-foo` is treated as `--foo=false`.
+ *   - Path flags: passed through verbatim (config.ts resolves them).
+ *   - Sensitive flags (auth secrets): support `@<path>` syntax so the
+ *     value can come from a file instead of argv (avoids shell history
+ *     / `ps` exposure). Same convention `curl` and `gh` use.
+ *   - Flag values always WIN over env. `pi-forge --port 4000` overrides
+ *     `PORT=3000` in the environment. Env is a fallback — if the flag
+ *     is absent, the existing env value persists, and config.ts handles
+ *     the default.
+ */
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+type FlagType = "string" | "number" | "boolean" | "list";
+type FlagGroup = "network" | "paths" | "auth" | "rate-limits" | "features" | "terminal";
+
+interface FlagDef {
+  name: string; // kebab-case CLI flag (without leading --)
+  env: string; // process.env key it writes to
+  type: FlagType;
+  group: FlagGroup;
+  desc: string;
+  defaultText: string; // shown in --help (not the actual default — config.ts owns that)
+  sensitive?: boolean; // enable @file syntax
+}
+
+const FLAGS: readonly FlagDef[] = [
+  // network
+  {
+    name: "port",
+    env: "PORT",
+    type: "number",
+    group: "network",
+    desc: "HTTP listen port",
+    defaultText: "3000",
+  },
+  {
+    name: "host",
+    env: "HOST",
+    type: "string",
+    group: "network",
+    desc: "Bind address (loopback by default; set 0.0.0.0 to expose to the network)",
+    defaultText: "127.0.0.1",
+  },
+  {
+    name: "cors-origin",
+    env: "CORS_ORIGIN",
+    type: "string",
+    group: "network",
+    desc: "CORS allow-origin (production only; dev is wide-open)",
+    defaultText: "(unset)",
+  },
+  {
+    name: "trust-proxy",
+    env: "TRUST_PROXY",
+    type: "boolean",
+    group: "network",
+    desc: "Trust X-Forwarded-* headers (set when behind a reverse proxy)",
+    defaultText: "false",
+  },
+  // paths
+  {
+    name: "workspace-path",
+    env: "WORKSPACE_PATH",
+    type: "string",
+    group: "paths",
+    desc: "Where project code lives",
+    defaultText: "~/.pi-forge/workspace",
+  },
+  {
+    name: "pi-config-dir",
+    env: "PI_CONFIG_DIR",
+    type: "string",
+    group: "paths",
+    desc: "Pi SDK config dir (auth/models/settings)",
+    defaultText: "~/.pi/agent",
+  },
+  {
+    name: "forge-data-dir",
+    env: "FORGE_DATA_DIR",
+    type: "string",
+    group: "paths",
+    desc: "Forge state dir (projects.json, mcp.json, overrides)",
+    defaultText: "~/.pi-forge",
+  },
+  {
+    name: "session-dir",
+    env: "SESSION_DIR",
+    type: "string",
+    group: "paths",
+    desc: "JSONL session storage",
+    defaultText: "${workspace-path}/.pi/sessions",
+  },
+  {
+    name: "client-dist-path",
+    env: "CLIENT_DIST_PATH",
+    type: "string",
+    group: "paths",
+    desc: "Built client (Vite output) dir",
+    defaultText: "(bundled with package)",
+  },
+  // auth
+  {
+    name: "ui-password",
+    env: "UI_PASSWORD",
+    type: "string",
+    group: "auth",
+    desc: "Browser login password (enables JWT auth). Use @<path> to read from a file.",
+    defaultText: "(unset, auth disabled unless --api-key)",
+    sensitive: true,
+  },
+  {
+    name: "api-key",
+    env: "API_KEY",
+    type: "string",
+    group: "auth",
+    desc: "Static bearer token for programmatic clients. Use @<path> to read from a file.",
+    defaultText: "(unset, auth disabled unless --ui-password)",
+    sensitive: true,
+  },
+  {
+    name: "jwt-secret",
+    env: "JWT_SECRET",
+    type: "string",
+    group: "auth",
+    desc: "JWT signing secret (auto-generated and persisted if unset). Use @<path>.",
+    defaultText: "(auto-generated)",
+    sensitive: true,
+  },
+  {
+    name: "jwt-expires-in-seconds",
+    env: "JWT_EXPIRES_IN_SECONDS",
+    type: "number",
+    group: "auth",
+    desc: "Browser JWT lifetime in seconds",
+    defaultText: "604800 (7d)",
+  },
+  {
+    name: "require-password-change",
+    env: "REQUIRE_PASSWORD_CHANGE",
+    type: "boolean",
+    group: "auth",
+    desc: "Require user to change password on first login (set when --ui-password is sealed-secret)",
+    defaultText: "false",
+  },
+  // features
+  {
+    name: "log-level",
+    env: "LOG_LEVEL",
+    type: "string",
+    group: "features",
+    desc: "Pino log level: trace|debug|info|warn|error|fatal",
+    defaultText: "info",
+  },
+  {
+    name: "serve-client",
+    env: "SERVE_CLIENT",
+    type: "boolean",
+    group: "features",
+    desc: "Serve the built React UI from this server (turn off if running Vite separately)",
+    defaultText: "true",
+  },
+  {
+    name: "minimal-ui",
+    env: "MINIMAL_UI",
+    type: "boolean",
+    group: "features",
+    desc: "Hide terminal/git/last-turn/settings panes; locked-down deploys",
+    defaultText: "false",
+  },
+  {
+    name: "hide-builtin-providers",
+    env: "HIDE_BUILTIN_PROVIDERS",
+    type: "boolean",
+    group: "features",
+    desc: "Hide built-in provider entries from the providers list",
+    defaultText: "false",
+  },
+  {
+    name: "expose-docs",
+    env: "EXPOSE_DOCS",
+    type: "boolean",
+    group: "features",
+    desc: "Expose /api/docs (Swagger UI + OpenAPI JSON)",
+    defaultText: "true",
+  },
+  {
+    name: "agent-secret-hygiene",
+    env: "AGENT_SECRET_HYGIENE_RULE",
+    type: "boolean",
+    group: "features",
+    desc: "Append a secret-hygiene rule to the agent's system prompt",
+    defaultText: "false",
+  },
+  // rate limits
+  {
+    name: "rate-limit-login-max",
+    env: "RATE_LIMIT_LOGIN_MAX",
+    type: "number",
+    group: "rate-limits",
+    desc: "Login attempts per window",
+    defaultText: "10",
+  },
+  {
+    name: "rate-limit-login-window-ms",
+    env: "RATE_LIMIT_LOGIN_WINDOW_MS",
+    type: "number",
+    group: "rate-limits",
+    desc: "Login rate-limit window (ms)",
+    defaultText: "60000",
+  },
+  {
+    name: "rate-limit-prompt-max",
+    env: "RATE_LIMIT_PROMPT_MAX",
+    type: "number",
+    group: "rate-limits",
+    desc: "Prompt/steer/compact/navigate calls per window",
+    defaultText: "60",
+  },
+  {
+    name: "rate-limit-prompt-window-ms",
+    env: "RATE_LIMIT_PROMPT_WINDOW_MS",
+    type: "number",
+    group: "rate-limits",
+    desc: "Prompt rate-limit window (ms)",
+    defaultText: "60000",
+  },
+  {
+    name: "rate-limit-upload-max",
+    env: "RATE_LIMIT_UPLOAD_MAX",
+    type: "number",
+    group: "rate-limits",
+    desc: "File upload calls per window",
+    defaultText: "30",
+  },
+  {
+    name: "rate-limit-upload-window-ms",
+    env: "RATE_LIMIT_UPLOAD_WINDOW_MS",
+    type: "number",
+    group: "rate-limits",
+    desc: "Upload rate-limit window (ms)",
+    defaultText: "60000",
+  },
+  {
+    name: "rate-limit-search-max",
+    env: "RATE_LIMIT_SEARCH_MAX",
+    type: "number",
+    group: "rate-limits",
+    desc: "File search calls per window",
+    defaultText: "60",
+  },
+  {
+    name: "rate-limit-search-window-ms",
+    env: "RATE_LIMIT_SEARCH_WINDOW_MS",
+    type: "number",
+    group: "rate-limits",
+    desc: "Search rate-limit window (ms)",
+    defaultText: "60000",
+  },
+  {
+    name: "rate-limit-push-max",
+    env: "RATE_LIMIT_PUSH_MAX",
+    type: "number",
+    group: "rate-limits",
+    desc: "Git push calls per window",
+    defaultText: "10",
+  },
+  {
+    name: "rate-limit-push-window-ms",
+    env: "RATE_LIMIT_PUSH_WINDOW_MS",
+    type: "number",
+    group: "rate-limits",
+    desc: "Push rate-limit window (ms)",
+    defaultText: "60000",
+  },
+  // terminal
+  {
+    name: "pty-idle-reap-ms",
+    env: "PTY_IDLE_REAP_MS",
+    type: "number",
+    group: "terminal",
+    desc: "How long a detached PTY survives before reap (ms; 0 disables reattach)",
+    defaultText: "600000 (10m)",
+  },
+  {
+    name: "terminal-passthrough-env",
+    env: "TERMINAL_PASSTHROUGH_ENV",
+    type: "list",
+    group: "terminal",
+    desc: "Extra env vars the integrated terminal inherits (comma- or space-separated)",
+    defaultText: "(empty allowlist)",
+  },
+] as const;
+
+const FLAGS_BY_NAME = new Map(FLAGS.map((f) => [f.name, f]));
+
+const BOOL_TRUE = new Set(["1", "true", "yes", "on"]);
+const BOOL_FALSE = new Set(["0", "false", "no", "off"]);
+
+export interface ParseResult {
+  /** Env writes to apply, in declaration order. */
+  envWrites: { key: string; value: string }[];
+  /** True if --help was passed. */
+  helpRequested: boolean;
+  /** True if --version / -v was passed. */
+  versionRequested: boolean;
+  /** Errors collected during parsing. Bin shim should print + exit 2 if non-empty. */
+  errors: string[];
+  /** Positional args after flags (rejected with an error today; reserved for future subcommands). */
+  positionals: string[];
+}
+
+/**
+ * Pre-process argv to handle `--no-<bool>` (parseArgs doesn't natively).
+ *
+ * `--no-foo` becomes `--foo=false` (only for declared boolean flags;
+ * unknown `--no-X` is left untouched so parseArgs surfaces it as a
+ * normal "Unknown option" error).
+ */
+function expandNegatedBooleans(args: string[]): string[] {
+  const out: string[] = [];
+  for (const arg of args) {
+    if (arg.startsWith("--no-")) {
+      const name = arg.slice("--no-".length);
+      const def = FLAGS_BY_NAME.get(name);
+      if (def && def.type === "boolean") {
+        out.push(`--${name}=false`);
+        continue;
+      }
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
+/** Read a sensitive flag's value, dereferencing `@<path>` syntax. */
+function resolveSensitive(value: string, flagName: string, errors: string[]): string | undefined {
+  if (!value.startsWith("@")) return value;
+  const path = value.slice(1);
+  if (path === "") {
+    errors.push(`--${flagName}: @ syntax requires a path (e.g. --${flagName} @/run/secrets/key)`);
+    return undefined;
+  }
+  try {
+    return readFileSync(path, "utf8").trim();
+  } catch (err) {
+    errors.push(
+      `--${flagName}: failed to read ${path}: ${(err as NodeJS.ErrnoException).code ?? (err as Error).message}`,
+    );
+    return undefined;
+  }
+}
+
+export function parseCliArgs(argv: string[]): ParseResult {
+  const result: ParseResult = {
+    envWrites: [],
+    helpRequested: false,
+    versionRequested: false,
+    errors: [],
+    positionals: [],
+  };
+
+  const expanded = expandNegatedBooleans(argv);
+
+  // parseArgs option config — booleans are `type: "string"` so we can
+  // accept BOTH `--foo` (bare) and `--foo true|false` uniformly. We
+  // post-process the value in our own bool-coercion step.
+  interface ParseArgsOpt {
+    type: "string" | "boolean";
+    multiple?: boolean;
+    short?: string;
+  }
+  const options: Record<string, ParseArgsOpt> = {
+    help: { type: "boolean", short: "h" },
+    version: { type: "boolean", short: "v" },
+  };
+  for (const f of FLAGS) {
+    if (f.type === "boolean") {
+      // Accept bare `--foo` (parsed as boolean true) and `--foo=value` (string).
+      // parseArgs can't represent both — pick string, treat presence-without-value
+      // by inserting "=true" in pre-pass.
+      options[f.name] = { type: "string" };
+    } else {
+      options[f.name] = { type: "string" };
+    }
+  }
+
+  // Second pre-pass: bare `--bool-flag` with no following arg (or a
+  // following arg that looks like another flag) → `--bool-flag=true`.
+  // Otherwise we leave it alone so parseArgs grabs the next arg as the
+  // value, and the bool-coercion step below produces a precise
+  // "expected a boolean" error rather than a generic "unexpected
+  // positional" complaint.
+  const finalArgs: string[] = [];
+  for (let i = 0; i < expanded.length; i++) {
+    const arg = expanded[i];
+    if (arg === undefined) continue;
+    if (arg.startsWith("--") && !arg.includes("=")) {
+      const name = arg.slice(2);
+      const def = FLAGS_BY_NAME.get(name);
+      if (def && def.type === "boolean") {
+        const next = expanded[i + 1];
+        if (next === undefined || next.startsWith("--") || next.startsWith("-")) {
+          finalArgs.push(`--${name}=true`);
+          continue;
+        }
+      }
+    }
+    finalArgs.push(arg);
+  }
+
+  let parsed: { values: Record<string, string | boolean | undefined>; positionals: string[] };
+  try {
+    parsed = parseArgs({
+      args: finalArgs,
+      options,
+      allowPositionals: true,
+      strict: true,
+    }) as typeof parsed;
+  } catch (err) {
+    result.errors.push((err as Error).message);
+    return result;
+  }
+
+  result.positionals = parsed.positionals;
+  if (parsed.values.help === true) result.helpRequested = true;
+  if (parsed.values.version === true) result.versionRequested = true;
+
+  if (parsed.positionals.length > 0) {
+    result.errors.push(
+      `Unexpected positional argument(s): ${parsed.positionals.join(", ")}. ` +
+        `pi-forge takes flags only — see --help.`,
+    );
+  }
+
+  for (const f of FLAGS) {
+    const raw = parsed.values[f.name];
+    if (raw === undefined) continue;
+    const rawStr = String(raw);
+
+    if (f.type === "boolean") {
+      const lc = rawStr.toLowerCase();
+      if (BOOL_TRUE.has(lc)) {
+        result.envWrites.push({ key: f.env, value: "true" });
+      } else if (BOOL_FALSE.has(lc)) {
+        result.envWrites.push({ key: f.env, value: "false" });
+      } else {
+        result.errors.push(
+          `--${f.name}: expected a boolean (true/false/on/off/1/0/yes/no), got ${JSON.stringify(rawStr)}`,
+        );
+      }
+      continue;
+    }
+
+    if (f.type === "number") {
+      const n = Number.parseInt(rawStr, 10);
+      if (!Number.isFinite(n) || n < 0 || String(n) !== rawStr.trim()) {
+        result.errors.push(
+          `--${f.name}: expected a non-negative integer, got ${JSON.stringify(rawStr)}`,
+        );
+        continue;
+      }
+      result.envWrites.push({ key: f.env, value: String(n) });
+      continue;
+    }
+
+    if (f.sensitive) {
+      const resolved = resolveSensitive(rawStr, f.name, result.errors);
+      if (resolved === undefined) continue;
+      if (resolved === "") {
+        result.errors.push(`--${f.name}: resolved value is empty`);
+        continue;
+      }
+      result.envWrites.push({ key: f.env, value: resolved });
+      continue;
+    }
+
+    // string + list pass through verbatim — config.ts parses lists.
+    result.envWrites.push({ key: f.env, value: rawStr });
+  }
+
+  return result;
+}
+
+/**
+ * Apply parsed env writes. Flag values WIN over any pre-existing env,
+ * matching the documented "flag overrides env" rule.
+ */
+export function applyCliEnv(parsed: ParseResult): void {
+  for (const { key, value } of parsed.envWrites) {
+    process.env[key] = value;
+  }
+}
+
+const GROUP_LABELS: Record<FlagGroup, string> = {
+  network: "Network",
+  paths: "Paths",
+  auth: "Authentication",
+  features: "Features",
+  "rate-limits": "Rate limits",
+  terminal: "Terminal",
+};
+
+export function buildHelpText(version: string): string {
+  const out: string[] = [];
+  out.push(`pi-forge ${version}`);
+  out.push("");
+  out.push("Browser UI for the pi coding agent.");
+  out.push("");
+  out.push("Usage:");
+  out.push("  pi-forge [options]");
+  out.push("");
+  out.push(
+    "Every option below has an equivalent environment variable. Flags win when both are set.",
+  );
+  out.push("");
+
+  const groups: FlagGroup[] = ["network", "paths", "auth", "features", "rate-limits", "terminal"];
+  for (const group of groups) {
+    const flags = FLAGS.filter((f) => f.group === group);
+    if (flags.length === 0) continue;
+    out.push(`${GROUP_LABELS[group]}:`);
+    const longest = Math.max(...flags.map((f) => f.name.length + (f.type === "boolean" ? 0 : 6)));
+    for (const f of flags) {
+      const flagCol = f.type === "boolean" ? `--${f.name}` : `--${f.name} <val>`;
+      const padded = flagCol.padEnd(longest + 4, " ");
+      out.push(`  ${padded}${f.desc}`);
+      out.push(`  ${"".padEnd(longest + 4, " ")}env: ${f.env}; default: ${f.defaultText}`);
+    }
+    out.push("");
+  }
+
+  out.push("Other:");
+  out.push("  --help, -h          Show this help and exit");
+  out.push("  --version, -v       Print version and exit");
+  out.push("");
+  out.push("Boolean flags accept true/false/on/off/1/0/yes/no, or use --no-<flag> for false.");
+  out.push(
+    "Sensitive flags (--ui-password, --api-key, --jwt-secret) accept @<path> to read from file.",
+  );
+  out.push("");
+  out.push("Examples:");
+  out.push("  pi-forge --port 4000 --workspace-path ~/Code");
+  out.push("  pi-forge --api-key @/run/secrets/api-key");
+  out.push("  pi-forge --no-expose-docs --minimal-ui");
+  out.push("");
+  return out.join("\n");
+}
+
+/** Exposed so tests can iterate the same source of truth. */
+export const FLAG_DEFS: readonly FlagDef[] = FLAGS;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -136,12 +136,14 @@ const JWT_SECRET =
 
 export const config = Object.freeze({
   port: readInt("PORT", 3000),
-  // HOST default depends on NODE_ENV. Production binds 0.0.0.0 (Docker
-  // image's normal mode); dev binds 127.0.0.1 so a `npm run dev` on a
-  // laptop doesn't silently expose the agent's shell + filesystem to
-  // anyone on the same WiFi/VLAN. Operators who want LAN access in dev
-  // can set HOST=0.0.0.0 explicitly.
-  host: readEnv("HOST") ?? (process.env.NODE_ENV === "production" ? "0.0.0.0" : "127.0.0.1"),
+  // HOST defaults to 127.0.0.1 in every mode. Binding loopback by
+  // default protects against silently exposing the agent's shell +
+  // filesystem to anyone on the same WiFi/VLAN/bridge — an opt-in,
+  // not an opt-out. Operators who want LAN access (or container-host
+  // port-forwarding to work) set `HOST=0.0.0.0` explicitly. The
+  // shipped Docker image does this in its Dockerfile so the
+  // documented `docker compose up` flow keeps working out of the box.
+  host: readEnv("HOST") ?? "127.0.0.1",
   logLevel: readEnv("LOG_LEVEL") ?? "info",
   isTest: (readEnv("NODE_ENV") ?? "") === "test",
   trustProxy: readBool("TRUST_PROXY", false),
@@ -239,11 +241,16 @@ export const config = Object.freeze({
      * is hashed and persisted to `${FORGE_DATA_DIR}/password-hash`,
      * and subsequent logins ignore the env value.
      *
-     * Defaults to true so deployments that bake an initial password
-     * into env (helm secret, docker-compose .env) don't accidentally
-     * leave that credential as the long-lived one.
+     * Defaults to false: pi-forge is single-tenant and the user
+     * setting `--ui-password` / `UI_PASSWORD` does so deliberately,
+     * so forcing them to immediately pick a different password is
+     * friction without a meaningful threat-model win. Deployments
+     * that bake an initial sealed-secret password into env (helm,
+     * docker-compose .env) and want the operator to swap it after
+     * first login can opt back in with `--require-password-change`
+     * (or `REQUIRE_PASSWORD_CHANGE=true`).
      */
-    requirePasswordChange: readBool("REQUIRE_PASSWORD_CHANGE", true),
+    requirePasswordChange: readBool("REQUIRE_PASSWORD_CHANGE", false),
     /** Where the persisted scrypt hash lives — see auth.ts. */
     passwordHashFile: join(FORGE_DATA_DIR, "password-hash"),
   }),

--- a/scripts/build-publish-dir.mjs
+++ b/scripts/build-publish-dir.mjs
@@ -168,20 +168,30 @@ Open <http://localhost:3000> and pick a workspace folder.
 
 ## Configuration
 
-All knobs are environment variables. Sensible defaults — set only what
-you need.
+Every knob is settable as a \`--flag\` on the \`pi-forge\` command OR as
+an environment variable. **Flags win when both are set.** Run
+\`pi-forge --help\` for the full grouped list.
 
-| Variable | Default | Purpose |
-|---|---|---|
-| \`PORT\` | \`3000\` | HTTP listen port |
-| \`WORKSPACE_PATH\` | \`~/.pi-forge/workspace\` | Where project code lives |
-| \`PI_CONFIG_DIR\` | \`~/.pi/agent\` | Pi SDK config (auth, models, settings) |
-| \`FORGE_DATA_DIR\` | \`~/.pi-forge\` | pi-forge state (project list) |
-| \`UI_PASSWORD\` | (unset) | Enables browser login if set |
-| \`API_KEY\` | (unset) | Enables \`Authorization: Bearer\` for programmatic use |
+\`\`\`bash
+pi-forge --port 4000 --workspace-path ~/Code
+pi-forge --api-key @/run/secrets/api-key --no-expose-docs
+\`\`\`
 
-If both \`UI_PASSWORD\` and \`API_KEY\` are unset, auth is disabled. For
-production, set at minimum \`API_KEY\`.
+The most common knobs:
+
+| Flag | Env var | Default | Purpose |
+|---|---|---|---|
+| \`--port\` | \`PORT\` | \`3000\` | HTTP listen port |
+| \`--workspace-path\` | \`WORKSPACE_PATH\` | \`~/.pi-forge/workspace\` | Where project code lives |
+| \`--pi-config-dir\` | \`PI_CONFIG_DIR\` | \`~/.pi/agent\` | Pi SDK config (auth, models, settings) |
+| \`--forge-data-dir\` | \`FORGE_DATA_DIR\` | \`~/.pi-forge\` | pi-forge state (project list) |
+| \`--ui-password\` | \`UI_PASSWORD\` | (unset) | Enables browser login if set |
+| \`--api-key\` | \`API_KEY\` | (unset) | Enables \`Authorization: Bearer\` for programmatic use |
+
+\`--ui-password\`, \`--api-key\`, and \`--jwt-secret\` accept \`@<path>\` to
+read the value from a file (avoids shell history leakage). If both
+\`--ui-password\` and \`--api-key\` are unset, auth is disabled — for
+production, set at minimum \`--api-key\`.
 
 ## Programmatic API
 

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -146,10 +146,10 @@ async function scenarioPasswordAndJwt(): Promise<void> {
     API_KEY: undefined,
     RATE_LIMIT_LOGIN_MAX: "3",
     RATE_LIMIT_LOGIN_WINDOW_MS: "60000",
-    // The default `requirePasswordChange=true` issues an initial-login
-    // token scoped to POST /auth/change-password only. This scenario
-    // tests that a *normal* JWT passes auth and reaches routes —
-    // change-password flow is its own concern and isn't exercised here.
+    // Pinned explicitly even though `false` is now the default — keeps
+    // this scenario's intent visible (we want a *normal* JWT, not the
+    // change-password-scoped initial-login token). The change-password
+    // flow is its own concern and isn't exercised here.
     REQUIRE_PASSWORD_CHANGE: "false",
   });
   try {

--- a/tests/test-cli-flags.ts
+++ b/tests/test-cli-flags.ts
@@ -1,0 +1,303 @@
+/**
+ * CLI argument parser tests for `pi-forge --flag` support.
+ *
+ * Pure unit-style — imports `parseCliArgs` from the compiled
+ * `dist/server/cli.js` and asserts:
+ *
+ * - Every declared flag in FLAG_DEFS round-trips to its env var.
+ * - Booleans accept both `--flag value` and `--flag=value`, plus
+ *   the bare `--flag` (true) and `--no-flag` (false) shortcuts.
+ * - Numeric flags reject non-numeric input.
+ * - Sensitive flags (`--ui-password`, `--api-key`, `--jwt-secret`)
+ *   accept `@<path>` and read from disk.
+ * - `--help` and `--version` are recognized.
+ * - Unknown flags + positional args produce parse errors instead of
+ *   being silently absorbed (regression guard — any new flag the
+ *   user typos should surface, not be ignored).
+ *
+ * Does NOT boot the server — the bin shim integration is so thin
+ * (4 lines: parse, apply, import, start) that exercising it would be
+ * a pure smoke test. The unit-level coverage here is what we trust.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`  PASS  ${label}`);
+  } else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+interface ParseResult {
+  envWrites: { key: string; value: string }[];
+  helpRequested: boolean;
+  versionRequested: boolean;
+  errors: string[];
+  positionals: string[];
+}
+
+interface FlagDef {
+  name: string;
+  env: string;
+  type: "string" | "number" | "boolean" | "list";
+  group: string;
+  desc: string;
+  defaultText: string;
+  sensitive?: boolean;
+}
+
+const cliModule = (await import(resolve(repoRoot, "packages/server/dist/cli.js"))) as {
+  parseCliArgs: (argv: string[]) => ParseResult;
+  applyCliEnv: (parsed: ParseResult) => void;
+  buildHelpText: (version: string) => string;
+  FLAG_DEFS: readonly FlagDef[];
+};
+const { parseCliArgs, buildHelpText, FLAG_DEFS } = cliModule;
+
+function envFor(parsed: ParseResult, key: string): string | undefined {
+  return parsed.envWrites.find((w) => w.key === key)?.value;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. every declared flag round-trips to its env var
+// ─────────────────────────────────────────────────────────────────────────────
+console.log("flag round-trip");
+{
+  const tmp = mkdtempSync(resolve(tmpdir(), "pi-cli-flags-"));
+  try {
+    const secretFile = resolve(tmp, "secret.txt");
+    writeFileSync(secretFile, "from-disk-value\n");
+
+    const argv: string[] = [];
+    const expected = new Map<string, string>();
+    for (const def of FLAG_DEFS) {
+      switch (def.type) {
+        case "string":
+          if (def.sensitive) {
+            argv.push(`--${def.name}`, `@${secretFile}`);
+            expected.set(def.env, "from-disk-value");
+          } else {
+            argv.push(`--${def.name}`, `value-for-${def.name}`);
+            expected.set(def.env, `value-for-${def.name}`);
+          }
+          break;
+        case "number":
+          argv.push(`--${def.name}`, "1234");
+          expected.set(def.env, "1234");
+          break;
+        case "boolean":
+          argv.push(`--${def.name}`, "true");
+          expected.set(def.env, "true");
+          break;
+        case "list":
+          argv.push(`--${def.name}`, "a,b,c");
+          expected.set(def.env, "a,b,c");
+          break;
+      }
+    }
+    const parsed = parseCliArgs(argv);
+    assert(
+      "no parse errors when every flag is set",
+      parsed.errors.length === 0,
+      parsed.errors.join("; "),
+    );
+    for (const [envKey, want] of expected) {
+      assert(`${envKey} → ${want}`, envFor(parsed, envKey) === want);
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. boolean coercion: bare flag, =value, and --no-foo
+// ─────────────────────────────────────────────────────────────────────────────
+console.log("\nboolean coercion");
+{
+  const bare = parseCliArgs(["--minimal-ui"]);
+  assert("bare --minimal-ui → true", envFor(bare, "MINIMAL_UI") === "true");
+
+  const eqFalse = parseCliArgs(["--minimal-ui=false"]);
+  assert("--minimal-ui=false → false", envFor(eqFalse, "MINIMAL_UI") === "false");
+
+  const noFlag = parseCliArgs(["--no-serve-client"]);
+  assert("--no-serve-client → false", envFor(noFlag, "SERVE_CLIENT") === "false");
+
+  const onValue = parseCliArgs(["--minimal-ui", "on"]);
+  assert("--minimal-ui on → true", envFor(onValue, "MINIMAL_UI") === "true");
+
+  const yesValue = parseCliArgs(["--expose-docs", "yes"]);
+  assert("--expose-docs yes → true", envFor(yesValue, "EXPOSE_DOCS") === "true");
+
+  const bogus = parseCliArgs(["--minimal-ui", "maybe"]);
+  assert(
+    "--minimal-ui maybe is rejected",
+    bogus.errors.some((e) => e.includes("--minimal-ui")) && bogus.errors.length > 0,
+    bogus.errors.join("; "),
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. numeric coercion
+// ─────────────────────────────────────────────────────────────────────────────
+console.log("\nnumeric coercion");
+{
+  const ok = parseCliArgs(["--port", "4000"]);
+  assert("--port 4000 → 4000", envFor(ok, "PORT") === "4000" && ok.errors.length === 0);
+
+  const float = parseCliArgs(["--port", "3.14"]);
+  assert(
+    "--port 3.14 is rejected",
+    float.errors.some((e) => e.includes("--port")),
+    float.errors.join("; "),
+  );
+
+  const negative = parseCliArgs(["--port", "-1"]);
+  assert(
+    "--port -1 is rejected",
+    negative.errors.some((e) => e.includes("--port")),
+    negative.errors.join("; "),
+  );
+
+  const word = parseCliArgs(["--port", "abc"]);
+  assert(
+    "--port abc is rejected",
+    word.errors.some((e) => e.includes("--port")),
+    word.errors.join("; "),
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. @file syntax for sensitive flags
+// ─────────────────────────────────────────────────────────────────────────────
+console.log("\n@file syntax");
+{
+  const tmp = mkdtempSync(resolve(tmpdir(), "pi-cli-secret-"));
+  try {
+    const secretFile = resolve(tmp, "api-key.txt");
+    writeFileSync(secretFile, "  sk-test-12345\n\n");
+    const ok = parseCliArgs(["--api-key", `@${secretFile}`]);
+    assert("--api-key @file → trimmed file content", envFor(ok, "API_KEY") === "sk-test-12345");
+
+    const missing = parseCliArgs(["--api-key", `@${tmp}/does-not-exist`]);
+    assert(
+      "--api-key @missing-file is rejected",
+      missing.errors.some((e) => e.includes("--api-key")),
+      missing.errors.join("; "),
+    );
+
+    const empty = parseCliArgs(["--api-key", "@"]);
+    assert(
+      "--api-key @ alone is rejected",
+      empty.errors.some((e) => e.includes("--api-key")),
+      empty.errors.join("; "),
+    );
+
+    const literal = parseCliArgs(["--api-key", "literal-value"]);
+    assert(
+      "--api-key literal-value is preserved",
+      envFor(literal, "API_KEY") === "literal-value" && literal.errors.length === 0,
+    );
+
+    const fileWithEmpty = resolve(tmp, "blank.txt");
+    writeFileSync(fileWithEmpty, "   \n");
+    const blank = parseCliArgs(["--api-key", `@${fileWithEmpty}`]);
+    assert(
+      "--api-key @blank-file is rejected as empty",
+      blank.errors.some((e) => e.includes("--api-key")),
+      blank.errors.join("; "),
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. --help and --version
+// ─────────────────────────────────────────────────────────────────────────────
+console.log("\nhelp + version");
+{
+  const help = parseCliArgs(["--help"]);
+  assert("--help is recognized", help.helpRequested === true);
+  const helpShort = parseCliArgs(["-h"]);
+  assert("-h is recognized", helpShort.helpRequested === true);
+  const version = parseCliArgs(["--version"]);
+  assert("--version is recognized", version.versionRequested === true);
+  const versionShort = parseCliArgs(["-v"]);
+  assert("-v is recognized", versionShort.versionRequested === true);
+
+  const helpText = buildHelpText("9.9.9");
+  assert("buildHelpText embeds the version", helpText.startsWith("pi-forge 9.9.9"));
+  const helpGroups = ["Network", "Paths", "Authentication", "Features", "Rate limits", "Terminal"];
+  assert(
+    "buildHelpText lists at least one flag from each group",
+    helpGroups.every((g) => helpText.includes(`${g}:`)),
+  );
+  assert("buildHelpText mentions @file convention", helpText.includes("@<path>"));
+  assert("buildHelpText mentions --no-<flag> negation", helpText.includes("--no-<flag>"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. unknown flags + positionals are rejected (no silent ignore)
+// ─────────────────────────────────────────────────────────────────────────────
+console.log("\nstrictness");
+{
+  const unknown = parseCliArgs(["--made-up-flag", "value"]);
+  assert("unknown flag is rejected", unknown.errors.length > 0, unknown.errors.join("; "));
+
+  const pos = parseCliArgs(["start"]);
+  assert(
+    "positional arg is rejected",
+    pos.errors.some((e) => e.toLowerCase().includes("positional")),
+    pos.errors.join("; "),
+  );
+
+  const empty = parseCliArgs([]);
+  assert(
+    "empty argv produces no errors and no env writes",
+    empty.errors.length === 0 && empty.envWrites.length === 0,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. flag overrides env (verified by applyCliEnv mutating process.env)
+// ─────────────────────────────────────────────────────────────────────────────
+console.log("\napplyCliEnv overrides existing env");
+{
+  const prev = process.env.PORT;
+  try {
+    process.env.PORT = "9999";
+    const parsed = parseCliArgs(["--port", "8888"]);
+    cliModule.applyCliEnv(parsed);
+    assert("--port wins over pre-existing PORT", process.env.PORT === "8888");
+
+    const parsedNoPort = parseCliArgs(["--minimal-ui"]);
+    process.env.PORT = "7777";
+    cliModule.applyCliEnv(parsedNoPort);
+    assert("PORT is preserved when --port is absent", process.env.PORT === "7777");
+  } finally {
+    if (prev === undefined) {
+      delete process.env.PORT;
+    } else {
+      process.env.PORT = prev;
+    }
+  }
+}
+
+console.log("");
+if (failures > 0) {
+  console.log(`FAIL  ${failures} assertion(s) failed`);
+  process.exit(1);
+}
+console.log("PASS  test-cli-flags");


### PR DESCRIPTION
## Summary

- **CLI flags for every operational env var.** \`pi-forge --port 4000 --workspace-path ~/Code\` now works — no more env wrappers needed for npm-installed users. Single source of truth in [\`packages/server/src/cli.ts\`](packages/server/src/cli.ts) drives parsing, env writes, and \`--help\`.
- **\`@<path>\` syntax for sensitive flags.** \`--ui-password\`, \`--api-key\`, and \`--jwt-secret\` accept \`@/run/secrets/key\` (curl/gh-style) so secrets stay out of shell history and \`ps\`.
- **Two default flips for safer single-tenant posture.** \`HOST\` now defaults to \`127.0.0.1\` everywhere (was \`0.0.0.0\` in production); \`REQUIRE_PASSWORD_CHANGE\` defaults to \`false\` (was \`true\`). The Docker image's \`Dockerfile\` already pins \`HOST=0.0.0.0\` explicitly, so \`docker compose up\` still works out of the box; \`docker-compose.yml\` + \`.env.example\` updated to reflect the new password-change default.
- **Backward compatible.** Every env var still works as a fallback; flag values win when both are set.

## Flag surface (32 flags grouped by category)

\`\`\`
Network:        --port, --host, --cors-origin, --trust-proxy
Paths:          --workspace-path, --pi-config-dir, --forge-data-dir,
                --session-dir, --client-dist-path
Authentication: --ui-password, --api-key, --jwt-secret,
                --jwt-expires-in-seconds, --require-password-change
Features:       --log-level, --serve-client, --minimal-ui,
                --hide-builtin-providers, --expose-docs,
                --agent-secret-hygiene
Rate limits:    --rate-limit-{login,prompt,upload,search,push}-{max,window-ms}
Terminal:       --pty-idle-reap-ms, --terminal-passthrough-env

Other:          --help, --version (plus --no-<bool> negation form)
\`\`\`

Run \`pi-forge --help\` for the full grouped table with per-flag env-var mapping and defaults.

## Test plan

- [x] \`tests/test-cli-flags.ts\` — 60 assertions covering parsing, coercion (numeric/boolean), \`@file\` (including missing/empty file rejection), \`--no-flag\` negation, \`applyCliEnv\` flag-overrides-env semantics, and strictness on unknown flags + positionals
- [x] Full integration suite (26 tests) — \`npm run test:ci\` green
- [x] \`npm run check\` clean (tsc + eslint + prettier)
- [x] Smoke-tested via \`publish/bin/pi-forge.mjs\` end-to-end against 21 representative flag combos (port, paths, @file auth, minimal-ui, expose-docs, rate-limit-login, cors-origin, host loopback, etc.) — all behaviors verified
- [x] Empirically verified the new defaults: server with \`--ui-password testpw\` returns \`mustChangePassword=false\`; server bound to default \`127.0.0.1\` refuses connections from the LAN IP

## Docs

- New "CLI flags" section in [\`docs/configuration.md\`](docs/configuration.md) covering the kebab-case mapping, \`@file\` convention, and \`--no-flag\` negation
- Env-var table rows for \`HOST\` and \`REQUIRE_PASSWORD_CHANGE\` updated for the flipped defaults
- \`README.md\` quickstart shows three example invocations
- \`CLAUDE.md\` adds a one-paragraph pointer at \`packages/server/src/cli.ts\` as the authoritative env↔flag table
- The synthesized \`publish/README.md\` (npm consumer-facing) documents the flag interface

## Out of scope (deferred — not blockers)

- \`DEBUG_FETCH\` / \`DEBUG_AGENT_EVENTS\` stay env-only — diagnostics, not operational config; trivial one-row addition to the \`FLAGS\` table if/when wanted
- \`SESSION_DIR\` / \`PTY_IDLE_REAP_MS\` end-to-end behavior assertions skipped in the smoke sweep (would need session/terminal setup); parsing-and-env-write coverage is in the unit test