### PR TITLE
chore(release): v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.2.1] — 2026-05-11
+
 ### Added
 
 - **Cross-session text search.** New search bar at the top of the app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,41 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Added
+
+- **Cross-session text search.** New search bar at the top of the app
+  searches user / assistant message text and tool-call args across every
+  session in every project. ⌘K / Ctrl+K focuses, ↑↓ navigates the
+  dropdown, Enter opens the matched session and scrolls the matched
+  message into view. Server-side `GET /api/v1/search/sessions?q=…`
+  uses ripgrep when available with a Node fallback over
+  `${SESSION_DIR}/**/*.jsonl`. Hidden on mobile. (#109)
+- **Single-conversation export.** New toolbar button in the chat view
+  exports the current session as Markdown (user/assistant headings,
+  fenced bash blocks, blockquoted tool results capped at 2 KB) or raw
+  JSONL (with subagent children inlined between the parent's `subagent`
+  tool call and result, bracketed by synthetic
+  `subagent_inline_start` / `subagent_inline_end` envelopes).
+  `GET /api/v1/sessions/:sessionId/export?format=jsonl|markdown`.
+  Hidden on mobile. (#110)
+- **Hunk-level git staging.** Each hunk in the git panel diff now has an
+  inline Stage / Unstage button on its header row (sticky-positioned so
+  it stays visible during horizontal scroll). Backed by
+  `POST /api/v1/git/apply-hunks`, which feeds a hunk-extracted patch
+  through `git apply --cached --recount [--reverse]`. Closes the
+  Phase 12 deferred item. (#111)
+
+### Changed
+
+- **Docs refresh pass.** README rewrite (245→166 lines) with grouped
+  doc index; AGENTS.md / CLAUDE.md realigned with current architecture
+  (`cli.ts` env↔flag table, `mcp/` manager, per-project override
+  files, `config-export.ts`); new `docs/mobile.md`; `CONTAINERS.md`
+  renamed to `containers.md`; landing quickstart restructured around
+  two install paths (npm vs Docker); pi-subagents card replaces
+  standalone auth card on landing; hero carousel screenshots refreshed
+  and extended to nine slides. (#112)
+
 ## [1.2.0] — 2026-05-09
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "workspaces": [
         "packages/*"
       ],
@@ -16924,7 +16924,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17003,7 +17003,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.74.0",
         "@earendil-works/pi-ai": "0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

v1.2.1 — three new chat-surface features and a docs refresh.

### Added

- **Cross-session text search** (#109) — top-of-app search bar across every session in every project. ⌘K / Ctrl+K, ↑↓ + Enter to jump and scroll the matched message into view. Backed by `GET /api/v1/search/sessions?q=…` (ripgrep with Node fallback). Hidden on mobile.
- **Single-conversation export** (#110) — chat-view toolbar exports the current session as Markdown or raw JSONL (subagent children inlined). `GET /api/v1/sessions/:sessionId/export?format=jsonl|markdown`. Hidden on mobile.
- **Hunk-level git staging** (#111) — inline Stage / Unstage button per hunk in the git diff (sticky-positioned for horizontal scroll). Backed by `POST /api/v1/git/apply-hunks` via `git apply --cached --recount [--reverse]`. Closes the deferred Phase 12 item.

### Changed

- **Docs refresh** (#112) — README rewrite, AGENTS.md realigned with current architecture, new `docs/mobile.md`, `CONTAINERS.md` → `containers.md`, two-path quickstart, refreshed hero carousel screenshots.

## Test plan

- [ ] CI green (`npm run test:ci`)
- [ ] Verify CHANGELOG.md `## [1.2.1] — 2026-05-11` is in place under a fresh empty `## [Unreleased]`
- [ ] Verify `version: 1.2.1` in `package.json`, `packages/server/package.json`, `packages/client/package.json`, `package-lock.json`
- [ ] After merge: `git tag v1.2.1 && git push origin v1.2.1` from main → release workflow builds the multi-arch image and cuts the GitHub release