### PR TITLE
feat: hide off-scope panels at mobile + fix auth-without-env (PR 2 of 4, replaces #103)

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -360,56 +360,64 @@ export function App() {
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <button
-            onClick={() => setChatOpenPersisted(!chatOpen)}
-            className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
-              chatOpen
-                ? "border-neutral-500 bg-neutral-800 text-neutral-100"
-                : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
-            }`}
-            title="Toggle the chat pane"
-          >
-            <MessageSquare size={13} />
-            Chat
-          </button>
-          <button
-            onClick={() => setEditorOpenPersisted(!editorOpen)}
-            className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
-              editorOpen
-                ? "border-neutral-500 bg-neutral-800 text-neutral-100"
-                : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
-            }`}
-            title="Toggle the editor pane (open tabs persist across reloads)"
-          >
-            <FileCode size={13} />
-            Editor
-          </button>
-          <button
-            onClick={() => setFilesOpenPersisted(!filesOpen)}
-            className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
-              filesOpen
-                ? "border-neutral-500 bg-neutral-800 text-neutral-100"
-                : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
-            }`}
-            title="Toggle the file browser tree"
-          >
-            <FolderTree size={13} />
-            Files
-          </button>
-          {!minimal && (
+          {/* Pane-toggle buttons (Chat / Editor / Files / Terminal) hide
+              at < md. The corresponding panes are also unmounted by the
+              isMobile gates below, so the toggles would have nothing to
+              act on anyway. `hidden md:contents` keeps the wrapper out
+              of the flex layout at md+ so spacing stays identical to
+              pre-mobile-PR behavior. */}
+          <div className="hidden md:contents">
             <button
-              onClick={() => setTerminalOpenPersisted(!terminalOpen)}
+              onClick={() => setChatOpenPersisted(!chatOpen)}
               className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
-                terminalOpen
+                chatOpen
                   ? "border-neutral-500 bg-neutral-800 text-neutral-100"
                   : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
               }`}
-              title="Toggle the integrated terminal"
+              title="Toggle the chat pane"
             >
-              <TerminalIcon size={13} />
-              Terminal
+              <MessageSquare size={13} />
+              Chat
             </button>
-          )}
+            <button
+              onClick={() => setEditorOpenPersisted(!editorOpen)}
+              className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
+                editorOpen
+                  ? "border-neutral-500 bg-neutral-800 text-neutral-100"
+                  : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
+              }`}
+              title="Toggle the editor pane (open tabs persist across reloads)"
+            >
+              <FileCode size={13} />
+              Editor
+            </button>
+            <button
+              onClick={() => setFilesOpenPersisted(!filesOpen)}
+              className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
+                filesOpen
+                  ? "border-neutral-500 bg-neutral-800 text-neutral-100"
+                  : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
+              }`}
+              title="Toggle the file browser tree"
+            >
+              <FolderTree size={13} />
+              Files
+            </button>
+            {!minimal && (
+              <button
+                onClick={() => setTerminalOpenPersisted(!terminalOpen)}
+                className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs ${
+                  terminalOpen
+                    ? "border-neutral-500 bg-neutral-800 text-neutral-100"
+                    : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
+                }`}
+                title="Toggle the integrated terminal"
+              >
+                <TerminalIcon size={13} />
+                Terminal
+              </button>
+            )}
+          </div>
           {/* MCP status badge stays visible in minimal — operators
               still want to see whether MCP servers are connected,
               they just can't reconfigure them from a locked-down
@@ -583,7 +591,8 @@ export function App() {
 
                 `chatColumnVisible` mirrors the rendering condition for
                 the chat column above — strictly chatOpen now. */}
-            {editorVisible &&
+            {!isMobile &&
+              editorVisible &&
               (() => {
                 const chatColumnVisible = chatOpen;
                 const editorIsLeftmost = !chatColumnVisible;
@@ -618,7 +627,8 @@ export function App() {
                 );
               })()}
 
-            {filesOpen &&
+            {!isMobile &&
+              filesOpen &&
               (() => {
                 const chatColumnVisible = chatOpen;
                 const filesIsLeftmost = !chatColumnVisible && !editorVisible;
@@ -721,7 +731,7 @@ export function App() {
           </main>
         </div>
 
-        {!minimal && terminalOpen && (
+        {!isMobile && !minimal && terminalOpen && (
           <>
             <ResizableDivider
               orientation="horizontal"

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -98,6 +98,7 @@ const CLIENT_DIST_PATH = resolve(
 const UI_PASSWORD = readEnv("UI_PASSWORD");
 const API_KEY = readEnv("API_KEY");
 const CORS_ORIGIN = readEnv("CORS_ORIGIN");
+const PASSWORD_HASH_FILE = join(FORGE_DATA_DIR, "password-hash");
 
 /**
  * Load a JWT signing key from `${FORGE_DATA_DIR}/jwt-secret`, or
@@ -106,8 +107,13 @@ const CORS_ORIGIN = readEnv("CORS_ORIGIN");
  * in K8s and Docker), reused across restarts so issued tokens stay
  * valid. Setting `JWT_SECRET` env explicitly skips this entirely.
  *
- * Only invoked when `UI_PASSWORD` is set — if browser auth isn't on,
- * we don't need a secret at all.
+ * Invoked when ANY browser-auth credential is in play: an env-supplied
+ * `UI_PASSWORD`, or a previously-persisted password-hash file (the
+ * latter survives env rotation, the same way jwt-secret does).
+ * Without this, a deployment that booted with `UI_PASSWORD` once and
+ * then dropped it after the user changed their password would be left
+ * with a hash on disk but no signing key — login would 500 trying to
+ * sign a JWT with `undefined`.
  */
 function loadOrGenerateJwtSecret(dataDir: string): string {
   const path = join(dataDir, "jwt-secret");
@@ -132,7 +138,9 @@ function loadOrGenerateJwtSecret(dataDir: string): string {
 
 const JWT_SECRET =
   readEnv("JWT_SECRET") ??
-  (UI_PASSWORD !== undefined ? loadOrGenerateJwtSecret(FORGE_DATA_DIR) : undefined);
+  (UI_PASSWORD !== undefined || existsSync(PASSWORD_HASH_FILE)
+    ? loadOrGenerateJwtSecret(FORGE_DATA_DIR)
+    : undefined);
 
 export const config = Object.freeze({
   port: readInt("PORT", 3000),
@@ -252,7 +260,7 @@ export const config = Object.freeze({
      */
     requirePasswordChange: readBool("REQUIRE_PASSWORD_CHANGE", false),
     /** Where the persisted scrypt hash lives — see auth.ts. */
-    passwordHashFile: join(FORGE_DATA_DIR, "password-hash"),
+    passwordHashFile: PASSWORD_HASH_FILE,
   }),
   /**
    * Per-route rate limits applied to the cost-heavy / disk-heavy / CPU-heavy

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -73,10 +73,25 @@ interface RunningServer {
   port: number;
   child: ChildProcess;
   base: string;
+  /** Absolute path the server is using as its FORGE_DATA_DIR. Exposed
+   *  so callers that want to reuse the same on-disk state across two
+   *  boots (password-hash, jwt-secret) can pass it back into a fresh
+   *  startServer({ ... }, { dataDir }). */
+  dataDir: string;
   stop: () => Promise<void>;
 }
 
-async function startServer(env: Record<string, string | undefined>): Promise<RunningServer> {
+interface StartServerOpts {
+  /** Reuse a pre-existing data dir (e.g. to test what happens after a
+   *  previous boot persisted a password-hash + jwt-secret to disk).
+   *  When omitted, a fresh mkdtemp dir is created and stop() removes it. */
+  dataDir?: string;
+}
+
+async function startServer(
+  env: Record<string, string | undefined>,
+  opts: StartServerOpts = {},
+): Promise<RunningServer> {
   const port = await pickFreePort();
   // Force per-spawn isolation of the data dir. The default
   // (~/.pi-forge) leaks any password-hash / jwt-secret / projects.json
@@ -85,8 +100,11 @@ async function startServer(env: Record<string, string | undefined>): Promise<Run
   // assume no on-disk hash exists, but `authEnabled()` reads
   // existsSync(passwordHashFile) and returns true even when neither
   // env var is set. mkdtemp gives each spawn a clean slate; the
-  // cleanup runs in stop().
-  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-test-auth-"));
+  // cleanup runs in stop() unless the caller supplied their own dir
+  // (in which case we leave cleanup to them so a follow-up boot can
+  // share the same on-disk state).
+  const ownsDataDir = opts.dataDir === undefined;
+  const dataDir = opts.dataDir ?? (await mkdtemp(join(tmpdir(), "pi-forge-test-auth-")));
   const workspacePath = join(dataDir, "workspace");
   const child = spawn(process.execPath, [serverEntry], {
     cwd: repoRoot,
@@ -112,7 +130,9 @@ async function startServer(env: Record<string, string | undefined>): Promise<Run
         setTimeout(() => child.kill("SIGKILL"), 1500).unref();
       });
     }
-    await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+    if (ownsDataDir) {
+      await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+    }
   };
 
   try {
@@ -121,7 +141,7 @@ async function startServer(env: Record<string, string | undefined>): Promise<Run
     await stop();
     throw err;
   }
-  return { port, child, base, stop };
+  return { port, child, base, dataDir, stop };
 }
 
 async function jsonPost(
@@ -258,10 +278,110 @@ async function scenarioAuthDisabled(): Promise<void> {
   }
 }
 
+/**
+ * Scenario D — persisted password-hash but NO env credentials.
+ *
+ * Models the real-world deployment shape that surfaced the bug we're
+ * regression-testing here: an operator boots once with `UI_PASSWORD`
+ * set, the user changes their password through the UI (which writes
+ * a scrypt hash to `${FORGE_DATA_DIR}/password-hash`), and then on
+ * subsequent boots the operator drops `UI_PASSWORD` from env (it's
+ * no longer the canonical credential — the hash file is). Pre-fix,
+ * the second boot left `JWT_SECRET = undefined` because it was only
+ * loaded when `UI_PASSWORD !== undefined`, and login 500'd trying to
+ * sign a JWT with `undefined`. Post-fix: `JWT_SECRET` is also loaded
+ * when the hash file exists, so login signs cleanly.
+ */
+async function scenarioPersistedHashOnly(): Promise<void> {
+  console.log("\n[scenario D] persisted password-hash, no env UI_PASSWORD/JWT_SECRET");
+  const initialPassword = "initial-pw";
+  const rotatedPassword = "rotated-pw";
+
+  // Scenario-owned data dir so both boots share the same on-disk state
+  // (hash file + jwt-secret persist across the restart). startServer
+  // would otherwise mkdtemp its own and rm it in stop(), wiping the
+  // hash file before boot 2 can read it.
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-test-auth-D-"));
+
+  // Boot 1: bring up with env-supplied password, log in, change to a
+  // new password (which persists the hash + jwt-secret to disk).
+  const srv1 = await startServer(
+    {
+      UI_PASSWORD: initialPassword,
+      JWT_SECRET: undefined,
+      API_KEY: undefined,
+      REQUIRE_PASSWORD_CHANGE: "false",
+    },
+    { dataDir },
+  );
+  try {
+    const login = await jsonPost(`${srv1.base}/api/v1/auth/login`, { password: initialPassword });
+    assert("[setup] initial login succeeds", login.status === 200);
+    const issued = (await login.json()) as { token: string };
+    const change = await jsonPost(
+      `${srv1.base}/api/v1/auth/change-password`,
+      { currentPassword: initialPassword, newPassword: rotatedPassword },
+      { Authorization: `Bearer ${issued.token}` },
+    );
+    assert("[setup] change-password succeeds", change.status === 200);
+  } finally {
+    await srv1.stop();
+  }
+
+  // Boot 2: same data dir, NO env credentials. Pre-fix this would
+  // come up with JWT_SECRET=undefined and login would 500. Post-fix
+  // the hash file's existence triggers JWT_SECRET load.
+  const srv2 = await startServer(
+    {
+      UI_PASSWORD: undefined,
+      JWT_SECRET: undefined,
+      API_KEY: undefined,
+      REQUIRE_PASSWORD_CHANGE: "false",
+    },
+    { dataDir },
+  );
+  try {
+    const status = await fetch(`${srv2.base}/api/v1/auth/status`);
+    const statusBody = (await status.json()) as { authEnabled: boolean };
+    assert(
+      "auth/status reports authEnabled=true (hash file alone enables it)",
+      statusBody.authEnabled === true,
+    );
+
+    const wrong = await jsonPost(`${srv2.base}/api/v1/auth/login`, {
+      password: "definitely-wrong",
+    });
+    assert("login with wrong password → 401 (not 500)", wrong.status === 401);
+
+    const right = await jsonPost(`${srv2.base}/api/v1/auth/login`, { password: rotatedPassword });
+    assert(
+      "login with rotated password → 200 (the regression: pre-fix this was 500)",
+      right.status === 200,
+    );
+    const issued = (await right.json()) as { token: string };
+    assert(
+      "re-issued token is non-empty",
+      typeof issued.token === "string" && issued.token.length > 0,
+    );
+
+    const probe = await fetch(`${srv2.base}/api/v1/__protected_probe`, {
+      headers: { Authorization: `Bearer ${issued.token}` },
+    });
+    assert(
+      "probe with the re-issued JWT passes auth (404 from not-found, not 401)",
+      probe.status === 404,
+    );
+  } finally {
+    await srv2.stop();
+    await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
 async function main(): Promise<void> {
   await scenarioPasswordAndJwt();
   await scenarioApiKeyOnly();
   await scenarioAuthDisabled();
+  await scenarioPersistedHashOnly();
 
   if (failures > 0) {
     console.log(`\n[test-auth] FAIL — ${failures} assertion(s) failed`);


### PR DESCRIPTION
**Replaces [#103](https://github.com/Devin-Marks/pi-forge/pull/103) which auto-closed when the parent PR (#102) merged with auto-delete-branch enabled — that deleted the base branch this PR was stacked on, and GitHub closes any PR whose base disappears. Branch was rebased onto the new main and force-pushed, which then locked out the reopen path. Same commits, same diff, just a new PR number. Stacked PRs #104 and #105 have been retargeted to point at this branch's new (rebased) tip.**

---

## Summary

Two atomic commits, both small, in one PR:

1. **`fix(auth)`** — Standalone server-side bug surfaced while testing the mobile drawer with `dev:remote`: when a persisted `password-hash` file exists but no `UI_PASSWORD` env is set, login 500'd because `JWT_SECRET` was only loaded when `UI_PASSWORD !== undefined`. Fix: also load (or generate) the JWT secret when the password-hash file exists. Models the real deployment shape where the operator boots once with `UI_PASSWORD`, the user changes it through the UI (env value becomes ignored), and on subsequent boots the operator drops `UI_PASSWORD` from env. Regression test added.

2. **`feat(client)`** — Mobile PR 2: hide editor / files / terminal panes (and their header toggle buttons) at `< 768 px`. Uses the `useIsMobile` hook from PR 1 to actually unmount the panes — so TerminalPanel doesn't burn a node-pty PTY for a panel the user can't see, and EditorPanel doesn't load CodeMirror's toolchain on a phone. Tailwind `hidden md:contents` hides the four header pane-toggles together with no spacing change at md+.

## Test plan

- [x] `npm run check` clean (tsc + eslint + prettier)
- [x] `npm run test:ci` — 26/26 PASS, including the new `scenarioPersistedHashOnly` in `tests/test-auth.ts`
- [x] Verified the auth regression test FAILS on the buggy code (temporarily reverted the config.ts fix → 4 assertions failed → restored fix → all pass)
- [x] Tested end-to-end on iPhone via `UI_PASSWORD='Letmein123!' npm run dev:remote`:
  - All four pane toggles disappear at phone width
  - Drawer + chat work; nothing tries to mount editor/terminal
  - Resize to ≥ 768 px → desktop layout fully restored, all panes work
- [x] Auth fix verified end-to-end: restarted dev:remote with no `UI_PASSWORD` env → `/auth/status` reports `authEnabled: true` → login with the previously-persisted password returns 200 (pre-fix would have been 500)

## ⚠️ Merge note for future stacked PRs

When merging this PR, **uncheck "Delete branch"** in the merge dialog. PR #104 (next in the stack) has its base branch set to `feat/mobile-hide-panels-and-auth-fix` — if this branch is deleted on merge, PR #104 will auto-close just like #103 did. Same caveat applies when merging #104 (delete-branch unchecks #105).

Once all four mobile PRs land, you can safely delete all the feature branches via the bulk-delete on GitHub or `git push origin --delete <branch>`.