### PR TITLE
fix(layout): scope sidebar drawer translate to mobile so modals center

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -520,9 +520,25 @@ export function App() {
           )}
           <ProjectSidebar
             className={
-              "fixed inset-y-0 left-0 z-40 transform shadow-2xl transition-transform duration-200 ease-out " +
-              "md:static md:inset-auto md:z-auto md:transform-none md:shadow-none md:transition-none md:translate-x-0 " +
-              (drawerOpen ? "translate-x-0" : "-translate-x-full")
+              // The drawer-slide translate is scoped with `max-md:` so
+              // it ONLY applies on mobile. Earlier this was an
+              // unscoped `translate-x-0` / `-translate-x-full` plus
+              // `md:transform-none` on top, but `transform-none` does
+              // not beat translate utilities in Tailwind's CSS source
+              // order: the translate's emitted `transform: translateX(
+              // ...)` won at md+, which (a) created a CSS containing
+              // block on the sidebar — squishing every `fixed inset-0`
+              // modal rendered inside it (ProjectPicker, project-delete,
+              // session bulk-delete) into the sidebar's bounding box —
+              // and (b) when we tried clearing it via removing the
+              // `md:translate-x-0` counter, the closed-drawer base
+              // `-translate-x-full` shoved the desktop sidebar off-
+              // screen. `max-md:` on both conditional translates
+              // emits no transform at md+ at all, so neither pathology
+              // triggers and the sidebar lays out in its natural flow.
+              "fixed inset-y-0 left-0 z-40 shadow-2xl transition-transform duration-200 ease-out " +
+              "md:static md:inset-auto md:z-auto md:shadow-none md:transition-none " +
+              (drawerOpen ? "max-md:translate-x-0" : "max-md:-translate-x-full")
             }
           />
           <main className="flex flex-1 overflow-hidden">


### PR DESCRIPTION
## Summary

Modals rendered as descendants of \`ProjectSidebar\` (ProjectPicker / + New Project, project-delete confirm, session bulk-delete confirm) were rendering inside the sidebar's bounding box instead of centering on screen — because the sidebar had a non-\`none\` transform at md+, which CSS treats as a containing block for \`fixed inset-0\` descendants.

## Root cause

Sidebar className had:

\`\`\`
"… transform … " +
"md:… md:transform-none … md:translate-x-0 " +
(drawerOpen ? "translate-x-0" : "-translate-x-full")
\`\`\`

Two compounding issues:

1. \`md:translate-x-0\` emitted a non-\`none\` \`transform: translate3d(0,0,0)\` which beats \`md:transform-none\` in Tailwind's CSS source order. Even an identity transform creates a containing block, so descendant \`fixed inset-0\` modals positioned relative to the sidebar instead of the viewport.
2. Naively removing \`md:translate-x-0\` doesn't work — the closed-drawer base \`-translate-x-full\` then shoves the entire desktop sidebar off-screen, since \`transform-none\` likewise doesn't beat \`-translate-x-full\` in source order.

## Fix

Scope both conditional translates with \`max-md:\` so they only apply below the md breakpoint. At md+ no transform utility is emitted on this element at all — the sidebar lays out naturally and modal descendants resolve \`fixed inset-0\` against the viewport. Mobile drawer animation still works because the translates apply where they should.

Removed the now-redundant bare \`transform\` and \`md:transform-none\` classes (translate utilities self-apply transform in Tailwind v3+, and neither was doing useful work after the fix).

## Test plan

- [ ] Click **+ New** in the sidebar header → ProjectPicker modal centers on screen, not inside the sidebar
- [ ] Click × on a project → project-delete modal centers
- [ ] Multi-select two sessions → click bulk **Delete** → confirm modal centers
- [ ] Resize the window narrow (< 768px) → sidebar disappears, hamburger appears, drawer slides in/out smoothly
- [ ] Resize back to desktop → sidebar reappears in normal flow