### PR TITLE
feat(client): PWA install polish + safe-area + mobile docs (PR 4 of 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ and the rest of the docs, follow the links in
 | Architecture & data flow | [`docs/architecture.md`](./docs/architecture.md) |
 | Configuration & env vars | [`docs/configuration.md`](./docs/configuration.md) |
 | MCP servers | [`docs/mcp.md`](./docs/mcp.md) |
+| Mobile / PWA install | [`docs/mobile.md`](./docs/mobile.md) |
 | Docker image | [`docs/CONTAINERS.md`](./docs/CONTAINERS.md) |
 | Production deployment | [`docs/deployment.md`](./docs/deployment.md) |
 | Kubernetes / OpenShift | [`kubernetes/DEPLOY.md`](./kubernetes/DEPLOY.md) |

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -1,0 +1,190 @@
+# Mobile
+
+pi-forge ships as an **installable PWA** with a mobile-tuned chat
+surface — talk to the agent and watch what it's doing from your
+phone. This page covers what works on mobile, how to install pi-forge
+as a home-screen app, and the operator gotchas (TLS requirement,
+service worker behavior).
+
+If you only ever use pi-forge on a desktop browser, you can skip this
+page. Nothing in mobile mode changes the desktop experience.
+
+---
+
+## What works on mobile
+
+The phone surface is **chat + project monitoring**. You can:
+
+- Send prompts to the agent, watch the streaming reply
+- Switch projects and sessions via the slide-in drawer
+- Use slash commands and `@` file references with phone-tuned popovers
+- Attach photos from gallery / camera, or files from the system file
+  manager
+- Abort an in-flight agent run
+
+Hidden on mobile (still available on desktop):
+
+- File browser tree
+- Per-turn diff panel
+- Git panel
+- File editor (CodeMirror)
+- Integrated terminal
+
+The hidden surfaces are also **unmounted** on mobile, not just
+hidden — so the editor's CodeMirror toolchain doesn't load and the
+terminal doesn't allocate a server-side PTY for a panel you can't
+see.
+
+If you want the desktop layout on a phone (e.g. you have a tablet,
+or you specifically need the terminal in a pinch), use your browser's
+**"Request Desktop Site"** toggle. The mobile breakpoint reacts to
+viewport width, not user-agent — flipping that switch makes the
+browser report a desktop viewport, the layout snaps back to full
+desktop UI, and everything works.
+
+---
+
+## Installing as a PWA
+
+Once installed, pi-forge runs fullscreen with no browser chrome,
+appears in your app drawer with the pi-forge icon, and respects your
+phone's safe-area insets (notch, home indicator, gesture bar).
+
+### iOS Safari
+
+The first time you visit pi-forge on a phone, an install hint
+appears at the top of the screen:
+
+> Install: tap **Share**, then **Add to Home Screen**.
+
+Follow the prompt. iOS PWAs run from the home icon as standalone
+apps — the install hint hides automatically once you launch from
+the icon.
+
+If you dismissed the hint and want to install later: tap the Safari
+share button (square with up-arrow) → **Add to Home Screen**. There's
+no programmatic install on iOS — `beforeinstallprompt` doesn't fire
+on Safari.
+
+### Android Chrome / Brave / Edge
+
+The first visit shows a banner with an **Install** button at the
+top. Tap it → the browser's native install dialog confirms → the app
+appears in your launcher.
+
+If you dismissed the banner, install via the browser's own menu:
+3-dot menu → **Install app** (or **Add to Home Screen** depending on
+the browser).
+
+---
+
+## Operator gotcha: HTTPS is required for install
+
+Both Android Chrome and iOS Safari only treat a site as installable
+over **HTTPS** (or `http://localhost`). A pi-forge instance reachable
+over plain `http://` on a LAN IP — for example, the dev `npm run
+dev:remote` flow at `http://10.0.0.5:5173` — will not show an install
+option, even when the manifest and service worker are otherwise
+correct.
+
+In production this is automatic: the documented Docker deployment
+sits behind a TLS-terminated reverse proxy (Caddy, nginx, Traefik)
+and the install path works without further configuration.
+
+For local PWA testing without a real cert, two reasonable paths:
+
+- **ngrok** (easiest): build the production bundle, serve it from
+  the Fastify server, expose with HTTPS via ngrok.
+
+  ```bash
+  npm run build
+  HOST=127.0.0.1 UI_PASSWORD='your-pw' node packages/server/dist/index.js &
+  ngrok http 3000
+  ```
+
+  Visit the `https://….ngrok.io` URL on your phone — Android's
+  install option appears in the menu and our banner fires.
+
+- **Chrome's insecure-origin-as-secure flag**: on the phone, visit
+  `chrome://flags#unsafely-treat-insecure-origin-as-secure`, add
+  your LAN IP (`http://10.0.0.5:3000`), enable, restart Chrome.
+  Then run the production bundle the same way as above. Brave has
+  the same flag at `brave://flags`.
+
+Note that `npm run dev` / `dev:remote` also disables the service
+worker (`devOptions: { enabled: false }` in `vite.config.ts`) so HMR
+keeps working — that's a second reason install won't work in dev.
+You need a production build (`npm run build`) for the SW to be
+active.
+
+---
+
+## Mobile-specific behaviors
+
+A few phone-only quirks worth knowing about as a user:
+
+- **Enter inserts a newline**, doesn't submit. Mobile virtual
+  keyboards don't surface Shift conveniently, so the desktop
+  "Shift+Enter for newline" rule is unworkable. Send is the
+  explicit Send button. The slash and `@` palettes still own
+  Enter when open (Enter picks the highlighted suggestion).
+
+- **Keyboard auto-dismisses on send** so the streaming reply isn't
+  eaten by half a screen of keyboard. Tap the textarea again to
+  bring it back for the next message.
+
+- **Textarea auto-grows** with what you type, capped at 30% of the
+  viewport height, then scrolls internally past that.
+
+- **Chat composer rides above the keyboard.** When the keyboard
+  appears, the visual viewport shrinks (via the `interactive-
+  widget=resizes-content` viewport hint) and the composer floats
+  to its top. No JS gymnastics — it's just CSS doing the right
+  thing once the meta tag is set.
+
+- **Attach button** (paperclip) opens a small popover with two
+  choices: **Photo** opens the gallery + camera picker; **File**
+  opens the system file manager. The popover collapses two
+  separate buttons into one entry-point so the textarea keeps its
+  width on a 360 px screen.
+
+- **Drawer + sidebar.** The project / session sidebar is a slide-in
+  drawer behind a hamburger button at the top-left. Tap the
+  hamburger or swipe right from the very left edge of the screen
+  to open it. Tap the backdrop or pick a project / session to
+  close.
+
+- **Theme-aware browser chrome.** Android Chrome paints its
+  address bar with our `theme-color` meta tag. The tag is updated
+  whenever you switch themes in Settings → General, so the chrome
+  blends with the active theme rather than always being dark.
+
+---
+
+## Not (yet) supported on mobile
+
+- **Native iOS / Android wrapper** (Capacitor, Tauri Mobile). pi-
+  forge is web-only. The PWA install path approximates a native
+  app for most use cases.
+- **Push notifications.** No "agent finished" alerts when the tab
+  is backgrounded. Deferred to post-v1.
+- **Background sync.** If you close the tab mid-stream, the agent
+  keeps running on the server but you won't see updates until you
+  reopen pi-forge.
+
+---
+
+## See also
+
+- [`docs/configuration.md`](./configuration.md) — environment
+  variables and CLI flags (including `MINIMAL_UI`, which mirrors
+  most of the mobile-mode hides for locked-down desktop deploys)
+- [`docs/deployment.md`](./deployment.md) — production deploy with
+  TLS at a reverse proxy (the prerequisite for PWA install in the
+  field)
+- [`packages/client/src/lib/theme.ts`](../packages/client/src/lib/theme.ts)
+  — theme registry + the `THEME_CHROME` table that drives the
+  per-theme `theme-color` meta tag
+- [`packages/client/src/components/InstallPrompt.tsx`](../packages/client/src/components/InstallPrompt.tsx)
+  — the install banner component, including the iOS-vs-Android
+  branching logic

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -8,6 +8,7 @@ import { useFileStore } from "./store/file-store";
 import { useUiConfigStore } from "./store/ui-config-store";
 import { LoginScreen } from "./components/LoginScreen";
 import { ChangePasswordScreen } from "./components/ChangePasswordScreen";
+import { InstallPrompt } from "./components/InstallPrompt";
 import { ProjectSidebar } from "./components/ProjectSidebar";
 import { ProjectPicker } from "./components/ProjectPicker";
 import { ChatView } from "./components/ChatView";
@@ -334,7 +335,17 @@ export function App() {
 
   return (
     <div className="flex h-screen flex-col bg-neutral-950 text-neutral-100">
-      <header className="flex items-center justify-between border-b border-neutral-800 px-4 py-2">
+      {/* Top-of-viewport chrome respects iOS Dynamic Island / notch
+          and Android cutouts via safe-area-inset-top. The viewport
+          meta in index.html already opts in with `viewport-fit=cover`
+          (PR 3); this is what actually consumes the inset so the
+          hamburger + brand don't sit under the status bar. Combined
+          with `py-2` so we have at least the original 8 px even on
+          devices with no inset. */}
+      <header
+        className="flex items-center justify-between border-b border-neutral-800 px-4 py-2"
+        style={{ paddingTop: "max(0.5rem, env(safe-area-inset-top))" }}
+      >
         <div className="flex items-center gap-3">
           {/* Hamburger — only at < md. Tapping toggles the drawer
               that wraps ProjectSidebar; the icon serves as the
@@ -438,6 +449,11 @@ export function App() {
           </button>
         </div>
       </header>
+
+      {/* PWA install prompt — mobile-only, dismissable, hidden when
+          already running standalone or after the user has dismissed
+          once. Self-gated to render nothing on desktop. */}
+      <InstallPrompt />
 
       {settingsOpen && (
         <SettingsPanel

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -1424,8 +1424,14 @@ export function ChatInput({ sessionId }: Props) {
       </div>
       {/* Tighter padding on mobile so the composer hugs the bottom
           of the viewport (and the on-screen keyboard, when open).
-          Desktop keeps the original `px-6 py-3` breathing room. */}
-      <div className="mx-auto max-w-3xl space-y-2 px-3 pb-2 pt-2 md:px-6 md:py-3">
+          Bottom padding rides the safe-area inset so the composer
+          sits above the iPhone home indicator / Android gesture bar
+          instead of being clipped by them. Desktop keeps the
+          original `px-6 py-3` breathing room. */}
+      <div
+        className="mx-auto max-w-3xl space-y-2 px-3 pt-2 md:px-6 md:py-3"
+        style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
+      >
         <div className="flex flex-wrap items-center gap-2">
           <ModelPicker
             providers={providers}

--- a/packages/client/src/components/InstallPrompt.tsx
+++ b/packages/client/src/components/InstallPrompt.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from "react";
+import { Share, X } from "lucide-react";
+import { useIsMobile } from "../lib/use-is-mobile";
+
+/**
+ * "Install pi-forge as an app" banner — shown on mobile, dismissable,
+ * with platform-specific behavior:
+ *
+ *   - **Android Chrome / Edge / Samsung Internet**: listens for the
+ *     `beforeinstallprompt` event, captures the deferred prompt, and
+ *     a tap on "Install" calls `prompt()` + `userChoice`. Browser
+ *     suppresses the event after install (or after the user has
+ *     dismissed enough times — heuristic), so we don't have to track
+ *     install state ourselves.
+ *
+ *   - **iOS Safari**: doesn't fire `beforeinstallprompt`; PWA install
+ *     is "Tap Share → Add to Home Screen" by hand. We render a hint
+ *     with the share glyph instead of an Install button.
+ *
+ *   - **Already-installed PWA**: hidden via the standalone-mode
+ *     check (`display-mode: standalone` media query OR iOS's
+ *     `navigator.standalone`). Once launched from the home icon, no
+ *     point nagging.
+ *
+ * Dismissal persists in localStorage so the banner doesn't re-appear
+ * after every reload. There's no "remind me later" — the user can
+ * always reach Add to Home Screen through the browser's own menu.
+ */
+
+const DISMISS_KEY = "pi-forge/install-prompt-dismissed";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+}
+
+function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  // iOS Safari sets a non-standard `navigator.standalone` (true when
+  // launched from the home icon). Other browsers respect the CSS
+  // `display-mode: standalone` media query.
+  if ((window.navigator as { standalone?: boolean }).standalone === true) return true;
+  return window.matchMedia?.("(display-mode: standalone)").matches ?? false;
+}
+
+function isIOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+  // Modern iOS Safari + Edge/Firefox iOS all share WebKit; the UA
+  // pattern is stable enough for "show iOS install hint" gating.
+  return /iphone|ipad|ipod/i.test(navigator.userAgent);
+}
+
+export function InstallPrompt(): React.JSX.Element | null {
+  const isMobile = useIsMobile();
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | undefined>(undefined);
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof localStorage === "undefined") return false;
+    return localStorage.getItem(DISMISS_KEY) === "true";
+  });
+  const [iosHint, setIosHint] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (isStandalone()) return; // already installed
+    if (dismissed) return;
+
+    const onBeforeInstall = (e: Event): void => {
+      e.preventDefault(); // suppress the browser's own mini-bar
+      setDeferred(e as BeforeInstallPromptEvent);
+    };
+    window.addEventListener("beforeinstallprompt", onBeforeInstall);
+    // iOS doesn't fire beforeinstallprompt — show the hint when
+    // mobile + iOS + not standalone. Delay so the banner doesn't
+    // race the first paint and feel intrusive.
+    if (isIOS() && isMobile) {
+      const timer = window.setTimeout(() => setIosHint(true), 1500);
+      return () => {
+        window.clearTimeout(timer);
+        window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+      };
+    }
+    return () => window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+  }, [isMobile, dismissed]);
+
+  const dismiss = (): void => {
+    setDismissed(true);
+    setDeferred(undefined);
+    setIosHint(false);
+    try {
+      localStorage.setItem(DISMISS_KEY, "true");
+    } catch {
+      // private mode — dismissal won't persist, accept that
+    }
+  };
+
+  const onInstall = async (): Promise<void> => {
+    if (deferred === undefined) return;
+    await deferred.prompt();
+    const choice = await deferred.userChoice;
+    setDeferred(undefined);
+    if (choice.outcome === "accepted") dismiss();
+  };
+
+  if (!isMobile || dismissed || isStandalone()) return null;
+  // Render only when we have something to show: a deferred Android
+  // prompt OR the iOS hint flag is on.
+  if (deferred === undefined && !iosHint) return null;
+
+  return (
+    <div className="border-b border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-200">
+      <div className="mx-auto flex max-w-3xl items-center gap-2">
+        <div className="min-w-0 flex-1">
+          {deferred !== undefined ? (
+            <span>Install pi-forge as an app for a fullscreen experience.</span>
+          ) : (
+            <span className="inline-flex flex-wrap items-center gap-1">
+              Install: tap <Share size={14} className="inline shrink-0 text-neutral-400" /> Share,
+              then <span className="font-medium">Add to Home Screen</span>.
+            </span>
+          )}
+        </div>
+        {deferred !== undefined && (
+          <button
+            type="button"
+            onClick={() => void onInstall()}
+            className="shrink-0 rounded-md bg-neutral-100 px-3 py-1.5 text-xs font-medium text-neutral-900 hover:bg-neutral-200"
+          >
+            Install
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Dismiss install prompt"
+          className="inline-flex min-h-9 min-w-9 shrink-0 items-center justify-center rounded text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/ProjectSidebar.tsx
+++ b/packages/client/src/components/ProjectSidebar.tsx
@@ -97,6 +97,15 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
   return (
     <aside
       className={`flex h-full w-64 flex-col border-r border-neutral-800 bg-neutral-950 ${className}`}
+      // Safe-area-aware top + bottom padding so the drawer chrome
+      // (header, sessions list) doesn't slide under iPhone notches /
+      // Android cutouts when the drawer is fullscreen-tall on
+      // mobile. env() returns 0 on devices without insets, so this
+      // is a no-op on desktop and on non-notched phones.
+      style={{
+        paddingTop: "env(safe-area-inset-top)",
+        paddingBottom: "env(safe-area-inset-bottom)",
+      }}
     >
       <header className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
         <span className="text-xs font-semibold uppercase tracking-wider text-neutral-400">

--- a/packages/client/src/lib/theme.ts
+++ b/packages/client/src/lib/theme.ts
@@ -54,14 +54,47 @@ function writePersistedTheme(id: ThemeId): void {
 }
 
 /**
+ * Per-theme `theme-color` for the browser chrome (Android Chrome
+ * paints the address bar with this; iOS PWA standalone mode uses
+ * it for the status-bar surround). Each value is the theme's
+ * `--color-neutral-950` from index.css — the same color the
+ * application header renders against, so the chrome blends into
+ * the app surface.
+ *
+ * Resolved via this lookup table (NOT readCssVar) because the meta
+ * tag needs to update synchronously on theme change before the next
+ * paint — reading from getComputedStyle right after applyTheme can
+ * race the browser's style recalc and return the previous theme's
+ * value. Hard-coded values stay in sync via the CSS-in-source-of-
+ * truth review checklist when adding a theme.
+ */
+const THEME_CHROME: Record<ThemeId, string> = {
+  dark: "#0a0a0a",
+  light: "#ffffff",
+  dracula: "#191a21",
+  "solarized-dark": "#002b36",
+  "catppuccin-mocha": "#11111b",
+};
+
+function syncThemeColorMeta(id: ThemeId): void {
+  if (typeof document === "undefined") return;
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta === null) return;
+  meta.setAttribute("content", THEME_CHROME[id] ?? THEME_CHROME.dark);
+}
+
+/**
  * Apply a theme to the document. Idempotent — safe to call from
  * both the boot path and the picker. Updates `<html data-theme>`
  * which the CSS in index.css uses as a selector to switch the
- * Tailwind neutral palette at runtime.
+ * Tailwind neutral palette at runtime, and syncs the
+ * `<meta name="theme-color">` tag so the browser chrome blends
+ * into the new palette.
  */
 export function applyTheme(id: ThemeId): void {
   if (typeof document === "undefined") return;
   document.documentElement.dataset.theme = id;
+  syncThemeColorMeta(id);
 }
 
 /** Synchronous boot helper called before React mounts. */

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -19,12 +19,30 @@ export default defineConfig({
       manifest: {
         name: "pi-forge",
         short_name: "pi-forge",
-        description: "Browser interface for the pi coding agent",
+        description:
+          "Self-hosted browser workbench for the pi coding agent — chat with the agent against your code, browse files, run a terminal, review diffs, all from one tab.",
+        // theme_color is the static fallback used during PWA install
+        // and at first paint before applyTheme() runs in the React
+        // boot path. Once the React app mounts, theme.ts swaps the
+        // <meta name="theme-color"> tag to match the user's chosen
+        // theme — see THEME_CHROME in lib/theme.ts. Keep this in
+        // sync with the dark theme's --color-neutral-950.
         theme_color: "#0a0a0a",
+        // Splash screen background (Android shows a solid-color
+        // splash before the SW serves index.html). Kept dark; light-
+        // theme users will get a brief flash on cold launch which is
+        // an acceptable trade-off vs forcing a per-theme manifest
+        // (which would require a rebuild per user preference).
         background_color: "#0a0a0a",
         display: "standalone",
         start_url: "/",
         scope: "/",
+        orientation: "any",
+        lang: "en",
+        // App-store-style categorization. Surfaced by Chrome's
+        // install UI and by some app launchers / browser extensions
+        // that index PWAs.
+        categories: ["productivity", "developer"],
         // Raster PNGs for the standard install sizes (192/512 are the
         // PWA spec's recommended baseline) plus a dedicated maskable
         // 512×512 with the glyph rendered into the middle 80% of the


### PR DESCRIPTION
**Stacked on [#104](https://github.com/Devin-Marks/pi-forge/pull/104) (PR 3) → [#103](https://github.com/Devin-Marks/pi-forge/pull/103) (PR 2) → [#102](https://github.com/Devin-Marks/pi-forge/pull/102) (PR 1).** Final PR of the 4-PR mobile-polish series. Once PRs 1–3 merge, GitHub auto-rebases this onto main.

## Summary

The previous three PRs made the chat surface usable on a phone; this one makes it feel like a native app once installed and adds the in-app install affordance + the operator docs.

## What's in the box

### Safe-area insets
Header, chat composer, and project drawer now consume `env(safe-area-inset-*)` so iPhone notches / Dynamic Island and Android cutouts don't clip the chrome, and the iPhone home indicator / Android gesture bar don't overlap the composer. \`viewport-fit=cover\` was set in PR 3; this is what actually consumes the inset. No-op on desktop and on non-notched phones.

### Per-theme \`theme-color\` meta tag
The meta tag was hard-coded to dark; light-theme users got a dark Android Chrome address bar that didn't match the app surface. New \`THEME_CHROME\` lookup table in \`lib/theme.ts\` maps each of the 5 themes to its \`--color-neutral-950\` value. \`applyTheme()\` now syncs the meta tag every time the theme changes (boot + picker + setTheme).

Hard-coded values (rather than reading via \`getComputedStyle\`) because the meta-tag write needs to happen before the next paint — reading computed style right after the data-theme swap can race the browser's style recalc.

### PWA manifest tuning (vite.config.ts)
- Description rewritten to actually describe pi-forge
- \`categories: ["productivity", "developer"]\` for app-store-style indexing
- \`lang: "en"\`, \`orientation: "any"\` (don't lock rotation)
- Doc-comments on \`theme_color\` + \`background_color\` calling out that they're the static fallback used during install + first paint, before applyTheme() takes over

### Install prompt banner (\`components/InstallPrompt.tsx\`)
New mobile-only dismissable banner mounted under the header.

- **Android Chrome / Brave / Edge**: listens for \`beforeinstallprompt\`, preventDefault's the browser's mini-bar, then renders an Install button that calls \`deferred.prompt()\`.
- **iOS Safari**: no \`beforeinstallprompt\` — we detect iOS UA + non-standalone and render a hint *"Install: tap Share, then Add to Home Screen"* with the share glyph.
- **Dismissal** persists in localStorage; standalone-mode check (display-mode media query OR \`navigator.standalone\`) hides it once the PWA is launched from the home icon.

### \`docs/mobile.md\` (new)
Covers what works on mobile, the iOS / Android install paths (including how to install if the banner was dismissed), the **HTTPS-required-for-install gotcha** for self-hosted operators with workaround recipes (ngrok and Chrome's \`insecure-origin-as-secure\` flag), and all the mobile-specific behaviors introduced across the 4-PR series (Enter inserts newline, keyboard auto-dismisses, attach popover, drawer + swipe, theme-aware chrome). Linked from the README documentation table.

## Test plan

- [x] \`npm run check\` clean (tsc + eslint + prettier)
- [x] \`npm run test:ci\` — 26/26 PASS (no client tests touched)
- [x] Tested on a real Android phone via \`UI_PASSWORD='Letmein123!' npm run dev:remote\`:
  - Header sits below the status bar (no clip under notch / cutout)
  - Composer rides above the home indicator / Android gesture bar
  - Drawer respects both top and bottom insets when open
  - Theme switching (Settings → General → Theme) updates the address-bar color in Chrome between Dark, Light, Dracula, Solarized Dark, Catppuccin Mocha
- [ ] **Install banner not testable in dev** — Android Chrome only fires \`beforeinstallprompt\` over HTTPS or localhost; LAN HTTP is rejected. Verified via code review + the operator-facing recipes in \`docs/mobile.md\`. Production deployments (Docker behind TLS-terminated reverse proxy) get install for free.

## Out of scope (deferred)

- Native iOS / Android wrapper (Capacitor, Tauri Mobile)
- Push notifications + background sync
- Manifest screenshots (would add ~1MB of duplicated PNGs to client public/; deferred as a future polish round)
- Apple-touch-startup-image splash screens for individual iOS device sizes (default solid \`background_color\` is fine for v1)

All documented in \`docs/mobile.md\`'s "Not (yet) supported" section.

## What this closes

This is the last of the four-PR mobile series. Once PRs 1–4 are all merged, the v1.2.0 mobile work is done — pi-forge has a usable phone experience without sacrificing any desktop functionality.