### PR TITLE
feat(client): mobile chat polish + PWA install (combines #104 + #105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ and the rest of the docs, follow the links in
 | Architecture & data flow | [`docs/architecture.md`](./docs/architecture.md) |
 | Configuration & env vars | [`docs/configuration.md`](./docs/configuration.md) |
 | MCP servers | [`docs/mcp.md`](./docs/mcp.md) |
+| Mobile / PWA install | [`docs/mobile.md`](./docs/mobile.md) |
 | Docker image | [`docs/CONTAINERS.md`](./docs/CONTAINERS.md) |
 | Production deployment | [`docs/deployment.md`](./docs/deployment.md) |
 | Kubernetes / OpenShift | [`kubernetes/DEPLOY.md`](./kubernetes/DEPLOY.md) |

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -1,0 +1,190 @@
+# Mobile
+
+pi-forge ships as an **installable PWA** with a mobile-tuned chat
+surface — talk to the agent and watch what it's doing from your
+phone. This page covers what works on mobile, how to install pi-forge
+as a home-screen app, and the operator gotchas (TLS requirement,
+service worker behavior).
+
+If you only ever use pi-forge on a desktop browser, you can skip this
+page. Nothing in mobile mode changes the desktop experience.
+
+---
+
+## What works on mobile
+
+The phone surface is **chat + project monitoring**. You can:
+
+- Send prompts to the agent, watch the streaming reply
+- Switch projects and sessions via the slide-in drawer
+- Use slash commands and `@` file references with phone-tuned popovers
+- Attach photos from gallery / camera, or files from the system file
+  manager
+- Abort an in-flight agent run
+
+Hidden on mobile (still available on desktop):
+
+- File browser tree
+- Per-turn diff panel
+- Git panel
+- File editor (CodeMirror)
+- Integrated terminal
+
+The hidden surfaces are also **unmounted** on mobile, not just
+hidden — so the editor's CodeMirror toolchain doesn't load and the
+terminal doesn't allocate a server-side PTY for a panel you can't
+see.
+
+If you want the desktop layout on a phone (e.g. you have a tablet,
+or you specifically need the terminal in a pinch), use your browser's
+**"Request Desktop Site"** toggle. The mobile breakpoint reacts to
+viewport width, not user-agent — flipping that switch makes the
+browser report a desktop viewport, the layout snaps back to full
+desktop UI, and everything works.
+
+---
+
+## Installing as a PWA
+
+Once installed, pi-forge runs fullscreen with no browser chrome,
+appears in your app drawer with the pi-forge icon, and respects your
+phone's safe-area insets (notch, home indicator, gesture bar).
+
+### iOS Safari
+
+The first time you visit pi-forge on a phone, an install hint
+appears at the top of the screen:
+
+> Install: tap **Share**, then **Add to Home Screen**.
+
+Follow the prompt. iOS PWAs run from the home icon as standalone
+apps — the install hint hides automatically once you launch from
+the icon.
+
+If you dismissed the hint and want to install later: tap the Safari
+share button (square with up-arrow) → **Add to Home Screen**. There's
+no programmatic install on iOS — `beforeinstallprompt` doesn't fire
+on Safari.
+
+### Android Chrome / Brave / Edge
+
+The first visit shows a banner with an **Install** button at the
+top. Tap it → the browser's native install dialog confirms → the app
+appears in your launcher.
+
+If you dismissed the banner, install via the browser's own menu:
+3-dot menu → **Install app** (or **Add to Home Screen** depending on
+the browser).
+
+---
+
+## Operator gotcha: HTTPS is required for install
+
+Both Android Chrome and iOS Safari only treat a site as installable
+over **HTTPS** (or `http://localhost`). A pi-forge instance reachable
+over plain `http://` on a LAN IP — for example, the dev `npm run
+dev:remote` flow at `http://10.0.0.5:5173` — will not show an install
+option, even when the manifest and service worker are otherwise
+correct.
+
+In production this is automatic: the documented Docker deployment
+sits behind a TLS-terminated reverse proxy (Caddy, nginx, Traefik)
+and the install path works without further configuration.
+
+For local PWA testing without a real cert, two reasonable paths:
+
+- **ngrok** (easiest): build the production bundle, serve it from
+  the Fastify server, expose with HTTPS via ngrok.
+
+  ```bash
+  npm run build
+  HOST=127.0.0.1 UI_PASSWORD='your-pw' node packages/server/dist/index.js &
+  ngrok http 3000
+  ```
+
+  Visit the `https://….ngrok.io` URL on your phone — Android's
+  install option appears in the menu and our banner fires.
+
+- **Chrome's insecure-origin-as-secure flag**: on the phone, visit
+  `chrome://flags#unsafely-treat-insecure-origin-as-secure`, add
+  your LAN IP (`http://10.0.0.5:3000`), enable, restart Chrome.
+  Then run the production bundle the same way as above. Brave has
+  the same flag at `brave://flags`.
+
+Note that `npm run dev` / `dev:remote` also disables the service
+worker (`devOptions: { enabled: false }` in `vite.config.ts`) so HMR
+keeps working — that's a second reason install won't work in dev.
+You need a production build (`npm run build`) for the SW to be
+active.
+
+---
+
+## Mobile-specific behaviors
+
+A few phone-only quirks worth knowing about as a user:
+
+- **Enter inserts a newline**, doesn't submit. Mobile virtual
+  keyboards don't surface Shift conveniently, so the desktop
+  "Shift+Enter for newline" rule is unworkable. Send is the
+  explicit Send button. The slash and `@` palettes still own
+  Enter when open (Enter picks the highlighted suggestion).
+
+- **Keyboard auto-dismisses on send** so the streaming reply isn't
+  eaten by half a screen of keyboard. Tap the textarea again to
+  bring it back for the next message.
+
+- **Textarea auto-grows** with what you type, capped at 30% of the
+  viewport height, then scrolls internally past that.
+
+- **Chat composer rides above the keyboard.** When the keyboard
+  appears, the visual viewport shrinks (via the `interactive-
+  widget=resizes-content` viewport hint) and the composer floats
+  to its top. No JS gymnastics — it's just CSS doing the right
+  thing once the meta tag is set.
+
+- **Attach button** (paperclip) opens a small popover with two
+  choices: **Photo** opens the gallery + camera picker; **File**
+  opens the system file manager. The popover collapses two
+  separate buttons into one entry-point so the textarea keeps its
+  width on a 360 px screen.
+
+- **Drawer + sidebar.** The project / session sidebar is a slide-in
+  drawer behind a hamburger button at the top-left. Tap the
+  hamburger or swipe right from the very left edge of the screen
+  to open it. Tap the backdrop or pick a project / session to
+  close.
+
+- **Theme-aware browser chrome.** Android Chrome paints its
+  address bar with our `theme-color` meta tag. The tag is updated
+  whenever you switch themes in Settings → General, so the chrome
+  blends with the active theme rather than always being dark.
+
+---
+
+## Not (yet) supported on mobile
+
+- **Native iOS / Android wrapper** (Capacitor, Tauri Mobile). pi-
+  forge is web-only. The PWA install path approximates a native
+  app for most use cases.
+- **Push notifications.** No "agent finished" alerts when the tab
+  is backgrounded. Deferred to post-v1.
+- **Background sync.** If you close the tab mid-stream, the agent
+  keeps running on the server but you won't see updates until you
+  reopen pi-forge.
+
+---
+
+## See also
+
+- [`docs/configuration.md`](./configuration.md) — environment
+  variables and CLI flags (including `MINIMAL_UI`, which mirrors
+  most of the mobile-mode hides for locked-down desktop deploys)
+- [`docs/deployment.md`](./deployment.md) — production deploy with
+  TLS at a reverse proxy (the prerequisite for PWA install in the
+  field)
+- [`packages/client/src/lib/theme.ts`](../packages/client/src/lib/theme.ts)
+  — theme registry + the `THEME_CHROME` table that drives the
+  per-theme `theme-color` meta tag
+- [`packages/client/src/components/InstallPrompt.tsx`](../packages/client/src/components/InstallPrompt.tsx)
+  — the install banner component, including the iOS-vs-Android
+  branching logic

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -2,7 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- `interactive-widget=resizes-content`: when the on-screen
+         keyboard appears on iOS / Android, shrink the visual viewport
+         (i.e. take the keyboard's space out of the layout) instead of
+         the default `resizes-visual` which leaves layout untouched and
+         lets the keyboard overlay the page. The chat input lives at
+         the bottom of a flex column, so this lets it ride above the
+         keyboard automatically — no JS / visualViewport handling
+         needed. Safe on desktop (no keyboard, no effect). -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <meta name="theme-color" content="#0a0a0a" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -8,6 +8,7 @@ import { useFileStore } from "./store/file-store";
 import { useUiConfigStore } from "./store/ui-config-store";
 import { LoginScreen } from "./components/LoginScreen";
 import { ChangePasswordScreen } from "./components/ChangePasswordScreen";
+import { InstallPrompt } from "./components/InstallPrompt";
 import { ProjectSidebar } from "./components/ProjectSidebar";
 import { ProjectPicker } from "./components/ProjectPicker";
 import { ChatView } from "./components/ChatView";
@@ -334,7 +335,17 @@ export function App() {
 
   return (
     <div className="flex h-screen flex-col bg-neutral-950 text-neutral-100">
-      <header className="flex items-center justify-between border-b border-neutral-800 px-4 py-2">
+      {/* Top-of-viewport chrome respects iOS Dynamic Island / notch
+          and Android cutouts via safe-area-inset-top. The viewport
+          meta in index.html already opts in with `viewport-fit=cover`
+          (PR 3); this is what actually consumes the inset so the
+          hamburger + brand don't sit under the status bar. Combined
+          with `py-2` so we have at least the original 8 px even on
+          devices with no inset. */}
+      <header
+        className="flex items-center justify-between border-b border-neutral-800 px-4 py-2"
+        style={{ paddingTop: "max(0.5rem, env(safe-area-inset-top))" }}
+      >
         <div className="flex items-center gap-3">
           {/* Hamburger — only at < md. Tapping toggles the drawer
               that wraps ProjectSidebar; the icon serves as the
@@ -438,6 +449,11 @@ export function App() {
           </button>
         </div>
       </header>
+
+      {/* PWA install prompt — mobile-only, dismissable, hidden when
+          already running standalone or after the user has dismissed
+          once. Self-gated to render nothing on desktop. */}
+      <InstallPrompt />
 
       {settingsOpen && (
         <SettingsPanel

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -1424,8 +1424,14 @@ export function ChatInput({ sessionId }: Props) {
       </div>
       {/* Tighter padding on mobile so the composer hugs the bottom
           of the viewport (and the on-screen keyboard, when open).
-          Desktop keeps the original `px-6 py-3` breathing room. */}
-      <div className="mx-auto max-w-3xl space-y-2 px-3 pb-2 pt-2 md:px-6 md:py-3">
+          Bottom padding rides the safe-area inset so the composer
+          sits above the iPhone home indicator / Android gesture bar
+          instead of being clipped by them. Desktop keeps the
+          original `px-6 py-3` breathing room. */}
+      <div
+        className="mx-auto max-w-3xl space-y-2 px-3 pt-2 md:px-6 md:py-3"
+        style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
+      >
         <div className="flex flex-wrap items-center gap-2">
           <ModelPicker
             providers={providers}

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { AtSign, Image as ImageIcon, Paperclip, RotateCcw, X } from "lucide-react";
 import { api, ApiError, type ProvidersListing } from "../lib/api-client";
+import { useIsMobile } from "../lib/use-is-mobile";
 import { EMPTY_MESSAGES, useSessionStore, type AgentMessageLike } from "../store/session-store";
 import { useActiveProject } from "../store/project-store";
 import { useUiConfigStore } from "../store/ui-config-store";
@@ -248,6 +249,7 @@ export function ChatInput({ sessionId }: Props) {
   // block at send time — see file-references.ts).
   const project = useActiveProject();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isMobile = useIsMobile();
 
   /**
    * User-chosen textarea height in pixels, driven by the drag handle
@@ -588,8 +590,20 @@ export function ChatInput({ sessionId }: Props) {
     return text === `/${firstWord}` || text.startsWith(`/${firstWord} `);
   }, [slashOpen, text, availablePrompts]);
 
-  const slashRunSelected = (): void => {
-    const cmd = slashFiltered[slashSelectedIdx];
+  /**
+   * Run the highlighted command. `overrideIdx` lets a tap handler
+   * pass the row's index directly instead of going through React
+   * state, which avoids a stale-state bug on touch: desktop relies
+   * on `onMouseEnter` to update `slashSelectedIdx` before
+   * `onMouseDown` fires, but a tap on a touchscreen has no enter
+   * event — mouseDown fires immediately and `setSlashSelectedIdx`
+   * (async) hasn't applied yet, so the read here returns whatever
+   * was previously highlighted. Tap handlers MUST pass the index;
+   * keyboard / Enter paths can omit it (state is already current).
+   */
+  const slashRunSelected = (overrideIdx?: number): void => {
+    const idx = overrideIdx ?? slashSelectedIdx;
+    const cmd = slashFiltered[idx];
     if (cmd === undefined || !cmd.available) return;
     setText("");
     setSlashSelectedIdx(0);
@@ -607,6 +621,19 @@ export function ChatInput({ sessionId }: Props) {
   const [attachments, setAttachments] = useState<File[]>([]);
   const previewUrlsRef = useRef<Map<File, string>>(new Map());
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Separate ref for the mobile-only image picker. Two inputs is
+  // cleaner than swapping a single input's `accept` attribute, which
+  // some browsers cache at element-mount and others don't.
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  // Popover state for the mobile attach menu (Photo / File). Single
+  // entry-point keeps the composer compact on phones — two buttons
+  // would steal ~90 px of horizontal real estate from the textarea.
+  const [attachMenuOpen, setAttachMenuOpen] = useState(false);
+  const attachMenuRef = useRef<HTMLDivElement | null>(null);
+  // Auto-grown textarea height for mobile (px). Recomputed on every
+  // text change as `min(scrollHeight, 30vh)` — desktop ignores this
+  // because it has the drag-resize handle for the same purpose.
+  const [autoHeight, setAutoHeight] = useState<number | undefined>(undefined);
 
   // Per-file size + count limits mirror the server's. Validating
   // client-side gives instant feedback; the server still re-checks.
@@ -1021,6 +1048,11 @@ export function ChatInput({ sessionId }: Props) {
       // should land on it from a fresh empty draft.
       setHistoryIdx(undefined);
       historyDraftRef.current = "";
+      // Mobile-only: dismiss the on-screen keyboard so the user
+      // can read the streaming reply without the keyboard eating
+      // half the viewport. Desktop keeps focus so the next prompt
+      // can be typed without re-clicking.
+      if (isMobile) textareaRef.current?.blur();
     } catch (err) {
       // Surface bash-exec errors inline (api.exec throws ApiError on
       // 4xx/5xx). Other paths still surface via store.error below.
@@ -1113,7 +1145,15 @@ export function ChatInput({ sessionId }: Props) {
         return;
       }
     }
-    if (e.key === "Enter" && !e.shiftKey) {
+    // Plain-Enter submits on desktop. On mobile we let the keyboard's
+    // Enter key insert a newline (default browser behavior) — sending
+    // happens via the explicit Send button. Mobile virtual keyboards
+    // don't expose Shift conveniently, so the desktop "Shift+Enter
+    // for newline" rule would force users into multi-line workflows
+    // with no working escape. The slash-palette and @-completion
+    // popover Enter paths above are unaffected — they still pick the
+    // highlighted suggestion regardless of viewport.
+    if (e.key === "Enter" && !e.shiftKey && !isMobile) {
       e.preventDefault();
       void submit();
       return;
@@ -1297,6 +1337,66 @@ export function ChatInput({ sessionId }: Props) {
     setText((prev) => prev.replace(re, (_match, lead: string) => lead).trimEnd());
   };
 
+  // Close the mobile attach popover on outside-click or Esc. The
+  // file-input click-then-pick flow doesn't bounce focus back here,
+  // so without an explicit close the popover would linger after the
+  // picker dismisses. Single Event-typed handler covers mousedown +
+  // touchstart so TS doesn't have to reconcile the per-event-name
+  // overloads with a union handler signature.
+  useEffect(() => {
+    if (!attachMenuOpen) return;
+    const onPointerDown = (e: Event): void => {
+      const root = attachMenuRef.current;
+      if (root === null) return;
+      if (root.contains(e.target as Node)) return;
+      setAttachMenuOpen(false);
+    };
+    // `KeyboardEvent` is shadowed by React's type import at the top
+    // of the file, so we can't write `(e: KeyboardEvent)` without
+    // hitting React's overload. Read the key off the raw Event
+    // instead — it's the same shape at runtime.
+    const onKey: EventListener = (e) => {
+      const key = (e as { key?: string }).key;
+      if (key === "Escape") setAttachMenuOpen(false);
+    };
+    window.addEventListener("mousedown", onPointerDown);
+    window.addEventListener("touchstart", onPointerDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onPointerDown);
+      window.removeEventListener("touchstart", onPointerDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [attachMenuOpen]);
+
+  // Mobile-only auto-grow: the textarea has a comfortable minimum
+  // height (matches the attach + send buttons' 44 px height so the
+  // composer row reads as one unified bar) and grows with input up
+  // to a 30vh cap, after which it scrolls internally. Measuring:
+  // collapse height to "auto" first (otherwise scrollHeight reports
+  // the previously-set expanded value and we can never shrink),
+  // measure, then store clamped to [min, max]. Desktop opts out —
+  // the drag handle owns textarea sizing there.
+  useEffect(() => {
+    if (!isMobile) {
+      if (autoHeight !== undefined) setAutoHeight(undefined);
+      return;
+    }
+    const ta = textareaRef.current;
+    if (ta === null) return;
+    const prev = ta.style.height;
+    ta.style.height = "auto";
+    const measured = ta.scrollHeight;
+    ta.style.height = prev;
+    const min = 44; // matches min-h-11 on attach/send buttons
+    const max = Math.round(window.innerHeight * 0.3);
+    const next = Math.max(min, Math.min(measured, max));
+    if (next !== autoHeight) setAutoHeight(next);
+    // Recompute when the input grows/shrinks or the viewport flips
+    // (orientation change → different 30vh).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, isMobile]);
+
   return (
     <div className="bg-neutral-950">
       {/*
@@ -1309,16 +1409,23 @@ export function ChatInput({ sessionId }: Props) {
         have to pixel-hunt; `-translate-y` shifts the click region up
         without growing the layout box.
       */}
+      {/* Drag-to-resize handle — hidden on mobile. Touch users have
+          no use for cursor-row-resize, and a hidden 5-px hit area
+          right above the textarea would intercept scroll gestures
+          on phones. */}
       <div
         role="separator"
         aria-orientation="horizontal"
         aria-label="Resize chat input"
         onPointerDown={startDividerDrag}
-        className="group relative h-px cursor-row-resize bg-neutral-800 hover:bg-neutral-600 active:bg-neutral-500"
+        className="group relative hidden h-px cursor-row-resize bg-neutral-800 hover:bg-neutral-600 active:bg-neutral-500 md:block"
       >
         <div className="absolute inset-x-0 -top-1 h-2" />
       </div>
-      <div className="mx-auto max-w-3xl space-y-2 px-6 py-3">
+      {/* Tighter padding on mobile so the composer hugs the bottom
+          of the viewport (and the on-screen keyboard, when open).
+          Desktop keeps the original `px-6 py-3` breathing room. */}
+      <div className="mx-auto max-w-3xl space-y-2 px-3 pb-2 pt-2 md:px-6 md:py-3">
         <div className="flex flex-wrap items-center gap-2">
           <ModelPicker
             providers={providers}
@@ -1353,7 +1460,10 @@ export function ChatInput({ sessionId }: Props) {
               {modelError !== undefined && (
                 <span className="text-[11px] text-red-400">{modelError}</span>
               )}
-              {textareaHeight !== undefined && (
+              {/* Reset is paired with the drag handle; hide on
+                  mobile since the handle is hidden there too and the
+                  textarea ignores the persisted height. */}
+              {!isMobile && textareaHeight !== undefined && (
                 <button
                   type="button"
                   onClick={resetTextareaHeight}
@@ -1379,33 +1489,107 @@ export function ChatInput({ sessionId }: Props) {
           />
         )}
         <div className="flex items-end gap-2">
+          {/* Files input — accepts everything. On desktop this is
+              the only attach affordance (the file dialog handles
+              browsing anywhere, including image folders, fine).
+              On mobile it's the "any file" companion to the image
+              button below. */}
           <input
             ref={fileInputRef}
             type="file"
             multiple
             className="hidden"
-            // Accept everything; the server (and addAttachments above)
-            // sort images vs text by MIME type. Restricting `accept`
-            // here would block legitimate code-file extensions the
-            // browser doesn't have a built-in MIME for.
             onChange={(e) => {
               if (e.target.files !== null) addAttachments(e.target.files);
               // Reset so re-selecting the same file fires onChange.
               e.target.value = "";
             }}
           />
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            disabled={submitting || isStreaming}
-            className="self-stretch rounded-md border border-neutral-700 bg-neutral-900 px-2 text-neutral-300 hover:border-neutral-500 hover:text-neutral-100 disabled:cursor-not-allowed disabled:opacity-50"
-            title={
-              isStreaming
-                ? "Attachments aren't sent on steer (mid-turn). Wait for the current run to finish."
-                : "Attach files (images go into model context; text files are prepended to the prompt)"
-            }
-          >
-            <Paperclip size={14} />
-          </button>
+          {/* Image input — mobile-only. `accept="image/*"` is what
+              both iOS Safari and Android Chrome use to surface the
+              gallery + camera picker. Reached from the attach
+              popover below; the popover is what hides the two
+              attach surfaces behind a single button so the composer
+              keeps its width on a phone. */}
+          {isMobile && (
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={(e) => {
+                if (e.target.files !== null) addAttachments(e.target.files);
+                e.target.value = "";
+              }}
+            />
+          )}
+          {/* Attach affordance.
+              - Mobile: single Paperclip that opens a small popover
+                with Photo + File entries (Slack/Discord style).
+                One button = one tap target's worth of horizontal
+                space, instead of the ~90 px two side-by-side
+                buttons would steal from the textarea on a 360 px
+                phone.
+              - Desktop: the same Paperclip directly opens the
+                file picker (no popover, since the desktop file
+                dialog already handles browsing anywhere). */}
+          {isMobile ? (
+            <div className="relative" ref={attachMenuRef}>
+              <button
+                onClick={() => setAttachMenuOpen((o) => !o)}
+                disabled={submitting || isStreaming}
+                aria-label="Attach"
+                aria-expanded={attachMenuOpen}
+                className="inline-flex min-h-11 min-w-11 items-center justify-center self-stretch rounded-md border border-neutral-700 bg-neutral-900 px-2 text-neutral-300 hover:border-neutral-500 hover:text-neutral-100 disabled:cursor-not-allowed disabled:opacity-50"
+                title={
+                  isStreaming
+                    ? "Attachments aren't sent on steer (mid-turn)."
+                    : "Attach a photo or a file"
+                }
+              >
+                <Paperclip size={16} />
+              </button>
+              {attachMenuOpen && (
+                <div className="absolute bottom-full left-0 z-20 mb-1 flex flex-col overflow-hidden rounded-md border border-neutral-700 bg-neutral-900 shadow-lg">
+                  <button
+                    onClick={() => {
+                      imageInputRef.current?.click();
+                      setAttachMenuOpen(false);
+                    }}
+                    className="flex min-h-11 items-center gap-2 px-3 text-left text-[14px] text-neutral-200 hover:bg-neutral-800"
+                  >
+                    <ImageIcon size={16} className="shrink-0 text-neutral-400" />
+                    Photo
+                  </button>
+                  <button
+                    onClick={() => {
+                      fileInputRef.current?.click();
+                      setAttachMenuOpen(false);
+                    }}
+                    className="flex min-h-11 items-center gap-2 border-t border-neutral-800 px-3 text-left text-[14px] text-neutral-200 hover:bg-neutral-800"
+                  >
+                    <Paperclip size={16} className="shrink-0 text-neutral-400" />
+                    File
+                  </button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={submitting || isStreaming}
+              aria-label="Attach files"
+              className="inline-flex items-center justify-center self-stretch rounded-md border border-neutral-700 bg-neutral-900 px-2 text-neutral-300 hover:border-neutral-500 hover:text-neutral-100 disabled:cursor-not-allowed disabled:opacity-50"
+              title={
+                isStreaming
+                  ? "Attachments aren't sent on steer (mid-turn). Wait for the current run to finish."
+                  : "Attach files (images go into model context; text files are prepended to the prompt)"
+              }
+            >
+              <Paperclip size={14} />
+            </button>
+          )}
           <div className="relative flex-1">
             {/* /-command palette — opens whenever the input starts
                 with `/` and has no newline. Listed top-to-bottom in
@@ -1415,7 +1599,10 @@ export function ChatInput({ sessionId }: Props) {
                 grayed and don't accept Enter. */}
             {slashOpen && slashFiltered.length > 0 && (
               <div className="absolute bottom-full left-0 right-0 z-10 mb-1 overflow-hidden rounded-md border border-neutral-700 bg-neutral-900 shadow-lg">
-                <div className="max-h-64 overflow-y-auto py-1">
+                {/* Taller list with more breathing room on mobile so
+                    each item is a comfortable tap target. md:max-h-64
+                    restores the desktop popover size. */}
+                <div className="max-h-[60vh] overflow-y-auto py-1 md:max-h-64">
                   {slashFiltered.map((cmd, i) => (
                     <button
                       key={cmd.name}
@@ -1423,11 +1610,13 @@ export function ChatInput({ sessionId }: Props) {
                         ev.preventDefault();
                         if (!cmd.available) return;
                         setSlashSelectedIdx(i);
-                        slashRunSelected();
+                        // Pass `i` directly — see the slashRunSelected
+                        // doc-comment for why state isn't safe here.
+                        slashRunSelected(i);
                       }}
                       onMouseEnter={() => setSlashSelectedIdx(i)}
                       disabled={!cmd.available}
-                      className={`block w-full px-3 py-1 text-left text-[12px] ${
+                      className={`block w-full px-3 py-2.5 text-left text-[14px] md:py-1 md:text-[12px] ${
                         i === slashSelectedIdx && cmd.available
                           ? "bg-neutral-800 text-neutral-100"
                           : "text-neutral-300 hover:bg-neutral-900/80"
@@ -1438,12 +1627,23 @@ export function ChatInput({ sessionId }: Props) {
                           : `${cmd.description} — unavailable right now`
                       }
                     >
-                      <span className="font-mono text-neutral-200">{cmd.name}</span>
-                      <span className="ml-2 text-[10px] text-neutral-500">{cmd.description}</span>
+                      {/* Stack name/description on phones — descriptions
+                          are too wide to fit on one line at 360 px and
+                          would either truncate or push the row taller
+                          than its tap-target sweet spot. md:flex
+                          restores the desktop side-by-side layout. */}
+                      <div className="flex flex-col md:block">
+                        <span className="font-mono text-neutral-200">{cmd.name}</span>
+                        <span className="text-[12px] text-neutral-500 md:ml-2 md:text-[10px]">
+                          {cmd.description}
+                        </span>
+                      </div>
                     </button>
                   ))}
                 </div>
-                <div className="border-t border-neutral-800 px-3 py-1 text-[10px] text-neutral-500">
+                {/* Hint footer — keyboard hints aren't useful on a
+                    touchscreen, hide on mobile to save vertical space. */}
+                <div className="hidden border-t border-neutral-800 px-3 py-1 text-[10px] text-neutral-500 md:block">
                   ↑↓ navigate · Enter/Tab run · Esc cancel
                 </div>
               </div>
@@ -1454,7 +1654,7 @@ export function ChatInput({ sessionId }: Props) {
                 item is closest to the input. */}
             {acToken !== undefined && acSuggestions.length > 0 && (
               <div className="absolute bottom-full left-0 right-0 z-10 mb-1 overflow-hidden rounded-md border border-neutral-700 bg-neutral-900 shadow-lg">
-                <div className="max-h-64 overflow-y-auto py-1">
+                <div className="max-h-[60vh] overflow-y-auto py-1 md:max-h-64">
                   {acSuggestions.map((path, i) => (
                     <button
                       key={path}
@@ -1466,7 +1666,7 @@ export function ChatInput({ sessionId }: Props) {
                         acInsert(path);
                       }}
                       onMouseEnter={() => setAcSelectedIdx(i)}
-                      className={`block w-full truncate px-3 py-1 text-left font-mono text-[12px] ${
+                      className={`block w-full truncate px-3 py-2.5 text-left font-mono text-[14px] md:py-1 md:text-[12px] ${
                         i === acSelectedIdx
                           ? "bg-neutral-800 text-neutral-100"
                           : "text-neutral-300 hover:bg-neutral-900/80"
@@ -1477,7 +1677,7 @@ export function ChatInput({ sessionId }: Props) {
                     </button>
                   ))}
                 </div>
-                <div className="border-t border-neutral-800 px-3 py-1 text-[10px] text-neutral-500">
+                <div className="hidden border-t border-neutral-800 px-3 py-1 text-[10px] text-neutral-500 md:block">
                   ↑↓ navigate · Enter/Tab insert · Esc close
                 </div>
               </div>
@@ -1501,19 +1701,45 @@ export function ChatInput({ sessionId }: Props) {
                 isAutoRetrying
                   ? "Auto-retry in progress — your message will be queued and sent after the retry completes…"
                   : isStreaming
-                    ? "Steer the agent (Enter to send, Shift+Enter for newline)…"
-                    : minimalUi
-                      ? "Ask pi (Enter to send, Shift+Enter for newline) — `/` runs commands, `@path` references files…"
-                      : "Ask pi (Enter to send, Shift+Enter for newline) — `/` runs commands, `!` runs bash, `@path` references files…"
+                    ? isMobile
+                      ? "Steer the agent…"
+                      : "Steer the agent (Enter to send, Shift+Enter for newline)…"
+                    : isMobile
+                      ? minimalUi
+                        ? "Ask pi — `/` runs commands, `@path` references files…"
+                        : "Ask pi — `/` runs commands, `!` runs bash, `@path` references files…"
+                      : minimalUi
+                        ? "Ask pi (Enter to send, Shift+Enter for newline) — `/` runs commands, `@path` references files…"
+                        : "Ask pi (Enter to send, Shift+Enter for newline) — `/` runs commands, `!` runs bash, `@path` references files…"
               }
               title={
                 isAutoRetrying
                   ? "The agent is auto-retrying after a provider error. New messages are queued and delivered when the retry succeeds."
                   : undefined
               }
-              rows={3}
-              style={textareaHeight !== undefined ? { height: `${textareaHeight}px` } : undefined}
-              className={`w-full resize-none rounded-md border bg-neutral-900 px-3 py-2 text-sm text-neutral-100 outline-none ${
+              // Mobile: starts at 2 lines, then auto-grows with the
+              // user's input via the useEffect above (capped at
+              // 30vh; scrolls internally past that). Desktop keeps
+              // its 3-row default and uses the drag handle for
+              // explicit resizing — autoHeight is undefined on
+              // desktop so the inline style only applies the
+              // user-dragged value.
+              rows={isMobile ? 2 : 3}
+              style={
+                isMobile && autoHeight !== undefined
+                  ? { height: `${autoHeight}px`, maxHeight: "30vh" }
+                  : !isMobile && textareaHeight !== undefined
+                    ? { height: `${textareaHeight}px` }
+                    : undefined
+              }
+              className={`block w-full resize-none rounded-md border bg-neutral-900 px-3 py-2 text-sm text-neutral-100 outline-none ${
+                // Match attach + send button min-height on mobile so
+                // every child of the row renders at the same baseline
+                // height. Without this the textarea collapses to its
+                // intrinsic scrollHeight (~37 px when empty) and sits
+                // visibly higher than the 44 px buttons.
+                "min-h-11 md:min-h-0 "
+              }${
                 bangMode === "local"
                   ? "border-amber-500 focus:border-amber-400"
                   : bangMode === "context"
@@ -1539,17 +1765,25 @@ export function ChatInput({ sessionId }: Props) {
             )}
           </div>
           {/*
-            Two buttons: Send (always) + Abort (streaming only). Pi's
-            SDK picks steer-vs-followUp natively when we POST /steer
-            during a run — we don't try to second-guess it. Abort is
-            its own button so it can't be hit by accident from a
-            misclick on Send.
+            Send + Abort. On mobile they stack vertically (Abort
+            above Send via flex-col-reverse, DOM order Send-then-
+            Abort so desktop's `md:flex-row` reads correctly left-
+            to-right). Crucially the wrapper is `self-stretch`, so
+            its height matches the parent row's height (the auto-
+            grown textarea). Each button takes `flex-1`, splitting
+            that height evenly. Net result: composer overall height
+            stays constant whether streaming or not — model picker
+            row above doesn't shift when Abort appears.
+
+            On desktop (md:) we revert to a row of natural-height
+            buttons; the desktop composer is taller and there's
+            plenty of room, so stretching looks weird there.
           */}
-          <div className="flex flex-row gap-1">
+          <div className="flex flex-col-reverse gap-1 self-stretch md:flex-row md:items-end md:self-auto">
             <button
               onClick={() => void submit()}
               disabled={(text.trim().length === 0 && attachments.length === 0) || submitting}
-              className="rounded-md bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-900 disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex-1 rounded-md bg-neutral-100 px-4 text-sm font-medium text-neutral-900 disabled:cursor-not-allowed disabled:opacity-50 md:flex-none md:py-2"
               title={
                 isStreaming
                   ? "Send (Pi queues at the next agent break — steer or follow-up depending on agent state)"
@@ -1561,7 +1795,7 @@ export function ChatInput({ sessionId }: Props) {
             {isStreaming && (
               <button
                 onClick={() => void abortSession(sessionId)}
-                className="rounded-md border border-red-700/50 px-3 py-2 text-sm text-red-300 hover:bg-red-900/20"
+                className="flex-1 rounded-md border border-red-700/60 bg-red-950/30 px-3 text-sm font-medium text-red-300 hover:bg-red-900/40 hover:text-red-100 md:flex-none md:py-2"
                 title="Stop the agent (or press Esc twice in the textbox)"
               >
                 Abort

--- a/packages/client/src/components/ChatMarkdown.tsx
+++ b/packages/client/src/components/ChatMarkdown.tsx
@@ -90,10 +90,13 @@ function CodeCopyButton({ code }: { code: string }) {
     <button
       type="button"
       onClick={onClick}
-      className="absolute right-1 top-1 rounded bg-neutral-800/80 p-1 text-neutral-400 opacity-0 transition-opacity hover:text-neutral-100 group-hover:opacity-100 focus:opacity-100"
+      // Mobile: always visible, ≥ 44 px tap target (no hover on touch).
+      // Desktop: hover-revealed via group-hover, compact size.
+      className="absolute right-1 top-1 inline-flex min-h-11 min-w-11 items-center justify-center rounded bg-neutral-800/80 p-1 text-neutral-400 transition-opacity hover:text-neutral-100 focus:opacity-100 md:min-h-0 md:min-w-0 md:opacity-0 md:group-hover:opacity-100"
       title="Copy code block"
+      aria-label="Copy code block"
     >
-      {copied ? <Check size={12} /> : <Copy size={12} />}
+      {copied ? <Check size={14} /> : <Copy size={14} />}
     </button>
   );
 }

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -513,7 +513,7 @@ function FileRefBadge({ ref: r }: { ref: FileRef }) {
         type="button"
         onClick={() => isInline && setExpanded((v) => !v)}
         disabled={!isInline}
-        className={`flex w-full items-center gap-1.5 px-2 py-1 text-left text-[11px] ${
+        className={`flex min-h-11 w-full items-center gap-1.5 px-2 py-1 text-left text-[11px] md:min-h-0 ${
           isInline ? "text-neutral-200 hover:bg-neutral-800" : "cursor-default text-emerald-200"
         }`}
         title={
@@ -1199,10 +1199,10 @@ function SubagentResultCard({
         {parsed.results.length === 1 && parsed.results[0]!.sessionFile !== undefined && (
           <button
             onClick={() => openByFile(parsed.results[0]!.sessionFile)}
-            className="inline-flex shrink-0 items-center gap-1 rounded border border-sky-700/60 px-1.5 py-0.5 text-[10px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100"
+            className="inline-flex min-h-11 shrink-0 items-center gap-1 rounded border border-sky-700/60 px-2 py-1 text-[12px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100 md:min-h-0 md:px-1.5 md:py-0.5 md:text-[10px]"
             title={`Open sub-agent session — ${parsed.results[0]!.sessionFile}`}
           >
-            <ExternalLink size={10} />
+            <ExternalLink size={12} />
             Open
           </button>
         )}
@@ -1403,10 +1403,11 @@ function CopyButton({ getText, title }: { getText: () => string; title: string }
     <button
       type="button"
       onClick={onClick}
-      className="rounded px-1.5 py-0.5 text-neutral-500 hover:bg-neutral-700/40 hover:text-neutral-300"
+      className="inline-flex min-h-11 min-w-11 items-center justify-center rounded px-1.5 py-0.5 text-neutral-500 hover:bg-neutral-700/40 hover:text-neutral-300 md:min-h-0 md:min-w-0"
       title={title}
+      aria-label={title}
     >
-      {copied ? <Check size={12} /> : <Copy size={12} />}
+      {copied ? <Check size={14} /> : <Copy size={14} />}
     </button>
   );
 }
@@ -1432,7 +1433,7 @@ function RawToggle({ showRaw, onToggle }: { showRaw: boolean; onToggle: (next: b
     <button
       type="button"
       onClick={() => onToggle(!showRaw)}
-      className="rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-500 hover:bg-neutral-700/40 hover:text-neutral-300"
+      className="inline-flex min-h-11 min-w-11 items-center justify-center rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-500 hover:bg-neutral-700/40 hover:text-neutral-300 md:min-h-0 md:min-w-0"
       title={showRaw ? "Show rendered markdown" : "Show raw text"}
     >
       {showRaw ? "rendered" : "raw"}

--- a/packages/client/src/components/InstallPrompt.tsx
+++ b/packages/client/src/components/InstallPrompt.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from "react";
+import { Share, X } from "lucide-react";
+import { useIsMobile } from "../lib/use-is-mobile";
+
+/**
+ * "Install pi-forge as an app" banner — shown on mobile, dismissable,
+ * with platform-specific behavior:
+ *
+ *   - **Android Chrome / Edge / Samsung Internet**: listens for the
+ *     `beforeinstallprompt` event, captures the deferred prompt, and
+ *     a tap on "Install" calls `prompt()` + `userChoice`. Browser
+ *     suppresses the event after install (or after the user has
+ *     dismissed enough times — heuristic), so we don't have to track
+ *     install state ourselves.
+ *
+ *   - **iOS Safari**: doesn't fire `beforeinstallprompt`; PWA install
+ *     is "Tap Share → Add to Home Screen" by hand. We render a hint
+ *     with the share glyph instead of an Install button.
+ *
+ *   - **Already-installed PWA**: hidden via the standalone-mode
+ *     check (`display-mode: standalone` media query OR iOS's
+ *     `navigator.standalone`). Once launched from the home icon, no
+ *     point nagging.
+ *
+ * Dismissal persists in localStorage so the banner doesn't re-appear
+ * after every reload. There's no "remind me later" — the user can
+ * always reach Add to Home Screen through the browser's own menu.
+ */
+
+const DISMISS_KEY = "pi-forge/install-prompt-dismissed";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+}
+
+function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  // iOS Safari sets a non-standard `navigator.standalone` (true when
+  // launched from the home icon). Other browsers respect the CSS
+  // `display-mode: standalone` media query.
+  if ((window.navigator as { standalone?: boolean }).standalone === true) return true;
+  return window.matchMedia?.("(display-mode: standalone)").matches ?? false;
+}
+
+function isIOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+  // Modern iOS Safari + Edge/Firefox iOS all share WebKit; the UA
+  // pattern is stable enough for "show iOS install hint" gating.
+  return /iphone|ipad|ipod/i.test(navigator.userAgent);
+}
+
+export function InstallPrompt(): React.JSX.Element | null {
+  const isMobile = useIsMobile();
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | undefined>(undefined);
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof localStorage === "undefined") return false;
+    return localStorage.getItem(DISMISS_KEY) === "true";
+  });
+  const [iosHint, setIosHint] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (isStandalone()) return; // already installed
+    if (dismissed) return;
+
+    const onBeforeInstall = (e: Event): void => {
+      e.preventDefault(); // suppress the browser's own mini-bar
+      setDeferred(e as BeforeInstallPromptEvent);
+    };
+    window.addEventListener("beforeinstallprompt", onBeforeInstall);
+    // iOS doesn't fire beforeinstallprompt — show the hint when
+    // mobile + iOS + not standalone. Delay so the banner doesn't
+    // race the first paint and feel intrusive.
+    if (isIOS() && isMobile) {
+      const timer = window.setTimeout(() => setIosHint(true), 1500);
+      return () => {
+        window.clearTimeout(timer);
+        window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+      };
+    }
+    return () => window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+  }, [isMobile, dismissed]);
+
+  const dismiss = (): void => {
+    setDismissed(true);
+    setDeferred(undefined);
+    setIosHint(false);
+    try {
+      localStorage.setItem(DISMISS_KEY, "true");
+    } catch {
+      // private mode — dismissal won't persist, accept that
+    }
+  };
+
+  const onInstall = async (): Promise<void> => {
+    if (deferred === undefined) return;
+    await deferred.prompt();
+    const choice = await deferred.userChoice;
+    setDeferred(undefined);
+    if (choice.outcome === "accepted") dismiss();
+  };
+
+  if (!isMobile || dismissed || isStandalone()) return null;
+  // Render only when we have something to show: a deferred Android
+  // prompt OR the iOS hint flag is on.
+  if (deferred === undefined && !iosHint) return null;
+
+  return (
+    <div className="border-b border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-200">
+      <div className="mx-auto flex max-w-3xl items-center gap-2">
+        <div className="min-w-0 flex-1">
+          {deferred !== undefined ? (
+            <span>Install pi-forge as an app for a fullscreen experience.</span>
+          ) : (
+            <span className="inline-flex flex-wrap items-center gap-1">
+              Install: tap <Share size={14} className="inline shrink-0 text-neutral-400" /> Share,
+              then <span className="font-medium">Add to Home Screen</span>.
+            </span>
+          )}
+        </div>
+        {deferred !== undefined && (
+          <button
+            type="button"
+            onClick={() => void onInstall()}
+            className="shrink-0 rounded-md bg-neutral-100 px-3 py-1.5 text-xs font-medium text-neutral-900 hover:bg-neutral-200"
+          >
+            Install
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Dismiss install prompt"
+          className="inline-flex min-h-9 min-w-9 shrink-0 items-center justify-center rounded text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/ProjectSidebar.tsx
+++ b/packages/client/src/components/ProjectSidebar.tsx
@@ -97,6 +97,15 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
   return (
     <aside
       className={`flex h-full w-64 flex-col border-r border-neutral-800 bg-neutral-950 ${className}`}
+      // Safe-area-aware top + bottom padding so the drawer chrome
+      // (header, sessions list) doesn't slide under iPhone notches /
+      // Android cutouts when the drawer is fullscreen-tall on
+      // mobile. env() returns 0 on devices without insets, so this
+      // is a no-op on desktop and on non-notched phones.
+      style={{
+        paddingTop: "env(safe-area-inset-top)",
+        paddingBottom: "env(safe-area-inset-bottom)",
+      }}
     >
       <header className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
         <span className="text-xs font-semibold uppercase tracking-wider text-neutral-400">

--- a/packages/client/src/lib/theme.ts
+++ b/packages/client/src/lib/theme.ts
@@ -54,14 +54,47 @@ function writePersistedTheme(id: ThemeId): void {
 }
 
 /**
+ * Per-theme `theme-color` for the browser chrome (Android Chrome
+ * paints the address bar with this; iOS PWA standalone mode uses
+ * it for the status-bar surround). Each value is the theme's
+ * `--color-neutral-950` from index.css — the same color the
+ * application header renders against, so the chrome blends into
+ * the app surface.
+ *
+ * Resolved via this lookup table (NOT readCssVar) because the meta
+ * tag needs to update synchronously on theme change before the next
+ * paint — reading from getComputedStyle right after applyTheme can
+ * race the browser's style recalc and return the previous theme's
+ * value. Hard-coded values stay in sync via the CSS-in-source-of-
+ * truth review checklist when adding a theme.
+ */
+const THEME_CHROME: Record<ThemeId, string> = {
+  dark: "#0a0a0a",
+  light: "#ffffff",
+  dracula: "#191a21",
+  "solarized-dark": "#002b36",
+  "catppuccin-mocha": "#11111b",
+};
+
+function syncThemeColorMeta(id: ThemeId): void {
+  if (typeof document === "undefined") return;
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta === null) return;
+  meta.setAttribute("content", THEME_CHROME[id] ?? THEME_CHROME.dark);
+}
+
+/**
  * Apply a theme to the document. Idempotent — safe to call from
  * both the boot path and the picker. Updates `<html data-theme>`
  * which the CSS in index.css uses as a selector to switch the
- * Tailwind neutral palette at runtime.
+ * Tailwind neutral palette at runtime, and syncs the
+ * `<meta name="theme-color">` tag so the browser chrome blends
+ * into the new palette.
  */
 export function applyTheme(id: ThemeId): void {
   if (typeof document === "undefined") return;
   document.documentElement.dataset.theme = id;
+  syncThemeColorMeta(id);
 }
 
 /** Synchronous boot helper called before React mounts. */

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -19,12 +19,30 @@ export default defineConfig({
       manifest: {
         name: "pi-forge",
         short_name: "pi-forge",
-        description: "Browser interface for the pi coding agent",
+        description:
+          "Self-hosted browser workbench for the pi coding agent — chat with the agent against your code, browse files, run a terminal, review diffs, all from one tab.",
+        // theme_color is the static fallback used during PWA install
+        // and at first paint before applyTheme() runs in the React
+        // boot path. Once the React app mounts, theme.ts swaps the
+        // <meta name="theme-color"> tag to match the user's chosen
+        // theme — see THEME_CHROME in lib/theme.ts. Keep this in
+        // sync with the dark theme's --color-neutral-950.
         theme_color: "#0a0a0a",
+        // Splash screen background (Android shows a solid-color
+        // splash before the SW serves index.html). Kept dark; light-
+        // theme users will get a brief flash on cold launch which is
+        // an acceptable trade-off vs forcing a per-theme manifest
+        // (which would require a rebuild per user preference).
         background_color: "#0a0a0a",
         display: "standalone",
         start_url: "/",
         scope: "/",
+        orientation: "any",
+        lang: "en",
+        // App-store-style categorization. Surfaced by Chrome's
+        // install UI and by some app launchers / browser extensions
+        // that index PWAs.
+        categories: ["productivity", "developer"],
         // Raster PNGs for the standard install sizes (192/512 are the
         // PWA spec's recommended baseline) plus a dedicated maskable
         // 512×512 with the glyph rendered into the middle 80% of the


### PR DESCRIPTION
**Recovery PR.** [#104](https://github.com/Devin-Marks/pi-forge/pull/104) and [#105](https://github.com/Devin-Marks/pi-forge/pull/105) both showed up as MERGED but their squash commits landed on their feature-branch bases (\`feat/mobile-hide-panels-and-auth-fix\` and \`feat/mobile-chat-polish\` respectively), not on main — that's what stacked PRs do when their base is another feature branch. Result: chat-polish and pwa-polish content was never actually deployed, and CI never ran on the merges (the workflow's \`pull_request: branches: [main]\` filter skipped both PRs because their bases weren't main).

This PR cherry-picks both squash commits onto a fresh branch from main, so the work lands properly with full CI coverage. Same content as #104 + #105, no functional changes.

## Commits (cherry-picked from #104 + #105 squashes verbatim)

- `b1ab97a feat(client): mobile chat-view polish — composer, palettes, touch targets (#104)`
- `9246fcf feat(client): PWA install polish — safe-area, theme-color, install banner (#105)`

The original commit messages are preserved verbatim, so the full per-PR rationale is in \`git log\` after this lands.

## What's in (combined)

### Mobile chat-view polish (originally #104)
- \`interactive-widget=resizes-content\` viewport hint
- Composer auto-grow on mobile (44 px min, 30vh cap)
- Drag handle + reset button hidden on mobile
- Tighter mobile composer padding
- Auto-dismiss keyboard on send
- Enter inserts newline (mobile only)
- Stacked Send + Abort with constant row height (no model-picker shift)
- Attach popover (Photo / File) replaces side-by-side buttons
- Slash + @ palette items bumped to ≥ 44 pt with stacked descriptions
- Touch targets ≥ 44 pt across copy / raw / file-ref / sub-agent buttons
- Slash dispatch bug fix (stale-state on touch)

### PWA install polish (originally #105)
- Safe-area insets on header, composer, drawer
- Per-theme \`theme-color\` meta tag (5 themes)
- Manifest tuning (description, categories, lang, orientation)
- Install prompt banner (Android \`beforeinstallprompt\` + iOS share-icon hint)
- New \`docs/mobile.md\` covering install paths + HTTPS-required-for-install gotcha + mobile-specific behaviors

## Test plan

- [x] \`npm run check\` clean (tsc + eslint + prettier)
- [x] \`npm run test:ci\` — 26/26 PASS
- [x] All behaviors were verified on a real Android phone via dev:remote during the original #104 + #105 work; cherry-picking introduces no new content
- [x] Will get full CI coverage this time around (base = main)

## Cleanup after merge

The dead feature branches can be bulk-deleted:
\`\`\`bash
git push origin --delete feat/mobile-hide-panels-and-auth-fix feat/mobile-chat-polish feat/mobile-pwa-polish
\`\`\`

Or via the GitHub branches page — they all show as merged-into-feature-branch, which is harmless but cluttery.