### PR TITLE
fix(diff): keep multi-digit gutter line numbers on one line

### DIFF
--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -182,6 +182,16 @@
   left: 0;
   z-index: 1;
   background: #0a0a0a;
+  /* Keep multi-digit line numbers on one line. With `table-layout:
+     auto` (set on `.diff` above) the gutter cell shrinks to its
+     content's break-points; without an explicit `nowrap`, browsers
+     can break "16" into "1" / "6" stacked vertically when the cell
+     is sticky-positioned and the table is laid out in a narrow
+     pane. `tabular-nums` keeps the digit widths consistent so the
+     gutter column doesn't jiggle as line numbers cross digit-count
+     boundaries (9→10, 99→100). */
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 .pi-diff-block .diff-decoration {
   background: #171717;


### PR DESCRIPTION
## Summary

Fixes the inline edit-diff visibly rendering taller than the matching git-diff and turn-diff for the same change — the gutter cell was breaking 2- and 3-digit line numbers across multiple visual rows (\`16\` rendered as \`1\` then \`6\` stacked).

## Root cause

Regression from #111. That PR switched \`.pi-diff-block .diff\` from \`table-layout: fixed\` (react-diff-view default) to \`auto\` so the code cell could claim remaining horizontal width via \`width: 100%\`. With \`auto\` layout + \`position: sticky\` on the gutter cell, browsers shrank the gutter to its content's natural break-points and — without \`white-space: nowrap\` — happily wrapped the digits of multi-digit line numbers onto separate visual lines.

## Fix

Two CSS rules on \`.pi-diff-block .diff-gutter\`:

- \`white-space: nowrap\` — guarantees line numbers stay on one line regardless of cell width
- \`font-variant-numeric: tabular-nums\` — keeps digit widths consistent so the gutter column doesn't jiggle horizontally as line numbers cross 9→10 / 99→100 boundaries

Same fix benefits the GitPanel and TurnDiffPanel diffs (they share \`.pi-diff-block\`).

## Test plan

- [ ] Open a session whose edit tool touched a file at line numbers ≥ 10. Verify gutter shows \`16\` on one row, not two
- [ ] Stage a hunk in GitPanel; verify hunk action strip + line numbers still render correctly
- [ ] Open TurnDiffPanel after a multi-edit turn; verify line-number columns are consistent across files
- [ ] Resize the chat pane narrow on desktop; verify the gutter doesn't suddenly start wrapping