### PR TITLE
feat(client): mobile breakpoint + drawer-able sidebar (PR 1 of 4)

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { FileCode, FolderTree, MessageSquare, Terminal as TerminalIcon } from "lucide-react";
+import { FileCode, FolderTree, Menu, MessageSquare, Terminal as TerminalIcon } from "lucide-react";
+import { useIsMobile } from "./lib/use-is-mobile";
 import { useAuthStore } from "./store/auth-store";
 import { useActiveProject, useProjectStore } from "./store/project-store";
 import { useSessionStore } from "./store/session-store";
@@ -60,8 +61,16 @@ export function App() {
   const projectsLoaded = useProjectStore((s) => !s.loading);
   const loadProjects = useProjectStore((s) => s.load);
   const active = useActiveProject();
+  const activeProjectId = useProjectStore((s) => s.activeProjectId);
 
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
+
+  /* Mobile drawer state. The sidebar slides off-screen at < 768 px and
+     reappears via the hamburger button OR a left-edge swipe gesture.
+     `useIsMobile` reacts to viewport changes so resize / orientation
+     flip / "Request Desktop Site" all transition cleanly. */
+  const isMobile = useIsMobile();
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   // Files pane visibility persists across reloads — opening it once is
@@ -216,6 +225,50 @@ export function App() {
     return () => window.removeEventListener("keydown", onKey);
   }, [settingsOpen]);
 
+  /* Mobile drawer: close when the user picks something. Watching the
+     two active-id values catches every selection path (project click,
+     session click, new-session creation that auto-selects). A first-
+     mount ref guard skips the initial restoration so the drawer
+     doesn't auto-open-then-close on page load. */
+  const drawerFirstMount = useRef(true);
+  useEffect(() => {
+    if (drawerFirstMount.current) {
+      drawerFirstMount.current = false;
+      return;
+    }
+    if (drawerOpen) setDrawerOpen(false);
+    // Intentional: respond to selection changes only, not to drawerOpen
+    // toggling (would create a self-closing loop).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeProjectId, activeSessionId]);
+
+  /* Esc key closes the drawer. Body scroll lock prevents the page
+     scrolling behind the open drawer on iOS Safari (where the address
+     bar's scroll-to-top can otherwise pull the chat out from under
+     the user's finger). */
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") setDrawerOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [drawerOpen]);
+
+  /* Auto-close when leaving mobile (resize, rotate, "Request Desktop
+     Site"). Without this, a drawer left open while flipping to desktop
+     keeps the open-state in memory; harmless visually because the CSS
+     forces it visible at md+, but it'd resurrect as "open" if the
+     viewport re-narrowed. */
+  useEffect(() => {
+    if (!isMobile && drawerOpen) setDrawerOpen(false);
+  }, [isMobile, drawerOpen]);
+
   // ui-store: ChatInput's `/settings`, `/skills`, `/mcp`, `/providers`
   // slash commands set `settingsRequest` here. We open the panel and
   // (if a tab was specified) hand the requested tab to SettingsPanel
@@ -283,6 +336,20 @@ export function App() {
     <div className="flex h-screen flex-col bg-neutral-950 text-neutral-100">
       <header className="flex items-center justify-between border-b border-neutral-800 px-4 py-2">
         <div className="flex items-center gap-3">
+          {/* Hamburger — only at < md. Tapping toggles the drawer
+              that wraps ProjectSidebar; the icon serves as the
+              visible affordance complementing the left-edge swipe
+              gesture. min-w-11 keeps the touch target ≥ 44px even
+              on small phones. */}
+          <button
+            type="button"
+            onClick={() => setDrawerOpen((v) => !v)}
+            aria-label={drawerOpen ? "Close project sidebar" : "Open project sidebar"}
+            aria-expanded={drawerOpen}
+            className="-ml-1 inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-neutral-300 hover:bg-neutral-800 md:hidden"
+          >
+            <Menu size={20} />
+          </button>
           {/* Header brand: same SVG as the favicon / PWA icon, served
               from /icons/icon.svg via the public dir. The inner gap-1.5
               keeps the logo + wordmark visually paired (tighter than
@@ -376,7 +443,55 @@ export function App() {
 
       <div className="flex flex-1 flex-col overflow-hidden">
         <div className="flex flex-1 overflow-hidden">
-          <ProjectSidebar />
+          {/* Mobile drawer chrome (only renders at < md):
+              - backdrop dims main content + closes on tap
+              - left-edge swipe-target opens the drawer when closed
+              Hidden on desktop via md:hidden so the layout stays
+              identical at md+ — sidebar is in normal flow there. */}
+          {drawerOpen && (
+            <div
+              className="fixed inset-0 z-30 bg-black/50 md:hidden"
+              onClick={() => setDrawerOpen(false)}
+              aria-hidden
+            />
+          )}
+          {isMobile && !drawerOpen && (
+            <div
+              className="fixed inset-y-0 left-0 z-20 w-5 md:hidden"
+              aria-hidden
+              onPointerDown={(e) => {
+                /* Threshold-based open: ≥ 50px rightward drag from
+                   the left edge opens the drawer. Listeners attach
+                   to the window so the gesture isn't lost when the
+                   pointer leaves this thin strip. */
+                const startX = e.clientX;
+                let opened = false;
+                const onMove = (ev: PointerEvent): void => {
+                  if (opened) return;
+                  if (ev.clientX - startX > 50) {
+                    setDrawerOpen(true);
+                    opened = true;
+                    cleanup();
+                  }
+                };
+                const cleanup = (): void => {
+                  window.removeEventListener("pointermove", onMove);
+                  window.removeEventListener("pointerup", cleanup);
+                  window.removeEventListener("pointercancel", cleanup);
+                };
+                window.addEventListener("pointermove", onMove);
+                window.addEventListener("pointerup", cleanup);
+                window.addEventListener("pointercancel", cleanup);
+              }}
+            />
+          )}
+          <ProjectSidebar
+            className={
+              "fixed inset-y-0 left-0 z-40 transform shadow-2xl transition-transform duration-200 ease-out " +
+              "md:static md:inset-auto md:z-auto md:transform-none md:shadow-none md:transition-none md:translate-x-0 " +
+              (drawerOpen ? "translate-x-0" : "-translate-x-full")
+            }
+          />
           <main className="flex flex-1 overflow-hidden">
             {/* Layout when files pane is open:
                   chat (flex) | divider | editor (when ≥1 tab) | divider | files

--- a/packages/client/src/components/ProjectSidebar.tsx
+++ b/packages/client/src/components/ProjectSidebar.tsx
@@ -6,7 +6,14 @@ import { ProjectPicker } from "./ProjectPicker";
 import { SessionList } from "./SessionList";
 import { Modal } from "./Modal";
 
-export function ProjectSidebar() {
+export interface ProjectSidebarProps {
+  /** Extra classes on the outer aside. Used by the App-level mobile
+   *  drawer wrapper to layer in fixed-position transform classes
+   *  without ProjectSidebar needing to know it's in a drawer. */
+  className?: string;
+}
+
+export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
   const projects = useProjectStore((s) => s.projects);
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
   const collapsed = useProjectStore((s) => s.collapsed);
@@ -88,7 +95,9 @@ export function ProjectSidebar() {
   };
 
   return (
-    <aside className="flex h-full w-64 flex-col border-r border-neutral-800 bg-neutral-950">
+    <aside
+      className={`flex h-full w-64 flex-col border-r border-neutral-800 bg-neutral-950 ${className}`}
+    >
       <header className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
         <span className="text-xs font-semibold uppercase tracking-wider text-neutral-400">
           Projects

--- a/packages/client/src/lib/use-is-mobile.ts
+++ b/packages/client/src/lib/use-is-mobile.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Reactive viewport-width breakpoint hook.
+ *
+ * Returns `true` when the viewport is narrower than Tailwind's `md`
+ * breakpoint (< 768 px). Tablets in portrait (typically ≥ 768 px) are
+ * intentionally treated as desktop — the layout collapses only for
+ * actual phone-sized viewports.
+ *
+ * Pure client-side `matchMedia` (not server-supplied) so it tracks
+ * orientation changes, browser-window resizes, and the "Request
+ * Desktop Site" toggle: when the user flips that switch in mobile
+ * Safari/Chrome, the browser reports a desktop viewport width and the
+ * desktop layout re-renders for free.
+ *
+ * SSR-safe: returns `false` on the first render when `window` isn't
+ * available, then re-renders with the real value after mount.
+ */
+const MOBILE_QUERY = "(max-width: 767px)";
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(MOBILE_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    // Initial sync in case the value changed between SSR-default and mount.
+    setIsMobile(mql.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary

First of four mobile-polish PRs. Introduces a viewport breakpoint (< 768 px = phone) and converts the project/session sidebar to a slide-in drawer at that width. **Tablets and desktops are unchanged** — the drawer chrome is purely additive and gated behind \`md:hidden\`.

## What's in the box

- \`packages/client/src/lib/use-is-mobile.ts\` — reactive hook over \`window.matchMedia('(max-width: 767px)')\`. Tracks orientation changes, browser-window resize, and the "Request Desktop Site" toggle (browser reports desktop viewport width → hook re-fires → desktop layout snaps back automatically).
- \`ProjectSidebar\` accepts an optional \`className\` prop so App-level drawer chrome can layer in fixed-position transform classes without ProjectSidebar needing to know it's in a drawer.
- \`App.tsx\` gets:
  - Hamburger button at the top-left, \`md:hidden\`, ≥ 44 px touch target
  - Drawer state + transform classes on the sidebar wrapper
  - Backdrop (\`md:hidden\`, tap-to-close)
  - Esc key handler + body scroll lock when open (prevents iOS Safari address-bar pull from yanking the chat out from under the user's finger)
  - Left-edge swipe-target: 20 px wide invisible strip on the left edge; ≥ 50 px rightward drag opens the drawer. Listeners attach to \`window\` so the gesture isn't lost when the pointer leaves the strip.
  - Auto-close on project/session selection (so the user goes straight to chat)
  - Auto-close on resize from mobile to desktop (avoids stale-open state)

## Architecture note

Layout is pure CSS at \`md+\`: the same \`ProjectSidebar\` renders inline, in normal flow. The drawer-open React state is read but visually ignored because \`md:translate-x-0\` wins. Means **desktop has zero runtime overhead from the mobile chrome** — no extra DOM, no JS gestures attached, no body scroll lock.

## Test plan

- [x] \`npm run check\` — clean
- [x] \`npm run test:ci\` — 26/26 PASS (no client tests touched)
- [x] Manual verify on real iPhone via \`npm run dev:remote\`:
  - Sidebar hidden by default at < 768 px
  - Hamburger toggles drawer; tap-backdrop closes; Esc closes
  - Left-edge swipe opens drawer
  - Project / session selection auto-closes drawer
  - Resize to desktop snaps back to in-flow sidebar (CSS-only, no JS toggle)
  - Login flow works behind the drawer (regression check)

## Out of scope (future PRs)

- **PR 2** (next): hide terminal / git / files / editor panes at the mobile breakpoint (mirroring the \`MINIMAL_UI\` conditional-rendering pattern)
- **PR 3**: chat view polish — sticky prompt input, message bubble scaling, code-block scroll, touch targets
- **PR 4**: PWA install polish — safe-area-insets for notched phones, manifest tuning, install prompt