### PR TITLE
fix(ui): animate thinking indicator + light-mode contrast pass

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -715,7 +715,7 @@ export function App() {
                                   ? "Git"
                                   : "Context"}
                           {t === "git" && gitChangedCount > 0 && (
-                            <span className="rounded bg-amber-900/40 px-1 py-0.5 text-[9px] text-amber-300">
+                            <span className="rounded bg-amber-900/40 px-1 py-0.5 text-[9px] text-amber-300 light:bg-amber-100 light:text-amber-800">
                               {gitChangedCount}
                             </span>
                           )}

--- a/packages/client/src/components/ChangePasswordScreen.tsx
+++ b/packages/client/src/components/ChangePasswordScreen.tsx
@@ -95,7 +95,7 @@ export function ChangePasswordScreen() {
           />
         </label>
         {error !== undefined && (
-          <p role="alert" className="text-sm text-red-400">
+          <p role="alert" className="text-sm text-red-400 light:text-red-700">
             {error}
           </p>
         )}

--- a/packages/client/src/components/ChatMarkdown.tsx
+++ b/packages/client/src/components/ChatMarkdown.tsx
@@ -45,6 +45,7 @@ import rehypeKatex from "rehype-katex";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
+import { themeDef, useThemeStore } from "../lib/theme";
 // KaTeX styles — pulled into the bundle by Vite. Without this, the math
 // nodes that rehype-katex emits land in the DOM with no fonts/spacing
 // applied and look like raw HTML.
@@ -148,6 +149,13 @@ interface Props {
  * decision, so we make it on the right signal.
  */
 const CodeRenderer = ({ className, children, ...rest }: HTMLAttributes<HTMLElement>): ReactNode => {
+  // Pair the Prism theme to the user-picked app theme. vsDark / vsLight
+  // are both close in saturation, so switching between them inside the
+  // same session doesn't visually jar the chat history. Called
+  // unconditionally at the top of the component so the rules-of-hooks
+  // ordering isn't broken by the inline-vs-block early return below.
+  const themeId = useThemeStore((s) => s.theme);
+  const isLight = themeDef(themeId).mode === "light";
   const langMatch = /language-([\w-]+)/.exec(className ?? "");
   // children is the code text. Coerce to string and strip a single
   // trailing newline that `react-markdown` reliably adds — leaving
@@ -168,17 +176,22 @@ const CodeRenderer = ({ className, children, ...rest }: HTMLAttributes<HTMLEleme
   // Default to plain "text" so prism still wraps the block with
   // its <pre> chrome (no token highlighting, just the styling).
   const language = langMatch?.[1] ?? "text";
+  const prismTheme = isLight ? prismThemes.vsLight : prismThemes.vsDark;
+  // Background tuned to sit one shade off the chat surface so the
+  // code block reads as a distinct region without competing with
+  // surrounding text contrast.
+  const codeBg = isLight ? "#f8fafc" : "#0d0d0d";
 
   return (
     // `group` enables the hover-revealed copy button positioned via
     // `group-hover:opacity-100` inside CodeCopyButton.
     <div className="group relative">
       <CodeCopyButton code={code} />
-      <Highlight code={code} language={language} theme={prismThemes.vsDark}>
+      <Highlight code={code} language={language} theme={prismTheme}>
         {({ style, tokens, getLineProps, getTokenProps }) => (
           <pre
             className="overflow-x-auto rounded border border-neutral-800 p-2 font-mono text-[12px]"
-            style={{ ...style, background: "#0d0d0d" }}
+            style={{ ...style, background: codeBg }}
           >
             {tokens.map((line, i) => {
               const lineProps = getLineProps({ line });
@@ -243,7 +256,7 @@ const components: Components = {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-blue-400 underline hover:text-blue-300"
+      className="text-blue-400 underline hover:text-blue-300 light:text-blue-700 light:hover:text-blue-900"
     >
       {children}
     </a>

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -280,7 +280,7 @@ export function ChatView({ sessionId }: Props) {
             </div>
           )}
           {exportError !== undefined && (
-            <span className="text-[10px] text-amber-400" role="status">
+            <span className="text-[10px] text-amber-400 light:text-amber-700" role="status">
               Export failed: {exportError}
             </span>
           )}
@@ -299,7 +299,7 @@ export function ChatView({ sessionId }: Props) {
             which meant a long-running streaming session pushed the
             "Reconnecting…" / compaction banners off-screen. */}
         {banner !== undefined && (
-          <div className="border-b border-amber-700/40 bg-amber-900/20 px-6 py-2 text-xs text-amber-200">
+          <div className="border-b border-amber-700/40 bg-amber-900/20 px-6 py-2 text-xs text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800">
             {banner}
           </div>
         )}
@@ -451,7 +451,7 @@ function QueuedMessages({ queued }: { queued: { steering: string[]; followUp: st
             <span
               className={
                 q.kind === "steer"
-                  ? "shrink-0 rounded bg-amber-900/30 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-amber-300"
+                  ? "shrink-0 rounded bg-amber-900/30 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-amber-300 light:bg-amber-100 light:text-amber-800"
                   : "shrink-0 rounded bg-neutral-800 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-neutral-400"
               }
               title={
@@ -478,7 +478,20 @@ function QueuedMessages({ queued }: { queued: { steering: string[]; followUp: st
  */
 function ActiveToolPlaceholder({ tool }: { tool: ActiveTool | undefined }) {
   if (tool === undefined) {
-    return <div className="text-xs italic text-neutral-500">Thinking…</div>;
+    return (
+      <div
+        className="flex items-center gap-2 text-xs italic text-neutral-500"
+        aria-live="polite"
+        aria-label="Agent is thinking"
+      >
+        <span>Thinking</span>
+        <span className="pi-thinking-dots" aria-hidden="true">
+          <span>.</span>
+          <span>.</span>
+          <span>.</span>
+        </span>
+      </div>
+    );
   }
   return (
     <div className="flex items-center gap-2 text-xs text-neutral-400">
@@ -525,8 +538,8 @@ function ChatEditDiff({
         <span className="flex min-w-0 items-baseline gap-2">
           <span className="text-neutral-500">edit{filename !== undefined ? " " : ""}</span>
           {filename !== undefined && <span className="truncate font-mono">{filename}</span>}
-          <span className="ml-2 text-emerald-400">+{adds}</span>
-          <span className="ml-1 text-red-400">−{dels}</span>
+          <span className="ml-2 text-emerald-400 light:text-emerald-700">+{adds}</span>
+          <span className="ml-1 text-red-400 light:text-red-700">−{dels}</span>
         </span>
         <button
           onClick={(e) => {
@@ -633,7 +646,9 @@ function FileRefBadge({ ref: r }: { ref: FileRef }) {
         onClick={() => isInline && setExpanded((v) => !v)}
         disabled={!isInline}
         className={`flex min-h-11 w-full items-center gap-1.5 px-2 py-1 text-left text-[11px] md:min-h-0 ${
-          isInline ? "text-neutral-200 hover:bg-neutral-800" : "cursor-default text-emerald-200"
+          isInline
+            ? "text-neutral-200 hover:bg-neutral-800"
+            : "cursor-default text-emerald-200 light:text-emerald-800"
         }`}
         title={
           isInline
@@ -648,7 +663,7 @@ function FileRefBadge({ ref: r }: { ref: FileRef }) {
             <ChevronRight size={12} />
           )
         ) : (
-          <AtSign size={12} className="text-emerald-300/80" />
+          <AtSign size={12} className="text-emerald-300/80 light:text-emerald-700" />
         )}
         <FileCode size={12} className={isInline ? "text-neutral-400" : "text-emerald-300/80"} />
         <span className="font-mono">{r.path}</span>
@@ -659,7 +674,11 @@ function FileRefBadge({ ref: r }: { ref: FileRef }) {
               : `${(r.content.length / 1024).toFixed(1)} KB`}
           </span>
         )}
-        {!isInline && <span className="text-[10px] text-emerald-300/70">on demand</span>}
+        {!isInline && (
+          <span className="text-[10px] text-emerald-300/70 light:text-emerald-700/80">
+            on demand
+          </span>
+        )}
       </button>
       {isInline && expanded && (
         <pre className="max-h-72 overflow-auto border-t border-neutral-800 bg-neutral-950 px-3 py-2 font-mono text-[11px] leading-relaxed text-neutral-300">
@@ -1009,7 +1028,7 @@ function ToolCallEntry({
             </span>
           )}
           {isError && (
-            <span className="rounded bg-red-900/30 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-red-300">
+            <span className="rounded bg-red-900/30 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-red-300 light:bg-red-100 light:text-red-800">
               error
             </span>
           )}
@@ -1033,8 +1052,8 @@ function ToolCallEntry({
             Output
             {editStats !== undefined && (
               <span className="ml-2 font-mono text-[10px]">
-                <span className="text-emerald-400">+{editStats.adds}</span>{" "}
-                <span className="text-red-400">-{editStats.dels}</span>
+                <span className="text-emerald-400 light:text-emerald-700">+{editStats.adds}</span>{" "}
+                <span className="text-red-400 light:text-red-700">-{editStats.dels}</span>
               </span>
             )}
             {editFn !== undefined && (
@@ -1137,11 +1156,11 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
   // Generic tool result fallback.
   return (
     <details
-      className={`rounded border ${isError ? "border-red-700/40" : "border-neutral-800"} bg-neutral-950 text-xs`}
+      className={`rounded border ${isError ? "border-red-700/40 light:border-red-300" : "border-neutral-800"} bg-neutral-950 text-xs`}
     >
       <summary className="cursor-pointer px-3 py-2 text-neutral-300">
         <span className="text-neutral-500">{toolName}</span>
-        {isError && <span className="ml-2 text-red-400">error</span>}
+        {isError && <span className="ml-2 text-red-400 light:text-red-700">error</span>}
       </summary>
       <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">{text}</pre>
     </details>
@@ -1206,13 +1225,18 @@ function SubagentInflightOrResult({
     else if (agent !== undefined) summary = agent;
   }
   return (
-    <div className="overflow-hidden rounded border border-l-2 border-sky-700/50 border-l-sky-400 bg-sky-950/15 text-xs">
+    <div className="overflow-hidden rounded border border-l-2 border-sky-700/50 border-l-sky-400 bg-sky-950/15 text-xs light:border-sky-300 light:border-l-sky-600 light:bg-sky-50">
       <div className="flex items-center justify-between gap-2 px-2.5 py-1.5">
         <div className="flex min-w-0 items-center gap-1.5">
-          <Users size={11} className="shrink-0 text-sky-300" />
-          <span className="truncate font-medium text-sky-100">Sub-agent running…</span>
+          <Users size={11} className="shrink-0 text-sky-300 light:text-sky-700" />
+          <span className="truncate font-medium text-sky-100 light:text-sky-900">
+            Sub-agent running…
+          </span>
           {summary !== undefined && (
-            <span className="ml-1 truncate font-mono text-[11px] text-sky-200/70" title={summary}>
+            <span
+              className="ml-1 truncate font-mono text-[11px] text-sky-200/70 light:text-sky-800/80"
+              title={summary}
+            >
               {summary}
             </span>
           )}
@@ -1292,25 +1316,25 @@ function SubagentResultCard({
   // intact (so the input + output sections are still inspectable
   // when the call errored).
   const borderColors = isError
-    ? "border-red-700/50 border-l-red-400 bg-red-950/15"
-    : "border-sky-700/50 border-l-sky-400 bg-sky-950/15";
+    ? "border-red-700/50 border-l-red-400 bg-red-950/15 light:border-red-300 light:border-l-red-600 light:bg-red-50"
+    : "border-sky-700/50 border-l-sky-400 bg-sky-950/15 light:border-sky-300 light:border-l-sky-600 light:bg-sky-50";
 
   return (
     <div className={`overflow-hidden rounded border border-l-2 ${borderColors} text-xs`}>
       <div className="flex items-center justify-between gap-2 px-2.5 py-1.5">
         <div className="flex min-w-0 items-center gap-1.5">
-          <Users size={11} className="shrink-0 text-sky-300" />
-          <span className="truncate font-medium text-sky-100">{headline}</span>
+          <Users size={11} className="shrink-0 text-sky-300 light:text-sky-700" />
+          <span className="truncate font-medium text-sky-100 light:text-sky-900">{headline}</span>
           {parsed.context !== undefined && (
             <span
-              className="shrink-0 rounded bg-sky-900/40 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-sky-200"
+              className="shrink-0 rounded bg-sky-900/40 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-sky-200 light:bg-sky-100 light:text-sky-800"
               title={parsed.context === "fork" ? "Forked from parent context" : "Fresh context"}
             >
               {parsed.context}
             </span>
           )}
           {isError && (
-            <span className="shrink-0 rounded bg-red-900/40 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-red-200">
+            <span className="shrink-0 rounded bg-red-900/40 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-red-200 light:bg-red-100 light:text-red-800">
               error
             </span>
           )}
@@ -1318,7 +1342,7 @@ function SubagentResultCard({
         {parsed.results.length === 1 && parsed.results[0]!.sessionFile !== undefined && (
           <button
             onClick={() => openByFile(parsed.results[0]!.sessionFile)}
-            className="inline-flex min-h-11 shrink-0 items-center gap-1 rounded border border-sky-700/60 px-2 py-1 text-[12px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100 md:min-h-0 md:px-1.5 md:py-0.5 md:text-[10px]"
+            className="inline-flex min-h-11 shrink-0 items-center gap-1 rounded border border-sky-700/60 px-2 py-1 text-[12px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100 light:border-sky-400 light:text-sky-800 light:hover:border-sky-600 light:hover:bg-sky-100 light:hover:text-sky-900 md:min-h-0 md:px-1.5 md:py-0.5 md:text-[10px]"
             title={`Open sub-agent session — ${parsed.results[0]!.sessionFile}`}
           >
             <ExternalLink size={12} />
@@ -1383,13 +1407,17 @@ function SubagentResultRow({
   const failed = result.exitCode !== 0;
   return (
     <div
-      className={`flex items-center justify-between gap-2 rounded border ${failed ? "border-red-700/40" : "border-sky-900/40"} bg-neutral-950/60 px-2 py-1.5`}
+      className={`flex items-center justify-between gap-2 rounded border ${failed ? "border-red-700/40 light:border-red-300" : "border-sky-900/40 light:border-sky-300"} bg-neutral-950/60 px-2 py-1.5`}
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2">
-          <span className="font-mono text-[11px] font-medium text-sky-200">{result.agent}</span>
+          <span className="font-mono text-[11px] font-medium text-sky-200 light:text-sky-800">
+            {result.agent}
+          </span>
           {failed && (
-            <span className="text-[10px] font-medium text-red-400">exit {result.exitCode}</span>
+            <span className="text-[10px] font-medium text-red-400 light:text-red-700">
+              exit {result.exitCode}
+            </span>
           )}
         </div>
         {result.task.length > 0 && (
@@ -1401,7 +1429,7 @@ function SubagentResultRow({
       {result.sessionFile !== undefined && (
         <button
           onClick={() => onOpenFile(result.sessionFile)}
-          className="inline-flex shrink-0 items-center gap-1 rounded border border-sky-700/60 px-1.5 py-0.5 text-[10px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100"
+          className="inline-flex shrink-0 items-center gap-1 rounded border border-sky-700/60 px-1.5 py-0.5 text-[10px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100 light:border-sky-400 light:text-sky-800 light:hover:border-sky-600 light:hover:bg-sky-100 light:hover:text-sky-900"
           title={result.sessionFile}
         >
           <ExternalLink size={10} />
@@ -1436,19 +1464,21 @@ function BashExecution({ message }: { message: AgentMessageLike }) {
             </span>
           )}
           {cancelled && (
-            <span className="rounded bg-amber-900/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-amber-300">
+            <span className="rounded bg-amber-900/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-amber-300 light:bg-amber-100 light:text-amber-800">
               timed out
             </span>
           )}
           {truncated && !cancelled && (
-            <span className="rounded bg-amber-900/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-amber-300">
+            <span className="rounded bg-amber-900/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-amber-300 light:bg-amber-100 light:text-amber-800">
               truncated
             </span>
           )}
           {exitCode !== undefined && (
             <span
               className={`rounded px-1.5 py-0.5 text-[10px] font-mono ${
-                exitCode === 0 ? "bg-emerald-900/30 text-emerald-300" : "bg-red-900/30 text-red-300"
+                exitCode === 0
+                  ? "bg-emerald-900/30 text-emerald-300 light:bg-emerald-100 light:text-emerald-800"
+                  : "bg-red-900/30 text-red-300 light:bg-red-100 light:text-red-800"
               }`}
               title={exitCode === 0 ? "exit 0" : `exit ${String(exitCode)}`}
             >

--- a/packages/client/src/components/CompactionCard.tsx
+++ b/packages/client/src/components/CompactionCard.tsx
@@ -32,11 +32,11 @@ export function CompactionCard({
   const timeLabel = `${when.toLocaleDateString()} ${when.toLocaleTimeString()}`;
   const archivedCount = event.archivedMessages.length;
   return (
-    <div className="my-2 rounded-md border border-dashed border-amber-700/50 bg-amber-900/10">
+    <div className="my-2 rounded-md border border-dashed border-amber-700/50 bg-amber-900/10 light:border-amber-300 light:bg-amber-50">
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-amber-200/90 hover:bg-amber-900/20"
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-amber-200/90 hover:bg-amber-900/20 light:text-amber-800 light:hover:bg-amber-100"
         title={
           open
             ? "Hide archived messages"
@@ -44,19 +44,19 @@ export function CompactionCard({
         }
       >
         {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        <Layers size={12} className="text-amber-400" />
+        <Layers size={12} className="text-amber-400 light:text-amber-700" />
         <span className="flex-1 truncate">{truncated.length > 0 ? truncated : "Compaction"}</span>
-        <span className="shrink-0 font-mono text-[10px] text-amber-300/70">
+        <span className="shrink-0 font-mono text-[10px] text-amber-300/70 light:text-amber-700/80">
           {archivedCount} msg · {event.tokensBefore.toLocaleString()} tok · {timeLabel}
         </span>
       </button>
       {open && (
-        <div className="border-t border-dashed border-amber-700/50 px-3 py-3">
+        <div className="border-t border-dashed border-amber-700/50 px-3 py-3 light:border-amber-300">
           {/* Full summary above the archived stream so the user can read
               the SDK-generated prose before drilling into the raw
               messages it summarised. */}
           {event.summary.length > 0 && (
-            <div className="mb-3 whitespace-pre-wrap rounded bg-amber-900/15 px-2 py-1 text-[11px] italic text-amber-100/80">
+            <div className="mb-3 whitespace-pre-wrap rounded bg-amber-900/15 px-2 py-1 text-[11px] italic text-amber-100/80 light:bg-amber-100 light:text-amber-800">
               {event.summary}
             </div>
           )}

--- a/packages/client/src/components/ContextInspectorPanel.tsx
+++ b/packages/client/src/components/ContextInspectorPanel.tsx
@@ -136,7 +136,7 @@ export function ContextInspectorPanel() {
       </div>
 
       {error !== undefined && (
-        <div className="border-b border-red-700/40 bg-red-900/20 px-3 py-1.5 text-[11px] text-red-300">
+        <div className="border-b border-red-700/40 bg-red-900/20 px-3 py-1.5 text-[11px] text-red-300 light:border-red-300 light:bg-red-50 light:text-red-700">
           {error}
         </div>
       )}
@@ -331,7 +331,9 @@ function TokenSummary({
         </div>
         <div className="flex items-center justify-between text-[11px] font-medium">
           <span className="text-neutral-300">Total cost</span>
-          <span className="font-mono text-emerald-400">{formatUsd(data.totalCost)}</span>
+          <span className="font-mono text-emerald-400 light:text-emerald-700">
+            {formatUsd(data.totalCost)}
+          </span>
         </div>
       </div>
 
@@ -623,7 +625,9 @@ function TurnsTable({
                   {formatTokens(promptTotal)}
                 </td>
                 <td className="pr-2 text-right">{formatTokens(t.outputTokens)}</td>
-                <td className="text-right text-emerald-400">{formatUsd(t.cost)}</td>
+                <td className="text-right text-emerald-400 light:text-emerald-700">
+                  {formatUsd(t.cost)}
+                </td>
               </tr>
             );
           })}
@@ -722,12 +726,15 @@ function MessageList({
             raw-view button) since the underlying message doesn't
             exist yet. */}
         {streamingTail !== undefined && q.length === 0 && (
-          <li className="rounded border border-violet-700/40 bg-violet-900/10">
+          <li className="rounded border border-violet-700/40 bg-violet-900/10 light:border-violet-300 light:bg-violet-50">
             <div className="flex items-start gap-2 px-2 py-1.5">
-              <Loader2 size={11} className="mt-0.5 shrink-0 animate-spin text-violet-300" />
+              <Loader2
+                size={11}
+                className="mt-0.5 shrink-0 animate-spin text-violet-300 light:text-violet-700"
+              />
               <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                 <div className="flex items-center gap-1.5">
-                  <span className="rounded bg-violet-900/40 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-violet-300">
+                  <span className="rounded bg-violet-900/40 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-violet-300 light:bg-violet-100 light:text-violet-800">
                     assistant (streaming)
                   </span>
                 </div>
@@ -782,7 +789,7 @@ function MessageRow({
               {role}
             </span>
             {isCompacted && (
-              <span className="rounded bg-fuchsia-900/40 px-1.5 py-0.5 text-[9px] text-fuchsia-300">
+              <span className="rounded bg-fuchsia-900/40 px-1.5 py-0.5 text-[9px] text-fuchsia-300 light:bg-fuchsia-100 light:text-fuchsia-800">
                 compacted
               </span>
             )}
@@ -898,10 +905,16 @@ function RawJsonModal({
 /* ------------------------------ helpers ------------------------------ */
 
 function roleClass(role: string): string {
-  if (role === "user") return "bg-sky-900/40 text-sky-300";
-  if (role === "assistant") return "bg-violet-900/40 text-violet-300";
-  if (role === "tool" || role === "toolResult") return "bg-amber-900/40 text-amber-300";
-  if (role === "compactionSummary") return "bg-fuchsia-900/40 text-fuchsia-300";
+  // Each role uses a dark-mode tint (bg-X-900/40 + text-X-300) paired
+  // with a light-mode counterpart (bg-X-100 + text-X-800) via the
+  // `light:` variant defined in index.css.
+  if (role === "user") return "bg-sky-900/40 text-sky-300 light:bg-sky-100 light:text-sky-800";
+  if (role === "assistant")
+    return "bg-violet-900/40 text-violet-300 light:bg-violet-100 light:text-violet-800";
+  if (role === "tool" || role === "toolResult")
+    return "bg-amber-900/40 text-amber-300 light:bg-amber-100 light:text-amber-800";
+  if (role === "compactionSummary")
+    return "bg-fuchsia-900/40 text-fuchsia-300 light:bg-fuchsia-100 light:text-fuchsia-800";
   if (role === "system") return "bg-neutral-800 text-neutral-400";
   return "bg-neutral-800 text-neutral-400";
 }
@@ -1006,7 +1019,9 @@ function renderExpanded(
       <div>
         <p className="mb-1 text-[10px] text-neutral-500">
           tool: <span className="font-mono">{String(message.toolName ?? "unknown")}</span>{" "}
-          {message.isError === true && <span className="text-red-400">(error)</span>}
+          {message.isError === true && (
+            <span className="text-red-400 light:text-red-700">(error)</span>
+          )}
         </p>
         <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-neutral-950 p-2 font-mono text-[10px] text-neutral-300">
           {jsonish(content)}

--- a/packages/client/src/components/DiffBlock.tsx
+++ b/packages/client/src/components/DiffBlock.tsx
@@ -256,15 +256,15 @@ function FileDiff({
               // them from showing through during scroll.
               out.push(
                 <Decoration key={`dec-${hunk.content}`}>
-                  <div className="relative flex items-center justify-between gap-2 border-y border-blue-700/30 bg-blue-950/30 py-px leading-none">
-                    <span className="sticky left-0 z-10 bg-blue-950 px-2 py-px text-[9px] uppercase tracking-wider text-blue-400">
+                  <div className="relative flex items-center justify-between gap-2 border-y border-blue-700/30 bg-blue-950/30 py-px leading-none light:border-blue-300 light:bg-blue-50">
+                    <span className="sticky left-0 z-10 bg-blue-950 px-2 py-px text-[9px] uppercase tracking-wider text-blue-400 light:bg-blue-100 light:text-blue-700">
                       Hunk {idx + 1}
                     </span>
                     <button
                       type="button"
                       onClick={() => onHunkAction(idx)}
                       disabled={hunkActionDisabled === true}
-                      className="sticky right-1 z-10 rounded border border-blue-500/60 bg-blue-900 px-1.5 py-px text-[10px] text-blue-100 hover:border-blue-400 hover:bg-blue-800 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="sticky right-1 z-10 rounded border border-blue-500/60 bg-blue-900 px-1.5 py-px text-[10px] text-blue-100 hover:border-blue-400 hover:bg-blue-800 disabled:cursor-not-allowed disabled:opacity-50 light:border-blue-500 light:bg-blue-200 light:text-blue-900 light:hover:border-blue-600 light:hover:bg-blue-300"
                     >
                       {hunkActionLabel ?? "Apply hunk"}
                     </button>
@@ -486,17 +486,19 @@ function FallbackDiff({ diff }: { diff: string }) {
 
 function lineClass(line: string): string {
   // Order matters: check `+++` / `---` BEFORE `+` / `-`.
+  // Each branch ships a dark-mode default + a `light:` counterpart so
+  // raw-diff lines remain legible when the user is on the Light theme.
   if (line.startsWith("+++") || line.startsWith("---")) {
     return "text-neutral-500";
   }
   if (line.startsWith("@@")) {
-    return "bg-neutral-900 text-cyan-400";
+    return "bg-neutral-900 text-cyan-400 light:text-cyan-700";
   }
   if (line.startsWith("+")) {
-    return "bg-emerald-950/60 text-emerald-200";
+    return "bg-emerald-950/60 text-emerald-200 light:bg-emerald-50 light:text-emerald-800";
   }
   if (line.startsWith("-")) {
-    return "bg-red-950/60 text-red-200";
+    return "bg-red-950/60 text-red-200 light:bg-red-50 light:text-red-800";
   }
   return "text-neutral-400";
 }

--- a/packages/client/src/components/EditorPanel.tsx
+++ b/packages/client/src/components/EditorPanel.tsx
@@ -227,7 +227,9 @@ function Tabs({
           const baseClass = active
             ? "bg-neutral-950 text-neutral-100"
             : "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200";
-          const conflictClass = extChanged ? "bg-amber-900/30 text-amber-200" : "";
+          const conflictClass = extChanged
+            ? "bg-amber-900/30 text-amber-200 light:bg-amber-100 light:text-amber-800"
+            : "";
           return (
             <div
               key={f.tabId}
@@ -240,7 +242,10 @@ function Tabs({
             >
               <button onClick={() => onActivate(f.path)} className="truncate">
                 {extChanged ? (
-                  <AlertTriangle size={11} className="mr-1 inline text-amber-400" />
+                  <AlertTriangle
+                    size={11}
+                    className="mr-1 inline text-amber-400 light:text-amber-700"
+                  />
                 ) : f.dirty ? (
                   // Filled 10-px circle (was a 12-px bullet character that
                   // mostly disappeared into the surrounding text). aria-
@@ -278,15 +283,17 @@ function ExternalChangeBanner({
   onDiscard: () => void;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 border-b border-amber-700/40 bg-amber-900/20 px-4 py-1.5 text-xs text-amber-200">
+    <div className="flex items-center justify-between gap-3 border-b border-amber-700/40 bg-amber-900/20 px-4 py-1.5 text-xs text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800">
       <span>
         File changed externally — local edits in this tab are stale. Reload from disk?
-        <span className="ml-2 font-mono text-[10px] text-amber-400/70">{path}</span>
+        <span className="ml-2 font-mono text-[10px] text-amber-400/70 light:text-amber-700/80">
+          {path}
+        </span>
       </span>
       <div className="flex gap-1">
         <button
           onClick={onReload}
-          className="rounded border border-amber-700/50 px-2 py-0.5 hover:bg-amber-900/30"
+          className="rounded border border-amber-700/50 px-2 py-0.5 hover:bg-amber-900/30 light:border-amber-400 light:hover:bg-amber-100"
         >
           Reload
         </button>
@@ -323,16 +330,16 @@ function StatusBar({
   // editing or retry. Cleared on the next successful save.
   if (saveError !== undefined) {
     label = `Save failed (${saveError}) — Cmd/Ctrl+S or Save to retry`;
-    className = "text-rose-400";
+    className = "text-rose-400 light:text-rose-700";
   } else if (saving) {
     label = "Saving…";
   } else if (dirty) {
     label = "Unsaved changes";
-    className = "text-amber-400";
+    className = "text-amber-400 light:text-amber-700";
   } else if (savedAt !== undefined) {
     const t = new Date(savedAt);
     label = `Saved ${t.toLocaleTimeString()}`;
-    className = "text-emerald-500";
+    className = "text-emerald-500 light:text-emerald-700";
   } else {
     label = "Up to date";
   }

--- a/packages/client/src/components/FileBrowserPanel.tsx
+++ b/packages/client/src/components/FileBrowserPanel.tsx
@@ -450,13 +450,13 @@ export function FileBrowserPanel() {
         onChange={(e) => void onUploadInputChange(e)}
       />
       {uploadStatus !== undefined && (
-        <div className="flex items-center gap-1.5 border-b border-emerald-700/40 bg-emerald-900/20 px-3 py-1.5 text-[11px] text-emerald-200">
+        <div className="flex items-center gap-1.5 border-b border-emerald-700/40 bg-emerald-900/20 px-3 py-1.5 text-[11px] text-emerald-200 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800">
           {!uploadStatus.startsWith("Uploaded") && <Loader2 size={11} className="animate-spin" />}
           <span>{uploadStatus}</span>
         </div>
       )}
       {error !== undefined && (
-        <div className="border-b border-red-700/40 bg-red-900/20 px-3 py-1.5 text-[11px] text-red-300">
+        <div className="border-b border-red-700/40 bg-red-900/20 px-3 py-1.5 text-[11px] text-red-300 light:border-red-300 light:bg-red-50 light:text-red-700">
           {error}
         </div>
       )}
@@ -469,7 +469,7 @@ export function FileBrowserPanel() {
           <div className="flex gap-1">
             <button
               onClick={() => setDialog({ kind: "deleteMany", paths: Array.from(selectedPaths) })}
-              className="rounded border border-red-700/50 px-2 py-0.5 text-red-300 hover:bg-red-900/20"
+              className="rounded border border-red-700/50 px-2 py-0.5 text-red-300 hover:bg-red-900/20 light:border-red-400 light:text-red-700 light:hover:bg-red-50"
             >
               Delete selected
             </button>
@@ -769,7 +769,7 @@ function ContextMenuItem(props: {
       title={props.title}
       className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs ${
         danger
-          ? "text-red-300 hover:bg-red-900/30 hover:text-red-100"
+          ? "text-red-300 hover:bg-red-900/30 hover:text-red-100 light:text-red-700 light:hover:bg-red-100 light:hover:text-red-900"
           : "text-neutral-200 hover:bg-neutral-800"
       }`}
     >
@@ -1024,7 +1024,7 @@ function Tree(props: TreeProps) {
                 e.stopPropagation();
                 props.onDelete(absPath, node.name, isDir);
               }}
-              className="rounded p-0.5 text-neutral-500 hover:bg-red-900/30 hover:text-red-300"
+              className="rounded p-0.5 text-neutral-500 hover:bg-red-900/30 hover:text-red-300 light:hover:bg-red-100 light:hover:text-red-700"
               title="Delete"
             >
               <Trash2 size={11} />

--- a/packages/client/src/components/GitPanel.tsx
+++ b/packages/client/src/components/GitPanel.tsx
@@ -323,7 +323,7 @@ export function GitPanel() {
           Default branch will be <code className="font-mono text-neutral-400">main</code>.
         </p>
         {opError !== undefined && (
-          <p className="text-[10px] text-red-400">git init failed: {opError}</p>
+          <p className="text-[10px] text-red-400 light:text-red-700">git init failed: {opError}</p>
         )}
       </div>
     );
@@ -619,12 +619,12 @@ export function GitPanel() {
       </div>
 
       {(statusError !== undefined || opError !== undefined) && (
-        <div className="border-b border-red-700/40 bg-red-900/20 px-3 py-1.5 text-[11px] text-red-300">
+        <div className="border-b border-red-700/40 bg-red-900/20 px-3 py-1.5 text-[11px] text-red-300 light:border-red-300 light:bg-red-50 light:text-red-700">
           {opError ?? statusError}
         </div>
       )}
       {opResult !== undefined && (
-        <div className="border-b border-emerald-700/40 bg-emerald-900/20 px-3 py-1.5 text-[11px] text-emerald-300">
+        <div className="border-b border-emerald-700/40 bg-emerald-900/20 px-3 py-1.5 text-[11px] text-emerald-300 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800">
           {opResult}
         </div>
       )}
@@ -899,7 +899,9 @@ export function GitPanel() {
                         <li
                           key={b.name}
                           className={`group flex items-center gap-1 rounded px-1 py-0.5 font-mono hover:bg-neutral-900 ${
-                            b.current ? "text-emerald-400" : "text-neutral-300"
+                            b.current
+                              ? "text-emerald-400 light:text-emerald-700"
+                              : "text-neutral-300"
                           }`}
                         >
                           <span className="w-3 shrink-0">
@@ -932,7 +934,7 @@ export function GitPanel() {
                                 <button
                                   onClick={() => setBranchDialog({ kind: "delete", name: b.name })}
                                   disabled={busy}
-                                  className="rounded p-0.5 text-neutral-500 hover:bg-red-900/30 hover:text-red-300 disabled:opacity-40"
+                                  className="rounded p-0.5 text-neutral-500 hover:bg-red-900/30 hover:text-red-300 disabled:opacity-40 light:hover:bg-red-100 light:hover:text-red-700"
                                   title="Delete branch"
                                 >
                                   <Trash2 size={10} />
@@ -992,14 +994,14 @@ export function GitPanel() {
                                   Options dropdown above. */}
                               <span className="font-mono text-neutral-200">{r.name}</span>
                               {diverged && (
-                                <span className="rounded bg-amber-900/30 px-1 py-0.5 text-[9px] uppercase tracking-wider text-amber-300">
+                                <span className="rounded bg-amber-900/30 px-1 py-0.5 text-[9px] uppercase tracking-wider text-amber-300 light:bg-amber-100 light:text-amber-800">
                                   fetch ≠ push
                                 </span>
                               )}
                               <button
                                 onClick={() => setRemoveRemoteName(r.name)}
                                 disabled={busy}
-                                className="ml-auto hidden rounded p-0.5 text-neutral-500 hover:bg-red-900/30 hover:text-red-300 disabled:opacity-40 group-hover:inline-flex"
+                                className="ml-auto hidden rounded p-0.5 text-neutral-500 hover:bg-red-900/30 hover:text-red-300 disabled:opacity-40 group-hover:inline-flex light:hover:bg-red-100 light:hover:text-red-700"
                                 title={`Remove remote "${r.name}"`}
                               >
                                 <Trash2 size={10} />
@@ -1248,8 +1250,8 @@ function FileGroup(props: FileGroupProps) {
                     // visible state on hover.
                     className={
                       revertPending
-                        ? "inline-flex items-center gap-1 rounded bg-red-900/40 px-1 py-0.5 text-[10px] text-red-200"
-                        : "hidden items-center gap-1 text-[10px] text-neutral-500 hover:text-red-300 group-hover:inline-flex"
+                        ? "inline-flex items-center gap-1 rounded bg-red-900/40 px-1 py-0.5 text-[10px] text-red-200 light:bg-red-100 light:text-red-800"
+                        : "hidden items-center gap-1 text-[10px] text-neutral-500 hover:text-red-300 group-hover:inline-flex light:hover:text-red-700"
                     }
                     title={
                       revertPending
@@ -1281,7 +1283,9 @@ function FileGroup(props: FileGroupProps) {
                   {diffState === "loading" ? (
                     <p className="px-3 py-2 italic text-neutral-500">Loading…</p>
                   ) : diffState === "error" ? (
-                    <p className="px-3 py-2 text-red-400">Failed to load diff.</p>
+                    <p className="px-3 py-2 text-red-400 light:text-red-700">
+                      Failed to load diff.
+                    </p>
                   ) : diffState.length === 0 ? (
                     <p className="px-3 py-2 italic text-neutral-500">
                       (no diff — file is binary or unchanged)
@@ -1493,9 +1497,9 @@ function RefBadge({ ref_ }: { ref_: string }) {
       ? ref_.replace(/^tag:\s*/, "")
       : ref_;
   const cls = isHead
-    ? "bg-emerald-900/40 text-emerald-300"
+    ? "bg-emerald-900/40 text-emerald-300 light:bg-emerald-100 light:text-emerald-800"
     : isTag
-      ? "bg-amber-900/40 text-amber-300"
+      ? "bg-amber-900/40 text-amber-300 light:bg-amber-100 light:text-amber-800"
       : ref_.includes("/")
         ? "bg-neutral-800 text-neutral-500"
         : "bg-neutral-800 text-neutral-300";

--- a/packages/client/src/components/GlobalSearchBar.tsx
+++ b/packages/client/src/components/GlobalSearchBar.tsx
@@ -184,7 +184,9 @@ export function GlobalSearchBar() {
     return (
       <>
         {before}
-        <mark className="rounded bg-amber-300/30 text-amber-100">{hit}</mark>
+        <mark className="rounded bg-amber-300/30 text-amber-100 light:bg-amber-200 light:text-amber-900">
+          {hit}
+        </mark>
         {after}
       </>
     );
@@ -241,7 +243,7 @@ export function GlobalSearchBar() {
         >
           {loading && <div className="px-3 py-2 text-xs text-neutral-400">Searching…</div>}
           {!loading && error !== undefined && (
-            <div className="px-3 py-2 text-xs text-amber-400">{error}</div>
+            <div className="px-3 py-2 text-xs text-amber-400 light:text-amber-700">{error}</div>
           )}
           {!loading && error === undefined && flatTargets.length === 0 && (
             <div className="px-3 py-2 text-xs text-neutral-500">No matches.</div>

--- a/packages/client/src/components/ProjectPicker.tsx
+++ b/packages/client/src/components/ProjectPicker.tsx
@@ -162,7 +162,9 @@ export function ProjectPicker({ onClose, required = false }: Props) {
                 </span>
               )}
             </label>
-            {error !== undefined && <p className="text-xs text-red-400">Error: {error}</p>}
+            {error !== undefined && (
+              <p className="text-xs text-red-400 light:text-red-700">Error: {error}</p>
+            )}
             <button
               type="submit"
               disabled={name.trim().length === 0 || submitting}
@@ -281,7 +283,7 @@ export function ProjectPicker({ onClose, required = false }: Props) {
         )}
 
         {error !== undefined && (
-          <p className="mt-3 text-sm text-red-400">
+          <p className="mt-3 text-sm text-red-400 light:text-red-700">
             {error === "path_not_allowed"
               ? "That folder is outside the workspace root."
               : error === "workspace_root_not_allowed"

--- a/packages/client/src/components/SearchPanel.tsx
+++ b/packages/client/src/components/SearchPanel.tsx
@@ -274,7 +274,7 @@ function SearchStatus({
     );
   }
   if (error !== undefined) {
-    return <div className="px-4 py-3 text-xs text-rose-400">{error}</div>;
+    return <div className="px-4 py-3 text-xs text-rose-400 light:text-rose-700">{error}</div>;
   }
   if (results === undefined) return null;
   if (results.matches.length === 0) {
@@ -286,12 +286,14 @@ function SearchStatus({
         {results.matches.length} match{results.matches.length === 1 ? "" : "es"} in {totalFiles}{" "}
         file{totalFiles === 1 ? "" : "s"}
         {results.truncated && (
-          <span className="ml-1 text-amber-400">· truncated at {RESULT_LIMIT}</span>
+          <span className="ml-1 text-amber-400 light:text-amber-700">
+            · truncated at {RESULT_LIMIT}
+          </span>
         )}
       </span>
       {results.engine === "node" && (
         <span
-          className="rounded bg-amber-900/40 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-amber-300"
+          className="rounded bg-amber-900/40 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-amber-300 light:bg-amber-100 light:text-amber-800"
           title="ripgrep was not found on this host — using the slower in-process fallback"
         >
           fallback
@@ -361,7 +363,9 @@ function renderSnippet(snippet: string, column: number, length: number): ReactEl
   return (
     <span>
       <span>{before}</span>
-      <span className="bg-amber-700/30 text-amber-100">{hit}</span>
+      <span className="bg-amber-700/30 text-amber-100 light:bg-amber-200 light:text-amber-900">
+        {hit}
+      </span>
       <span>{after}</span>
     </span>
   );

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -269,7 +269,7 @@ export function SessionList({ projectId }: Props) {
           <div className="flex gap-1">
             <button
               onClick={() => setDeleteDialog({ sessionIds: Array.from(selectedIds) })}
-              className="rounded border border-red-700/50 px-1.5 py-0.5 text-red-300 hover:bg-red-900/20"
+              className="rounded border border-red-700/50 px-1.5 py-0.5 text-red-300 hover:bg-red-900/20 light:border-red-400 light:text-red-700 light:hover:bg-red-50"
             >
               Delete
             </button>
@@ -464,9 +464,9 @@ function SessionRow(props: SessionRowProps) {
           className="flex-1 truncate text-left"
           title={`${s.sessionId} — double-click to rename, Cmd/Ctrl+click to select for bulk delete`}
         >
-          {s.isLive && <span className="mr-1 text-emerald-500">●</span>}
+          {s.isLive && <span className="mr-1 text-emerald-500 light:text-emerald-700">●</span>}
           {isChild && (
-            <span className="mr-1 text-purple-400" title="sub-agent">
+            <span className="mr-1 text-purple-400 light:text-purple-700" title="sub-agent">
               ↳
             </span>
           )}
@@ -493,8 +493,8 @@ function SessionRow(props: SessionRowProps) {
             // border combos — pinning the height makes the swap
             // visually identical from a layout standpoint.
             isArmedForDelete
-              ? "inline-flex h-6 items-center rounded border border-red-500 px-1.5 text-[11px] font-medium uppercase leading-none tracking-wide text-red-300 hover:bg-red-500/10"
-              : "inline-flex h-6 w-6 items-center justify-center rounded text-neutral-500 hover:text-red-400"
+              ? "inline-flex h-6 items-center rounded border border-red-500 px-1.5 text-[11px] font-medium uppercase leading-none tracking-wide text-red-300 hover:bg-red-500/10 light:border-red-600 light:text-red-700 light:hover:bg-red-100"
+              : "inline-flex h-6 w-6 items-center justify-center rounded text-neutral-500 hover:text-red-400 light:hover:text-red-700"
           }
           title={
             isArmedForDelete

--- a/packages/client/src/components/SessionTreePanel.tsx
+++ b/packages/client/src/components/SessionTreePanel.tsx
@@ -338,7 +338,7 @@ export function SessionTreePanel({ sessionId, projectId, onClose }: Props) {
         </header>
 
         {error !== undefined && (
-          <div className="border-b border-red-700/40 bg-red-900/20 px-4 py-1.5 text-xs text-red-300">
+          <div className="border-b border-red-700/40 bg-red-900/20 px-4 py-1.5 text-xs text-red-300 light:border-red-300 light:bg-red-50 light:text-red-700">
             {error}
           </div>
         )}
@@ -471,7 +471,7 @@ function NavigateConfirmDialog({
         className="flex flex-col gap-3 px-4 py-3 text-xs text-neutral-200"
       >
         {state?.isStreaming === true && (
-          <p className="rounded border border-amber-700/50 bg-amber-900/20 px-2 py-1.5 text-amber-200">
+          <p className="rounded border border-amber-700/50 bg-amber-900/20 px-2 py-1.5 text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800">
             The agent is currently running. Navigating will abort the in-progress turn.
           </p>
         )}
@@ -540,7 +540,7 @@ function NavigateConfirmDialog({
             type="submit"
             className={`rounded-md px-3 py-1 text-xs font-medium ${
               state?.isStreaming === true
-                ? "bg-amber-600 text-amber-50 hover:bg-amber-500"
+                ? "bg-amber-600 text-amber-50 hover:bg-amber-500 light:bg-amber-500 light:text-white light:hover:bg-amber-600"
                 : "bg-neutral-100 text-neutral-900 hover:bg-white"
             }`}
           >
@@ -630,7 +630,7 @@ function TreeRow({
             <button
               onClick={onFork}
               disabled={disabled}
-              className="rounded p-1 text-neutral-500 hover:bg-neutral-800 hover:text-emerald-300 disabled:opacity-40"
+              className="rounded p-1 text-neutral-500 hover:bg-neutral-800 hover:text-emerald-300 disabled:opacity-40 light:hover:text-emerald-700"
               title="Fork BEFORE this message — opens a new session with the message text loaded into the input for editing."
             >
               <GitBranch size={11} />
@@ -649,13 +649,13 @@ function TreeRow({
             <span
               className={`rounded px-1.5 py-0.5 text-[9px] uppercase tracking-wider ${
                 node.role === "user"
-                  ? "bg-sky-900/40 text-sky-300"
+                  ? "bg-sky-900/40 text-sky-300 light:bg-sky-100 light:text-sky-800"
                   : node.role === "assistant"
-                    ? "bg-violet-900/40 text-violet-300"
+                    ? "bg-violet-900/40 text-violet-300 light:bg-violet-100 light:text-violet-800"
                     : node.type === "branch_summary"
-                      ? "bg-amber-900/40 text-amber-300"
+                      ? "bg-amber-900/40 text-amber-300 light:bg-amber-100 light:text-amber-800"
                       : node.type === "compaction"
-                        ? "bg-fuchsia-900/40 text-fuchsia-300"
+                        ? "bg-fuchsia-900/40 text-fuchsia-300 light:bg-fuchsia-100 light:text-fuchsia-800"
                         : "bg-neutral-800 text-neutral-400"
               }`}
             >
@@ -679,13 +679,13 @@ function TreeRow({
               </span>
             )}
             {node.isLeaf && (
-              <span className="rounded bg-emerald-900/40 px-1.5 py-0.5 text-[9px] text-emerald-300">
+              <span className="rounded bg-emerald-900/40 px-1.5 py-0.5 text-[9px] text-emerald-300 light:bg-emerald-100 light:text-emerald-800">
                 leaf
               </span>
             )}
             {node.siblings > 1 && (
               <span
-                className="text-[9px] text-amber-400"
+                className="text-[9px] text-amber-400 light:text-amber-700"
                 title={`${node.siblings} branches diverge from this point`}
               >
                 ⑂ {node.siblings}
@@ -1282,24 +1282,24 @@ function GraphNode({
           <span
             className={`rounded px-1.5 py-0.5 text-[9px] uppercase tracking-wider ${
               turn.roleLabel === "user"
-                ? "bg-sky-900/40 text-sky-300"
+                ? "bg-sky-900/40 text-sky-300 light:bg-sky-100 light:text-sky-800"
                 : turn.roleLabel === "compact"
-                  ? "bg-fuchsia-900/40 text-fuchsia-300"
+                  ? "bg-fuchsia-900/40 text-fuchsia-300 light:bg-fuchsia-100 light:text-fuchsia-800"
                   : turn.roleLabel === "branch"
-                    ? "bg-amber-900/40 text-amber-300"
+                    ? "bg-amber-900/40 text-amber-300 light:bg-amber-100 light:text-amber-800"
                     : "bg-neutral-800 text-neutral-400"
             }`}
           >
             {turn.roleLabel}
           </span>
           {turn.isLeafTurn && (
-            <span className="rounded bg-emerald-900/40 px-1.5 py-0.5 text-[9px] text-emerald-300">
+            <span className="rounded bg-emerald-900/40 px-1.5 py-0.5 text-[9px] text-emerald-300 light:bg-emerald-100 light:text-emerald-800">
               leaf
             </span>
           )}
           {turn.hasMultipleChildren && (
             <span
-              className="text-[9px] text-amber-400"
+              className="text-[9px] text-amber-400 light:text-amber-700"
               title={`${turn.childCount} branches diverge from here`}
             >
               ⑂ {turn.childCount}
@@ -1319,7 +1319,7 @@ function GraphNode({
               onForkAfterTurn();
             }}
             disabled={disabled}
-            className="ml-auto rounded p-0.5 text-neutral-500 hover:bg-neutral-800 hover:text-emerald-300 disabled:opacity-40"
+            className="ml-auto rounded p-0.5 text-neutral-500 hover:bg-neutral-800 hover:text-emerald-300 disabled:opacity-40 light:hover:text-emerald-700"
             title="Fork AFTER this turn — opens a new session that includes this turn's full output, ready for the next prompt."
           >
             <GitBranch size={11} />

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -288,7 +288,7 @@ function ProvidersTab({ onError }: { onError: (msg: string | undefined) => void 
                 <span
                   className={`rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${
                     configured
-                      ? "bg-emerald-900/40 text-emerald-300"
+                      ? "bg-emerald-900/40 text-emerald-300 light:bg-emerald-100 light:text-emerald-800"
                       : "bg-neutral-800 text-neutral-500"
                   }`}
                 >
@@ -350,16 +350,25 @@ function ProvidersTab({ onError }: { onError: (msg: string | undefined) => void 
               </div>
             )}
             <details className="mt-2">
-              <summary className="cursor-pointer text-[11px] text-neutral-500">
+              <summary className="cursor-pointer text-[11px] text-neutral-500 light:text-neutral-600">
                 {p.models.length} model{p.models.length === 1 ? "" : "s"}
               </summary>
               <ul className="mt-1 space-y-0.5 text-[11px]">
                 {p.models.map((m) => (
                   <li key={m.id} className="flex justify-between font-mono">
-                    <span className={m.hasAuth ? "text-neutral-300" : "text-neutral-600"}>
+                    {/* hasAuth uses neutral-300 (dark text in dark theme,
+                        readable in light after scale inversion). The "no
+                        key" row uses neutral-600 in dark, which inverts
+                        to near-white in light — explicitly bump that
+                        path to a much darker shade for AA contrast. */}
+                    <span
+                      className={
+                        m.hasAuth ? "text-neutral-300" : "text-neutral-600 light:text-neutral-400"
+                      }
+                    >
                       {m.name}
                     </span>
-                    <span className="text-neutral-600">
+                    <span className="text-neutral-600 light:text-neutral-400">
                       ctx {Math.round(m.contextWindow / 1000)}k
                     </span>
                   </li>
@@ -453,7 +462,7 @@ function CustomProvidersJson({ onError }: { onError: (msg: string | undefined) =
           />
           <div className="mt-2 flex items-center justify-end gap-2 text-xs">
             {savedAt !== undefined && (
-              <span className="text-emerald-400" aria-live="polite">
+              <span className="text-emerald-400 light:text-emerald-700" aria-live="polite">
                 Saved
               </span>
             )}
@@ -676,7 +685,7 @@ function SettingsJsonEditor({
       />
       <div className="flex items-center justify-end gap-2 text-xs">
         {savedAt !== undefined && (
-          <span className="text-emerald-400" aria-live="polite">
+          <span className="text-emerald-400 light:text-emerald-700" aria-live="polite">
             Saved
           </span>
         )}
@@ -903,7 +912,7 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
         the pi-forge-private file at{" "}
         <code className="font-mono">{`\${FORGE_DATA_DIR}/skills-overrides.json`}</code>.
       </p>
-      <div className="rounded border border-amber-700/40 bg-amber-900/10 px-3 py-2 text-[11px] text-amber-200">
+      <div className="rounded border border-amber-700/40 bg-amber-900/10 px-3 py-2 text-[11px] text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800">
         Skill changes apply to the <strong>next session</strong> you start in the affected project.
         Live sessions keep the skill set they booted with — start a new session to use a freshly
         enabled skill.
@@ -948,8 +957,8 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
                     <span
                       className={`rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${
                         s.projectOverride === "enabled"
-                          ? "bg-emerald-900/40 text-emerald-300"
-                          : "bg-red-900/40 text-red-300"
+                          ? "bg-emerald-900/40 text-emerald-300 light:bg-emerald-100 light:text-emerald-800"
+                          : "bg-red-900/40 text-red-300 light:bg-red-100 light:text-red-800"
                       }`}
                       title={`Active project ('${project.name}') has an override`}
                     >
@@ -966,7 +975,7 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
                   disabled={busy}
                   className={`rounded border px-2 py-0.5 ${
                     s.enabled
-                      ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300"
+                      ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800"
                       : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
                   }`}
                   title="Global enable in pi's settings.skills"
@@ -1144,7 +1153,7 @@ function PromptsTab({ onError }: { onError: (msg: string | undefined) => void })
         pi&apos;s <code className="font-mono">settings.prompts</code>; per-project overrides write
         to <code className="font-mono">{`\${FORGE_DATA_DIR}/prompts-overrides.json`}</code>.
       </p>
-      <div className="rounded border border-amber-700/40 bg-amber-900/10 px-3 py-2 text-[11px] text-amber-200">
+      <div className="rounded border border-amber-700/40 bg-amber-900/10 px-3 py-2 text-[11px] text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800">
         Prompt changes apply to the <strong>next session</strong> you start in the affected project.
         Live sessions keep the prompt set they booted with — start a new session to use a freshly
         enabled prompt.
@@ -1189,8 +1198,8 @@ function PromptsTab({ onError }: { onError: (msg: string | undefined) => void })
                     <span
                       className={`rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${
                         p.projectOverride === "enabled"
-                          ? "bg-emerald-900/40 text-emerald-300"
-                          : "bg-red-900/40 text-red-300"
+                          ? "bg-emerald-900/40 text-emerald-300 light:bg-emerald-100 light:text-emerald-800"
+                          : "bg-red-900/40 text-red-300 light:bg-red-100 light:text-red-800"
                       }`}
                       title={`Active project ('${project.name}') has an override`}
                     >
@@ -1207,7 +1216,7 @@ function PromptsTab({ onError }: { onError: (msg: string | undefined) => void })
                   disabled={busy}
                   className={`rounded border px-2 py-0.5 ${
                     p.enabled
-                      ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300"
+                      ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800"
                       : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
                   }`}
                   title="Global enable in pi's settings.prompts"
@@ -1332,9 +1341,9 @@ function TriStatePicker({
       className={`rounded px-2 py-0.5 text-[11px] ${
         active
           ? state === "enabled"
-            ? "bg-emerald-900/40 text-emerald-300"
+            ? "bg-emerald-900/40 text-emerald-300 light:bg-emerald-100 light:text-emerald-800"
             : state === "disabled"
-              ? "bg-red-900/40 text-red-300"
+              ? "bg-red-900/40 text-red-300 light:bg-red-100 light:text-red-800"
               : "bg-neutral-800 text-neutral-400"
           : "text-neutral-500 hover:bg-neutral-800 hover:text-neutral-300"
       }`}
@@ -1395,7 +1404,7 @@ function AddOverrideDropdown({
           setPicked("");
         }}
         disabled={disabled || picked.length === 0}
-        className="rounded bg-emerald-900/40 px-2 py-0.5 text-emerald-300 disabled:opacity-50"
+        className="rounded bg-emerald-900/40 px-2 py-0.5 text-emerald-300 disabled:opacity-50 light:bg-emerald-100 light:text-emerald-800"
       >
         Enable here
       </button>
@@ -1689,7 +1698,7 @@ function ToolCascadeRow({
             disabled={busy}
             className={`rounded border px-2 py-0.5 disabled:opacity-50 ${
               globalEnabled
-                ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300"
+                ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800"
                 : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
             }`}
             title="Global default for every project that doesn't override"
@@ -1970,7 +1979,7 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
           {busy ? "Exporting…" : "Download config archive"}
         </button>
         {lastExport !== undefined && (
-          <p className="mt-2 text-xs text-emerald-400">
+          <p className="mt-2 text-xs text-emerald-400 light:text-emerald-700">
             Exported <code className="font-mono">{lastExport.filename}</code> (
             {lastExport.files.length === 0
               ? "no files were on disk"
@@ -2001,12 +2010,12 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
         {lastImport !== undefined && (
           <div className="mt-3 space-y-1 text-xs">
             {lastImport.imported.length > 0 && (
-              <p className="text-emerald-400">
+              <p className="text-emerald-400 light:text-emerald-700">
                 Imported: <code className="font-mono">{lastImport.imported.join(", ")}</code>
               </p>
             )}
             {lastImport.skipped.length > 0 && (
-              <p className="text-amber-400">
+              <p className="text-amber-400 light:text-amber-700">
                 Skipped (not in allow-list):{" "}
                 <code className="font-mono">{lastImport.skipped.join(", ")}</code>
               </p>
@@ -2056,7 +2065,7 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
               No skills to export — your skills directory is empty.
             </p>
           ) : (
-            <p className="mt-2 text-xs text-emerald-400">
+            <p className="mt-2 text-xs text-emerald-400 light:text-emerald-700">
               Exported <code className="font-mono">{lastSkillsExport.filename}</code> (
               {lastSkillsExport.fileCount} file{lastSkillsExport.fileCount === 1 ? "" : "s"} packed)
             </p>
@@ -2115,14 +2124,14 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
         {lastSkillsImport !== undefined && (
           <div className="mt-3 space-y-1 text-xs">
             {lastSkillsImport.imported.length > 0 && (
-              <p className="text-emerald-400">
+              <p className="text-emerald-400 light:text-emerald-700">
                 Imported {lastSkillsImport.imported.length} file
                 {lastSkillsImport.imported.length === 1 ? "" : "s"}:{" "}
                 <code className="font-mono">{lastSkillsImport.imported.join(", ")}</code>
               </p>
             )}
             {lastSkillsImport.skipped.length > 0 && (
-              <div className="text-amber-400">
+              <div className="text-amber-400 light:text-amber-700">
                 <p>
                   Skipped {lastSkillsImport.skipped.length} entr
                   {lastSkillsImport.skipped.length === 1 ? "y" : "ies"}:
@@ -2417,7 +2426,7 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
           disabled={busy}
           className={`rounded border px-3 py-1 text-xs ${
             enabled
-              ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300"
+              ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800"
               : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
           }`}
         >
@@ -2620,7 +2629,7 @@ function McpServerList(props: {
                           onClick={() => props.onToggle?.(s.name, !s.enabled)}
                           className={`rounded border px-2 py-0.5 ${
                             s.enabled
-                              ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300"
+                              ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800"
                               : "border-neutral-700 text-neutral-400 hover:border-neutral-500"
                           }`}
                         >
@@ -2870,7 +2879,7 @@ function GeneralTab() {
             href="https://github.com/badlogic/pi-mono"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-blue-400 underline hover:text-blue-300"
+            className="text-blue-400 underline hover:text-blue-300 light:text-blue-700 light:hover:text-blue-900"
           >
             pi coding agent
           </a>
@@ -2901,7 +2910,7 @@ function GeneralTab() {
               href="https://github.com/Devin-Marks/pi-forge"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-400 underline hover:text-blue-300"
+              className="text-blue-400 underline hover:text-blue-300 light:text-blue-700 light:hover:text-blue-900"
             >
               github.com/Devin-Marks/pi-forge
             </a>
@@ -2911,7 +2920,7 @@ function GeneralTab() {
               href="https://github.com/Devin-Marks/pi-forge/blob/main/CHANGELOG.md"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-400 underline hover:text-blue-300"
+              className="text-blue-400 underline hover:text-blue-300 light:text-blue-700 light:hover:text-blue-900"
             >
               Changelog
             </a>
@@ -2921,7 +2930,7 @@ function GeneralTab() {
               href="https://github.com/Devin-Marks/pi-forge/blob/main/SECURITY.md"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-400 underline hover:text-blue-300"
+              className="text-blue-400 underline hover:text-blue-300 light:text-blue-700 light:hover:text-blue-900"
             >
               Security
             </a>
@@ -3038,7 +3047,7 @@ function ChangePasswordSection() {
           </p>
         )}
         {savedFlash && (
-          <p role="status" className="text-xs text-emerald-400">
+          <p role="status" className="text-xs text-emerald-400 light:text-emerald-700">
             Password updated.
           </p>
         )}

--- a/packages/client/src/components/TerminalPanel.tsx
+++ b/packages/client/src/components/TerminalPanel.tsx
@@ -142,7 +142,7 @@ export function TerminalPanel() {
           })}
           <button
             onClick={onNewTab}
-            className="ml-1 flex items-center gap-1 rounded px-2 py-0.5 text-xs text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
+            className="ml-1 flex items-center gap-1 rounded px-2 py-0.5 text-xs text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200 light:text-neutral-200 light:hover:bg-neutral-800 light:hover:text-neutral-50"
             title="New terminal"
           >
             <Plus size={14} />

--- a/packages/client/src/components/TurnDiffPanel.tsx
+++ b/packages/client/src/components/TurnDiffPanel.tsx
@@ -172,14 +172,16 @@ export function TurnDiffPanel() {
                 <span className="flex min-w-0 items-baseline gap-2">
                   <span className="truncate font-mono text-neutral-200">{name}</span>
                   {entry.isPureAddition && (
-                    <span className="rounded bg-emerald-900/40 px-1 py-0.5 text-[9px] uppercase tracking-wider text-emerald-300">
+                    <span className="rounded bg-emerald-900/40 px-1 py-0.5 text-[9px] uppercase tracking-wider text-emerald-300 light:bg-emerald-100 light:text-emerald-800">
                       new
                     </span>
                   )}
                 </span>
                 <span className="flex shrink-0 items-baseline gap-2 text-[11px]">
-                  <span className="text-emerald-400">+{entry.additions}</span>
-                  <span className="text-red-400">−{entry.deletions}</span>
+                  <span className="text-emerald-400 light:text-emerald-700">
+                    +{entry.additions}
+                  </span>
+                  <span className="text-red-400 light:text-red-700">−{entry.deletions}</span>
                 </span>
               </button>
               {open && <DiffBlock diff={entry.diff} viewType={viewType} />}

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -1,5 +1,17 @@
 @import "tailwindcss";
 
+/* Custom Tailwind variant: `light:` applies when the active theme is
+   the Light theme (data-theme="light" on <html>). The dark themes
+   remap only the neutral scale via CSS vars (see the `[data-theme]`
+   blocks below), but semantic-colored utilities like `text-red-300`,
+   `bg-sky-900/40`, `text-blue-400` are raw Tailwind palette values
+   that don't change between themes — so on a light background they
+   collapse into low-contrast washes. Use `light:` to attach a
+   higher-contrast counterpart, e.g.
+   `text-red-300 light:text-red-700` or
+   `bg-sky-900/40 light:bg-sky-100`. */
+@custom-variant light (&:where([data-theme="light"] *));
+
 /* ----------------------------- themes -----------------------------
    Tailwind v4 emits `bg-neutral-950` etc. as
    `background-color: var(--color-neutral-950)`. We retheme the app
@@ -198,6 +210,95 @@
   color: #a3a3a3;
 }
 
+/* Light-mode overrides for the diff renderer. The dark-mode defaults
+   above are hardcoded hex values (not `var(--color-neutral-*)`)
+   because they have to compose with react-diff-view's own internal
+   variable scheme, and the green/red diff swatches don't belong on
+   the neutral scale. To support light mode we re-declare the same
+   variables and direct properties under the light-theme scope so
+   text stays readable on white, the sticky gutter blends into the
+   page background, and added/deleted line highlights use light
+   tinted backgrounds instead of near-black dark ones. */
+[data-theme="light"] .pi-diff-block {
+  --diff-text-color: #0a0a0a;
+  --diff-selection-background-color: #cbd5e1;
+  --diff-gutter-insert-background-color: #bbf7d0;
+  --diff-gutter-insert-text-color: #14532d;
+  --diff-gutter-delete-background-color: #fecaca;
+  --diff-gutter-delete-text-color: #7f1d1d;
+  --diff-code-insert-background-color: #dcfce7;
+  --diff-code-insert-text-color: #14532d;
+  --diff-code-insert-edit-background-color: #86efac;
+  --diff-code-insert-edit-text-color: #052e16;
+  --diff-code-delete-background-color: #fee2e2;
+  --diff-code-delete-text-color: #7f1d1d;
+  --diff-code-delete-edit-background-color: #fca5a5;
+  --diff-code-delete-edit-text-color: #450a0a;
+  --diff-omit-gutter-line-color: #cbd5e1;
+}
+[data-theme="light"] .pi-diff-block .diff {
+  color: #0a0a0a;
+}
+[data-theme="light"] .pi-diff-block .diff-gutter {
+  color: #525252;
+  background: #ffffff;
+}
+[data-theme="light"] .pi-diff-block .diff-decoration {
+  background: #f3f4f6;
+  color: #525252;
+}
+/* Syntax token colors re-tuned for white backgrounds — keep the
+   hue family (orange/green/cyan/pink/indigo/yellow) from dark mode
+   for muscle-memory continuity, drop the lightness so AA contrast
+   holds against the light tinted diff backgrounds. */
+[data-theme="light"] .pi-diff-block .token.comment,
+[data-theme="light"] .pi-diff-block .token.prolog,
+[data-theme="light"] .pi-diff-block .token.doctype,
+[data-theme="light"] .pi-diff-block .token.cdata {
+  color: #6b7280;
+}
+[data-theme="light"] .pi-diff-block .token.punctuation {
+  color: #475569;
+}
+[data-theme="light"] .pi-diff-block .token.property,
+[data-theme="light"] .pi-diff-block .token.tag,
+[data-theme="light"] .pi-diff-block .token.boolean,
+[data-theme="light"] .pi-diff-block .token.number,
+[data-theme="light"] .pi-diff-block .token.constant,
+[data-theme="light"] .pi-diff-block .token.symbol,
+[data-theme="light"] .pi-diff-block .token.deleted {
+  color: #b45309;
+}
+[data-theme="light"] .pi-diff-block .token.selector,
+[data-theme="light"] .pi-diff-block .token.attr-name,
+[data-theme="light"] .pi-diff-block .token.string,
+[data-theme="light"] .pi-diff-block .token.char,
+[data-theme="light"] .pi-diff-block .token.builtin,
+[data-theme="light"] .pi-diff-block .token.inserted {
+  color: #15803d;
+}
+[data-theme="light"] .pi-diff-block .token.operator,
+[data-theme="light"] .pi-diff-block .token.entity,
+[data-theme="light"] .pi-diff-block .token.url,
+[data-theme="light"] .pi-diff-block .language-css .token.string,
+[data-theme="light"] .pi-diff-block .style .token.string {
+  color: #0e7490;
+}
+[data-theme="light"] .pi-diff-block .token.atrule,
+[data-theme="light"] .pi-diff-block .token.attr-value,
+[data-theme="light"] .pi-diff-block .token.keyword {
+  color: #be185d;
+}
+[data-theme="light"] .pi-diff-block .token.function,
+[data-theme="light"] .pi-diff-block .token.class-name {
+  color: #4338ca;
+}
+[data-theme="light"] .pi-diff-block .token.regex,
+[data-theme="light"] .pi-diff-block .token.important,
+[data-theme="light"] .pi-diff-block .token.variable {
+  color: #a16207;
+}
+
 /* Single-column gutter (UNIFIED ONLY). react-diff-view's unified
    mode renders TWO `<col class="diff-gutter-col">` elements + two
    `<td.diff-gutter>` per row (old + new line number). Our
@@ -305,4 +406,56 @@
      the bubble instead of pushing the selection rectangle out past
      the right edge. */
   overflow-wrap: anywhere;
+}
+
+/* ----------------------------- thinking indicator -----------------------------
+   Three-dot ellipsis with staggered opacity pulse, used by the chat
+   "Thinking…" placeholder while the agent is busy. Independent of
+   Tailwind's `animate-pulse` because we want each dot offset by 200ms
+   so the eye reads it as motion, not a synchronized fade. Keeps the
+   user oriented that the stream is alive vs. silently disconnected. */
+@keyframes pi-thinking-dot {
+  0%,
+  80%,
+  100% {
+    opacity: 0.2;
+  }
+  40% {
+    opacity: 1;
+  }
+}
+.pi-thinking-dots {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.15em;
+  margin-left: 0.25em;
+}
+.pi-thinking-dots > span {
+  animation: pi-thinking-dot 1.4s infinite ease-in-out both;
+}
+.pi-thinking-dots > span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.pi-thinking-dots > span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pi-thinking-dots > span {
+    animation: none;
+    opacity: 0.6;
+  }
+}
+
+/* ----------------------------- logo recolor -----------------------------
+   The app logo at `/icons/icon.svg` is a pure-white-on-transparent
+   shape, picked to read against the default dark chrome. In light
+   mode it disappears against the white page surface. Inverting the
+   image with `filter: invert(1)` turns pure-white pixels into pure
+   black, which is exactly the black variant we need for the light
+   theme. Avoids shipping a parallel asset file or threading a
+   theme-aware `src` swap through every `<img>` usage. Scoped to
+   the existing icon src attribute so it can't accidentally invert
+   any other image. */
+[data-theme="light"] img[src="/icons/icon.svg"] {
+  filter: invert(1);
 }


### PR DESCRIPTION
## Summary

Two visible regressions surfaced in v1.2.2:

### 1. Animated thinking indicator

The "Thinking…" placeholder was a static italic string with no motion, leaving users wondering whether the SSE stream had silently dropped. Now renders three opacity-pulsed dots staggered 200 ms apart so the eye reads it as active.

- New \`.pi-thinking-dots\` CSS class with a 1.4s keyframe animation.
- Honors \`prefers-reduced-motion\` — collapses to a static 60%-opacity ellipsis.
- \`aria-live="polite"\` + \`aria-label="Agent is thinking"\` so screen readers announce the state.

### 2. Light-mode contrast pass

The existing \`data-theme\` scheme only remaps the **neutral** scale; **semantic colors** (red errors, sky subagent cards, blue links, amber warnings, emerald success, etc.) stayed as raw Tailwind palette values and collapsed into low-contrast washes on white.

**Structural fix:** add a Tailwind v4 \`@custom-variant light (data-theme="light")\` in \`index.css\`. Existing utilities stay dark-default; light-mode counterparts attach via the \`light:\` prefix (e.g. \`text-red-300 light:text-red-700\`).

**Applied to:**
- **Error banners + buttons:** ContextInspector, FileBrowser, SessionTree, SessionList, ProjectPicker, ChangePassword, Git
- **Subagent (sky) cards:** in-flight + result variants, headline + context badge, error border, both "Open" buttons, agent-name label, exit-code text
- **Blue links** (ChatMarkdown, SettingsPanel) + DiffBlock's hunk staging row + Apply hunk button
- **Status badges** across Skills / Prompts / Tools / Providers tabs (enabled/disabled, project override, "key set" etc.)
- **Compaction card, queue badges, search highlights, role badges** (user / assistant / tool / compaction)
- **Right-pane Git tab change-count badge**
- **Provider settings model list** dim text (was illegible — \`text-neutral-600\` inverts to near-white)
- **Terminal pane "New" button**

**Diff renderer** in light mode: \`[data-theme="light"] .pi-diff-block { ... }\` block re-declares the hardcoded dark colors — sticky line-number gutter background, diff text color, add/delete line tints, decoration row, and all 8 Prism syntax-token color families re-picked at lower lightness to hold AA contrast.

**Chat code blocks** (ChatMarkdown.tsx): now reads the active theme via \`useThemeStore\` and swaps Prism \`vsDark\` → \`vsLight\` + the inline background (\`#0d0d0d\` → \`#f8fafc\`) for light mode.

**Logo:** \`filter: invert(1)\` on \`img[src="/icons/icon.svg"]\` under \`[data-theme="light"]\` — the source SVG is pure white, so invert produces pure black without shipping a parallel asset file.

## Test plan

- [x] \`npm run build\` ✅
- [x] \`npm run check\` (typecheck + eslint + prettier) ✅
- [x] \`npm run test:ci\` (minus environment-fragile pty-reattach/terminal) ✅ — 27/27

### Manual verification recommended after merge

- [ ] Open a long-running session, fire a prompt, watch for the staggered thinking dots — should clearly read as "active" not "stalled".
- [ ] Settings → Appearance → Light. Walk through:
  - [ ] Trigger an error (e.g. revoke an API key and try a prompt) — red banner readable
  - [ ] Run a subagent — sky card + Open button readable
  - [ ] Open a chat that includes a fenced code block — uses vsLight + readable bg
  - [ ] Open an inline edit diff — gutter background blends, line numbers readable, +/- tints not muddy
  - [ ] Open Git tab — change-count badge, status badges, HEAD/tag refs readable
  - [ ] Open Settings → MCP + Skills + Tools + Prompts — enable/disable + project-override badges readable
  - [ ] Open Terminal — "New" button readable
  - [ ] Check the logo in the header — should be black on the light theme