### PR TITLE
chore(release): v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.2.2] — 2026-05-11
+
 ### Fixed
 
 - **Inline edit-diff gutter line numbers no longer wrap.** Multi-digit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,44 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Inline edit-diff gutter line numbers no longer wrap.** Multi-digit
+  line numbers in the chat's inline edit-tool diff (e.g. `16`, `100`)
+  rendered as digits stacked vertically (`1` over `6`) when the gutter
+  cell got compressed under `table-layout: auto`, making the inline
+  view visibly taller than the matching git-diff and turn-diff for
+  the same change. Adds `white-space: nowrap` and
+  `font-variant-numeric: tabular-nums` to `.pi-diff-block .diff-gutter`.
+  Same fix benefits GitPanel and TurnDiffPanel since they share the
+  scope. (#115)
+- **Per-row session delete swaps the modal for inline click-to-confirm.**
+  Single-row delete on a session now uses a two-click pattern: first ×
+  click arms the row (icon flips to a red-outlined `Confirm` button);
+  second click within 3 s actually deletes. Click anywhere else,
+  Escape, or the auto-disarm timer cancel without deleting. Bulk-
+  delete (multi-select toolbar) keeps the existing confirm modal
+  because the count-of-N context is part of the prompt. Sidesteps the
+  modal-centering regression for the common case AND reduces sidebar-
+  flow interruption. (#116)
+- **Sidebar modals (ProjectPicker, project-delete, session bulk-
+  delete) center on screen again.** A non-`none` transform on the
+  sidebar at md+ — emitted by the `md:translate-x-0` counter that was
+  trying to neutralize the mobile drawer-slide — was creating a CSS
+  containing block, so every `fixed inset-0` modal rendered as a
+  descendant of the sidebar got positioned inside the sidebar's
+  bounding box instead of against the viewport. Visually: modals
+  "squished into the session browser." Fix scopes the drawer
+  translate to `max-md:` so no transform is emitted at md+ at all.
+  (#117)
+
+### Changed
+
+- **Hero carousel images refreshed.** img0, img1, and img2-6 now
+  share a consistent 4112×2580 (~16:10) aspect ratio. img1 was
+  previously stale from before the recent in-session diff render
+  fixes. (#114, #118, #119)
+
 ## [1.2.1] — 2026-05-11
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "workspaces": [
         "packages/*"
       ],
@@ -16924,7 +16924,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17003,7 +17003,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.74.0",
         "@earendil-works/pi-ai": "0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

v1.2.2 — three UI regression fixes plus refreshed hero carousel images.

### Fixed

- **Inline edit-diff gutter line numbers no longer wrap** (#115) — multi-digit line numbers (e.g. \`16\`, \`100\`) were rendering as digits stacked vertically because the gutter cell shrank to its content's break-points under \`table-layout: auto\`. Adds \`white-space: nowrap\` + \`tabular-nums\` to \`.pi-diff-block .diff-gutter\`.
- **Per-row session delete swaps modal for inline click-to-confirm** (#116) — first × click arms the row (icon flips to red-outlined \`Confirm\`); second click within 3 s actually deletes. Esc / outside click / 3 s timer cancel. Bulk-delete keeps its modal.
- **Sidebar modals center on screen again** (#117) — a non-\`none\` transform on the sidebar at md+ was creating a CSS containing block, so \`fixed inset-0\` modal descendants got squished into the sidebar's bounding box. Scopes the drawer translate to \`max-md:\` so no transform is emitted at md+.

### Changed

- **Hero carousel screenshots refreshed** (#114, #118, #119) — img0 + img1 updated to share the carousel's 4112×2580 (~16:10) aspect ratio. \`docs/site/\` rebuilt so the deployed Pages site picks them up.

## Test plan

- [ ] CI green (\`npm run test:ci\`)
- [ ] CHANGELOG.md \`## [1.2.2] — 2026-05-11\` is in place under a fresh empty \`## [Unreleased]\`
- [ ] \`version: 1.2.2\` in \`package.json\`, \`packages/server/package.json\`, \`packages/client/package.json\`, \`package-lock.json\`
- [ ] After merge: \`git tag v1.2.2 && git push origin v1.2.2\` from main → release workflow builds the multi-arch image and cuts the GitHub release