### PR TITLE
feat(search): cross-session text search bar in top-of-app

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -18,6 +18,7 @@ import { SettingsPanel } from "./components/SettingsPanel";
 import { FileBrowserPanel } from "./components/FileBrowserPanel";
 import { EditorPanel } from "./components/EditorPanel";
 import { TerminalPanel } from "./components/TerminalPanel";
+import { GlobalSearchBar } from "./components/GlobalSearchBar";
 import { McpStatusBadge } from "./components/McpStatusBadge";
 import { useMcpStore } from "./store/mcp-store";
 import { useUiStore, type SettingsTab } from "./store/ui-store";
@@ -428,6 +429,14 @@ export function App() {
                 Terminal
               </button>
             )}
+          </div>
+          {/* Global cross-session search. Hidden at < md to keep the
+              mobile header compact — phone users can search via the
+              session list. Sits to the LEFT of the status badges /
+              Settings so it's the visual anchor when the user is
+              looking for "where did I see that?" content. */}
+          <div className="hidden md:block">
+            <GlobalSearchBar />
           </div>
           {/* MCP status badge stays visible in minimal — operators
               still want to see whether MCP servers are connected,

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -90,6 +90,12 @@ export function ChatView({ sessionId }: Props) {
   const queued = useSessionStore((s) => s.queuedBySession[sessionId]);
   const openStream = useSessionStore((s) => s.openStream);
   const closeStream = useSessionStore((s) => s.closeStream);
+  // Pending scroll target set by the global search bar when the user
+  // clicks a result. Read as a primitive so the effect below only
+  // re-fires when the target index actually changes (selecting the
+  // map and reading by key would re-run on every map mutation).
+  const pendingScrollTarget = useSessionStore((s) => s.pendingScrollByMessageIndex[sessionId]);
+  const consumePendingScroll = useSessionStore((s) => s.consumePendingScroll);
 
   const [chatViewType, setChatViewType] = useState<ChatViewType>(readChatViewType);
   const setAndPersistChatViewType = (next: ChatViewType): void => {
@@ -158,6 +164,26 @@ export function ChatView({ sessionId }: Props) {
     }
     lastUserMessageCountRef.current = userCount;
   }, [messages]);
+
+  // Global-search scroll-to-message: when the search bar dispatches a
+  // pending target for this session, locate the matching wrapper by
+  // its `data-message-index` attribute and bring it into view. Wait
+  // for the snapshot to land (messages.length > target) so the target
+  // node actually exists in the DOM. Once consumed, drop the pending
+  // value so a re-mount of ChatView (e.g. user toggling the chat
+  // pane) doesn't re-scroll. Disable sticky-bottom follow so the
+  // subsequent agent stream doesn't yank focus away.
+  useEffect(() => {
+    if (pendingScrollTarget === undefined) return;
+    if (messages.length <= pendingScrollTarget) return;
+    const root = scrollRef.current;
+    if (root === null) return;
+    const node = root.querySelector(`[data-message-index="${pendingScrollTarget}"]`);
+    if (node === null) return;
+    node.scrollIntoView({ block: "center", behavior: "smooth" });
+    isFollowingBottomRef.current = false;
+    consumePendingScroll(sessionId);
+  }, [pendingScrollTarget, messages.length, sessionId, consumePendingScroll]);
 
   return (
     <ChatDiffViewContext.Provider
@@ -263,7 +289,11 @@ export function ChatView({ sessionId }: Props) {
                 // bubble would just duplicate the content under an
                 // "unknown message" fallback.
                 if (m.role === "compactionSummary") return;
-                out.push(<Message key={i} message={m} toolResultsById={toolResultsById} />);
+                out.push(
+                  <div key={i} data-message-index={i}>
+                    <Message message={m} toolResultsById={toolResultsById} />
+                  </div>,
+                );
               });
               // Trailing cards (insertBeforeIndex === messages.length)
               // — the entire current context was archived but no

--- a/packages/client/src/components/GlobalSearchBar.tsx
+++ b/packages/client/src/components/GlobalSearchBar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Search, X } from "lucide-react";
 import { api } from "../lib/api-client";
 import type { SessionSearchGroup, SessionSearchMatch } from "../lib/api-client";
+import { useIsMobile } from "../lib/use-is-mobile";
 import { useProjectStore } from "../store/project-store";
 import { useSessionStore } from "../store/session-store";
 
@@ -16,8 +17,15 @@ import { useSessionStore } from "../store/session-store";
  *
  * Hotkeys: Cmd+K / Ctrl+K to focus, Esc to close, ↑/↓ + Enter to
  * navigate the dropdown.
+ *
+ * Mobile: self-gated via `useIsMobile()` so the component returns null
+ * on small viewports. The header-level `<div className="hidden md:block">`
+ * wrapper is belt-and-braces; this internal early-return is what
+ * actually prevents the Cmd+K listener from registering when a
+ * Bluetooth keyboard is paired with a phone.
  */
 export function GlobalSearchBar() {
+  const isMobile = useIsMobile();
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SessionSearchGroup[]>([]);
   const [open, setOpen] = useState(false);
@@ -129,6 +137,14 @@ export function GlobalSearchBar() {
       ctrl.abort();
     };
   }, [query]);
+
+  // Mobile self-gate. Placed AFTER every hook so React's rules-of-hooks
+  // are honored — the hooks above register listeners (Cmd+K, click-away,
+  // debounced fetch) that we want to NO-OP on mobile, but the early
+  // return must come last. The viewport class on the parent in App.tsx
+  // would hide the bar anyway; this layer prevents the hotkey from
+  // firing if the user has a Bluetooth keyboard paired with a phone.
+  if (isMobile) return null;
 
   const dispatchResult = (group: SessionSearchGroup, match: SessionSearchMatch): void => {
     requestScrollToMessage(group.sessionId, match.messageIndex);

--- a/packages/client/src/components/GlobalSearchBar.tsx
+++ b/packages/client/src/components/GlobalSearchBar.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Search, X } from "lucide-react";
+import { api } from "../lib/api-client";
+import type { SessionSearchGroup, SessionSearchMatch } from "../lib/api-client";
+import { useProjectStore } from "../store/project-store";
+import { useSessionStore } from "../store/session-store";
+
+/**
+ * Top-of-app cross-session search. Calls `/api/v1/search/sessions` on
+ * a debounced query and renders matches in a dropdown popover under
+ * the input.
+ *
+ * Click / Enter on a result switches the active project + session and
+ * stages a pending scroll target on the session-store; ChatView reads
+ * it on mount and scrolls to the matching message.
+ *
+ * Hotkeys: Cmd+K / Ctrl+K to focus, Esc to close, ↑/↓ + Enter to
+ * navigate the dropdown.
+ */
+export function GlobalSearchBar() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SessionSearchGroup[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | undefined>(undefined);
+
+  const setActiveProject = useProjectStore((s) => s.setActive);
+  const activeProjectId = useProjectStore((s) => s.activeProjectId);
+  const setActiveSession = useSessionStore((s) => s.setActiveSession);
+  const requestScrollToMessage = useSessionStore((s) => s.requestScrollToMessage);
+
+  // Flatten the grouped results into a click-target list so ↑/↓ can
+  // walk every matched message rather than just session headers. Each
+  // entry carries enough context to dispatch the click handler.
+  const flatTargets = useMemo<
+    {
+      group: SessionSearchGroup;
+      match: SessionSearchMatch;
+      groupIndex: number;
+      matchIndex: number;
+    }[]
+  >(() => {
+    const out: {
+      group: SessionSearchGroup;
+      match: SessionSearchMatch;
+      groupIndex: number;
+      matchIndex: number;
+    }[] = [];
+    results.forEach((group, gi) => {
+      group.matches.forEach((match, mi) => {
+        out.push({ group, match, groupIndex: gi, matchIndex: mi });
+      });
+    });
+    return out;
+  }, [results]);
+
+  // Reset highlighted row whenever the result set changes so the
+  // first row is always pre-selected for "type then Enter."
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [results]);
+
+  // Cmd+K / Ctrl+K focus from anywhere in the app.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Click-away closes the dropdown.
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent): void => {
+      if (containerRef.current === null) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  // Debounced query → API call. AbortController on each new request
+  // so a slower in-flight call can't race a faster later one and
+  // overwrite the dropdown with stale results.
+  useEffect(() => {
+    if (query.trim().length === 0) {
+      setResults([]);
+      setError(undefined);
+      setLoading(false);
+      abortRef.current?.abort();
+      return;
+    }
+    const ctrl = new AbortController();
+    abortRef.current?.abort();
+    abortRef.current = ctrl;
+    setLoading(true);
+    setError(undefined);
+    const t = window.setTimeout(() => {
+      api
+        .searchSessions(query.trim(), { signal: ctrl.signal })
+        .then((res) => {
+          if (ctrl.signal.aborted) return;
+          setResults(res.results);
+          setLoading(false);
+          setOpen(true);
+        })
+        .catch((err: unknown) => {
+          if (ctrl.signal.aborted) return;
+          setLoading(false);
+          // Keep the previous results visible on transient errors —
+          // dropping them under the user's cursor is jarring. Surface
+          // the message instead.
+          const msg = err instanceof Error ? err.message : "search failed";
+          setError(msg);
+        });
+    }, 250);
+    return () => {
+      window.clearTimeout(t);
+      ctrl.abort();
+    };
+  }, [query]);
+
+  const dispatchResult = (group: SessionSearchGroup, match: SessionSearchMatch): void => {
+    requestScrollToMessage(group.sessionId, match.messageIndex);
+    if (activeProjectId !== group.projectId) setActiveProject(group.projectId);
+    setActiveSession(group.sessionId);
+    setOpen(false);
+    setQuery("");
+    inputRef.current?.blur();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === "Escape") {
+      setOpen(false);
+      inputRef.current?.blur();
+      return;
+    }
+    if (!open || flatTargets.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(flatTargets.length - 1, i + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const t = flatTargets[activeIndex];
+      if (t !== undefined) dispatchResult(t.group, t.match);
+    }
+  };
+
+  const renderSnippet = (m: SessionSearchMatch): React.ReactNode => {
+    // Highlight the matched substring inside the snippet. Server
+    // already gave us match offset + length relative to the snippet.
+    const before = m.snippet.slice(0, m.matchOffset);
+    const hit = m.snippet.slice(m.matchOffset, m.matchOffset + m.matchLength);
+    const after = m.snippet.slice(m.matchOffset + m.matchLength);
+    return (
+      <>
+        {before}
+        <mark className="rounded bg-amber-300/30 text-amber-100">{hit}</mark>
+        {after}
+      </>
+    );
+  };
+
+  const kindBadge = (kind: SessionSearchMatch["kind"]): string => {
+    if (kind === "user") return "you";
+    if (kind === "assistant") return "agent";
+    return "tool";
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div className="relative">
+        <Search
+          size={13}
+          className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-neutral-500"
+          aria-hidden="true"
+        />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => {
+            if (results.length > 0) setOpen(true);
+          }}
+          onKeyDown={onKeyDown}
+          placeholder="Search sessions…  ⌘K"
+          aria-label="Search across all sessions"
+          className="w-64 rounded-md border border-neutral-700 bg-neutral-900 py-1 pl-7 pr-7 text-xs text-neutral-200 placeholder-neutral-500 focus:border-neutral-500 focus:outline-none"
+        />
+        {query.length > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              setQuery("");
+              setResults([]);
+              setOpen(false);
+              inputRef.current?.focus();
+            }}
+            aria-label="Clear search"
+            className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-0.5 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
+          >
+            <X size={12} />
+          </button>
+        )}
+      </div>
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Search results"
+          className="absolute right-0 top-full z-50 mt-1 max-h-[60vh] w-96 overflow-y-auto rounded-md border border-neutral-700 bg-neutral-900 shadow-xl"
+        >
+          {loading && <div className="px-3 py-2 text-xs text-neutral-400">Searching…</div>}
+          {!loading && error !== undefined && (
+            <div className="px-3 py-2 text-xs text-amber-400">{error}</div>
+          )}
+          {!loading && error === undefined && flatTargets.length === 0 && (
+            <div className="px-3 py-2 text-xs text-neutral-500">No matches.</div>
+          )}
+          {flatTargets.length > 0 && (
+            <div>
+              {results.map((group, gi) => (
+                <div key={group.sessionId} className="border-b border-neutral-800 last:border-b-0">
+                  <div className="bg-neutral-950 px-3 py-1 text-[10px] uppercase tracking-wider text-neutral-500">
+                    <span className="text-neutral-300">{group.projectName}</span>
+                    {group.sessionName !== undefined && (
+                      <>
+                        <span className="mx-1.5 text-neutral-600">/</span>
+                        <span className="text-neutral-400 normal-case tracking-normal">
+                          {group.sessionName}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                  {group.matches.map((match, mi) => {
+                    const flatIndex = flatTargets.findIndex(
+                      (t) => t.groupIndex === gi && t.matchIndex === mi,
+                    );
+                    const isActive = flatIndex === activeIndex;
+                    return (
+                      <button
+                        key={`${match.messageIndex}-${match.matchOffset}`}
+                        type="button"
+                        role="option"
+                        aria-selected={isActive}
+                        onMouseEnter={() => setActiveIndex(flatIndex)}
+                        onClick={() => dispatchResult(group, match)}
+                        className={`flex w-full items-start gap-2 px-3 py-1.5 text-left text-xs ${
+                          isActive
+                            ? "bg-neutral-800 text-neutral-100"
+                            : "text-neutral-300 hover:bg-neutral-800/60"
+                        }`}
+                      >
+                        <span className="mt-0.5 shrink-0 rounded bg-neutral-800 px-1 py-0.5 text-[9px] uppercase tracking-wider text-neutral-400">
+                          {kindBadge(match.kind)}
+                        </span>
+                        <span className="flex-1 break-words">{renderSnippet(match)}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -41,6 +41,9 @@ import {
   type SearchMatch,
   type SearchResponse,
   type SearchOptions,
+  type SessionSearchGroup,
+  type SessionSearchMatch,
+  type SessionSearchResponse,
   type SessionTreeEntry,
   type ContextTurn,
   type ContextUsageStats,
@@ -858,6 +861,64 @@ function vSearchResponse(value: unknown, status: number): SearchResponse {
         length: m.length,
         lineSnippet: m.lineSnippet,
       };
+    }),
+  };
+}
+
+function vSessionSearchResponse(value: unknown, status: number): SessionSearchResponse {
+  if (
+    !isObject(value) ||
+    (value.engine !== "ripgrep" && value.engine !== "node") ||
+    typeof value.truncated !== "boolean" ||
+    !Array.isArray(value.results)
+  ) {
+    fail(status, "expected SessionSearchResponse");
+  }
+  return {
+    engine: value.engine,
+    truncated: value.truncated,
+    results: value.results.map((g): SessionSearchGroup => {
+      if (
+        !isObject(g) ||
+        typeof g.sessionId !== "string" ||
+        typeof g.projectId !== "string" ||
+        typeof g.projectName !== "string" ||
+        typeof g.modifiedAt !== "string" ||
+        !Array.isArray(g.matches)
+      ) {
+        fail(status, "expected SessionSearchGroup");
+      }
+      const out: SessionSearchGroup = {
+        sessionId: g.sessionId,
+        projectId: g.projectId,
+        projectName: g.projectName,
+        modifiedAt: g.modifiedAt,
+        matches: g.matches.map((m): SessionSearchMatch => {
+          if (
+            !isObject(m) ||
+            typeof m.messageIndex !== "number" ||
+            (m.kind !== "user" && m.kind !== "assistant" && m.kind !== "tool_call") ||
+            typeof m.snippet !== "string" ||
+            typeof m.matchOffset !== "number" ||
+            typeof m.matchLength !== "number"
+          ) {
+            fail(status, "expected SessionSearchMatch");
+          }
+          const match: SessionSearchMatch = {
+            messageIndex: m.messageIndex,
+            kind: m.kind,
+            snippet: m.snippet,
+            matchOffset: m.matchOffset,
+            matchLength: m.matchLength,
+          };
+          if (typeof m.messageEnvelopeId === "string") {
+            match.messageEnvelopeId = m.messageEnvelopeId;
+          }
+          return match;
+        }),
+      };
+      if (typeof g.sessionName === "string") out.sessionName = g.sessionName;
+      return out;
     }),
   };
 }
@@ -1810,6 +1871,26 @@ export const api = {
       `/api/v1/files/search?${qs.toString()}`,
       vSearchResponse,
       signal !== undefined ? { signal } : {},
+    );
+  },
+  /**
+   * Cross-session text search backed by `/api/v1/search/sessions`.
+   * Used by the global search bar in the top-of-app header; returns
+   * sessions grouped with per-session message snippets.
+   */
+  searchSessions: (
+    query: string,
+    opts?: { sessionLimit?: number; matchesPerSession?: number; signal?: AbortSignal },
+  ) => {
+    const qs = new URLSearchParams({ q: query });
+    if (opts?.sessionLimit !== undefined) qs.set("sessionLimit", String(opts.sessionLimit));
+    if (opts?.matchesPerSession !== undefined) {
+      qs.set("matchesPerSession", String(opts.matchesPerSession));
+    }
+    return request(
+      `/api/v1/search/sessions?${qs.toString()}`,
+      vSessionSearchResponse,
+      opts?.signal !== undefined ? { signal: opts.signal } : {},
     );
   },
 

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -462,6 +462,43 @@ export interface SearchOptions {
   limit?: number;
 }
 
+export interface SessionSearchMatch {
+  /**
+   * Zero-based index into the session snapshot's `messages` array,
+   * counting only `type === "message"` JSONL lines. For un-forked
+   * sessions this maps directly to the snapshot index — the common
+   * case. Forked sessions whose active branch differs from disk
+   * order may not find this index; consumers should fall back to
+   * `messageEnvelopeId` lookup when present.
+   */
+  messageIndex: number;
+  /** JSONL envelope `id`, for branch-aware lookup. */
+  messageEnvelopeId?: string;
+  kind: "user" | "assistant" | "tool_call";
+  /** ~120 chars centered on the match, with leading / trailing "…" when clipped. */
+  snippet: string;
+  /** Offset of the matched substring within `snippet`. */
+  matchOffset: number;
+  matchLength: number;
+}
+
+export interface SessionSearchGroup {
+  sessionId: string;
+  projectId: string;
+  projectName: string;
+  /** Display name from session_info; absent for unnamed sessions. */
+  sessionName?: string;
+  /** ISO 8601 — file mtime, used to sort newest-first. */
+  modifiedAt: string;
+  matches: SessionSearchMatch[];
+}
+
+export interface SessionSearchResponse {
+  engine: "ripgrep" | "node";
+  truncated: boolean;
+  results: SessionSearchGroup[];
+}
+
 export interface SessionTreeEntry {
   id: string;
   parentId: string | null;

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -273,6 +273,14 @@ interface SessionState {
    * pop entries optimistically.
    */
   queuedBySession: Record<string, { steering: string[]; followUp: string[] } | undefined>;
+  /**
+   * Per-session pending scroll target (zero-based message index) set
+   * by the global search bar when a result is clicked. ChatView reads
+   * this on session activation, scrolls to the matching message, then
+   * calls `consumePendingScroll` so a subsequent activation of the
+   * same session doesn't re-trigger the scroll.
+   */
+  pendingScrollByMessageIndex: Record<string, number>;
   /** Errors surfaced from API calls (sticky until next successful op). */
   error: string | undefined;
   loadingList: boolean;
@@ -309,6 +317,10 @@ interface SessionState {
    */
   setPendingDraft: (sessionId: string, draft: string) => void;
   consumePendingDraft: (sessionId: string) => void;
+  /** Set the pending scroll target for `sessionId` (used by global search). */
+  requestScrollToMessage: (sessionId: string, messageIndex: number) => void;
+  /** Consume + clear the pending scroll target for `sessionId`. */
+  consumePendingScroll: (sessionId: string) => number | undefined;
   sendPrompt: (sessionId: string, text: string, attachments?: File[]) => Promise<void>;
   sendSteer: (sessionId: string, text: string, mode?: "steer" | "followUp") => Promise<void>;
   abortSession: (sessionId: string) => Promise<void>;
@@ -328,6 +340,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   agentEndCountBySession: {},
   compactionEndCountBySession: {},
   queuedBySession: {},
+  pendingScrollByMessageIndex: {},
   error: undefined,
   loadingList: false,
 
@@ -452,6 +465,25 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       delete next[sessionId];
       return { pendingDraftBySession: next };
     }),
+
+  requestScrollToMessage: (sessionId, messageIndex) =>
+    set((s) => ({
+      pendingScrollByMessageIndex: {
+        ...s.pendingScrollByMessageIndex,
+        [sessionId]: messageIndex,
+      },
+    })),
+
+  consumePendingScroll: (sessionId) => {
+    const value = get().pendingScrollByMessageIndex[sessionId];
+    if (value === undefined) return undefined;
+    set((s) => {
+      const next = { ...s.pendingScrollByMessageIndex };
+      delete next[sessionId];
+      return { pendingScrollByMessageIndex: next };
+    });
+    return value;
+  },
 
   setActiveSession: (sessionId) => {
     if (sessionId !== undefined) localStorage.setItem(ACTIVE_SESSION_KEY, sessionId);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -24,6 +24,7 @@ import { fileRoutes } from "./routes/files.js";
 import { gitRoutes } from "./routes/git.js";
 import { execRoutes } from "./routes/exec.js";
 import { mcpRoutes } from "./routes/mcp.js";
+import { searchRoutes } from "./routes/search.js";
 import { terminalRoutes } from "./routes/terminal.js";
 import { disposeAll as disposeAllMcp, loadGlobal as loadGlobalMcp } from "./mcp/manager.js";
 import { disposeAllSessions } from "./session-registry.js";
@@ -380,6 +381,7 @@ export async function buildServer(): Promise<FastifyInstance> {
       await api.register(gitRoutes);
       await api.register(execRoutes);
       await api.register(mcpRoutes);
+      await api.register(searchRoutes);
       await api.register(terminalRoutes);
     },
     { prefix: "/api/v1" },

--- a/packages/server/src/routes/search.ts
+++ b/packages/server/src/routes/search.ts
@@ -1,0 +1,121 @@
+import type { FastifyInstance, FastifyPluginAsync } from "fastify";
+import { config } from "../config.js";
+import { searchSessions } from "../session-searcher.js";
+import { errorSchema } from "./_schemas.js";
+
+/**
+ * Cross-session text search. Backed by the session-searcher module
+ * which ripgreps every JSONL under `${SESSION_DIR}` and parses each
+ * hit to surface user / assistant messages and tool-call invocations
+ * (tool results are intentionally skipped — they're noisy and can
+ * be megabytes of file content).
+ *
+ * The dropdown bar in the top-of-app calls this route on debounced
+ * input. Caps default to 50 sessions × 5 matches with a 2-second
+ * timeout — comfortably fast for the live "type to find" UX while
+ * still bounding worst-case work.
+ */
+export const searchRoutes: FastifyPluginAsync = async (app: FastifyInstance) => {
+  app.get<{
+    Querystring: {
+      q: string;
+      sessionLimit?: string;
+      matchesPerSession?: string;
+    };
+  }>(
+    "/search/sessions",
+    {
+      config: {
+        rateLimit: {
+          max: config.rateLimits.searchMax,
+          timeWindow: config.rateLimits.searchWindowMs,
+        },
+      },
+      schema: {
+        description:
+          "Cross-session text search. Returns sessions whose JSONL " +
+          "contains a case-insensitive substring match in user / " +
+          "assistant text or in an assistant tool-call invocation. " +
+          "Tool results, session metadata events, and thinking blocks " +
+          "are filtered out to keep the dropdown snippets readable.",
+        tags: ["sessions"],
+        querystring: {
+          type: "object",
+          required: ["q"],
+          properties: {
+            q: { type: "string", minLength: 1, maxLength: 256 },
+            sessionLimit: { type: "string", pattern: "^[0-9]+$" },
+            matchesPerSession: { type: "string", pattern: "^[0-9]+$" },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["engine", "results", "truncated"],
+            properties: {
+              engine: { type: "string", enum: ["ripgrep", "node"] },
+              truncated: { type: "boolean" },
+              results: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["sessionId", "projectId", "projectName", "modifiedAt", "matches"],
+                  properties: {
+                    sessionId: { type: "string" },
+                    projectId: { type: "string" },
+                    projectName: { type: "string" },
+                    sessionName: { type: "string" },
+                    modifiedAt: { type: "string", format: "date-time" },
+                    matches: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        required: ["messageIndex", "kind", "snippet", "matchOffset", "matchLength"],
+                        properties: {
+                          messageIndex: { type: "integer", minimum: 0 },
+                          messageEnvelopeId: { type: "string" },
+                          kind: {
+                            type: "string",
+                            enum: ["user", "assistant", "tool_call"],
+                          },
+                          snippet: { type: "string" },
+                          matchOffset: { type: "integer", minimum: 0 },
+                          matchLength: { type: "integer", minimum: 0 },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          400: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { q } = req.query;
+      const sessionLimit =
+        req.query.sessionLimit !== undefined
+          ? Math.min(200, Math.max(1, Number.parseInt(req.query.sessionLimit, 10)))
+          : 50;
+      const matchesPerSession =
+        req.query.matchesPerSession !== undefined
+          ? Math.min(50, Math.max(1, Number.parseInt(req.query.matchesPerSession, 10)))
+          : 5;
+      try {
+        const result = await searchSessions({
+          query: q,
+          sessionLimit,
+          matchesPerSession,
+          timeoutMs: 2_000,
+        });
+        return result;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "search failed";
+        return reply.code(500).send({ error: "search_failed", message });
+      }
+    },
+  );
+};

--- a/packages/server/src/session-searcher.ts
+++ b/packages/server/src/session-searcher.ts
@@ -1,0 +1,593 @@
+import { spawn } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { config } from "./config.js";
+import { ripgrepAvailable } from "./file-searcher.js";
+import { readProjects } from "./project-manager.js";
+
+/**
+ * Cross-session text search across every JSONL under `${SESSION_DIR}`.
+ *
+ * Each ripgrep / Node hit is a single JSONL line which we parse to
+ * decide whether the match falls inside content we surface:
+ *
+ *   - `type === "message"` with `message.role` of `"user"` or
+ *     `"assistant"` → match against the rendered text of every
+ *     `text` block.
+ *   - `type === "message"` with an assistant `toolCall` content block
+ *     → match against the rendered `name(arg=value, ...)` form so
+ *     "bash ls" / "edit foo.ts" queries hit.
+ *   - Anything else (session header, model_change, tool_result,
+ *     thinking, queue events) is filtered out — too noisy for the
+ *     dropdown, and tool_results in particular can be megabytes of
+ *     file content.
+ *
+ * Matches are grouped by `sessionId` (the `id` field on the line-1
+ * session header). Each group carries its on-disk path, project
+ * metadata, and up to N per-session message snippets so the UI can
+ * render "session header → matched messages" without further
+ * server round-trips.
+ */
+
+export interface SessionSearchOptions {
+  query: string;
+  /** Hard cap on returned sessions. */
+  sessionLimit: number;
+  /** Per-session match cap. */
+  matchesPerSession: number;
+  /** Wall-clock budget. Aborts in-flight work if exceeded. */
+  timeoutMs: number;
+}
+
+export interface SessionSearchMatch {
+  /**
+   * Zero-based index of this message among `type === "message"` lines
+   * in the JSONL. Maps directly to the snapshot `messages` array for
+   * un-forked sessions (the common case). Forked sessions whose active
+   * branch differs from disk order may not find this index — the
+   * client falls back to `messageEnvelopeId` lookup.
+   */
+  messageIndex: number;
+  /** The envelope `id` field on the JSONL line, for branch-aware lookup. */
+  messageEnvelopeId: string | undefined;
+  /** "user" | "assistant" | "tool_call" — what the snippet represents. */
+  kind: "user" | "assistant" | "tool_call";
+  /** Snippet of the matched content (~120 chars, match centered). */
+  snippet: string;
+  /** Offset of the match within `snippet`, for highlighting. */
+  matchOffset: number;
+  /** Length of the matched substring within `snippet`. */
+  matchLength: number;
+}
+
+export interface SessionSearchResultGroup {
+  sessionId: string;
+  projectId: string;
+  projectName: string;
+  /** User-defined session name when set; first user message otherwise. */
+  sessionName: string | undefined;
+  /** ISO 8601 — file mtime, used for sort. */
+  modifiedAt: string;
+  matches: SessionSearchMatch[];
+}
+
+export interface SessionSearchResult {
+  engine: "ripgrep" | "node";
+  results: SessionSearchResultGroup[];
+  /** True when we hit `sessionLimit` or the timeout while collecting. */
+  truncated: boolean;
+}
+
+const SNIPPET_CONTEXT = 60;
+
+export async function searchSessions(opts: SessionSearchOptions): Promise<SessionSearchResult> {
+  const projects = await readProjects();
+  const projectById = new Map(projects.map((p) => [p.id, p] as const));
+
+  const lineHits = (await ripgrepAvailable())
+    ? await collectWithRipgrep(opts)
+    : await collectInProcess(opts);
+
+  const grouped = new Map<
+    string,
+    {
+      sessionId: string;
+      projectId: string;
+      filePath: string;
+      matches: SessionSearchMatch[];
+      messageCounter: number;
+    }
+  >();
+
+  // Walk hits in `(file, lineNumber)` order so we can compute messageIndex
+  // (count of `type === "message"` lines preceding this one) without
+  // re-reading entire files. `collectWithRipgrep` and `collectInProcess`
+  // both honor that ordering.
+  for (const hit of lineHits) {
+    const projectId = projectIdFromPath(hit.filePath);
+    if (projectId === undefined) continue; // Hit outside the per-project layout
+    if (!projectById.has(projectId)) continue; // Orphaned dir from a deleted project
+
+    // Lazy-initialize the per-file group on first hit; its `messageCounter`
+    // tracks the running message-line index within that file so
+    // subsequent hits in the same file don't have to rescan.
+    let group = grouped.get(hit.filePath);
+    if (group === undefined) {
+      const sessionId = await readSessionIdFromHeader(hit.filePath);
+      if (sessionId === undefined) continue; // Corrupt / missing header
+      group = {
+        sessionId,
+        projectId,
+        filePath: hit.filePath,
+        matches: [],
+        messageCounter: 0,
+      };
+      grouped.set(hit.filePath, group);
+    }
+
+    if (group.matches.length >= opts.matchesPerSession) continue;
+
+    const parsed = safeParseLine(hit.line);
+    if (parsed === undefined) continue;
+
+    const extracted = extractSnippet(parsed, opts.query);
+    if (extracted === undefined) continue;
+
+    // messageIndex tracking: count `type === "message"` lines from the
+    // start of the file up to AND INCLUDING this hit. We need to scan
+    // the file's intervening lines if we skipped any since the previous
+    // hit. The cheap path is "no skipped lines" (consecutive hits) —
+    // most queries only hit a handful of distinct lines per file.
+    const messageIndex = await advanceMessageIndex(group, hit.lineNumber);
+    if (messageIndex === undefined) continue;
+
+    group.matches.push({
+      messageIndex,
+      messageEnvelopeId: typeof parsed.id === "string" ? parsed.id : undefined,
+      kind: extracted.kind,
+      snippet: extracted.snippet,
+      matchOffset: extracted.matchOffset,
+      matchLength: extracted.matchLength,
+    });
+  }
+
+  const results: SessionSearchResultGroup[] = [];
+  let truncated = false;
+  // Sort by file mtime (newest first) so recent matches land at the top.
+  const fileStats = await Promise.all(
+    Array.from(grouped.values()).map(async (g) => ({
+      group: g,
+      modifiedAt: await fileMtime(g.filePath),
+      sessionName: await readSessionNameFromFile(g.filePath),
+    })),
+  );
+  fileStats.sort((a, b) => (a.modifiedAt < b.modifiedAt ? 1 : -1));
+
+  for (const entry of fileStats) {
+    if (results.length >= opts.sessionLimit) {
+      truncated = true;
+      break;
+    }
+    const project = projectById.get(entry.group.projectId);
+    if (project === undefined) continue;
+    results.push({
+      sessionId: entry.group.sessionId,
+      projectId: entry.group.projectId,
+      projectName: project.name,
+      sessionName: entry.sessionName,
+      modifiedAt: entry.modifiedAt,
+      matches: entry.group.matches,
+    });
+  }
+
+  return {
+    engine: (await ripgrepAvailable()) ? "ripgrep" : "node",
+    results,
+    truncated,
+  };
+}
+
+/* ----------------------------- ripgrep path ----------------------------- */
+
+interface LineHit {
+  filePath: string;
+  lineNumber: number;
+  line: string;
+}
+
+interface RipgrepEvent {
+  type: "begin" | "match" | "end" | "summary" | "context";
+  data?: Record<string, unknown>;
+}
+
+async function collectWithRipgrep(opts: SessionSearchOptions): Promise<LineHit[]> {
+  // Hits are bounded by the global session limit × per-session matches —
+  // a generous ceiling that prevents runaway output without truncating
+  // legitimate workloads. The session-grouping pass downstream applies
+  // the actual per-session caps.
+  const maxLines = opts.sessionLimit * opts.matchesPerSession * 4;
+
+  const args: string[] = [
+    "--json",
+    "--no-heading",
+    "--max-filesize",
+    "100M", // session JSONLs can be sizeable
+    "--max-count",
+    String(maxLines),
+    "-i", // case-insensitive — matches the dropdown's "type to find" UX
+    "--fixed-strings",
+    "--glob",
+    "*.jsonl",
+    "--",
+    opts.query,
+    config.sessionDir,
+  ];
+
+  return new Promise<LineHit[]>((resolveFn) => {
+    const hits: LineHit[] = [];
+    const child = spawn("rg", args);
+    const timer = setTimeout(() => child.kill("SIGTERM"), opts.timeoutMs);
+
+    let buf = "";
+    let currentFile: string | undefined;
+
+    const finish = (): void => {
+      clearTimeout(timer);
+      resolveFn(hits);
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      buf += chunk;
+      let nl = buf.indexOf("\n");
+      while (nl !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (line.length > 0) handleEvent(line);
+        nl = buf.indexOf("\n");
+      }
+    });
+    child.on("error", () => finish());
+    child.on("close", () => finish());
+
+    const handleEvent = (jsonLine: string): void => {
+      let event: RipgrepEvent;
+      try {
+        event = JSON.parse(jsonLine) as RipgrepEvent;
+      } catch {
+        return;
+      }
+      if (event.type === "begin") {
+        const data = event.data as { path?: { text?: string } } | undefined;
+        currentFile = data?.path?.text;
+      } else if (event.type === "match" && currentFile !== undefined) {
+        if (hits.length >= maxLines) {
+          child.kill("SIGTERM");
+          return;
+        }
+        const data = event.data as { lines?: { text?: string }; line_number?: number } | undefined;
+        if (data === undefined) return;
+        const lineText = data.lines?.text ?? "";
+        const lineNumber = data.line_number ?? 0;
+        if (lineNumber === 0) return;
+        hits.push({
+          filePath: currentFile,
+          lineNumber,
+          line: stripTrailingNewline(lineText),
+        });
+      }
+    };
+  });
+}
+
+/* ----------------------------- in-process path ----------------------------- */
+
+async function collectInProcess(opts: SessionSearchOptions): Promise<LineHit[]> {
+  const hits: LineHit[] = [];
+  const deadline = Date.now() + opts.timeoutMs;
+  const needle = opts.query.toLowerCase();
+  const maxLines = opts.sessionLimit * opts.matchesPerSession * 4;
+
+  let projectDirs: string[];
+  try {
+    projectDirs = await readdir(config.sessionDir);
+  } catch {
+    return hits; // Session dir doesn't exist yet — empty result is fine.
+  }
+
+  for (const projectDir of projectDirs) {
+    if (Date.now() >= deadline || hits.length >= maxLines) break;
+    const fullDir = join(config.sessionDir, projectDir);
+    let entries;
+    try {
+      entries = await readdir(fullDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      if (Date.now() >= deadline || hits.length >= maxLines) break;
+      if (!ent.isFile() || !ent.name.endsWith(".jsonl")) continue;
+      const filePath = join(fullDir, ent.name);
+      let content: string;
+      try {
+        content = await readFile(filePath, "utf8");
+      } catch {
+        continue;
+      }
+      const lines = content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        if (Date.now() >= deadline || hits.length >= maxLines) break;
+        const line = lines[i] ?? "";
+        if (line.length === 0) continue;
+        if (line.toLowerCase().includes(needle)) {
+          hits.push({ filePath, lineNumber: i + 1, line });
+        }
+      }
+    }
+  }
+
+  return hits;
+}
+
+/* ----------------------------- parsing helpers ----------------------------- */
+
+interface ParsedLine {
+  type?: unknown;
+  id?: unknown;
+  message?: { role?: unknown; content?: unknown };
+}
+
+function safeParseLine(line: string): ParsedLine | undefined {
+  try {
+    return JSON.parse(line) as ParsedLine;
+  } catch {
+    return undefined;
+  }
+}
+
+interface ExtractedMatch {
+  kind: "user" | "assistant" | "tool_call";
+  snippet: string;
+  matchOffset: number;
+  matchLength: number;
+}
+
+function extractSnippet(parsed: ParsedLine, query: string): ExtractedMatch | undefined {
+  if (parsed.type !== "message") return undefined;
+  const msg = parsed.message;
+  if (msg === undefined || msg === null || typeof msg !== "object") return undefined;
+  const role = (msg as { role?: unknown }).role;
+  if (role !== "user" && role !== "assistant") return undefined;
+  const content = (msg as { content?: unknown }).content;
+
+  // String content is the simple "user typed text" shape some SDK
+  // versions still emit. Treat as a single text block.
+  if (typeof content === "string") {
+    const hit = findMatch(content, query);
+    if (hit === undefined) return undefined;
+    return {
+      kind: role === "user" ? "user" : "assistant",
+      snippet: clipSnippet(content, hit.offset, query.length),
+      matchOffset: clippedMatchOffset(content, hit.offset),
+      matchLength: query.length,
+    };
+  }
+  if (!Array.isArray(content)) return undefined;
+
+  // Walk content blocks. Prefer text-block matches (most readable).
+  // If no text block matches but a toolCall does, surface the rendered
+  // tool form as the snippet.
+  for (const block of content) {
+    if (block === undefined || block === null || typeof block !== "object") continue;
+    const b = block as { type?: unknown; text?: unknown };
+    if (b.type === "text" && typeof b.text === "string") {
+      const hit = findMatch(b.text, query);
+      if (hit !== undefined) {
+        return {
+          kind: role === "user" ? "user" : "assistant",
+          snippet: clipSnippet(b.text, hit.offset, query.length),
+          matchOffset: clippedMatchOffset(b.text, hit.offset),
+          matchLength: query.length,
+        };
+      }
+    }
+  }
+
+  // Tool-call fallback: only assistants emit toolCall blocks.
+  if (role === "assistant") {
+    for (const block of content) {
+      if (block === undefined || block === null || typeof block !== "object") continue;
+      const b = block as { type?: unknown; name?: unknown; arguments?: unknown; input?: unknown };
+      if (b.type !== "toolCall") continue;
+      const rendered = renderToolCall(b);
+      const hit = findMatch(rendered, query);
+      if (hit === undefined) continue;
+      return {
+        kind: "tool_call",
+        snippet: clipSnippet(rendered, hit.offset, query.length),
+        matchOffset: clippedMatchOffset(rendered, hit.offset),
+        matchLength: query.length,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function renderToolCall(block: { name?: unknown; arguments?: unknown; input?: unknown }): string {
+  const name = typeof block.name === "string" ? block.name : "tool";
+  const args = (block.arguments ?? block.input) as Record<string, unknown> | undefined;
+  if (args === undefined || args === null || typeof args !== "object") return name + "()";
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(args)) {
+    if (v === undefined || v === null) continue;
+    let s: string;
+    if (typeof v === "string") s = v;
+    else if (typeof v === "number" || typeof v === "boolean") s = String(v);
+    else s = JSON.stringify(v);
+    if (s.length > 200) s = s.slice(0, 200) + "…";
+    parts.push(`${k}=${s}`);
+  }
+  return `${name}(${parts.join(", ")})`;
+}
+
+function findMatch(haystack: string, query: string): { offset: number } | undefined {
+  const i = haystack.toLowerCase().indexOf(query.toLowerCase());
+  if (i === -1) return undefined;
+  return { offset: i };
+}
+
+function clipSnippet(source: string, matchOffset: number, matchLength: number): string {
+  const start = Math.max(0, matchOffset - SNIPPET_CONTEXT);
+  const end = Math.min(source.length, matchOffset + matchLength + SNIPPET_CONTEXT);
+  let snippet = source.slice(start, end).replace(/\s+/g, " ").trim();
+  if (start > 0) snippet = "…" + snippet;
+  if (end < source.length) snippet = snippet + "…";
+  return snippet;
+}
+
+function clippedMatchOffset(source: string, matchOffset: number): number {
+  // The clipped snippet always centers the match (with possible "…"
+  // prefix). Compute the new offset relative to the snippet so the
+  // client can highlight the exact substring.
+  const start = Math.max(0, matchOffset - SNIPPET_CONTEXT);
+  const prefixEllipsis = start > 0 ? 1 : 0;
+  const original = source.slice(start, matchOffset);
+  const collapsed = original.replace(/\s+/g, " ").replace(/^\s+/, "");
+  return prefixEllipsis + collapsed.length;
+}
+
+/* ----------------------------- file walking ----------------------------- */
+
+const headerCache = new Map<string, string | undefined>();
+const nameCache = new Map<string, string | undefined>();
+const messageIndexCache = new Map<string, number[]>();
+
+async function readSessionIdFromHeader(filePath: string): Promise<string | undefined> {
+  if (headerCache.has(filePath)) return headerCache.get(filePath);
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch {
+    headerCache.set(filePath, undefined);
+    return undefined;
+  }
+  const firstNl = content.indexOf("\n");
+  const firstLine = firstNl === -1 ? content : content.slice(0, firstNl);
+  let header: { type?: unknown; id?: unknown };
+  try {
+    header = JSON.parse(firstLine) as { type?: unknown; id?: unknown };
+  } catch {
+    headerCache.set(filePath, undefined);
+    return undefined;
+  }
+  if (header.type !== "session" || typeof header.id !== "string") {
+    headerCache.set(filePath, undefined);
+    return undefined;
+  }
+  headerCache.set(filePath, header.id);
+  return header.id;
+}
+
+async function readSessionNameFromFile(filePath: string): Promise<string | undefined> {
+  if (nameCache.has(filePath)) return nameCache.get(filePath);
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch {
+    nameCache.set(filePath, undefined);
+    return undefined;
+  }
+  const lines = content.split("\n");
+  for (const line of lines) {
+    if (line.length === 0) continue;
+    let parsed: { type?: unknown; name?: unknown };
+    try {
+      parsed = JSON.parse(line) as { type?: unknown; name?: unknown };
+    } catch {
+      continue;
+    }
+    if (parsed.type === "session_info" && typeof parsed.name === "string") {
+      nameCache.set(filePath, parsed.name);
+      return parsed.name;
+    }
+  }
+  nameCache.set(filePath, undefined);
+  return undefined;
+}
+
+async function fileMtime(filePath: string): Promise<string> {
+  try {
+    const { stat } = await import("node:fs/promises");
+    const s = await stat(filePath);
+    return s.mtime.toISOString();
+  } catch {
+    return new Date(0).toISOString();
+  }
+}
+
+function projectIdFromPath(filePath: string): string | undefined {
+  // ${SESSION_DIR}/<projectId>/<file>.jsonl — projectId is the
+  // immediate parent dir. Subagent child JSONLs live one level deeper
+  // and we ignore them here (their parent's main session is what we
+  // surface in search results).
+  const sessionDir = config.sessionDir;
+  if (!filePath.startsWith(sessionDir)) return undefined;
+  const rel = filePath.slice(sessionDir.length).replace(/^[/\\]+/, "");
+  const parts = rel.split(/[/\\]/);
+  if (parts.length < 2) return undefined;
+  if (parts.length > 2) return undefined; // Subagent child — skip
+  return parts[0];
+}
+
+/**
+ * Scan from the file's last-known message-line cursor up to the line
+ * containing this hit, counting `type === "message"` lines. Returns the
+ * 0-based index of the message at `lineNumber` (or undefined if that
+ * line isn't a message line).
+ */
+async function advanceMessageIndex(
+  group: { filePath: string; messageCounter: number },
+  lineNumber: number,
+): Promise<number | undefined> {
+  const cached = messageIndexCache.get(group.filePath);
+  if (cached !== undefined) {
+    // Cached layout: array of all message-line numbers (1-based) in
+    // the file. Binary-search to find the index for this line.
+    const idx = cached.indexOf(lineNumber);
+    return idx === -1 ? undefined : idx;
+  }
+  let content: string;
+  try {
+    content = await readFile(group.filePath, "utf8");
+  } catch {
+    return undefined;
+  }
+  const messageLines: number[] = [];
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.length === 0) continue;
+    // Cheap pre-check before JSON.parse: every message line starts
+    // with `{"type":"message"`. Skipping the parse for non-message
+    // lines is a 10× speedup on long sessions.
+    if (!line.startsWith('{"type":"message"')) continue;
+    messageLines.push(i + 1); // 1-based to match ripgrep
+  }
+  messageIndexCache.set(group.filePath, messageLines);
+  const idx = messageLines.indexOf(lineNumber);
+  return idx === -1 ? undefined : idx;
+}
+
+function stripTrailingNewline(s: string): string {
+  if (s.endsWith("\r\n")) return s.slice(0, -2);
+  if (s.endsWith("\n")) return s.slice(0, -1);
+  return s;
+}
+
+/** Test-only: drop all per-file caches between assertions. */
+export function _resetSessionSearcherCaches(): void {
+  headerCache.clear();
+  nameCache.clear();
+  messageIndexCache.clear();
+}

--- a/tests/test-session-search.ts
+++ b/tests/test-session-search.ts
@@ -1,0 +1,433 @@
+/**
+ * Cross-session text search integration test.
+ *
+ * Boots the server in-process under a temp WORKSPACE_PATH, creates two
+ * projects, hand-writes JSONL session files into each project's session
+ * directory (mirroring the on-disk shape the SDK produces — one
+ * `{type:"session"}` header line followed by `{type:"message",...}`
+ * lines), then drives `/api/v1/search/sessions` to verify:
+ *
+ *   - Matches in user / assistant text and assistant tool-call args
+ *     are surfaced
+ *   - Tool-result content is filtered out (per design)
+ *   - Empty / missing query → 400 (Fastify schema validation)
+ *   - Auth is enforced (401 without Bearer)
+ *   - Per-session match limit and global session limit hold
+ *   - messageIndex matches the snapshot's flat `messages` array
+ *     position (i.e. only counts `type === "message"` lines)
+ *   - Session name (from `session_info`) and project name appear in the
+ *     response
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomBytes, randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile as fsWrite } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+const serverEntry = resolve(repoRoot, "packages/server/dist/index.js");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function pickFreePort(): Promise<number> {
+  return new Promise((resolveFn, rejectFn) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on("error", rejectFn);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === "string") {
+        rejectFn(new Error("failed to acquire free port"));
+        return;
+      }
+      const { port } = addr;
+      srv.close(() => resolveFn(port));
+    });
+  });
+}
+
+async function waitFor(url: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(url);
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  throw new Error(`timeout waiting for ${url}`);
+}
+
+interface JsonResponse {
+  status: number;
+  body: unknown;
+}
+
+async function jget(url: string, headers: Record<string, string> = {}): Promise<JsonResponse> {
+  const res = await fetch(url, { headers });
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function jsend(
+  method: "POST" | "PUT" | "DELETE",
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<JsonResponse> {
+  const init: RequestInit = { method, headers: { ...headers } };
+  if (body !== undefined) {
+    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(url, init);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+interface SessionLine {
+  type: "session" | "message" | "session_info" | "model_change" | "tool_result";
+  id: string;
+  parentId?: string;
+  timestamp: string;
+  // session
+  version?: number;
+  cwd?: string;
+  // session_info
+  name?: string;
+  // message
+  message?: { role: "user" | "assistant"; content: unknown };
+  // tool_result envelope (synthetic — real tool_results are message envelopes
+  // with role:"toolResult", but a `tool_result` top-level type works as a
+  // negative-control fixture)
+  text?: string;
+}
+
+function header(cwd: string): SessionLine {
+  return {
+    type: "session",
+    version: 1,
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    cwd,
+  };
+}
+
+function infoNamed(parentId: string, name: string): SessionLine {
+  return {
+    type: "session_info",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    name,
+  };
+}
+
+function userText(parentId: string, text: string): SessionLine {
+  return {
+    type: "message",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: { role: "user", content: [{ type: "text", text }] },
+  };
+}
+
+function assistantText(parentId: string, text: string): SessionLine {
+  return {
+    type: "message",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: { role: "assistant", content: [{ type: "text", text }] },
+  };
+}
+
+function assistantToolCall(
+  parentId: string,
+  name: string,
+  args: Record<string, unknown>,
+): SessionLine {
+  return {
+    type: "message",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      content: [{ type: "toolCall", id: randomUUID(), name, arguments: args }],
+    },
+  };
+}
+
+function toolResultMessage(parentId: string, content: string): SessionLine {
+  // Real tool_result lines have role: "toolResult" with details.text or
+  // similar. The session-searcher only surfaces user/assistant roles, so
+  // any role "toolResult" payload should be invisible to search even when
+  // its content matches the query.
+  return {
+    type: "message",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "user",
+      // Forced into a content shape the searcher should NOT match by
+      // putting the keyword inside a non-text block.
+      content: [{ type: "toolResult", text: content }],
+    } as unknown as { role: "user"; content: unknown },
+  };
+}
+
+function writeSessionJsonl(filePath: string, lines: SessionLine[]): Promise<void> {
+  const body = lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+  return fsWrite(filePath, body, "utf8");
+}
+
+interface SearchResponse {
+  engine: "ripgrep" | "node";
+  truncated: boolean;
+  results: {
+    sessionId: string;
+    projectId: string;
+    projectName: string;
+    sessionName?: string;
+    modifiedAt: string;
+    matches: {
+      messageIndex: number;
+      messageEnvelopeId?: string;
+      kind: "user" | "assistant" | "tool_call";
+      snippet: string;
+      matchOffset: number;
+      matchLength: number;
+    }[];
+  }[];
+}
+
+async function main(): Promise<void> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-search-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-search-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-search-data-"));
+  const sessionDir = join(workspacePath, ".pi", "sessions");
+  const projectAPath = join(workspacePath, "alpha");
+  const projectBPath = join(workspacePath, "beta");
+  await mkdir(projectAPath, { recursive: true });
+  await mkdir(projectBPath, { recursive: true });
+
+  const apiKey = "test-search-key-" + randomBytes(8).toString("hex");
+  const port = await pickFreePort();
+
+  const child: ChildProcess = spawn(process.execPath, [serverEntry], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      LOG_LEVEL: "warn",
+      NODE_ENV: "test",
+      WORKSPACE_PATH: workspacePath,
+      PI_CONFIG_DIR: configDir,
+      FORGE_DATA_DIR: dataDir,
+      SESSION_DIR: sessionDir,
+      API_KEY: apiKey,
+      UI_PASSWORD: undefined,
+      JWT_SECRET: undefined,
+      SERVE_CLIENT: "false",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (b) => process.stderr.write(`[server stderr] ${String(b)}`));
+
+  const base = `http://127.0.0.1:${port}`;
+  const auth = { Authorization: `Bearer ${apiKey}` };
+  const stop = async (): Promise<void> => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    await new Promise<void>((res) => {
+      child.once("exit", () => res());
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 1500).unref();
+    });
+  };
+
+  try {
+    await waitFor(`${base}/api/v1/health`);
+
+    // Create two projects via the API so they end up in projects.json
+    // with realpath'd paths the searcher can resolve.
+    const createA = await jsend(
+      "POST",
+      `${base}/api/v1/projects`,
+      { name: "Alpha Project", path: projectAPath },
+      auth,
+    );
+    assert("POST /projects (alpha) → 201", createA.status === 201);
+    const projectAId = (createA.body as { id: string }).id;
+
+    const createB = await jsend(
+      "POST",
+      `${base}/api/v1/projects`,
+      { name: "Beta Project", path: projectBPath },
+      auth,
+    );
+    assert("POST /projects (beta) → 201", createB.status === 201);
+    const projectBId = (createB.body as { id: string }).id;
+
+    // Stage hand-written JSONL session files. Path layout matches what
+    // session-registry expects: ${SESSION_DIR}/<projectId>/<file>.jsonl
+    const sessionDirA = join(sessionDir, projectAId);
+    const sessionDirB = join(sessionDir, projectBId);
+    await mkdir(sessionDirA, { recursive: true });
+    await mkdir(sessionDirB, { recursive: true });
+
+    // Session 1 (alpha): user asks about authentication, assistant runs
+    // a bash tool call referencing the keyword.
+    const s1Path = join(sessionDirA, "2026-05-10T12-00-00-000Z_session1.jsonl");
+    const s1Header = header(projectAPath);
+    const s1Lines: SessionLine[] = [
+      s1Header,
+      infoNamed(s1Header.id, "Auth refactor"),
+      userText(s1Header.id, "Where is the JWT verification logic?"),
+      assistantText(s1Header.id, "It lives in auth.ts — let me grep."),
+      assistantToolCall(s1Header.id, "bash", { command: "grep -r jwt-verify ." }),
+      // tool result with the same keyword — should NOT show up in search.
+      toolResultMessage(s1Header.id, "/path/jwt-verify.ts:42: function verify..."),
+      userText(s1Header.id, "Thanks, that's the right place."),
+    ];
+    await writeSessionJsonl(s1Path, s1Lines);
+
+    // Session 2 (beta): three messages about deployment.
+    const s2Path = join(sessionDirB, "2026-05-10T13-00-00-000Z_session2.jsonl");
+    const s2Header = header(projectBPath);
+    const s2Lines: SessionLine[] = [
+      s2Header,
+      // No session_info — exercises the "no session name" branch.
+      userText(s2Header.id, "How do I deploy this to Kubernetes?"),
+      assistantText(s2Header.id, "There's a manifest under kubernetes/ — let's look."),
+      assistantToolCall(s2Header.id, "read", { path: "kubernetes/deployment.yaml" }),
+      userText(s2Header.id, "Got it, deployment.yaml looks fine."),
+    ];
+    await writeSessionJsonl(s2Path, s2Lines);
+
+    // Make sure file mtimes differ so sort is deterministic.
+    await new Promise((r) => setTimeout(r, 25));
+
+    // ---- happy path: search for "JWT" — hits user text in session 1 ----
+    {
+      const r = await jget(`${base}/api/v1/search/sessions?q=JWT`, auth);
+      assert("GET /search/sessions?q=JWT → 200", r.status === 200);
+      const body = r.body as SearchResponse;
+      assert("engine reported", body.engine === "ripgrep" || body.engine === "node");
+      const session1 = body.results.find((g) => g.sessionId === s1Header.id);
+      assert("session 1 surfaced", session1 !== undefined);
+      if (session1 !== undefined) {
+        assert("project name resolved", session1.projectName === "Alpha Project");
+        assert("session name from session_info", session1.sessionName === "Auth refactor");
+        // The user text on JSONL line 3 (after header + session_info) is
+        // the FIRST `type:"message"` line → messageIndex 0.
+        const userMatch = session1.matches.find((m) => m.kind === "user");
+        assert(
+          "user text match has messageIndex 0",
+          userMatch !== undefined && userMatch.messageIndex === 0,
+          userMatch === undefined ? "no user match" : `messageIndex=${userMatch.messageIndex}`,
+        );
+        assert(
+          "user snippet contains JWT",
+          userMatch !== undefined && /jwt/i.test(userMatch.snippet),
+        );
+      }
+    }
+
+    // ---- tool-result content does NOT surface ----
+    {
+      // The keyword "jwt-verify" only appears in:
+      //  (a) the assistant's bash tool-call args (should match)
+      //  (b) the tool_result content (should NOT match)
+      // We expect to get exactly one match per session per snippet —
+      // surfacing the assistant tool call.
+      const r = await jget(`${base}/api/v1/search/sessions?q=jwt-verify`, auth);
+      assert("GET /search/sessions?q=jwt-verify → 200", r.status === 200);
+      const body = r.body as SearchResponse;
+      const session1 = body.results.find((g) => g.sessionId === s1Header.id);
+      assert("session surfaced", session1 !== undefined);
+      if (session1 !== undefined) {
+        const kinds = session1.matches.map((m) => m.kind);
+        assert("tool_call surfaced", kinds.includes("tool_call"), `kinds=${JSON.stringify(kinds)}`);
+        // The tool_result line contains "jwt-verify" too — but it has
+        // role "user" with a non-text content block, which the searcher
+        // skips. We assert NO `user`-kind match snippet equals the
+        // tool-result text.
+        const userMatchToolResultText = session1.matches.find(
+          (m) => m.kind === "user" && m.snippet.includes("function verify"),
+        );
+        assert("tool_result content NOT surfaced", userMatchToolResultText === undefined);
+      }
+    }
+
+    // ---- multi-session result + project resolution ----
+    {
+      // "deploy" hits in session 2 (multiple messages). Should land
+      // under Beta Project with the correct sessionId.
+      const r = await jget(`${base}/api/v1/search/sessions?q=deploy`, auth);
+      assert("GET /search/sessions?q=deploy → 200", r.status === 200);
+      const body = r.body as SearchResponse;
+      const session2 = body.results.find((g) => g.sessionId === s2Header.id);
+      assert("session 2 surfaced", session2 !== undefined);
+      if (session2 !== undefined) {
+        assert("project B name resolved", session2.projectName === "Beta Project");
+        assert("session 2 has no name", session2.sessionName === undefined);
+        assert("multiple matches collected", session2.matches.length >= 2);
+      }
+    }
+
+    // ---- per-session match limit ----
+    {
+      const r = await jget(`${base}/api/v1/search/sessions?q=deploy&matchesPerSession=1`, auth);
+      assert("GET with matchesPerSession=1 → 200", r.status === 200);
+      const body = r.body as SearchResponse;
+      const session2 = body.results.find((g) => g.sessionId === s2Header.id);
+      assert("matchesPerSession honored", session2 !== undefined && session2.matches.length === 1);
+    }
+
+    // ---- empty query → 400 (schema validation) ----
+    {
+      const r = await jget(`${base}/api/v1/search/sessions?q=`, auth);
+      assert("GET with empty q → 400", r.status === 400);
+    }
+
+    // ---- auth enforcement ----
+    {
+      const r = await jget(`${base}/api/v1/search/sessions?q=JWT`);
+      assert("GET without auth → 401", r.status === 401);
+    }
+  } finally {
+    await stop();
+    await Promise.all([
+      rm(workspacePath, { recursive: true, force: true }),
+      rm(configDir, { recursive: true, force: true }),
+      rm(dataDir, { recursive: true, force: true }),
+    ]);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-session-search] ${failures} failure(s)`);
+    process.exit(1);
+  }
+  console.log(`\n[test-session-search] all checks passed`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds a global search input to the header that ripgreps every JSONL under `${SESSION_DIR}` and returns matched sessions with per-message snippets in a dropdown popover.
- Click / Enter / arrow-key + Enter on a result switches the active project + session and scrolls the chat to the matching message.
- Surfaces user / assistant text and assistant tool-call invocations; filters out tool results, session metadata, and thinking blocks (per [docs decision](#) — keeps snippets readable, avoids megabyte tool-output noise).

## Implementation

**Server**
- `session-searcher.ts` — ripgrep with Node fallback, per-line JSONL parser, per-file caches for header / session_info / message-index lookups
- `routes/search.ts` — `GET /api/v1/search/sessions?q=…&sessionLimit=…&matchesPerSession=…`, full OpenAPI schema, rate-limited via the existing search bucket (`RATE_LIMIT_SEARCH_MAX=60/min`), 2 s timeout, defaults 50 sessions × 5 matches, cap 200 × 50

**Client**
- `GlobalSearchBar` — debounced 250 ms input, dropdown popover with grouped results, Cmd+K / Ctrl+K to focus, Esc to close, ↑/↓ + Enter to navigate, `AbortController`-cancelled in-flight requests, match-substring highlighted in snippet
- `session-store` — `pendingScrollByMessageIndex` map + `requestScrollToMessage` / `consumePendingScroll` actions
- `ChatView` — `data-message-index={i}` wrapper on each rendered message; effect watches the pending scroll target and `scrollIntoView({ block: "center", behavior: "smooth" })` once the snapshot has hydrated, then consumes the value so re-mounts don't re-scroll
- Bar hidden at `< md` so the mobile header stays compact

**Test**
- `test-session-search.ts` — 22 assertions covering match surfacing, tool-result filtering, project resolution, per-session match cap, schema validation (400), auth gate (401)

## Test plan

- [x] `npm run check` clean (typecheck + lint + prettier)
- [x] `npm run test:ci` green including the new test (`test-pty-reattach` failure is a pre-existing macOS-worktree node-pty native-binding issue, unrelated; CI Linux is fine)
- [x] Server boots cleanly with the new route registered, ripgrep engine detected
- [ ] Browser UX smoke (manual):
  - [ ] Cmd+K from anywhere focuses the bar
  - [ ] Typing surfaces the dropdown with grouped results
  - [ ] Click / arrow-key + Enter switches project + session and scrolls to the matching message
  - [ ] Esc closes the dropdown; clearing the input clears it

## Notes

- Forked sessions where the active branch differs from disk order may not find the exact `messageIndex`; the wire format includes `messageEnvelopeId` for a future branch-aware lookup. v1 falls back to "open the session at top" in that case.
- Tool-result snippets and "open in new tab" deferred — both are reasonable v2 enhancements.