### PR TITLE
feat(agent): per-project system prompt addendum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ tmp/
 # Git worktrees (in-tree convention: `git worktree add .worktrees/<branch>`)
 .worktrees/
 
+# Claude Code harness state (auto-created worktrees, transcripts, etc.)
+.claude/
+
 # Local working notes (not committed)
 notes/
 pi-webui-dev-plan.md

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -28,6 +28,7 @@ type Tab =
   | "tools"
   | "skills"
   | "prompts"
+  | "systemPrompt"
   | "appearance"
   | "backup"
   | "general";
@@ -74,7 +75,15 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           // deployments often want to disable bash/edit/write at the
           // tool level, regardless of what providers / agent settings
           // are exposed.
-          (["skills", "prompts", "tools", "appearance", "backup", "general"] as const)
+          ([
+            "skills",
+            "prompts",
+            "systemPrompt",
+            "tools",
+            "appearance",
+            "backup",
+            "general",
+          ] as const)
         : ([
             "providers",
             "agent",
@@ -82,6 +91,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
             "tools",
             "skills",
             "prompts",
+            "systemPrompt",
             "appearance",
             "backup",
             "general",
@@ -143,11 +153,13 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
                           ? "Skills"
                           : t === "prompts"
                             ? "Prompts"
-                            : t === "appearance"
-                              ? "Appearance"
-                              : t === "backup"
-                                ? "Backup"
-                                : "General"}
+                            : t === "systemPrompt"
+                              ? "System Prompt"
+                              : t === "appearance"
+                                ? "Appearance"
+                                : t === "backup"
+                                  ? "Backup"
+                                  : "General"}
               </button>
             ))}
           </div>
@@ -197,6 +209,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           {tab === "tools" && <ToolsTab onError={setError} />}
           {tab === "skills" && <SkillsTab onError={setError} />}
           {tab === "prompts" && <PromptsTab onError={setError} />}
+          {tab === "systemPrompt" && <SystemPromptTab onError={setError} />}
           {tab === "appearance" && <AppearanceTab />}
           {tab === "backup" && <BackupTab onError={setError} />}
           {tab === "general" && <GeneralTab />}
@@ -1744,6 +1757,172 @@ function ToolCascadeRow({
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+// ---------------- System Prompt tab ----------------
+
+/**
+ * Per-project addendum appended to the agent's base system prompt
+ * via pi's `appendSystemPrompt` extension hook. Pi's base prompt
+ * defines the tool-calling protocol — REPLACING it would break
+ * tool use, so this surface is APPEND-only. Changes take effect on
+ * the NEXT session created in the project; already-running sessions
+ * keep the prompt they were built with.
+ */
+function SystemPromptTab({ onError }: { onError: (msg: string | undefined) => void }) {
+  const project = useActiveProject();
+  const [addendum, setAddendum] = useState<string | undefined>(undefined);
+  const [draft, setDraft] = useState("");
+  const [maxBytes, setMaxBytes] = useState(20_000);
+  const [busy, setBusy] = useState(false);
+  const [savedMsg, setSavedMsg] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (project === undefined) {
+      setAddendum(undefined);
+      setDraft("");
+      return;
+    }
+    let cancelled = false;
+    onError(undefined);
+    void (async () => {
+      try {
+        const res = await api.getProjectSystemPrompt(project.id);
+        if (cancelled) return;
+        setAddendum(res.addendum);
+        setDraft(res.addendum);
+        setMaxBytes(res.maxBytes);
+      } catch (err) {
+        if (cancelled) return;
+        onError(`Failed to load system prompt: ${errorCode(err)}`);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [project?.id]);
+
+  if (project === undefined) {
+    return (
+      <p className="text-xs italic text-neutral-500">
+        Pick a project from the header to edit its system prompt addendum.
+      </p>
+    );
+  }
+  if (addendum === undefined) {
+    return (
+      <p className="text-xs italic text-neutral-500">Loading system prompt for {project.name}…</p>
+    );
+  }
+
+  const byteLen = new Blob([draft]).size;
+  const overBudget = byteLen > maxBytes;
+  const dirty = draft !== addendum;
+
+  const save = async (): Promise<void> => {
+    if (overBudget) return;
+    setBusy(true);
+    setSavedMsg(undefined);
+    onError(undefined);
+    try {
+      const res = await api.setProjectSystemPrompt(project.id, draft);
+      setAddendum(res.addendum);
+      setDraft(res.addendum);
+      setMaxBytes(res.maxBytes);
+      setSavedMsg("Saved. Applies to the next session you start in this project.");
+      window.setTimeout(() => setSavedMsg(undefined), 4_000);
+    } catch (err) {
+      onError(`Save failed: ${errorCode(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clear = async (): Promise<void> => {
+    if (!confirm(`Clear the system prompt addendum for "${project.name}"?`)) return;
+    setBusy(true);
+    setSavedMsg(undefined);
+    onError(undefined);
+    try {
+      const res = await api.setProjectSystemPrompt(project.id, "");
+      setAddendum(res.addendum);
+      setDraft(res.addendum);
+      setMaxBytes(res.maxBytes);
+      setSavedMsg("Cleared. Applies to the next session you start in this project.");
+      window.setTimeout(() => setSavedMsg(undefined), 4_000);
+    } catch (err) {
+      onError(`Clear failed: ${errorCode(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1 text-xs text-neutral-400">
+        <p>
+          Free-form text appended to the agent's base system prompt for sessions in{" "}
+          <strong className="text-neutral-200">{project.name}</strong>. Use this to layer
+          project-specific behavior on top of pi's defaults — coding conventions, domain context,
+          persona, etc.
+        </p>
+        <p className="text-[11px]">
+          Append-only — the base prompt (which defines the tool-calling protocol) is not editable.
+          Changes apply to the <strong>next session</strong> you start in this project; running
+          sessions keep the prompt they were built with.
+        </p>
+      </div>
+
+      <textarea
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        disabled={busy}
+        rows={14}
+        spellCheck={false}
+        placeholder="e.g. This project uses TypeScript strict mode and never uses default exports. Always run `npm run check` before declaring a task complete."
+        className="w-full resize-y rounded border border-neutral-800 bg-neutral-900 px-3 py-2 font-mono text-xs leading-relaxed text-neutral-100 placeholder:text-neutral-600 focus:border-neutral-600 focus:outline-none disabled:opacity-50"
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-2 text-[11px]">
+        <span className={overBudget ? "text-red-400" : "text-neutral-500"}>
+          {byteLen.toLocaleString()} / {maxBytes.toLocaleString()} bytes
+          {overBudget && " — too long, please trim before saving"}
+        </span>
+        <div className="flex items-center gap-2">
+          {savedMsg !== undefined && <span className="text-green-400">{savedMsg}</span>}
+          {dirty && (
+            <button
+              type="button"
+              onClick={() => setDraft(addendum)}
+              disabled={busy}
+              className="rounded border border-neutral-800 px-3 py-1 text-xs text-neutral-300 hover:border-neutral-600 disabled:opacity-50"
+            >
+              Revert
+            </button>
+          )}
+          {addendum.length > 0 && (
+            <button
+              type="button"
+              onClick={() => void clear()}
+              disabled={busy}
+              className="rounded border border-neutral-800 px-3 py-1 text-xs text-neutral-300 hover:border-red-500 hover:text-red-300 disabled:opacity-50"
+            >
+              Clear
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={busy || overBudget || !dirty}
+            className="rounded bg-neutral-100 px-3 py-1 text-xs font-medium text-neutral-900 hover:bg-white disabled:opacity-50"
+          >
+            {busy ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1126,6 +1126,27 @@ export const api = {
     const qs = path !== undefined ? `?path=${encodeURIComponent(path)}` : "";
     return request(`/api/v1/projects/browse${qs}`, vBrowse);
   },
+  getProjectSystemPrompt: (id: string) =>
+    request(
+      `/api/v1/projects/${encodeURIComponent(id)}/system-prompt`,
+      (v, s): { addendum: string; maxBytes: number } => {
+        if (!isObject(v) || typeof v.addendum !== "string" || typeof v.maxBytes !== "number") {
+          fail(s, "expected { addendum: string, maxBytes: number }");
+        }
+        return { addendum: v.addendum, maxBytes: v.maxBytes };
+      },
+    ),
+  setProjectSystemPrompt: (id: string, addendum: string) =>
+    request(
+      `/api/v1/projects/${encodeURIComponent(id)}/system-prompt`,
+      (v, s): { addendum: string; maxBytes: number } => {
+        if (!isObject(v) || typeof v.addendum !== "string" || typeof v.maxBytes !== "number") {
+          fail(s, "expected { addendum: string, maxBytes: number }");
+        }
+        return { addendum: v.addendum, maxBytes: v.maxBytes };
+      },
+      { method: "PUT", body: { addendum } },
+    ),
   mkdir: (parentPath: string, name: string) =>
     request("/api/v1/projects/browse/mkdir", vMkdir, {
       method: "POST",

--- a/packages/server/src/agent-resource-loader.ts
+++ b/packages/server/src/agent-resource-loader.ts
@@ -48,6 +48,7 @@ import {
 import { config } from "./config.js";
 import { getProjectDisabledSkillNames } from "./skill-overrides.js";
 import { getProjectDisabledPromptNames } from "./prompt-overrides.js";
+import { getProjectSystemPromptAddendum } from "./system-prompt-overrides.js";
 
 /**
  * Plain string (not a backtick template) so what's stored is exactly
@@ -97,13 +98,21 @@ export async function buildForgeResourceLoader(
   projectId?: string,
 ): Promise<ResourceLoader> {
   const appendSystemPrompt = config.agentSecretHygieneRule ? [FORGE_SECRET_HYGIENE_RULE] : [];
-  const [disabledSkills, disabledPrompts] =
+  const [disabledSkills, disabledPrompts, projectAddendum] =
     projectId !== undefined
       ? await Promise.all([
           getProjectDisabledSkillNames(projectId),
           getProjectDisabledPromptNames(projectId),
+          getProjectSystemPromptAddendum(projectId),
         ])
-      : [new Set<string>(), new Set<string>()];
+      : [new Set<string>(), new Set<string>(), ""];
+  // Per-project user-authored addendum lands AFTER the secret-hygiene
+  // rule so any operator-set behavioral baseline appears first, with
+  // the user's project-scoped customizations following — mirrors how
+  // most layered-prompt systems compose (system → org → project).
+  if (projectAddendum.length > 0) {
+    appendSystemPrompt.push(projectAddendum);
+  }
   const baseOptions = {
     cwd,
     agentDir,

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -222,6 +222,16 @@ export const config = Object.freeze({
    */
   promptOverridesFile: join(FORGE_DATA_DIR, "prompts-overrides.json"),
   /**
+   * Path to the forge-private per-project system-prompt addendum file.
+   * Each project can store a free-form text block that is appended
+   * to the agent's base system prompt (via pi's `appendSystemPrompt`
+   * extension hook) for every session created in that project. Pi's
+   * base prompt defines the tool-calling protocol — REPLACING it
+   * would break tool use, so this is APPEND-only. Same data-dir
+   * placement rationale as the other override files.
+   */
+  systemPromptOverridesFile: join(FORGE_DATA_DIR, "system-prompt-overrides.json"),
+  /**
    * Whether `/api/docs` (Swagger UI + OpenAPI JSON spec) is reachable.
    * Defaults to true so Docker / production deploys keep working without
    * extra config (the README quickstart documents `/api/docs`). When

--- a/packages/server/src/project-manager.ts
+++ b/packages/server/src/project-manager.ts
@@ -14,6 +14,7 @@ import { randomUUID } from "node:crypto";
 import { config } from "./config.js";
 import { clearProjectOverrides as clearProjectSkillOverrides } from "./skill-overrides.js";
 import { clearProjectPromptOverrides } from "./prompt-overrides.js";
+import { clearProjectSystemPromptAddendum } from "./system-prompt-overrides.js";
 
 /**
  * Project ids are always `randomUUID()` output. Mirrors the same
@@ -262,6 +263,9 @@ export async function deleteProject(
   });
   await clearProjectPromptOverrides(id).catch((err: unknown) => {
     warn({ err, id }, "prompt-overrides cleanup failed");
+  });
+  await clearProjectSystemPromptAddendum(id).catch((err: unknown) => {
+    warn({ err, id }, "system-prompt-overrides cleanup failed");
   });
   if (opts.cascadeSessionDir === true) {
     // Wipe the project's session directory. Best-effort — a missing

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -14,6 +14,11 @@ import {
   readProjects,
   renameProject,
 } from "../project-manager.js";
+import {
+  getProjectSystemPromptAddendum,
+  MAX_ADDENDUM_BYTES,
+  setProjectSystemPromptAddendum,
+} from "../system-prompt-overrides.js";
 import { errorSchema } from "./_schemas.js";
 
 const projectSchema = {
@@ -264,6 +269,95 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
       } catch (err) {
         return handleError(reply, err);
       }
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/projects/:id/system-prompt",
+    {
+      schema: {
+        description:
+          "Return the project's system-prompt addendum — free-form text " +
+          "appended to the agent's base system prompt for every session in " +
+          "this project. Empty string when no addendum is set. The base " +
+          "prompt (pi's tool-calling protocol) is NOT exposed or editable; " +
+          "this is APPEND-only.",
+        tags: ["projects"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["addendum", "maxBytes"],
+            properties: {
+              addendum: { type: "string" },
+              maxBytes: { type: "integer" },
+            },
+          },
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const project = await getProject(req.params.id);
+      if (!project) return reply.code(404).send({ error: "project_not_found" });
+      const addendum = await getProjectSystemPromptAddendum(req.params.id);
+      return { addendum, maxBytes: MAX_ADDENDUM_BYTES };
+    },
+  );
+
+  fastify.put<{ Params: { id: string }; Body: { addendum: string } }>(
+    "/projects/:id/system-prompt",
+    {
+      schema: {
+        description:
+          "Replace the project's system-prompt addendum. Pass an empty " +
+          "string (or whitespace-only) to clear the addendum. Takes effect " +
+          "on the NEXT session created in this project — already-running " +
+          "sessions keep the prompt they were built with.",
+        tags: ["projects"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          required: ["addendum"],
+          additionalProperties: false,
+          properties: {
+            addendum: { type: "string", maxLength: MAX_ADDENDUM_BYTES },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["addendum", "maxBytes"],
+            properties: {
+              addendum: { type: "string" },
+              maxBytes: { type: "integer" },
+            },
+          },
+          400: errorSchema,
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const project = await getProject(req.params.id);
+      if (!project) return reply.code(404).send({ error: "project_not_found" });
+      // Belt-and-suspenders: schema enforces maxLength at the character
+      // level, but multi-byte input could in principle exceed the byte
+      // cap. Reject explicitly so the persisted file is bounded.
+      if (Buffer.byteLength(req.body.addendum, "utf8") > MAX_ADDENDUM_BYTES) {
+        return reply.code(400).send({ error: "addendum_too_large" });
+      }
+      await setProjectSystemPromptAddendum(req.params.id, req.body.addendum);
+      const addendum = await getProjectSystemPromptAddendum(req.params.id);
+      return { addendum, maxBytes: MAX_ADDENDUM_BYTES };
     },
   );
 

--- a/packages/server/src/system-prompt-overrides.ts
+++ b/packages/server/src/system-prompt-overrides.ts
@@ -1,0 +1,126 @@
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { chmodSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+import { config } from "./config.js";
+
+/**
+ * pi-forge-private per-project system-prompt addendum at
+ * `${FORGE_DATA_DIR}/system-prompt-overrides.json`. Each project can
+ * store a free-form text block that is appended (via pi's
+ * `appendSystemPrompt` extension hook) to the agent's base system
+ * prompt for every session created in that project. Pi's base prompt
+ * defines the tool-calling protocol — REPLACING it would break tool
+ * use, so this surface is APPEND-only, the same hook
+ * `FORGE_SECRET_HYGIENE_RULE` rides through.
+ *
+ * Lives in the data dir for the same reasons skill-overrides does:
+ * install-private, not team-shared; pi's SDK has no per-project
+ * concept here so we can't safely co-tenant with `settings.json`.
+ *
+ * Single file (vs a dir of per-project files): matches the
+ * skill/tool/prompt-overrides shape — one atomic write, one read
+ * at session create.
+ */
+
+interface SystemPromptOverrides {
+  /** Map from projectId → that project's addendum text. */
+  projects: Record<string, string>;
+}
+
+/** Hard cap on the stored addendum. Keeps a runaway paste from
+ * silently bloating every system prompt by tens of KB and matches
+ * what users will realistically write (a paragraph or two). The
+ * route layer enforces the same cap so the wire surface fails
+ * fast with 400 rather than persisting unbounded text. */
+export const MAX_ADDENDUM_BYTES = 20_000;
+
+async function ensureDir(): Promise<void> {
+  await mkdir(dirname(config.systemPromptOverridesFile), { recursive: true });
+}
+
+async function atomicWrite(data: SystemPromptOverrides): Promise<void> {
+  await ensureDir();
+  const path = config.systemPromptOverridesFile;
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+  try {
+    chmodSync(tmp, 0o600);
+  } catch {
+    // best-effort
+  }
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
+}
+
+async function readAll(): Promise<SystemPromptOverrides> {
+  try {
+    const raw = await readFile(config.systemPromptOverridesFile, "utf8");
+    if (raw.trim().length === 0) return { projects: {} };
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null || !("projects" in parsed)) {
+      return { projects: {} };
+    }
+    const projects = (parsed as { projects?: unknown }).projects;
+    if (typeof projects !== "object" || projects === null) return { projects: {} };
+    const out: SystemPromptOverrides = { projects: {} };
+    for (const [pid, val] of Object.entries(projects as Record<string, unknown>)) {
+      if (typeof val !== "string") continue;
+      out.projects[pid] = val;
+    }
+    return out;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return { projects: {} };
+    throw err;
+  }
+}
+
+/**
+ * Return the project's saved addendum, or an empty string if the
+ * project has no override. Empty string and "no entry at all" are
+ * intentionally collapsed — the wire surface treats both as "no
+ * addendum to append" and there is no third tri-state to preserve.
+ */
+export async function getProjectSystemPromptAddendum(projectId: string): Promise<string> {
+  const cur = await readAll();
+  return cur.projects[projectId] ?? "";
+}
+
+/**
+ * Set the project's addendum. Passing an empty string (or a string
+ * that trims to empty) clears the entry so the file doesn't grow
+ * with effectively-empty keys after a user clears the textbox.
+ *
+ * Caller is responsible for length validation — the route layer does
+ * this against `MAX_ADDENDUM_BYTES` before writing.
+ */
+export async function setProjectSystemPromptAddendum(
+  projectId: string,
+  text: string,
+): Promise<void> {
+  const cur = await readAll();
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    if (cur.projects[projectId] === undefined) return;
+    delete cur.projects[projectId];
+  } else {
+    cur.projects[projectId] = text;
+  }
+  await atomicWrite(cur);
+}
+
+/**
+ * Drop the project's addendum entry — called from the project
+ * delete path so the overrides file doesn't accumulate orphaned
+ * entries after a project is removed.
+ */
+export async function clearProjectSystemPromptAddendum(projectId: string): Promise<void> {
+  const cur = await readAll();
+  if (cur.projects[projectId] === undefined) return;
+  delete cur.projects[projectId];
+  await atomicWrite(cur);
+}

--- a/tests/test-system-prompt.ts
+++ b/tests/test-system-prompt.ts
@@ -1,0 +1,256 @@
+/**
+ * Per-project system-prompt addendum integration test.
+ *
+ * Verifies:
+ *   - GET / PUT /projects/:id/system-prompt round-trip
+ *   - Empty string clears the entry on disk (doesn't grow the file)
+ *   - Byte-cap rejection at the route layer (400)
+ *   - Unknown projectId → 404 on both GET and PUT
+ *   - Cascade-delete: deleting a project removes its addendum entry
+ *   - End-to-end wiring: the addendum reaches AgentSession.systemPrompt
+ *     via pi's `appendSystemPrompt` extension hook (no live LLM call —
+ *     just the SDK's `systemPrompt` getter, which is built from the
+ *     ResourceLoader output that buildForgeResourceLoader feeds in).
+ */
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+interface JsonResponse {
+  status: number;
+  body: unknown;
+}
+
+async function jget(base: string, path: string): Promise<JsonResponse> {
+  const res = await fetch(`${base}${path}`);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function jsend(
+  base: string,
+  method: "POST" | "PUT" | "PATCH" | "DELETE",
+  path: string,
+  body?: unknown,
+): Promise<JsonResponse> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(`${base}${path}`, init);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function main(): Promise<void> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-sysp-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-sysp-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-sysp-data-"));
+  process.env.WORKSPACE_PATH = workspacePath;
+  process.env.PI_CONFIG_DIR = configDir;
+  process.env.FORGE_DATA_DIR = dataDir;
+  process.env.SESSION_DIR = join(workspacePath, ".pi", "sessions");
+  process.env.NODE_ENV = "test";
+  delete process.env.UI_PASSWORD;
+  delete process.env.JWT_SECRET;
+  delete process.env.API_KEY;
+  // Keep the secret-hygiene rule out of the picture so byte counting
+  // doesn't have to account for two append entries.
+  delete process.env.AGENT_SECRET_HYGIENE_RULE;
+
+  console.log(`[test-system-prompt] WORKSPACE_PATH=${workspacePath}`);
+  console.log(`[test-system-prompt] PI_CONFIG_DIR=${configDir}`);
+  console.log(`[test-system-prompt] FORGE_DATA_DIR=${dataDir}`);
+
+  const serverModule = (await import(
+    resolve(repoRoot, "packages/server/dist/index.js")
+  )) as unknown as {
+    buildServer: () => Promise<{
+      listen: (opts: { port: number; host: string }) => Promise<string>;
+      close: () => Promise<void>;
+    }>;
+  };
+  const registryModule = (await import(
+    resolve(repoRoot, "packages/server/dist/session-registry.js")
+  )) as unknown as {
+    createSession: (
+      projectId: string,
+      workspacePath: string,
+    ) => Promise<{
+      sessionId: string;
+      session: { systemPrompt: string };
+    }>;
+    disposeSession: (id: string) => Promise<void>;
+  };
+
+  const fastify = await serverModule.buildServer();
+  const base = await fastify.listen({ port: 0, host: "127.0.0.1" });
+
+  try {
+    // 1. Create a project to scope the addendum to.
+    const proj = await jsend(base, "POST", "/api/v1/projects", {
+      name: "test-system-prompt",
+      path: workspacePath,
+    });
+    assert("create project → 201", proj.status === 201);
+    const projectId = (proj.body as { id: string }).id;
+
+    // 2. GET on a fresh project returns an empty addendum + the cap.
+    {
+      const r = await jget(base, `/api/v1/projects/${projectId}/system-prompt`);
+      assert("GET fresh project → 200", r.status === 200);
+      const body = r.body as { addendum: string; maxBytes: number };
+      assert("  addendum is empty string", body.addendum === "");
+      assert(
+        "  maxBytes is a positive integer",
+        Number.isInteger(body.maxBytes) && body.maxBytes > 0,
+        JSON.stringify(body),
+      );
+    }
+
+    // 3. PUT a non-empty addendum.
+    const SAMPLE =
+      "This project uses TypeScript strict mode. Prefer named exports over default exports.";
+    {
+      const r = await jsend(base, "PUT", `/api/v1/projects/${projectId}/system-prompt`, {
+        addendum: SAMPLE,
+      });
+      assert("PUT addendum → 200", r.status === 200);
+      const body = r.body as { addendum: string };
+      assert("  echoed addendum matches input", body.addendum === SAMPLE);
+    }
+
+    // 4. GET reads what was written.
+    {
+      const r = await jget(base, `/api/v1/projects/${projectId}/system-prompt`);
+      assert("GET after write → 200", r.status === 200);
+      const body = r.body as { addendum: string };
+      assert("  persisted addendum matches", body.addendum === SAMPLE);
+    }
+
+    // 5. On-disk file shape.
+    {
+      const raw = await readFile(join(dataDir, "system-prompt-overrides.json"), "utf8");
+      const parsed = JSON.parse(raw) as { projects: Record<string, string> };
+      assert("  on-disk file has projects map", parsed.projects[projectId] === SAMPLE);
+    }
+
+    // 6. The addendum actually reaches the agent's system prompt.
+    {
+      const live = await registryModule.createSession(projectId, workspacePath);
+      try {
+        const sp = live.session.systemPrompt;
+        assert(
+          "  AgentSession.systemPrompt contains the addendum",
+          typeof sp === "string" && sp.includes(SAMPLE),
+          `len=${sp.length}; ends='${sp.slice(-200)}'`,
+        );
+      } finally {
+        await registryModule.disposeSession(live.sessionId);
+      }
+    }
+
+    // 7. Empty string clears the entry (file no longer mentions this project).
+    {
+      const r = await jsend(base, "PUT", `/api/v1/projects/${projectId}/system-prompt`, {
+        addendum: "",
+      });
+      assert("PUT empty addendum → 200", r.status === 200);
+      const body = r.body as { addendum: string };
+      assert("  echoed addendum is empty after clear", body.addendum === "");
+      const raw = await readFile(join(dataDir, "system-prompt-overrides.json"), "utf8");
+      const parsed = JSON.parse(raw) as { projects: Record<string, string> };
+      assert(
+        "  cleared project absent from on-disk file",
+        parsed.projects[projectId] === undefined,
+        JSON.stringify(parsed),
+      );
+    }
+
+    // 8. Whitespace-only is treated as empty (no stored entry).
+    {
+      const r = await jsend(base, "PUT", `/api/v1/projects/${projectId}/system-prompt`, {
+        addendum: "   \n\t  \n",
+      });
+      assert("PUT whitespace-only → 200", r.status === 200);
+      const raw = await readFile(join(dataDir, "system-prompt-overrides.json"), "utf8");
+      const parsed = JSON.parse(raw) as { projects: Record<string, string> };
+      assert(
+        "  whitespace-only does not create an entry",
+        parsed.projects[projectId] === undefined,
+        JSON.stringify(parsed),
+      );
+    }
+
+    // 9. Byte-cap rejection. The schema's maxLength enforces the char cap;
+    //    we exercise it with a large single-byte-char string.
+    {
+      const huge = "x".repeat(20_001);
+      const r = await jsend(base, "PUT", `/api/v1/projects/${projectId}/system-prompt`, {
+        addendum: huge,
+      });
+      // Fastify's schema validator rejects with 400 before our handler runs.
+      assert("PUT oversize addendum → 400", r.status === 400, JSON.stringify(r.body));
+    }
+
+    // 10. Unknown projectId.
+    const FAKE = "00000000-0000-0000-0000-000000000000";
+    {
+      const g = await jget(base, `/api/v1/projects/${FAKE}/system-prompt`);
+      assert("GET unknown project → 404", g.status === 404);
+      const p = await jsend(base, "PUT", `/api/v1/projects/${FAKE}/system-prompt`, {
+        addendum: "hi",
+      });
+      assert("PUT unknown project → 404", p.status === 404);
+    }
+
+    // 11. Cascade-delete: project deletion removes the addendum entry.
+    {
+      // Re-write an addendum so we have something to verify gets removed.
+      const w = await jsend(base, "PUT", `/api/v1/projects/${projectId}/system-prompt`, {
+        addendum: "to-be-deleted",
+      });
+      assert("re-PUT before delete → 200", w.status === 200);
+      const d = await jsend(base, "DELETE", `/api/v1/projects/${projectId}`);
+      assert("DELETE project → 200", d.status === 200);
+      const raw = await readFile(join(dataDir, "system-prompt-overrides.json"), "utf8");
+      const parsed = JSON.parse(raw) as { projects: Record<string, string> };
+      assert(
+        "  addendum removed from disk after project delete",
+        parsed.projects[projectId] === undefined,
+        JSON.stringify(parsed),
+      );
+    }
+  } finally {
+    await fastify.close();
+    await rm(workspacePath, { recursive: true, force: true }).catch(() => undefined);
+    await rm(configDir, { recursive: true, force: true }).catch(() => undefined);
+    await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-system-prompt] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-system-prompt] PASS");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a Settings → **System Prompt** tab that lets each project store a free-form text block appended to the agent's base system prompt for every session created in that project.

- **Append-only.** Pi's base prompt defines the tool-calling protocol; replacing it would break tool use. We use pi's `appendSystemPrompt` extension hook (the same one `FORGE_SECRET_HYGIENE_RULE` already rides through) so the addendum stacks on top of the base prompt rather than replacing it.
- **Per-project**, mirroring the existing `skill-overrides` / `tool-overrides` / `prompt-overrides` pattern.
- **Stored** at \`\${FORGE_DATA_DIR}/system-prompt-overrides.json\` (mode 0o600, atomic write). 20 KB cap on the addendum — bounded so a runaway paste can't silently bloat every system prompt.
- **Takes effect on the next session** created in the project; already-running sessions keep the prompt they were built with.
- **Cascade-deletes** when the project is removed.

### Server

- `system-prompt-overrides.ts` (new) — store module; same shape as `skill-overrides.ts`.
- `agent-resource-loader.ts` — appends per-project addendum after `FORGE_SECRET_HYGIENE_RULE` (org → project layering).
- `config.ts` — new `systemPromptOverridesFile` path entry.
- `routes/projects.ts` — `GET` + `PUT /api/v1/projects/:id/system-prompt`. Schema-enforced 20 KB cap; 404 on unknown project; empty string clears the entry; 400 on byte-cap overflow.
- `project-manager.ts` — cascade-delete the addendum on project deletion.

### Client

- `lib/api-client/index.ts` — typed `getProjectSystemPrompt` + `setProjectSystemPrompt`.
- `components/SettingsPanel.tsx` — new "System Prompt" tab (visible in both minimal and full modes) with textarea, byte counter, Revert / Clear / Save controls, "applies to next session" hint.

### Other

- Ignore \`.claude/\` (Claude Code harness state lands there when worktrees are created via the tool).

## Test plan

- [x] \`npm run build\` ✅
- [x] \`npm run check\` (typecheck + eslint + prettier) ✅
- [x] \`npm run test:ci\` (minus environment-fragile pty-reattach/terminal tests) ✅
- [x] New \`tests/test-system-prompt.ts\` — 21 assertions covering round-trip, on-disk shape, empty/whitespace clears, byte-cap 400, unknown project 404 (GET + PUT), cascade-delete on project removal, **and end-to-end wiring (AgentSession.systemPrompt actually contains the addendum after createSession)**.

### Manual verification recommended after merge

- [x] Open Settings → System Prompt, paste a project-specific instruction (e.g. "Always run \`npm run check\` before declaring complete"), start a new session, verify the agent follows it.
- [x] Clear the addendum, start another session, verify the agent reverts to default behavior.