### PR TITLE
feat(export): single-conversation export to Markdown or raw JSONL

### DIFF
--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRight,
   Columns2,
   Copy,
+  Download,
   ExternalLink,
   FileCode,
   GitBranch,
@@ -22,6 +23,8 @@ import {
   type CompactionEvent,
 } from "../store/session-store";
 import { useActiveProject, useProjectStore } from "../store/project-store";
+import { api, ApiError } from "../lib/api-client";
+import { useIsMobile } from "../lib/use-is-mobile";
 import { ChatMarkdown } from "./ChatMarkdown";
 import { CompactionCard } from "./CompactionCard";
 import { DiffBlock } from "./DiffBlock";
@@ -107,6 +110,53 @@ export function ChatView({ sessionId }: Props) {
   const project = useActiveProject();
   const [treeOpen, setTreeOpen] = useState(false);
 
+  // Conversation export menu (Markdown / Raw JSONL). Hidden on mobile —
+  // the file-download flow is desktop-shaped (browser save dialog,
+  // open-in-editor follow-ups) and a phone user typically doesn't
+  // want a .md / .jsonl landing in their Downloads folder anyway.
+  const isMobile = useIsMobile();
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
+  const [exportError, setExportError] = useState<string | undefined>(undefined);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!exportMenuOpen) return;
+    const onDoc = (e: MouseEvent): void => {
+      if (exportMenuRef.current === null) return;
+      if (!exportMenuRef.current.contains(e.target as Node)) setExportMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [exportMenuOpen]);
+  const doExport = async (format: "markdown" | "jsonl"): Promise<void> => {
+    setExportMenuOpen(false);
+    setExportError(undefined);
+    try {
+      const { blob, filename } = await api.exportSession(sessionId, format);
+      // Same trigger pattern FileBrowserPanel / SettingsPanel use:
+      // synthesize an `<a download>`, click, then revoke the blob URL
+      // on the next tick so Safari has time to grab it.
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? `${err.code} (${err.status})`
+          : err instanceof Error
+            ? err.message
+            : "export_failed";
+      setExportError(message);
+      // Auto-clear after a few seconds so a transient error doesn't
+      // sit forever.
+      window.setTimeout(() => setExportError(undefined), 4_000);
+    }
+  };
+
   // Open SSE on mount, close on unmount/session change. The store ensures
   // openStream is idempotent for the same id.
   useEffect(() => {
@@ -164,11 +214,50 @@ export function ChatView({ sessionId }: Props) {
       value={{ viewType: chatViewType, setViewType: setAndPersistChatViewType }}
     >
       <div className="flex flex-1 flex-col overflow-hidden">
-        {/* Chat-level toolbar. Single button today (session tree); add
-            future per-session controls (export, copy session id, etc.)
-            here. Pinned above the scroll container so the affordance
-            stays reachable from any scroll position. */}
+        {/* Chat-level toolbar. Per-session controls (export, session
+            tree, etc.) — pinned above the scroll container so the
+            affordances stay reachable from any scroll position. */}
         <div className="flex items-center justify-end gap-1 border-b border-neutral-800 bg-neutral-900/30 px-3 py-1">
+          {!isMobile && (
+            <div ref={exportMenuRef} className="relative">
+              <button
+                onClick={() => setExportMenuOpen((v) => !v)}
+                aria-haspopup="menu"
+                aria-expanded={exportMenuOpen}
+                className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200"
+                title="Export this conversation"
+              >
+                <Download size={11} />
+                Export
+              </button>
+              {exportMenuOpen && (
+                <div
+                  role="menu"
+                  className="absolute right-0 top-full z-30 mt-1 min-w-[12rem] rounded-md border border-neutral-700 bg-neutral-900 py-1 shadow-xl"
+                >
+                  <button
+                    role="menuitem"
+                    onClick={() => void doExport("markdown")}
+                    className="block w-full px-3 py-1.5 text-left text-xs text-neutral-200 hover:bg-neutral-800"
+                  >
+                    Markdown <span className="text-neutral-500">(.md)</span>
+                  </button>
+                  <button
+                    role="menuitem"
+                    onClick={() => void doExport("jsonl")}
+                    className="block w-full px-3 py-1.5 text-left text-xs text-neutral-200 hover:bg-neutral-800"
+                  >
+                    Raw JSONL <span className="text-neutral-500">(.jsonl)</span>
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+          {exportError !== undefined && (
+            <span className="text-[10px] text-amber-400" role="status">
+              Export failed: {exportError}
+            </span>
+          )}
           <button
             onClick={() => setTreeOpen(true)}
             className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200"

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1613,6 +1613,46 @@ export const api = {
   },
 
   /**
+   * Export a single conversation as Markdown or raw JSONL. The server
+   * inlines pi-subagents children into the parent's transcript at the
+   * matching `subagent` tool call. Returns a blob + filename in the
+   * same shape as exportConfig / exportSkills so the download-trigger
+   * logic in the UI can stay uniform.
+   */
+  exportSession: async (
+    sessionId: string,
+    format: "markdown" | "jsonl",
+  ): Promise<{ blob: Blob; filename: string }> => {
+    const headers: Record<string, string> = {};
+    const stored = getStoredToken();
+    if (stored !== undefined) headers.Authorization = `Bearer ${stored.token}`;
+    const res = await fetch(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/export?format=${format}`,
+      { headers },
+    );
+    if (res.status === 401) {
+      clearStoredToken();
+      window.dispatchEvent(new Event(UNAUTHORIZED_EVENT));
+      throw new ApiError(401, "unauthorized");
+    }
+    if (!res.ok) {
+      let code = "request_failed";
+      try {
+        const body = (await res.json()) as { error?: unknown };
+        if (typeof body.error === "string") code = body.error;
+      } catch {
+        // body wasn't JSON — keep generic code
+      }
+      throw new ApiError(res.status, code);
+    }
+    const blob = await res.blob();
+    const cd = res.headers.get("Content-Disposition") ?? "";
+    const fallback = format === "markdown" ? "session.md" : "session.jsonl";
+    const filename = parseContentDispositionFilename(cd) ?? fallback;
+    return { blob, filename };
+  },
+
+  /**
    * Upload skills to the server. Accepts either a single tar.gz
    * (auto-detected by `.tar.gz` / `.tgz` suffix) OR a list of files
    * from a folder picker (`<input webkitdirectory>`); each file's

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -23,6 +23,7 @@ import { configRoutes } from "./routes/config.js";
 import { fileRoutes } from "./routes/files.js";
 import { gitRoutes } from "./routes/git.js";
 import { execRoutes } from "./routes/exec.js";
+import { exportRoutes } from "./routes/export.js";
 import { mcpRoutes } from "./routes/mcp.js";
 import { terminalRoutes } from "./routes/terminal.js";
 import { disposeAll as disposeAllMcp, loadGlobal as loadGlobalMcp } from "./mcp/manager.js";
@@ -379,6 +380,7 @@ export async function buildServer(): Promise<FastifyInstance> {
       await api.register(fileRoutes);
       await api.register(gitRoutes);
       await api.register(execRoutes);
+      await api.register(exportRoutes);
       await api.register(mcpRoutes);
       await api.register(terminalRoutes);
     },

--- a/packages/server/src/routes/export.ts
+++ b/packages/server/src/routes/export.ts
@@ -1,0 +1,75 @@
+import type { FastifyInstance, FastifyPluginAsync } from "fastify";
+import { exportAsJsonl, exportAsMarkdown, SessionNotFoundError } from "../session-exporter.js";
+import { errorSchema } from "./_schemas.js";
+
+/**
+ * Single-session conversation export. Two formats:
+ *
+ *   - `jsonl` — raw on-disk session JSONL with subagent children
+ *     inlined between the parent's `subagent` tool call and its
+ *     matching tool result, bracketed by synthetic
+ *     `subagent_inline_start` / `subagent_inline_end` envelopes.
+ *   - `markdown` — flat human-readable transcript: user / assistant
+ *     bubbles, tool calls as fenced code blocks, tool results as
+ *     blockquotes (capped per-result), subagent children nested
+ *     under the parent's tool call.
+ *
+ * Triggered from the chat-view toolbar in the browser UI; usable
+ * programmatically for backups / archiving.
+ */
+export const exportRoutes: FastifyPluginAsync = async (app: FastifyInstance) => {
+  app.get<{
+    Params: { sessionId: string };
+    Querystring: { format: "jsonl" | "markdown" };
+  }>(
+    "/sessions/:sessionId/export",
+    {
+      schema: {
+        description:
+          "Export a single conversation as JSONL or Markdown. Subagent " +
+          "children are inlined into the parent export. Returns the file " +
+          "as an attachment with a filename derived from the session name " +
+          "(or session id when unnamed).",
+        tags: ["sessions"],
+        params: {
+          type: "object",
+          required: ["sessionId"],
+          properties: { sessionId: { type: "string", minLength: 1 } },
+        },
+        querystring: {
+          type: "object",
+          required: ["format"],
+          properties: {
+            format: { type: "string", enum: ["jsonl", "markdown"] },
+          },
+        },
+        response: {
+          // Body is binary-ish (utf-8 text but with attachment headers);
+          // schema-less response keeps Fastify from second-guessing the
+          // string body. 4xx are JSON envelopes per the project standard.
+          400: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      try {
+        const artifact =
+          req.query.format === "jsonl"
+            ? await exportAsJsonl(req.params.sessionId)
+            : await exportAsMarkdown(req.params.sessionId);
+        reply
+          .header("Content-Type", artifact.contentType)
+          .header("Content-Disposition", `attachment; filename="${artifact.filename}"`);
+        return reply.send(artifact.content);
+      } catch (err) {
+        if (err instanceof SessionNotFoundError) {
+          return reply.code(404).send({ error: "session_not_found", message: err.message });
+        }
+        const message = err instanceof Error ? err.message : "export failed";
+        return reply.code(500).send({ error: "export_failed", message });
+      }
+    },
+  );
+};

--- a/packages/server/src/session-exporter.ts
+++ b/packages/server/src/session-exporter.ts
@@ -1,0 +1,556 @@
+import { readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { discoverSessionsOnDisk, findSessionLocation } from "./session-registry.js";
+import { getProject, readProjects } from "./project-manager.js";
+
+/**
+ * Single-session exporter. Two output formats:
+ *
+ *   - **JSONL** — the raw on-disk session JSONL with subagent child
+ *     JSONLs inlined between the parent's `subagent` tool call and its
+ *     matching tool result. Inline boundaries use synthetic envelope
+ *     types `subagent_inline_start` / `subagent_inline_end` so SDK
+ *     consumers that don't understand them treat them as unknown and
+ *     skip (matching the SDK's own forward-compat policy).
+ *   - **Markdown** — a flat human-readable transcript: user / assistant
+ *     bubbles, tool calls as fenced code blocks, tool results as
+ *     blockquotes (capped at TOOL_RESULT_CAP bytes per result).
+ *     Subagent children render nested at h3 under the parent's tool
+ *     call section.
+ *
+ * Sub-agent matching is **positional**: the Nth `subagent` tool call
+ * gets the Nth chronologically-sorted child. pi-subagents creates the
+ * child JSONL at tool invocation time so this ordering holds in
+ * practice. Mismatched counts (e.g. a failed call that never spawned
+ * a child) inline what we have and skip the rest — better than
+ * pretending the data isn't there.
+ */
+
+/** Soft cap per tool-result rendering in markdown — keeps exports skim-able. */
+const TOOL_RESULT_CAP = 2_000;
+
+export interface ExportArtifact {
+  /** UTF-8 string ready to send to the client. */
+  content: string;
+  /** Filename hint for the Content-Disposition header. */
+  filename: string;
+  /** Suitable Content-Type. */
+  contentType: string;
+}
+
+export class SessionNotFoundError extends Error {
+  constructor(sessionId: string) {
+    super(`session ${sessionId} not found`);
+    this.name = "SessionNotFoundError";
+  }
+}
+
+/**
+ * Locate a session by id. Walks every project's on-disk session dir
+ * (delegating to `discoverSessionsOnDisk` so subagent children are
+ * resolvable too) and returns the discovered metadata for the match.
+ */
+async function findSessionFile(sessionId: string): Promise<
+  | {
+      filePath: string;
+      projectId: string;
+      workspacePath: string;
+      sessionName?: string;
+      parentSessionId?: string;
+    }
+  | undefined
+> {
+  const loc = await findSessionLocation(sessionId);
+  if (loc === undefined) return undefined;
+  const discovered = await discoverSessionsOnDisk(loc.projectId, loc.workspacePath);
+  const match = discovered.find((d) => d.sessionId === sessionId);
+  if (match === undefined) return undefined;
+  const out: {
+    filePath: string;
+    projectId: string;
+    workspacePath: string;
+    sessionName?: string;
+    parentSessionId?: string;
+  } = {
+    filePath: match.path,
+    projectId: loc.projectId,
+    workspacePath: loc.workspacePath,
+  };
+  if (match.name !== undefined) out.sessionName = match.name;
+  if (match.parentSessionId !== undefined) out.parentSessionId = match.parentSessionId;
+  return out;
+}
+
+/**
+ * Discover and chronologically-sort the subagent children of `parentSessionId`
+ * within the same project. Returns `[]` for sessions with no children,
+ * including sessions that ARE themselves children (we don't recurse beyond
+ * one level — see the module doc).
+ */
+async function loadChildSessions(
+  parentSessionId: string,
+  projectId: string,
+  workspacePath: string,
+): Promise<{ sessionId: string; filePath: string; createdAt: Date }[]> {
+  const discovered = await discoverSessionsOnDisk(projectId, workspacePath);
+  const children = discovered
+    .filter((d) => d.parentSessionId === parentSessionId)
+    .map((d) => ({ sessionId: d.sessionId, filePath: d.path, createdAt: d.createdAt }))
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  return children;
+}
+
+/* ----------------------------- JSONL export ----------------------------- */
+
+export async function exportAsJsonl(sessionId: string): Promise<ExportArtifact> {
+  const located = await findSessionFile(sessionId);
+  if (located === undefined) throw new SessionNotFoundError(sessionId);
+
+  const parentContent = await readFile(located.filePath, "utf8");
+  const parentLines = splitLines(parentContent);
+
+  // For child sessions, no further inlining — return the file as-is.
+  // The user is exporting "this conversation" and the child is already
+  // a complete conversation in itself.
+  const isChild = located.parentSessionId !== undefined;
+  if (isChild) {
+    return {
+      content: parentContent.endsWith("\n") ? parentContent : parentContent + "\n",
+      filename: filenameFor(located.sessionName ?? sessionId, "jsonl"),
+      contentType: "application/x-ndjson",
+    };
+  }
+
+  const children = await loadChildSessions(sessionId, located.projectId, located.workspacePath);
+  // Pre-load every child's content so the inline pass doesn't await
+  // per-line. Children typically count in the single digits.
+  const childContents = await Promise.all(
+    children.map(async (c) => ({ ...c, lines: splitLines(await readFile(c.filePath, "utf8")) })),
+  );
+
+  // Walk the parent's lines; when we see an assistant message with a
+  // `subagent` tool-call block, immediately after the parent line emit
+  // the next child's full JSONL bracketed by inline-boundary envelopes.
+  const out: string[] = [];
+  let childCursor = 0;
+  for (const line of parentLines) {
+    out.push(line);
+    const callId = subagentToolCallIdFromLine(line);
+    if (callId === undefined) continue;
+    const child = childContents[childCursor];
+    if (child === undefined) continue;
+    childCursor += 1;
+    out.push(
+      JSON.stringify({
+        type: "subagent_inline_start",
+        parentToolCallId: callId,
+        childSessionId: child.sessionId,
+      }),
+    );
+    for (const childLine of child.lines) out.push(childLine);
+    out.push(
+      JSON.stringify({
+        type: "subagent_inline_end",
+        childSessionId: child.sessionId,
+      }),
+    );
+  }
+  // Trailing-orphan children (counts didn't match): append them at the
+  // tail wrapped in the same envelope. Better to surface than to drop.
+  for (let i = childCursor; i < childContents.length; i++) {
+    const child = childContents[i];
+    if (child === undefined) continue;
+    out.push(
+      JSON.stringify({
+        type: "subagent_inline_start",
+        parentToolCallId: null,
+        childSessionId: child.sessionId,
+        note: "orphaned — no matching parent tool call",
+      }),
+    );
+    for (const childLine of child.lines) out.push(childLine);
+    out.push(
+      JSON.stringify({
+        type: "subagent_inline_end",
+        childSessionId: child.sessionId,
+      }),
+    );
+  }
+
+  return {
+    content: out.join("\n") + "\n",
+    filename: filenameFor(located.sessionName ?? sessionId, "jsonl"),
+    contentType: "application/x-ndjson",
+  };
+}
+
+/* ----------------------------- Markdown export ----------------------------- */
+
+export async function exportAsMarkdown(sessionId: string): Promise<ExportArtifact> {
+  const located = await findSessionFile(sessionId);
+  if (located === undefined) throw new SessionNotFoundError(sessionId);
+
+  const parentContent = await readFile(located.filePath, "utf8");
+  const parentLines = splitLines(parentContent);
+
+  const project = await getProject(located.projectId);
+  const projectName = project?.name ?? "(unknown project)";
+  const isChild = located.parentSessionId !== undefined;
+  const children = isChild
+    ? []
+    : await loadChildSessions(sessionId, located.projectId, located.workspacePath);
+  const childContents = await Promise.all(
+    children.map(async (c) => ({ ...c, lines: splitLines(await readFile(c.filePath, "utf8")) })),
+  );
+
+  const out: string[] = [];
+  out.push(...renderHeader(parentLines, located.sessionName, sessionId, projectName));
+  out.push("");
+
+  let childCursor = 0;
+  for (const line of parentLines) {
+    const parsed = safeParse(line);
+    if (parsed === undefined) continue;
+    const md = renderLine(parsed, /* depth */ 2);
+    if (md.length === 0) continue;
+    out.push(md);
+    out.push("");
+    // Inline a child after the matching subagent tool call.
+    const callId = subagentToolCallIdFromParsed(parsed);
+    if (callId === undefined) continue;
+    const child = childContents[childCursor];
+    if (child === undefined) continue;
+    childCursor += 1;
+    out.push(`<details><summary>↳ subagent ${child.sessionId}</summary>`);
+    out.push("");
+    for (const childLine of child.lines) {
+      const childParsed = safeParse(childLine);
+      if (childParsed === undefined) continue;
+      // Nest one heading-depth deeper so the child's user/assistant
+      // sections render as h3 under the parent's h2 tool-call entry.
+      const childMd = renderLine(childParsed, /* depth */ 3);
+      if (childMd.length === 0) continue;
+      out.push(childMd);
+      out.push("");
+    }
+    out.push("</details>");
+    out.push("");
+  }
+  // Orphaned children (count mismatch) at the tail.
+  for (let i = childCursor; i < childContents.length; i++) {
+    const child = childContents[i];
+    if (child === undefined) continue;
+    out.push("---");
+    out.push("");
+    out.push(`### ↳ subagent ${child.sessionId} (orphaned — no matching parent tool call)`);
+    out.push("");
+    for (const childLine of child.lines) {
+      const childParsed = safeParse(childLine);
+      if (childParsed === undefined) continue;
+      const childMd = renderLine(childParsed, 3);
+      if (childMd.length === 0) continue;
+      out.push(childMd);
+      out.push("");
+    }
+  }
+
+  return {
+    content:
+      out
+        .join("\n")
+        .replace(/\n{3,}/g, "\n\n")
+        .trimEnd() + "\n",
+    filename: filenameFor(located.sessionName ?? sessionId, "md"),
+    contentType: "text/markdown; charset=utf-8",
+  };
+}
+
+/* ----------------------------- rendering helpers ----------------------------- */
+
+interface ParsedLine {
+  type?: unknown;
+  id?: unknown;
+  parentId?: unknown;
+  timestamp?: unknown;
+  // session header
+  cwd?: unknown;
+  // session_info
+  name?: unknown;
+  // message envelope
+  message?: { role?: unknown; content?: unknown; toolCallId?: unknown; details?: unknown };
+  // model_change
+  provider?: unknown;
+  modelId?: unknown;
+}
+
+function splitLines(content: string): string[] {
+  return content.split("\n").filter((l) => l.length > 0);
+}
+
+function safeParse(line: string): ParsedLine | undefined {
+  try {
+    return JSON.parse(line) as ParsedLine;
+  } catch {
+    return undefined;
+  }
+}
+
+function renderHeader(
+  lines: string[],
+  sessionName: string | undefined,
+  sessionId: string,
+  projectName: string,
+): string[] {
+  let createdAt: string | undefined;
+  let cwd: string | undefined;
+  let model: string | undefined;
+  for (const line of lines) {
+    const parsed = safeParse(line);
+    if (parsed === undefined) continue;
+    if (parsed.type === "session") {
+      if (typeof parsed.timestamp === "string") createdAt = parsed.timestamp;
+      if (typeof parsed.cwd === "string") cwd = parsed.cwd;
+    } else if (parsed.type === "model_change" && model === undefined) {
+      const provider = typeof parsed.provider === "string" ? parsed.provider : undefined;
+      const modelId = typeof parsed.modelId === "string" ? parsed.modelId : undefined;
+      if (provider !== undefined && modelId !== undefined) model = `${provider} / ${modelId}`;
+      else if (modelId !== undefined) model = modelId;
+    }
+    if (createdAt !== undefined && cwd !== undefined && model !== undefined) break;
+  }
+
+  const out: string[] = [];
+  out.push(`# ${sessionName ?? "Session"}`);
+  out.push("");
+  out.push(`- **Session id:** \`${sessionId}\``);
+  out.push(`- **Project:** ${projectName}`);
+  if (createdAt !== undefined) out.push(`- **Created:** ${createdAt}`);
+  if (model !== undefined) out.push(`- **Model:** ${model}`);
+  if (cwd !== undefined) out.push(`- **Workspace:** \`${cwd}\``);
+  return out;
+}
+
+function renderLine(parsed: ParsedLine, depth: 2 | 3): string {
+  if (parsed.type !== "message") return "";
+  const msg = parsed.message;
+  if (msg === undefined || msg === null || typeof msg !== "object") return "";
+  const role = (msg as { role?: unknown }).role;
+  const ts = typeof parsed.timestamp === "string" ? prettyTimestamp(parsed.timestamp) : "";
+  if (role === "user") {
+    return renderUserMessage(msg, depth, ts);
+  }
+  if (role === "assistant") {
+    return renderAssistantMessage(msg, depth, ts);
+  }
+  if (role === "toolResult") {
+    return renderStandaloneToolResult(msg);
+  }
+  return "";
+}
+
+function renderUserMessage(
+  msg: { role?: unknown; content?: unknown },
+  depth: 2 | 3,
+  ts: string,
+): string {
+  const heading = depth === 2 ? "## You" : "### You";
+  const out: string[] = [ts.length > 0 ? `${heading} — ${ts}` : heading, ""];
+  out.push(...renderContent(msg.content));
+  return out.join("\n");
+}
+
+function renderAssistantMessage(
+  msg: { role?: unknown; content?: unknown },
+  depth: 2 | 3,
+  ts: string,
+): string {
+  const heading = depth === 2 ? "## Assistant" : "### Assistant";
+  const out: string[] = [ts.length > 0 ? `${heading} — ${ts}` : heading, ""];
+  out.push(...renderContent(msg.content));
+  return out.join("\n");
+}
+
+function renderStandaloneToolResult(msg: { content?: unknown; details?: unknown }): string {
+  // toolResult lines render as blockquote bodies under the tool call
+  // they pair with — rendered separately when the SDK doesn't emit
+  // them inline with the call (loose pre-pairing).
+  const text = pickToolResultText(msg);
+  if (text.length === 0) return "";
+  return blockquote(truncate(text, TOOL_RESULT_CAP));
+}
+
+function renderContent(content: unknown): string[] {
+  // String form: simple "user typed text" — render as a paragraph.
+  if (typeof content === "string") {
+    return content.length > 0 ? [content] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const out: string[] = [];
+  for (const block of content) {
+    if (block === undefined || block === null || typeof block !== "object") continue;
+    const b = block as {
+      type?: unknown;
+      text?: unknown;
+      name?: unknown;
+      arguments?: unknown;
+      input?: unknown;
+      filename?: unknown;
+      mimeType?: unknown;
+      data?: unknown;
+    };
+    if (b.type === "text" && typeof b.text === "string") {
+      out.push(b.text);
+    } else if (b.type === "thinking") {
+      const t = typeof b.text === "string" ? b.text : "";
+      // Thinking blocks fold into a <details> so the transcript stays
+      // skim-able; reviewers can expand to see the full chain.
+      out.push("<details><summary>Thinking</summary>");
+      out.push("");
+      if (t.length > 0) out.push(t);
+      out.push("</details>");
+    } else if (b.type === "toolCall") {
+      out.push(renderToolCall(b));
+    } else if (b.type === "image") {
+      const filename = typeof b.filename === "string" ? b.filename : "image";
+      const mime = typeof b.mimeType === "string" ? b.mimeType : "";
+      out.push(`*[image: ${filename}${mime !== "" ? " (" + mime + ")" : ""}]*`);
+    } else if (b.type === "file") {
+      const filename = typeof b.filename === "string" ? b.filename : "file";
+      out.push(`*[file: ${filename}]*`);
+    } else if (b.type === "toolResult") {
+      // toolResult content blocks carry the result payload either as a
+      // top-level `content` (string or block list) or under `details`;
+      // pickToolResultText accepts either shape.
+      const text = pickToolResultText(b as { content?: unknown; details?: unknown });
+      if (text.length > 0) out.push(blockquote(truncate(text, TOOL_RESULT_CAP)));
+    }
+  }
+  return out;
+}
+
+function renderToolCall(b: { name?: unknown; arguments?: unknown; input?: unknown }): string {
+  const name = typeof b.name === "string" ? b.name : "tool";
+  const args = (b.arguments ?? b.input) as Record<string, unknown> | undefined;
+  // Per-tool language hints make the rendered code blocks meaningful
+  // to clipboard / GitHub renderers. Default to plain text.
+  const lang = languageForTool(name);
+  const body = stringifyArgs(name, args);
+  return `**${name}**\n\n\`\`\`${lang}\n${body}\n\`\`\``;
+}
+
+function languageForTool(name: string): string {
+  if (name === "bash") return "bash";
+  if (name === "edit" || name === "write") return "diff";
+  if (name === "read" || name === "ls" || name === "find" || name === "grep") return "";
+  return "";
+}
+
+function stringifyArgs(name: string, args: Record<string, unknown> | undefined): string {
+  if (args === undefined || args === null || typeof args !== "object") return "";
+  // Special-case `bash` so the command renders as a bare shell line —
+  // most natural form for the most common tool.
+  if (name === "bash" && typeof args.command === "string") {
+    return args.command;
+  }
+  // Generic: pretty-print the args object.
+  return JSON.stringify(args, null, 2);
+}
+
+function pickToolResultText(b: { content?: unknown; details?: unknown }): string {
+  // Tool results in pi can be either:
+  //   - top-level string (legacy)
+  //   - content[].text (assistant-style block list)
+  //   - details.text / details.diff (SDK envelope variant)
+  // Render whichever the line happens to carry; never guess.
+  const details = b.details as { text?: unknown; diff?: unknown } | undefined;
+  if (typeof details?.text === "string") return details.text;
+  if (typeof details?.diff === "string") return details.diff;
+  if (typeof b.content === "string") return b.content;
+  if (Array.isArray(b.content)) {
+    const text = b.content
+      .filter(
+        (block): block is { type: string; text: string } =>
+          block !== null &&
+          typeof block === "object" &&
+          (block as { type?: unknown }).type === "text" &&
+          typeof (block as { text?: unknown }).text === "string",
+      )
+      .map((block) => block.text)
+      .join("\n");
+    if (text.length > 0) return text;
+  }
+  return "";
+}
+
+function blockquote(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+function truncate(text: string, cap: number): string {
+  if (text.length <= cap) return text;
+  return `${text.slice(0, cap)}\n… (truncated, ${text.length} bytes total)`;
+}
+
+function prettyTimestamp(iso: string): string {
+  // Strip the millisecond + Z noise so the rendered transcript isn't
+  // dominated by timestamps; ISO date + HH:MM:SS is plenty.
+  const m = /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})/.exec(iso);
+  if (m === null) return iso;
+  return `${m[1]} ${m[2]}`;
+}
+
+function subagentToolCallIdFromLine(line: string): string | undefined {
+  const parsed = safeParse(line);
+  if (parsed === undefined) return undefined;
+  return subagentToolCallIdFromParsed(parsed);
+}
+
+function subagentToolCallIdFromParsed(parsed: ParsedLine): string | undefined {
+  if (parsed.type !== "message") return undefined;
+  const msg = parsed.message;
+  if (msg === undefined || msg === null || typeof msg !== "object") return undefined;
+  if ((msg as { role?: unknown }).role !== "assistant") return undefined;
+  const content = (msg as { content?: unknown }).content;
+  if (!Array.isArray(content)) return undefined;
+  for (const block of content) {
+    if (block === undefined || block === null || typeof block !== "object") continue;
+    const b = block as { type?: unknown; name?: unknown; id?: unknown };
+    if (b.type === "toolCall" && b.name === "subagent" && typeof b.id === "string") {
+      return b.id;
+    }
+  }
+  return undefined;
+}
+
+function filenameFor(label: string, ext: "md" | "jsonl"): string {
+  const slug = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  const date = new Date().toISOString().slice(0, 10);
+  const base = slug.length > 0 ? slug : "session";
+  return `${base}-${date}.${ext}`;
+}
+
+/** Test helper — never called from the route. */
+export function _readProjectsForTest(): ReturnType<typeof readProjects> {
+  return readProjects();
+}
+
+/** Test helper — fully resolves a session file (without reading contents). */
+export async function _findSessionFileForTest(
+  sessionId: string,
+): Promise<{ filePath: string; projectId: string } | undefined> {
+  const f = await findSessionFile(sessionId);
+  if (f === undefined) return undefined;
+  return { filePath: f.filePath, projectId: f.projectId };
+}
+
+/** Used by the route to compute a deterministic dirname for diagnostics. */
+export function _exportDirForTest(filePath: string): string {
+  return dirname(filePath);
+}

--- a/tests/test-session-export.ts
+++ b/tests/test-session-export.ts
@@ -1,0 +1,463 @@
+/**
+ * Single-session conversation export integration test.
+ *
+ * Boots the server in-process under a temp WORKSPACE_PATH, creates a
+ * project, hand-writes a parent JSONL session + one subagent child
+ * JSONL into the per-project session directory (mirroring the on-disk
+ * layout pi-subagents produces:
+ * `<sessionDir>/<projectId>/<parentBasename>/<runId>/<child>.jsonl`),
+ * then drives `/api/v1/sessions/:id/export?format=…` to verify:
+ *
+ *   - JSONL export is byte-faithful for child sessions
+ *   - JSONL export inlines the child between the parent's `subagent`
+ *     tool call and its tool result, bracketed by the synthetic
+ *     `subagent_inline_start` / `subagent_inline_end` envelopes
+ *   - Markdown export contains expected sections (`## You`,
+ *     `## Assistant`, `**bash**` fenced block, blockquote tool-result,
+ *     `<details>` for thinking + subagent inline)
+ *   - Markdown header surfaces session name + project name + cwd
+ *   - Tool-result blockquote truncates at TOOL_RESULT_CAP with the
+ *     "(truncated, N bytes total)" sentinel
+ *   - Filename in Content-Disposition uses session-name slug
+ *   - Unknown sessionId → 404
+ *   - Bad format → 400
+ *   - 401 without auth
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomBytes, randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile as fsWrite } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+const serverEntry = resolve(repoRoot, "packages/server/dist/index.js");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function pickFreePort(): Promise<number> {
+  return new Promise((resolveFn, rejectFn) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on("error", rejectFn);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === "string") {
+        rejectFn(new Error("failed to acquire free port"));
+        return;
+      }
+      const { port } = addr;
+      srv.close(() => resolveFn(port));
+    });
+  });
+}
+
+async function waitFor(url: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(url);
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  throw new Error(`timeout waiting for ${url}`);
+}
+
+interface FetchResult {
+  status: number;
+  headers: Record<string, string>;
+  text: string;
+}
+
+async function jget(url: string, headers: Record<string, string> = {}): Promise<FetchResult> {
+  const res = await fetch(url, { headers });
+  const text = await res.text();
+  const out: Record<string, string> = {};
+  res.headers.forEach((v, k) => {
+    out[k.toLowerCase()] = v;
+  });
+  return { status: res.status, headers: out, text };
+}
+
+async function jsend(
+  method: "POST",
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<FetchResult> {
+  const init: RequestInit = { method, headers: { ...headers } };
+  if (body !== undefined) {
+    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(url, init);
+  const text = await res.text();
+  const out: Record<string, string> = {};
+  res.headers.forEach((v, k) => {
+    out[k.toLowerCase()] = v;
+  });
+  return { status: res.status, headers: out, text };
+}
+
+interface JsonlLine {
+  type: string;
+  id: string;
+  parentId?: string;
+  timestamp: string;
+  version?: number;
+  cwd?: string;
+  name?: string;
+  message?: { role: string; content: unknown };
+  provider?: string;
+  modelId?: string;
+}
+
+function header(cwd: string, sessionId: string): JsonlLine {
+  return {
+    type: "session",
+    version: 1,
+    id: sessionId,
+    timestamp: new Date().toISOString(),
+    cwd,
+  };
+}
+
+function modelChange(parentId: string, provider: string, modelId: string): JsonlLine {
+  return {
+    type: "model_change",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    provider,
+    modelId,
+  };
+}
+
+function infoNamed(parentId: string, name: string): JsonlLine {
+  return {
+    type: "session_info",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    name,
+  };
+}
+
+function userText(parentId: string, text: string): JsonlLine {
+  return {
+    type: "message",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: { role: "user", content: [{ type: "text", text }] },
+  };
+}
+
+function assistantText(parentId: string, text: string): JsonlLine {
+  return {
+    type: "message",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: { role: "assistant", content: [{ type: "text", text }] },
+  };
+}
+
+function assistantBash(parentId: string, command: string, callId: string): JsonlLine {
+  return {
+    type: "message",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      content: [{ type: "toolCall", id: callId, name: "bash", arguments: { command } }],
+    },
+  };
+}
+
+function assistantSubagent(parentId: string, prompt: string, callId: string): JsonlLine {
+  return {
+    type: "message",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      content: [{ type: "toolCall", id: callId, name: "subagent", arguments: { prompt } }],
+    },
+  };
+}
+
+function toolResult(parentId: string, callId: string, text: string): JsonlLine {
+  // Cast through `unknown` so the synthetic `toolCallId` + `details`
+  // fields land on the wire shape pickToolResultText reads from
+  // without forcing JsonlLine to model every variant the SDK emits.
+  const line: unknown = {
+    type: "message",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "toolResult",
+      content: [],
+      toolCallId: callId,
+      details: { text },
+    },
+  };
+  return line as JsonlLine;
+}
+
+function thinkingMessage(parentId: string, text: string): JsonlLine {
+  return {
+    type: "message",
+    id: randomUUID(),
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      content: [
+        { type: "thinking", text },
+        { type: "text", text: "Done thinking." },
+      ],
+    },
+  };
+}
+
+function writeJsonl(filePath: string, lines: JsonlLine[]): Promise<void> {
+  const body = lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+  return fsWrite(filePath, body, "utf8");
+}
+
+async function main(): Promise<void> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-export-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-export-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-export-data-"));
+  const sessionDir = join(workspacePath, ".pi", "sessions");
+  const projectPath = join(workspacePath, "demo");
+  await mkdir(projectPath, { recursive: true });
+
+  const apiKey = "test-export-key-" + randomBytes(8).toString("hex");
+  const port = await pickFreePort();
+
+  const child: ChildProcess = spawn(process.execPath, [serverEntry], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      LOG_LEVEL: "warn",
+      NODE_ENV: "test",
+      WORKSPACE_PATH: workspacePath,
+      PI_CONFIG_DIR: configDir,
+      FORGE_DATA_DIR: dataDir,
+      SESSION_DIR: sessionDir,
+      API_KEY: apiKey,
+      UI_PASSWORD: undefined,
+      JWT_SECRET: undefined,
+      SERVE_CLIENT: "false",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (b) => process.stderr.write(`[server stderr] ${String(b)}`));
+
+  const base = `http://127.0.0.1:${port}`;
+  const auth = { Authorization: `Bearer ${apiKey}` };
+  const stop = async (): Promise<void> => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    await new Promise<void>((res) => {
+      child.once("exit", () => res());
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 1500).unref();
+    });
+  };
+
+  try {
+    await waitFor(`${base}/api/v1/health`);
+
+    // Create a project so projects.json has it (the exporter walks
+    // every project's session dir to resolve a sessionId).
+    const created = await jsend(
+      "POST",
+      `${base}/api/v1/projects`,
+      { name: "Demo Project", path: projectPath },
+      auth,
+    );
+    assert("POST /projects → 201", created.status === 201);
+    const project = JSON.parse(created.text) as { id: string };
+
+    const sessionDirForProject = join(sessionDir, project.id);
+    await mkdir(sessionDirForProject, { recursive: true });
+
+    // ---- Build the parent session JSONL ----
+    const parentSessionId = randomUUID();
+    const parentBasename = `2026-05-10T12-00-00-000Z_${parentSessionId}`;
+    const parentFile = join(sessionDirForProject, `${parentBasename}.jsonl`);
+    const subagentCallId = "call_subagent_1";
+    const bashCallId = "call_bash_1";
+    const longResult = "x".repeat(3000); // > TOOL_RESULT_CAP (2000)
+    const parentLines: JsonlLine[] = [
+      header(projectPath, parentSessionId),
+      modelChange(parentSessionId, "anthropic", "claude-sonnet-4-6"),
+      infoNamed(parentSessionId, "Refactor auth module"),
+      userText(parentSessionId, "Run a quick smoke and dispatch the refactor work."),
+      assistantBash(parentSessionId, "ls -la", bashCallId),
+      toolResult(
+        parentSessionId,
+        bashCallId,
+        "total 8\ndrwxr-xr-x  3 user  staff   96 May 10 ...\n",
+      ),
+      thinkingMessage(parentSessionId, "Let me delegate the refactor."),
+      assistantSubagent(parentSessionId, "Refactor packages/server/src/auth.ts", subagentCallId),
+      toolResult(parentSessionId, subagentCallId, longResult),
+      userText(parentSessionId, "Thanks, looks good."),
+    ];
+    await writeJsonl(parentFile, parentLines);
+
+    // ---- Build the subagent child JSONL at the pi-subagents path ----
+    const childSessionId = randomUUID();
+    const childRunId = "run-1";
+    const childDir = join(sessionDirForProject, parentBasename, childRunId);
+    await mkdir(childDir, { recursive: true });
+    const childFile = join(childDir, `${childSessionId}.jsonl`);
+    const childLines: JsonlLine[] = [
+      header(projectPath, childSessionId),
+      infoNamed(childSessionId, "subagent: refactor auth"),
+      userText(childSessionId, "Refactor packages/server/src/auth.ts"),
+      assistantText(childSessionId, "I'll start by reading the file."),
+      assistantBash(childSessionId, "cat packages/server/src/auth.ts", "child_bash_1"),
+      toolResult(childSessionId, "child_bash_1", "// auth.ts contents..."),
+    ];
+    await writeJsonl(childFile, childLines);
+
+    // ---- JSONL export of the parent ----
+    {
+      const r = await jget(`${base}/api/v1/sessions/${parentSessionId}/export?format=jsonl`, auth);
+      assert("GET export?format=jsonl → 200", r.status === 200);
+      assert(
+        "Content-Type is ndjson",
+        r.headers["content-type"]?.includes("application/x-ndjson") ?? false,
+      );
+      const cd = r.headers["content-disposition"] ?? "";
+      assert(
+        "filename slug uses session name",
+        cd.includes("refactor-auth-module") && cd.endsWith(`.jsonl"`),
+        `Content-Disposition: ${cd}`,
+      );
+      // Inline boundaries appear in order around the child's content.
+      const startIdx = r.text.indexOf('"subagent_inline_start"');
+      const endIdx = r.text.indexOf('"subagent_inline_end"');
+      const childHdrIdx = r.text.indexOf(`"id":"${childSessionId}"`);
+      assert("subagent_inline_start present", startIdx >= 0);
+      assert("subagent_inline_end present", endIdx > startIdx);
+      assert(
+        "child header inlined between boundaries",
+        childHdrIdx > startIdx && childHdrIdx < endIdx,
+      );
+      // Boundary references the parent tool call id.
+      assert(
+        "inline_start references parent tool call id",
+        r.text.includes(`"parentToolCallId":"${subagentCallId}"`),
+      );
+    }
+
+    // ---- JSONL export of the CHILD itself — no further inlining ----
+    {
+      const r = await jget(`${base}/api/v1/sessions/${childSessionId}/export?format=jsonl`, auth);
+      assert("GET child export?format=jsonl → 200", r.status === 200);
+      assert("child export has no inline boundaries", !r.text.includes("subagent_inline_start"));
+    }
+
+    // ---- Markdown export of the parent ----
+    {
+      const r = await jget(
+        `${base}/api/v1/sessions/${parentSessionId}/export?format=markdown`,
+        auth,
+      );
+      assert("GET export?format=markdown → 200", r.status === 200);
+      assert(
+        "Content-Type is markdown",
+        r.headers["content-type"]?.includes("text/markdown") ?? false,
+      );
+      const cd = r.headers["content-disposition"] ?? "";
+      assert(
+        "markdown filename slug uses session name",
+        cd.includes("refactor-auth-module") && cd.endsWith(`.md"`),
+        `Content-Disposition: ${cd}`,
+      );
+      const md = r.text;
+      assert("markdown header has session name", md.includes("# Refactor auth module"));
+      assert("project surfaced", md.includes("Demo Project"));
+      assert("model surfaced", md.includes("anthropic"));
+      assert("user heading present", md.includes("## You"));
+      assert("assistant heading present", md.includes("## Assistant"));
+      assert("bash tool fenced", md.includes("**bash**") && md.includes("```bash\nls -la"));
+      assert("tool result blockquoted", md.includes("> total 8"));
+      assert(
+        "long tool result truncated with sentinel",
+        md.includes("(truncated, 3000 bytes total)"),
+      );
+      assert("thinking folded into <details>", md.includes("<summary>Thinking</summary>"));
+      assert(
+        "subagent inlined under details",
+        md.includes(`<summary>↳ subagent ${childSessionId}</summary>`),
+      );
+      assert(
+        "subagent inline contains child user text",
+        md.includes("Refactor packages/server/src/auth.ts"),
+      );
+      assert(
+        "subagent uses h3 nested heading",
+        md.includes("### You") || md.includes("### Assistant"),
+      );
+    }
+
+    // ---- 404 on unknown session id ----
+    {
+      const r = await jget(`${base}/api/v1/sessions/${randomUUID()}/export?format=markdown`, auth);
+      assert("unknown sessionId → 404", r.status === 404);
+    }
+
+    // ---- 400 on bad format ----
+    {
+      const r = await jget(`${base}/api/v1/sessions/${parentSessionId}/export?format=xml`, auth);
+      assert("bad format → 400", r.status === 400);
+    }
+
+    // ---- 401 without auth ----
+    {
+      const r = await jget(`${base}/api/v1/sessions/${parentSessionId}/export?format=jsonl`);
+      assert("unauthenticated → 401", r.status === 401);
+    }
+  } finally {
+    await stop();
+    await Promise.all([
+      rm(workspacePath, { recursive: true, force: true }),
+      rm(configDir, { recursive: true, force: true }),
+      rm(dataDir, { recursive: true, force: true }),
+    ]);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-session-export] ${failures} failure(s)`);
+    process.exit(1);
+  }
+  console.log(`\n[test-session-export] all checks passed`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds an Export button to the chat-view toolbar with a small dropdown for Markdown (.md) or Raw JSONL (.jsonl) per-session export.
- Subagent children are inlined into the parent's transcript at the matching `subagent` tool call (rendered nested in Markdown, bracketed by synthetic envelopes in JSONL).
- Hidden on mobile (`useIsMobile()` early-return) — file-download flow is desktop-shaped.

## Implementation

**Server**
- `session-exporter.ts` — format-specific renderers
  - **Markdown**: user / assistant headings with timestamps, tool calls as fenced code blocks (per-tool language hint: `bash`, `diff`, etc.), tool results as blockquotes capped at 2 KB per result with a `(truncated, N bytes total)` sentinel, thinking blocks folded into `<details>`. Subagent children render at h3 inside `<details>`.
  - **JSONL**: raw on-disk file with subagent JSONLs inlined between the parent's `subagent` tool call and its matching tool result, bracketed by synthetic `subagent_inline_start` / `subagent_inline_end` envelopes.
  - Subagent matching is **positional** — Nth tool call gets Nth child by `createdAt`. Mismatched counts inline what's there and surface the rest as orphaned at the tail; never drops data.
- `routes/export.ts` — `GET /api/v1/sessions/:sessionId/export?format=jsonl|markdown` with `Content-Disposition: attachment; filename="<slug>-<date>.<ext>"`, 404 / 400 / 500 envelopes via the shared schema.

**Client**
- `api.exportSession(sessionId, format)` — returns `{ blob, filename }`, mirroring `exportConfig` / `exportSkills`.
- `ChatView` toolbar — Export button next to Tree, opens dropdown with two formats. Trigger uses the same temporary-anchor + `revokeObjectURL` pattern as the file browser. Inline error surface auto-clears after 4 s.
- Hidden on mobile via `useIsMobile()` early-return.

**Test**
- `tests/test-session-export.ts` — 25 assertions covering:
  - JSONL byte fidelity for child sessions
  - Parent inline boundaries with `parentToolCallId` reference
  - Child header inlined between envelopes
  - Markdown headings + fenced bash + blockquote tool result + truncation sentinel + thinking + subagent-as-details
  - Slug filename in `Content-Disposition`
  - 404 (unknown session), 400 (bad format), 401 (no auth)

## Test plan

- [x] `npm run check` clean (typecheck + lint + prettier)
- [x] `npm run test:ci` — 25/25 pass including the new test (`test-pty-reattach` skipped — pre-existing macOS-worktree node-pty native-binding issue, unrelated; CI Linux is fine)
- [ ] Browser UX smoke (manual):
  - [ ] Click Export → dropdown opens; Esc / click-away closes it
  - [ ] Markdown download produces a `.md` with the session name slug
  - [ ] JSONL download produces a `.jsonl` and (if a subagent ran) shows the inline envelopes
  - [ ] Mobile breakpoint hides the Export button entirely

## Notes

- Markdown image attachments render as `*[image: filename]*` placeholders rather than embedding base64 — keeps file size sane; a power user can always grab raw bytes from JSONL.
- One level of subagent recursion only (children of children aren't followed). Rare in practice; v2 if needed.
- Tool-result blockquote cap is hard-coded at 2 KB. If you want it tunable later it's a one-line constant in `session-exporter.ts`.