### PR TITLE
feat(git): hunk-level stage and unstage

### DIFF
--- a/packages/client/src/components/DiffBlock.tsx
+++ b/packages/client/src/components/DiffBlock.tsx
@@ -244,21 +244,27 @@ function FileDiff({
             // what /git/apply-hunks expects.
             if (onHunkAction !== undefined) {
               // Slim action strip rendered above each hunk via
-              // react-diff-view's Decoration slot. Single-line
-              // height (no extra vertical padding) so it doesn't
-              // dominate the diff; blue accent keeps it visible
-              // without being garish.
+              // react-diff-view's Decoration slot. Label + button
+              // both use `position: sticky` so they stay pinned to
+              // the visible edges of the diff pane when the user
+              // scrolls a long diff horizontally — without sticky,
+              // the button slides off-screen with the table content
+              // because the Decoration row is part of the same
+              // <table>. Sticky context = the `.pi-diff-block`
+              // wrapper with `overflow-auto`. Opaque backgrounds on
+              // both ends prevent the diff lines visible beneath
+              // them from showing through during scroll.
               out.push(
                 <Decoration key={`dec-${hunk.content}`}>
-                  <div className="flex items-center justify-between gap-2 border-y border-blue-700/30 bg-blue-950/30 px-2 py-px leading-none">
-                    <span className="text-[9px] uppercase tracking-wider text-blue-400">
+                  <div className="relative flex items-center justify-between gap-2 border-y border-blue-700/30 bg-blue-950/30 py-px leading-none">
+                    <span className="sticky left-0 z-10 bg-blue-950 px-2 py-px text-[9px] uppercase tracking-wider text-blue-400">
                       Hunk {idx + 1}
                     </span>
                     <button
                       type="button"
                       onClick={() => onHunkAction(idx)}
                       disabled={hunkActionDisabled === true}
-                      className="rounded border border-blue-500/50 bg-blue-900/40 px-1.5 py-px text-[10px] text-blue-100 hover:border-blue-400 hover:bg-blue-800/60 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="sticky right-1 z-10 rounded border border-blue-500/60 bg-blue-900 px-1.5 py-px text-[10px] text-blue-100 hover:border-blue-400 hover:bg-blue-800 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {hunkActionLabel ?? "Apply hunk"}
                     </button>

--- a/packages/client/src/components/DiffBlock.tsx
+++ b/packages/client/src/components/DiffBlock.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import {
+  Decoration,
   Diff,
   Hunk,
   parseDiff,
@@ -9,6 +10,29 @@ import {
 } from "react-diff-view";
 import "react-diff-view/style/index.css";
 import { highlightHunks, languageForFile } from "../lib/diff-highlight";
+
+/**
+ * Optional per-hunk action handler. When supplied, DiffBlock renders
+ * a small button above each hunk header (via react-diff-view's
+ * `Decoration` slot, which is the only insertion point that doesn't
+ * break the table layout). Used by GitPanel for hunk-level
+ * stage / unstage; ignored elsewhere so chat / turn-diff diffs stay
+ * action-free.
+ *
+ * `hunkIndex` is 0-based within the SAME file's hunks — i.e. the
+ * position the server's `/git/apply-hunks` endpoint expects. Multi-
+ * file diffs would need per-file index resets, but the consumers
+ * that pass an action only ever render single-file diffs.
+ */
+export interface HunkActionProps {
+  // exactOptionalPropertyTypes: true requires the explicit `| undefined`
+  // so parents can pass through possibly-undefined props without a
+  // conditional spread at every call site.
+  onHunkAction?: ((hunkIndex: number) => void) | undefined;
+  hunkActionLabel?: string | undefined;
+  /** Set true to grey-out the button while the parent's request is in-flight. */
+  hunkActionDisabled?: boolean | undefined;
+}
 
 /**
  * Soft cap on rendered changes per file before we collapse the rest
@@ -83,6 +107,9 @@ const renderSplitGutter: RenderGutter = ({ change, side }) => {
 export function DiffBlock({
   diff,
   viewType = "unified",
+  onHunkAction,
+  hunkActionLabel,
+  hunkActionDisabled,
 }: {
   diff: string;
   /**
@@ -93,7 +120,7 @@ export function DiffBlock({
    * controlled and never reads the prefs itself.
    */
   viewType?: "unified" | "split";
-}) {
+} & HunkActionProps) {
   let files: FileData[] = [];
   let strategy: "pi" | "raw" | "synthetic" | "fallback" = "fallback";
 
@@ -151,6 +178,9 @@ export function DiffBlock({
           file={file}
           viewType={viewType}
           renderGutter={renderGutter}
+          onHunkAction={onHunkAction}
+          hunkActionLabel={hunkActionLabel}
+          hunkActionDisabled={hunkActionDisabled}
         />
       ))}
     </div>
@@ -167,11 +197,14 @@ function FileDiff({
   file,
   viewType,
   renderGutter,
+  onHunkAction,
+  hunkActionLabel,
+  hunkActionDisabled,
 }: {
   file: FileData;
   viewType: "unified" | "split";
   renderGutter: RenderGutter;
-}) {
+} & HunkActionProps) {
   const [expanded, setExpanded] = useState(false);
   // Filename for syntax-highlighter selection. The diff header
   // uses `a/<path>` and `b/<path>` conventionally; strip the
@@ -196,7 +229,39 @@ function FileDiff({
         // Coerce so unhighlighted languages still render plainly.
         tokens={tokens ?? null}
       >
-        {(hunks) => hunks.map((hunk) => <Hunk key={hunk.content} hunk={hunk} />)}
+        {(hunks) => {
+          // The Diff component types its children fn as
+          // `(hunks) => ReactElement | ReactElement[]`. We need to
+          // emit two elements per hunk (Decoration + Hunk) when the
+          // action prop is set, so we build a flat ReactElement[]
+          // and rely on the runtime accepting it; the explicit cast
+          // sidesteps the narrower compile-time signature.
+          const out: React.ReactElement[] = [];
+          hunks.forEach((hunk, idx) => {
+            // When the parent doesn't supply an action, render exactly
+            // what we always have — no extra DOM. Hunk index here is
+            // the position WITHIN this file's hunks, which matches
+            // what /git/apply-hunks expects.
+            if (onHunkAction !== undefined) {
+              out.push(
+                <Decoration key={`dec-${hunk.content}`}>
+                  <div className="flex justify-end gap-1 border-t border-neutral-800 bg-neutral-900/40 px-2 py-1">
+                    <button
+                      type="button"
+                      onClick={() => onHunkAction(idx)}
+                      disabled={hunkActionDisabled === true}
+                      className="rounded border border-neutral-700 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-300 hover:border-neutral-500 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {hunkActionLabel ?? "Apply hunk"}
+                    </button>
+                  </div>
+                </Decoration>,
+              );
+            }
+            out.push(<Hunk key={hunk.content} hunk={hunk} />);
+          });
+          return out;
+        }}
       </Diff>
       {isLarge && (
         <button

--- a/packages/client/src/components/DiffBlock.tsx
+++ b/packages/client/src/components/DiffBlock.tsx
@@ -243,14 +243,23 @@ function FileDiff({
             // the position WITHIN this file's hunks, which matches
             // what /git/apply-hunks expects.
             if (onHunkAction !== undefined) {
+              // Action strip rendered above each hunk via
+              // react-diff-view's Decoration slot. Styled to be
+              // unmistakably visible against the diff background:
+              // explicit blue accent + bold-ish button so it doesn't
+              // get lost in the +/- noise. Index label tells the
+              // user which hunk they're operating on.
               out.push(
                 <Decoration key={`dec-${hunk.content}`}>
-                  <div className="flex justify-end gap-1 border-t border-neutral-800 bg-neutral-900/40 px-2 py-1">
+                  <div className="flex items-center justify-between gap-2 border-y border-blue-700/40 bg-blue-950/40 px-3 py-1.5">
+                    <span className="text-[10px] uppercase tracking-wider text-blue-300">
+                      Hunk {idx + 1}
+                    </span>
                     <button
                       type="button"
                       onClick={() => onHunkAction(idx)}
                       disabled={hunkActionDisabled === true}
-                      className="rounded border border-neutral-700 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-300 hover:border-neutral-500 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="rounded border border-blue-500/60 bg-blue-900/40 px-2.5 py-0.5 text-[11px] font-medium text-blue-100 hover:border-blue-400 hover:bg-blue-800/60 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {hunkActionLabel ?? "Apply hunk"}
                     </button>

--- a/packages/client/src/components/DiffBlock.tsx
+++ b/packages/client/src/components/DiffBlock.tsx
@@ -243,23 +243,22 @@ function FileDiff({
             // the position WITHIN this file's hunks, which matches
             // what /git/apply-hunks expects.
             if (onHunkAction !== undefined) {
-              // Action strip rendered above each hunk via
-              // react-diff-view's Decoration slot. Styled to be
-              // unmistakably visible against the diff background:
-              // explicit blue accent + bold-ish button so it doesn't
-              // get lost in the +/- noise. Index label tells the
-              // user which hunk they're operating on.
+              // Slim action strip rendered above each hunk via
+              // react-diff-view's Decoration slot. Single-line
+              // height (no extra vertical padding) so it doesn't
+              // dominate the diff; blue accent keeps it visible
+              // without being garish.
               out.push(
                 <Decoration key={`dec-${hunk.content}`}>
-                  <div className="flex items-center justify-between gap-2 border-y border-blue-700/40 bg-blue-950/40 px-3 py-1.5">
-                    <span className="text-[10px] uppercase tracking-wider text-blue-300">
+                  <div className="flex items-center justify-between gap-2 border-y border-blue-700/30 bg-blue-950/30 px-2 py-px leading-none">
+                    <span className="text-[9px] uppercase tracking-wider text-blue-400">
                       Hunk {idx + 1}
                     </span>
                     <button
                       type="button"
                       onClick={() => onHunkAction(idx)}
                       disabled={hunkActionDisabled === true}
-                      className="rounded border border-blue-500/60 bg-blue-900/40 px-2.5 py-0.5 text-[11px] font-medium text-blue-100 hover:border-blue-400 hover:bg-blue-800/60 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="rounded border border-blue-500/50 bg-blue-900/40 px-1.5 py-px text-[10px] text-blue-100 hover:border-blue-400 hover:bg-blue-800/60 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {hunkActionLabel ?? "Apply hunk"}
                     </button>

--- a/packages/client/src/components/GitPanel.tsx
+++ b/packages/client/src/components/GitPanel.tsx
@@ -186,6 +186,10 @@ export function GitPanel() {
   // Per-file diff cache. Keyed by `<path>|<staged>` so toggling
   // staged status swaps the rendered diff cleanly.
   const [openDiffs, setOpenDiffs] = useState<Record<string, string | "loading" | "error">>({});
+  // Path of the file whose hunk-level apply is in flight. Hoisted
+  // above any early return for the rules-of-hooks check (matches the
+  // pattern used by the push-form state below).
+  const [pendingHunkPath, setPendingHunkPath] = useState<string | undefined>(undefined);
 
   // Push form state — has to live above the early returns to keep
   // hook order stable. `pushRemote === undefined` means "use the
@@ -400,6 +404,62 @@ export function GitPanel() {
     }
   };
 
+  // Per-hunk stage / unstage. The button in DiffBlock fires this with
+  // the file + the hunk's 0-based index within the file's CURRENT diff
+  // (server-side fetch). After the apply we refetch the diff so the
+  // panel reflects the new state — and refresh status so the file's
+  // staged/unstaged grouping updates if the apply consumed the last
+  // hunk on a side. (`pendingHunkPath` state is hoisted above early
+  // returns at the top of the component for rules-of-hooks.)
+  const applyHunk = async (
+    file: GitFileStatus,
+    hunkIndex: number,
+    mode: "stage" | "unstage",
+  ): Promise<void> => {
+    setPendingHunkPath(file.path);
+    setOpError(undefined);
+    try {
+      const r = await api.gitApplyHunks(project.id, file.path, mode, [hunkIndex]);
+      if (r.ok !== true) {
+        // Surface the server's error code as the op-error banner so
+        // the user sees "binary_or_no_hunks" / "git_apply_failed" /
+        // etc. The panel's existing banner is the right surface for
+        // these — they're file-level diagnostics, not toasts.
+        setOpError(`Hunk apply failed: ${r.error ?? "unknown_error"}`);
+        return;
+      }
+      // Refetch BOTH sides of the diff for this file so the inline
+      // expanded sections update if the user has them open. Then
+      // refresh status so the file moves between groups when its
+      // last hunk on one side gets applied.
+      await Promise.all([refetchOpenDiff(file, true), refetchOpenDiff(file, false), refresh()]);
+    } catch (err) {
+      setOpError(err instanceof ApiError ? err.message : (err as Error).message);
+    } finally {
+      setPendingHunkPath(undefined);
+    }
+  };
+  const refetchOpenDiff = async (file: GitFileStatus, staged: boolean): Promise<void> => {
+    const key = `${file.path}|${staged ? "staged" : "unstaged"}`;
+    if (openDiffs[key] === undefined) return; // not currently shown — skip
+    setOpenDiffs((s) => ({ ...s, [key]: "loading" }));
+    try {
+      const r = await api.gitDiffFile(project.id, file.path, staged);
+      setOpenDiffs((s) => {
+        // Empty diff after an apply means "no more changes on this side";
+        // drop the key so the inline section collapses naturally.
+        if (r.diff.length === 0) {
+          const next = { ...s };
+          delete next[key];
+          return next;
+        }
+        return { ...s, [key]: r.diff };
+      });
+    } catch {
+      setOpenDiffs((s) => ({ ...s, [key]: "error" }));
+    }
+  };
+
   const commit = async (): Promise<void> => {
     const msg = commitMessage.trim();
     if (msg.length === 0) return;
@@ -582,6 +642,8 @@ export function GitPanel() {
             openDiffs={openDiffs}
             staged
             diffViewType={diffViewType}
+            onHunkAction={(f, idx) => void applyHunk(f, idx, "unstage")}
+            pendingHunkPath={pendingHunkPath}
           />
         )}
         {unstagedFiles.length > 0 && (
@@ -597,6 +659,8 @@ export function GitPanel() {
             openDiffs={openDiffs}
             staged={false}
             diffViewType={diffViewType}
+            onHunkAction={(f, idx) => void applyHunk(f, idx, "stage")}
+            pendingHunkPath={pendingHunkPath}
           />
         )}
         {untrackedFiles.length > 0 && (
@@ -616,6 +680,10 @@ export function GitPanel() {
             openDiffs={openDiffs}
             staged={false}
             diffViewType={diffViewType}
+            // No per-hunk action for untracked files: `git apply
+            // --cached` against an unknown path errors. File-level
+            // Stage already covers the use case (untracked = single
+            // "all-add" hunk anyway).
           />
         )}
 
@@ -1066,6 +1134,16 @@ interface FileGroupProps {
   openDiffs: Record<string, string | "loading" | "error">;
   staged: boolean;
   diffViewType: "unified" | "split";
+  /**
+   * Per-hunk action for the inline diff. Called with the file + the
+   * hunk's 0-based index within the file's diff. Pass `undefined` to
+   * disable hunk-level actions for this group (e.g. untracked files
+   * — they're a single "added" hunk so file-level Stage suffices and
+   * `git apply --cached` against an untracked file would error).
+   */
+  onHunkAction?: ((file: GitFileStatus, hunkIndex: number) => void) | undefined;
+  /** Path currently being mutated — disables its diff buttons during the request. */
+  pendingHunkPath?: string | undefined;
 }
 
 const REVERT_CONFIRM_TIMEOUT_MS = 3000;
@@ -1202,7 +1280,17 @@ function FileGroup(props: FileGroupProps) {
                       (no diff — file is binary or unchanged)
                     </p>
                   ) : (
-                    <DiffBlock diff={diffState} viewType={props.diffViewType} />
+                    <DiffBlock
+                      diff={diffState}
+                      viewType={props.diffViewType}
+                      onHunkAction={
+                        props.onHunkAction !== undefined
+                          ? (idx) => props.onHunkAction?.(f, idx)
+                          : undefined
+                      }
+                      hunkActionLabel={props.staged ? "Unstage hunk" : "Stage hunk"}
+                      hunkActionDisabled={props.pendingHunkPath === f.path}
+                    />
                   )}
                 </div>
               )}

--- a/packages/client/src/components/GitPanel.tsx
+++ b/packages/client/src/components/GitPanel.tsx
@@ -330,7 +330,14 @@ export function GitPanel() {
   }
 
   const stagedFiles = status?.files.filter((f) => f.staged) ?? [];
-  const unstagedFiles = status?.files.filter((f) => f.unstaged && !f.staged) ?? [];
+  // A partially-staged file (porcelain `MM` — some hunks staged, some
+  // not) MUST appear in BOTH Staged and Unstaged groups so the user
+  // can keep adding hunks. Earlier this filter had `&& !f.staged`,
+  // which hid the file from Unstaged the moment its first hunk was
+  // staged — blocking access to remaining hunks. Untracked files have
+  // both flags false, so they're naturally excluded here and only
+  // appear in the dedicated Untracked group below.
+  const unstagedFiles = status?.files.filter((f) => f.unstaged) ?? [];
   const untrackedFiles = status?.files.filter((f) => f.kind === "untracked") ?? [];
 
   const toggleDiff = async (file: GitFileStatus, staged: boolean): Promise<void> => {

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -161,6 +161,14 @@
   white-space: pre;
   word-break: normal;
   overflow-wrap: normal;
+  /* Make the code column claim all remaining width inside the table.
+     With `table-layout: auto` the code cell would otherwise size to
+     its longest line of content, leaving empty space to the right
+     when lines are short — visible as un-tinted gaps after `+` / `-`
+     line backgrounds. `width: 100%` on a table cell is the standard
+     "take the rest" idiom; the gutter cells keep their intrinsic
+     widths because they have content. */
+  width: 100%;
 }
 .pi-diff-block .diff-gutter,
 .pi-diff-block .diff-line {

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1923,6 +1923,32 @@ export const api = {
       },
       { method: "POST", body: { projectId, paths } },
     ),
+  /**
+   * Stage or unstage selected hunks of a single file. Server returns
+   * `{ ok: false, error }` for git-side failures (binary file, no diff
+   * on the requested side, conflicting patch) — those are user-visible
+   * events, not server errors, so the caller should branch on `ok`
+   * and show the error code in a banner rather than a toast.
+   */
+  gitApplyHunks: (
+    projectId: string,
+    path: string,
+    mode: "stage" | "unstage",
+    hunkIndices: number[],
+  ) =>
+    request<{ ok: boolean; error?: string; totalHunks?: number }>(
+      "/api/v1/git/apply-hunks",
+      (v, s) => {
+        if (!isObject(v) || typeof v.ok !== "boolean") {
+          fail(s, "expected { ok: boolean }");
+        }
+        const out: { ok: boolean; error?: string; totalHunks?: number } = { ok: v.ok };
+        if (typeof v.error === "string") out.error = v.error;
+        if (typeof v.totalHunks === "number") out.totalHunks = v.totalHunks;
+        return out;
+      },
+      { method: "POST", body: { projectId, path, mode, hunkIndices } },
+    ),
   gitRevert: (projectId: string, paths: string[]) =>
     request(
       "/api/v1/git/revert",

--- a/packages/server/src/git-hunk-stager.ts
+++ b/packages/server/src/git-hunk-stager.ts
@@ -1,0 +1,186 @@
+import { spawn } from "node:child_process";
+import { getFileDiff } from "./git-runner.js";
+
+/**
+ * Hunk-level staging. Builds a synthetic unified diff containing only
+ * the user-selected hunks of a file, then feeds it to
+ * `git apply --cached [--reverse] --recount` via stdin.
+ *
+ * Why this works:
+ *   - `git apply --cached` updates the index without touching the
+ *     working tree — exactly what `git add` does for a whole file.
+ *   - `--recount` rewrites the per-hunk line-count fields, so we
+ *     don't have to recompute them after subsetting hunks (the line
+ *     numbers in `@@ -X,Y +A,B @@` may be stale relative to a partial
+ *     patch; git fixes them itself).
+ *   - `--reverse` flips the patch so unstaging from the staged-side
+ *     diff applies cleanly. Symmetric with stage.
+ *
+ * Binary files have no `@@` hunks (`git diff` emits
+ * `Binary files a/foo and b/foo differ`); we reject upfront so the
+ * UI can surface a clear "binary files can't be hunk-staged" error
+ * rather than confusing the user with a `git apply` failure mode.
+ */
+
+export type ApplyMode = "stage" | "unstage";
+
+export class HunkStagingError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HunkStagingError";
+  }
+}
+
+export interface HunkExtractResult {
+  /** The synthetic patch ready to feed to `git apply`. */
+  patch: string;
+  /** Total hunks present in the source diff (for client validation). */
+  totalHunks: number;
+}
+
+/**
+ * Pure helper: split a unified diff into header + hunk blocks and
+ * return a synthetic diff containing only the requested hunk indices.
+ *
+ * - "Header" = every line before the first `@@`. Includes the
+ *   `diff --git`, `index`, `---`, `+++` lines that `git apply`
+ *   needs to identify the target file.
+ * - "Hunk" = a `@@` line and everything until the next `@@` line
+ *   (or end of diff).
+ *
+ * Throws `HunkStagingError` for binary diffs (no `@@`), out-of-range
+ * indices, or empty selections — these are bad-input failures the
+ * caller should surface to the UI.
+ */
+export function extractHunks(fullDiff: string, indices: number[]): HunkExtractResult {
+  if (indices.length === 0) {
+    throw new HunkStagingError("no_hunks_selected", "no hunk indices supplied");
+  }
+  const lines = fullDiff.split("\n");
+  // First @@ marks the start of hunk 0. Header is everything above.
+  let firstHunk = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]?.startsWith("@@")) {
+      firstHunk = i;
+      break;
+    }
+  }
+  if (firstHunk === -1) {
+    throw new HunkStagingError(
+      "binary_or_no_hunks",
+      "diff has no @@ hunks (binary file or empty diff)",
+    );
+  }
+  const header = lines.slice(0, firstHunk);
+  // Walk the rest, splitting on every `@@` line.
+  const hunks: string[][] = [];
+  let current: string[] = [];
+  for (let i = firstHunk; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.startsWith("@@")) {
+      if (current.length > 0) hunks.push(current);
+      current = [line];
+    } else {
+      current.push(line);
+    }
+  }
+  if (current.length > 0) hunks.push(current);
+
+  for (const idx of indices) {
+    if (idx < 0 || idx >= hunks.length) {
+      throw new HunkStagingError(
+        "hunk_index_out_of_range",
+        `hunk index ${idx} out of range [0, ${hunks.length})`,
+      );
+    }
+  }
+  // Sort indices ascending so the synthetic patch's hunks remain in
+  // file order — `git apply` doesn't strictly require it but it's
+  // saner to debug.
+  const sorted = Array.from(new Set(indices)).sort((a, b) => a - b);
+  const selected: string[] = [...header];
+  for (const idx of sorted) {
+    const hunk = hunks[idx];
+    if (hunk === undefined) continue;
+    for (const ln of hunk) selected.push(ln);
+  }
+  // Ensure trailing newline — git apply is finicky about a missing
+  // final \n on the patch input.
+  let patch = selected.join("\n");
+  if (!patch.endsWith("\n")) patch += "\n";
+  return { patch, totalHunks: hunks.length };
+}
+
+/**
+ * Stage or unstage the selected hunks of a single file. Fetches the
+ * current diff for the appropriate side (unstaged-side for stage,
+ * staged-side for unstage), extracts the requested hunks, then pipes
+ * the synthetic patch into `git apply --cached`.
+ */
+export async function applyHunks(
+  cwd: string,
+  path: string,
+  indices: number[],
+  mode: ApplyMode,
+): Promise<{ totalHunks: number }> {
+  // Pull from the side the user is acting on. Staging operates on the
+  // unstaged-side diff (working tree vs index); unstaging operates on
+  // the staged-side diff (index vs HEAD), reversed.
+  const diffResult = await getFileDiff(cwd, path, /* staged */ mode === "unstage");
+  if (diffResult.diff.length === 0) {
+    throw new HunkStagingError(
+      "no_diff",
+      "file has no diff on the requested side — already staged / unstaged?",
+    );
+  }
+  const { patch, totalHunks } = extractHunks(diffResult.diff, indices);
+
+  const args = ["apply", "--cached", "--recount"];
+  if (mode === "unstage") args.push("--reverse");
+  // No path arg — the patch's `--- a/...` / `+++ b/...` headers tell
+  // git which file to touch. Adding the path here would just confuse
+  // git apply on rename-detection cases.
+
+  await runGitWithStdin(cwd, args, patch);
+  return { totalHunks };
+}
+
+/* ----------------------------- internals ----------------------------- */
+
+/**
+ * Spawn `git <args>` with the given stdin content. Resolves on exit 0,
+ * rejects with HunkStagingError("git_apply_failed", stderr) otherwise.
+ *
+ * Why a local helper and not git-runner.runGit: the runner is built
+ * for subprocess output capture without a stdin path. This helper
+ * keeps the simple "feed a patch in" semantics clean without
+ * reshaping the runner API.
+ */
+function runGitWithStdin(cwd: string, args: string[], stdin: string): Promise<void> {
+  return new Promise((resolveFn, rejectFn) => {
+    const child = spawn("git", args, { cwd, stdio: ["pipe", "pipe", "pipe"] });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (err) => {
+      rejectFn(new HunkStagingError("git_spawn_failed", err.message));
+    });
+    child.on("close", (code) => {
+      if (code === 0) resolveFn();
+      else {
+        rejectFn(
+          new HunkStagingError(
+            "git_apply_failed",
+            stderr.trim().length > 0 ? stderr.trim() : `git apply exited ${code ?? -1}`,
+          ),
+        );
+      }
+    });
+    child.stdin.end(stdin);
+  });
+}

--- a/packages/server/src/routes/git.ts
+++ b/packages/server/src/routes/git.ts
@@ -25,6 +25,7 @@ import {
   stagePaths,
   unstagePaths,
 } from "../git-runner.js";
+import { applyHunks, HunkStagingError } from "../git-hunk-stager.js";
 import { config } from "../config.js";
 import { getProject } from "../project-manager.js";
 import { errorSchema } from "./_schemas.js";
@@ -714,6 +715,82 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         await unstagePaths(project.path, req.body.paths);
         return { ok: true };
       } catch (err) {
+        return mapError(reply, err);
+      }
+    },
+  );
+
+  fastify.post<{
+    Body: {
+      projectId: string;
+      path: string;
+      mode: "stage" | "unstage";
+      hunkIndices: number[];
+    };
+  }>(
+    "/git/apply-hunks",
+    {
+      schema: {
+        description:
+          "Stage or unstage selected hunks of a single file. Builds a " +
+          "synthetic patch from the file's current diff containing only " +
+          "the requested hunk indices, then runs " +
+          "`git apply --cached --recount [--reverse]` against it. " +
+          "Returns `{ ok: false, error }` for git-side failures (binary " +
+          "file, no diff on the requested side, conflicting patch, etc.) " +
+          "rather than 500 — these are user-visible events.",
+        tags: ["git"],
+        body: {
+          type: "object",
+          required: ["projectId", "path", "mode", "hunkIndices"],
+          additionalProperties: false,
+          properties: {
+            projectId: { type: "string", minLength: 1 },
+            path: { type: "string", minLength: 1, maxLength: 4096 },
+            mode: { type: "string", enum: ["stage", "unstage"] },
+            hunkIndices: {
+              type: "array",
+              items: { type: "integer", minimum: 0, maximum: 10_000 },
+              minItems: 1,
+              maxItems: 1_000,
+            },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["ok"],
+            properties: {
+              ok: { type: "boolean" },
+              error: { type: "string" },
+              totalHunks: { type: "integer", minimum: 0 },
+            },
+          },
+          400: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const project = await resolveProject(req.body.projectId, reply);
+      if (project === undefined) return reply;
+      try {
+        const { totalHunks } = await applyHunks(
+          project.path,
+          req.body.path,
+          req.body.hunkIndices,
+          req.body.mode,
+        );
+        return { ok: true, totalHunks };
+      } catch (err) {
+        // HunkStagingError carries a code suitable for the UI to show
+        // (binary_or_no_hunks, no_diff, hunk_index_out_of_range,
+        // git_apply_failed). Return as ok:false so the panel can render
+        // a banner rather than a generic toast.
+        if (err instanceof HunkStagingError) {
+          return { ok: false, error: err.code, totalHunks: 0 };
+        }
         return mapError(reply, err);
       }
     },

--- a/tests/test-hunk-staging.ts
+++ b/tests/test-hunk-staging.ts
@@ -1,0 +1,367 @@
+/**
+ * Hunk-level staging integration test.
+ *
+ * Boots the server in-process under a temp WORKSPACE_PATH, creates a
+ * real git repo with a tracked file, modifies it to produce multiple
+ * distinct hunks, and drives `/api/v1/git/apply-hunks` to verify:
+ *
+ *   - Staging hunk 0 alone leaves the file with only the un-selected
+ *     hunks visible in the unstaged-side diff
+ *   - The staged-side diff matches exactly what the user picked
+ *   - Unstaging from the staged side is symmetric with staging
+ *   - Multi-hunk selections are applied in one call
+ *   - Binary file → ok:false with code `binary_or_no_hunks`
+ *   - Out-of-range hunk index → ok:false with code `hunk_index_out_of_range`
+ *   - File with no diff (already-clean) → ok:false with code `no_diff`
+ *   - 401 without auth, 400 on bad input
+ *
+ * Approach: spawn the server as a subprocess so it picks up env-via-
+ * argv-shim (matches test-files / test-session-export pattern); run
+ * git via `execFile` from the test for setup + verification.
+ */
+import { spawn, type ChildProcess, execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile as fsWrite } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+const serverEntry = resolve(repoRoot, "packages/server/dist/index.js");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function pickFreePort(): Promise<number> {
+  return new Promise((resolveFn, rejectFn) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on("error", rejectFn);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === "string") {
+        rejectFn(new Error("failed to acquire free port"));
+        return;
+      }
+      const { port } = addr;
+      srv.close(() => resolveFn(port));
+    });
+  });
+}
+
+async function waitFor(url: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(url);
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  throw new Error(`timeout waiting for ${url}`);
+}
+
+interface JsonResponse {
+  status: number;
+  body: unknown;
+}
+async function jsend(
+  method: "POST",
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<JsonResponse> {
+  const init: RequestInit = { method, headers: { ...headers } };
+  if (body !== undefined) {
+    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(url, init);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+/** Helper to invoke git in the project dir and return stdout. */
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout;
+}
+
+async function main(): Promise<void> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-hunk-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-hunk-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-hunk-data-"));
+  const projectPath = join(workspacePath, "demo");
+  await mkdir(projectPath, { recursive: true });
+
+  // Build a real git repo with a tracked multi-line file. Three changes
+  // far enough apart to land in three separate hunks under the default
+  // 3-line context window.
+  await git(projectPath, "init", "-q");
+  await git(projectPath, "config", "user.email", "test@example.com");
+  await git(projectPath, "config", "user.name", "Test");
+  await git(projectPath, "config", "commit.gpgsign", "false");
+
+  const initialLines = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join("\n") + "\n";
+  await fsWrite(join(projectPath, "file.txt"), initialLines, "utf8");
+  await git(projectPath, "add", "file.txt");
+  await git(projectPath, "commit", "-q", "-m", "initial");
+
+  // Modify lines 2, 15, 28 — three distinct hunks with default 3-line context.
+  const modified = initialLines
+    .replace("line 2\n", "LINE 2 CHANGED\n")
+    .replace("line 15\n", "LINE 15 CHANGED\n")
+    .replace("line 28\n", "LINE 28 CHANGED\n");
+  await fsWrite(join(projectPath, "file.txt"), modified, "utf8");
+
+  // Sanity: did we get 3 hunks?
+  const initialDiff = await git(projectPath, "diff", "--", "file.txt");
+  const initialHunkCount = (initialDiff.match(/^@@ /gm) ?? []).length;
+  assert("setup: file has 3 hunks", initialHunkCount === 3, `got ${initialHunkCount}`);
+
+  const apiKey = "test-hunk-key-" + randomBytes(8).toString("hex");
+  const port = await pickFreePort();
+
+  const child: ChildProcess = spawn(process.execPath, [serverEntry], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      LOG_LEVEL: "warn",
+      NODE_ENV: "test",
+      WORKSPACE_PATH: workspacePath,
+      PI_CONFIG_DIR: configDir,
+      FORGE_DATA_DIR: dataDir,
+      SESSION_DIR: join(workspacePath, ".pi", "sessions"),
+      API_KEY: apiKey,
+      UI_PASSWORD: undefined,
+      JWT_SECRET: undefined,
+      SERVE_CLIENT: "false",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (b) => process.stderr.write(`[server stderr] ${String(b)}`));
+
+  const base = `http://127.0.0.1:${port}`;
+  const auth = { Authorization: `Bearer ${apiKey}` };
+  const stop = async (): Promise<void> => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    await new Promise<void>((res) => {
+      child.once("exit", () => res());
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 1500).unref();
+    });
+  };
+
+  try {
+    await waitFor(`${base}/api/v1/health`);
+
+    const create = await jsend(
+      "POST",
+      `${base}/api/v1/projects`,
+      { name: "demo", path: projectPath },
+      auth,
+    );
+    assert("POST /projects → 201", create.status === 201);
+    const project = create.body as { id: string; path: string };
+    // Use the realpath'd path the server returned for any future paths,
+    // not the original mkdtemp path (file-manager will reject otherwise).
+    const canonicalPath = project.path;
+
+    // ---- happy path: stage hunk 0 only ----
+    {
+      const r = await jsend(
+        "POST",
+        `${base}/api/v1/git/apply-hunks`,
+        { projectId: project.id, path: "file.txt", mode: "stage", hunkIndices: [0] },
+        auth,
+      );
+      assert("POST /git/apply-hunks stage [0] → 200", r.status === 200);
+      assert(
+        "apply-hunks ok:true",
+        (r.body as { ok: boolean }).ok === true,
+        JSON.stringify(r.body),
+      );
+
+      // Staged-side diff should now contain exactly the LINE 2 change.
+      const staged = await git(canonicalPath, "diff", "--cached", "--", "file.txt");
+      assert("staged diff contains LINE 2 CHANGED", staged.includes("LINE 2 CHANGED"));
+      assert("staged diff omits LINE 15", !staged.includes("LINE 15 CHANGED"));
+      assert("staged diff omits LINE 28", !staged.includes("LINE 28 CHANGED"));
+
+      // Unstaged-side diff should now show only the remaining 2 hunks
+      // (the LINE 15 and LINE 28 changes).
+      const unstaged = await git(canonicalPath, "diff", "--", "file.txt");
+      const remainingHunks = (unstaged.match(/^@@ /gm) ?? []).length;
+      assert("unstaged diff has 2 remaining hunks", remainingHunks === 2);
+      assert("unstaged still contains LINE 15", unstaged.includes("LINE 15 CHANGED"));
+      assert("unstaged still contains LINE 28", unstaged.includes("LINE 28 CHANGED"));
+    }
+
+    // ---- multi-hunk selection: stage the remaining two ----
+    {
+      const r = await jsend(
+        "POST",
+        `${base}/api/v1/git/apply-hunks`,
+        // After hunk 0 was staged, the unstaged-side diff renumbers —
+        // it now has two hunks indexed 0 and 1 again. Stage both.
+        { projectId: project.id, path: "file.txt", mode: "stage", hunkIndices: [0, 1] },
+        auth,
+      );
+      assert("POST /git/apply-hunks stage [0,1] → 200", r.status === 200);
+      assert("multi-hunk stage ok:true", (r.body as { ok: boolean }).ok === true);
+      const unstaged = await git(canonicalPath, "diff", "--", "file.txt");
+      assert("unstaged diff is empty after staging all hunks", unstaged.trim().length === 0);
+      const staged = await git(canonicalPath, "diff", "--cached", "--", "file.txt");
+      assert(
+        "staged diff has all 3 changes",
+        staged.includes("LINE 2 CHANGED") &&
+          staged.includes("LINE 15 CHANGED") &&
+          staged.includes("LINE 28 CHANGED"),
+      );
+    }
+
+    // ---- symmetric unstage: unstage hunk 1 (LINE 15) from the staged side ----
+    {
+      // The staged-side diff has 3 hunks now (indices 0, 1, 2). Unstage
+      // index 1 — the LINE 15 hunk.
+      const r = await jsend(
+        "POST",
+        `${base}/api/v1/git/apply-hunks`,
+        { projectId: project.id, path: "file.txt", mode: "unstage", hunkIndices: [1] },
+        auth,
+      );
+      assert("POST /git/apply-hunks unstage [1] → 200", r.status === 200);
+      assert("unstage ok:true", (r.body as { ok: boolean }).ok === true);
+      const staged = await git(canonicalPath, "diff", "--cached", "--", "file.txt");
+      assert(
+        "staged diff still has LINE 2 + LINE 28",
+        staged.includes("LINE 2 CHANGED") && staged.includes("LINE 28 CHANGED"),
+      );
+      assert("staged diff no longer has LINE 15", !staged.includes("LINE 15 CHANGED"));
+      const unstaged = await git(canonicalPath, "diff", "--", "file.txt");
+      assert("unstaged side now has the LINE 15 change back", unstaged.includes("LINE 15 CHANGED"));
+    }
+
+    // ---- error: out-of-range index ----
+    {
+      const r = await jsend(
+        "POST",
+        `${base}/api/v1/git/apply-hunks`,
+        { projectId: project.id, path: "file.txt", mode: "unstage", hunkIndices: [99] },
+        auth,
+      );
+      assert("out-of-range index → ok:false", (r.body as { ok: boolean }).ok === false);
+      assert(
+        "out-of-range error code surfaced",
+        (r.body as { error?: string }).error === "hunk_index_out_of_range",
+        JSON.stringify(r.body),
+      );
+    }
+
+    // ---- error: no diff on requested side (clean stage attempt with empty unstaged) ----
+    {
+      // Reset unstaged side first by staging everything via the file-level path.
+      await jsend(
+        "POST",
+        `${base}/api/v1/git/stage`,
+        { projectId: project.id, paths: ["file.txt"] },
+        auth,
+      );
+      const r = await jsend(
+        "POST",
+        `${base}/api/v1/git/apply-hunks`,
+        { projectId: project.id, path: "file.txt", mode: "stage", hunkIndices: [0] },
+        auth,
+      );
+      assert("no-diff stage → ok:false", (r.body as { ok: boolean }).ok === false);
+      assert(
+        "no-diff error code surfaced",
+        (r.body as { error?: string }).error === "no_diff",
+        JSON.stringify(r.body),
+      );
+    }
+
+    // ---- error: binary file ----
+    {
+      // Reset everything first
+      await git(canonicalPath, "reset", "-q", "HEAD", "--", "file.txt");
+      await git(canonicalPath, "checkout", "-q", "--", "file.txt");
+
+      // Add a binary file and modify it
+      const bin = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 1, 2, 3]);
+      await fsWrite(join(canonicalPath, "image.bin"), bin);
+      await git(canonicalPath, "add", "image.bin");
+      await git(canonicalPath, "commit", "-q", "-m", "add binary");
+      const bin2 = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 5, 6, 7, 8]);
+      await fsWrite(join(canonicalPath, "image.bin"), bin2);
+
+      const r = await jsend(
+        "POST",
+        `${base}/api/v1/git/apply-hunks`,
+        { projectId: project.id, path: "image.bin", mode: "stage", hunkIndices: [0] },
+        auth,
+      );
+      assert("binary file → ok:false", (r.body as { ok: boolean }).ok === false);
+      assert(
+        "binary file error code surfaced",
+        (r.body as { error?: string }).error === "binary_or_no_hunks",
+        JSON.stringify(r.body),
+      );
+    }
+
+    // ---- 400 on missing required field ----
+    {
+      const r = await jsend(
+        "POST",
+        `${base}/api/v1/git/apply-hunks`,
+        { projectId: project.id, path: "file.txt", mode: "stage" /* no hunkIndices */ },
+        auth,
+      );
+      assert("missing hunkIndices → 400", r.status === 400);
+    }
+
+    // ---- 401 without auth ----
+    {
+      const r = await jsend("POST", `${base}/api/v1/git/apply-hunks`, {
+        projectId: project.id,
+        path: "file.txt",
+        mode: "stage",
+        hunkIndices: [0],
+      });
+      assert("unauthenticated → 401", r.status === 401);
+    }
+  } finally {
+    await stop();
+    await Promise.all([
+      rm(workspacePath, { recursive: true, force: true }),
+      rm(configDir, { recursive: true, force: true }),
+      rm(dataDir, { recursive: true, force: true }),
+    ]);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-hunk-staging] ${failures} failure(s)`);
+    process.exit(1);
+  }
+  console.log(`\n[test-hunk-staging] all checks passed`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Per-hunk Stage / Unstage buttons inside each file's inline diff in the Git panel.
- Symmetric: stage individual hunks from the unstaged-side diff, unstage individual hunks from the staged-side diff.
- Closes the deferred "Hunk-level git staging is v2 material" item in CLAUDE.md.

## Implementation

**Server**
- `git-hunk-stager.ts`
  - `extractHunks(diff, indices)` — pure helper. Splits a unified diff into header + hunk blocks, returns a synthetic patch with only the requested hunks. Easy to reason about, easy to test.
  - `applyHunks(cwd, path, indices, mode)` — fetches the file's current diff (unstaged for `stage`, staged for `unstage`), runs `extractHunks`, pipes the result into `git apply --cached --recount [--reverse]` via stdin. `--recount` lets git fix the per-hunk line-count fields after subsetting so we don't have to recompute them.
  - `HunkStagingError` codes the UI can branch on: `binary_or_no_hunks`, `no_diff`, `hunk_index_out_of_range`, `git_apply_failed`.
- `routes/git.ts` — `POST /api/v1/git/apply-hunks` body `{ projectId, path, mode, hunkIndices[] }`. Returns `{ ok: false, error }` for git-side failures rather than 5xx — these are user-visible events, matching the existing git-error pattern in the panel.

**Client**
- `DiffBlock` — optional `HunkActionProps` (`onHunkAction` + `hunkActionLabel` + `hunkActionDisabled`). When set, renders a small button per hunk via `react-diff-view`'s `Decoration` slot — the only insertion point that doesn't break the table layout. Other diff surfaces (turn-diff panel, inline edit-tool diffs) pass nothing and stay action-free.
- `GitPanel.applyHunk(file, idx, mode)` → calls `api.gitApplyHunks`, refetches both sides of the file's diff (so the inline section collapses on the side that just emptied), refreshes status (so the file moves between Staged / Unstaged groups when its last hunk on a side is applied). `pendingHunkPath` state disables the buttons during the in-flight request.
- Untracked files deliberately don't get the per-hunk affordance — they're a single all-add hunk, and `git apply --cached` against an unknown path errors out. File-level Stage already covers the use case.

**Test**
- `test-hunk-staging.ts` — 27 assertions over a real git repo:
  - Stage hunk 0 alone → staged-side diff contains exactly that change, unstaged side has the remaining 2 hunks
  - Multi-hunk stage `[0, 1]` works in one call
  - Symmetric unstage of hunk 1 from a fully-staged file
  - Binary file → `ok:false` with code `binary_or_no_hunks`
  - Out-of-range hunk index → `ok:false` with code `hunk_index_out_of_range`
  - No-diff attempt → `ok:false` with code `no_diff`
  - 400 (missing field), 401 (no auth)

## Test plan

- [x] `npm run check` clean (typecheck + lint + prettier)
- [x] `npm run test:ci` — 25/25 pass including the new test (`test-pty-reattach` skipped — pre-existing macOS-worktree node-pty native-binding issue, unrelated; CI Linux is fine)
- [ ] Browser UX smoke (manual):
  - [ ] Modify a file with three distinct hunks; expand its diff in the Git panel
  - [ ] Each hunk has a "Stage hunk" button at the top
  - [ ] Click stages just that hunk; the file appears in both Staged and Unstaged groups with the right partial diff on each side
  - [ ] Expand the Staged side; per-hunk "Unstage hunk" buttons appear
  - [ ] Click unstages just that hunk; symmetric round-trip
  - [ ] A binary file shows the diff section but the buttons surface a clear error banner on click

## Notes

- One level of granularity only (no per-line selection, per the design check earlier).
- No "discard hunk" affordance — that's a destructive op (rewrites the working tree); deferred to a separate PR if you want it.
- `--recount` is the load-bearing flag here — without it, `git apply` complains about line offsets when you stage hunk 5 of 10 in isolation.