### PR TITLE
feat(quick-actions): toolbar chip menu with command + prompt kinds

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -6,6 +6,7 @@ import { useActiveProject, useProjectStore } from "./store/project-store";
 import { useSessionStore } from "./store/session-store";
 import { useFileStore } from "./store/file-store";
 import { useUiConfigStore } from "./store/ui-config-store";
+import { useQuickActionsStore } from "./store/quick-actions-store";
 import { LoginScreen } from "./components/LoginScreen";
 import { ChangePasswordScreen } from "./components/ChangePasswordScreen";
 import { InstallPrompt } from "./components/InstallPrompt";
@@ -309,6 +310,14 @@ export function App() {
     // path by transitioning isAuthenticated→true with mustChange→false.
     if (isAuthenticated && !mustChangePassword) void loadProjects();
   }, [isAuthenticated, mustChangePassword, loadProjects]);
+
+  // Quick-action chips load once after auth — same trigger as projects.
+  // Failure is non-fatal (the store keeps `loaded: false` and the
+  // chip simply never appears in the toolbar).
+  const loadQuickActions = useQuickActionsStore((s) => s.load);
+  useEffect(() => {
+    if (isAuthenticated && !mustChangePassword) void loadQuickActions();
+  }, [isAuthenticated, mustChangePassword, loadQuickActions]);
 
   // MCP status polling — single 30s ticker shared by the header badge
   // and the Settings MCP tab. Starts after auth (the route is

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -13,6 +13,7 @@ import { EMPTY_MESSAGES, useSessionStore, type AgentMessageLike } from "../store
 import { useActiveProject } from "../store/project-store";
 import { useUiConfigStore } from "../store/ui-config-store";
 import { useUiStore } from "../store/ui-store";
+import { useComposerStore } from "../store/composer-store";
 
 /**
  * Pull the user's prior prompts out of the session message history,
@@ -422,6 +423,37 @@ export function ChatInput({ sessionId }: Props) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [project?.id, promptsRefreshTrigger]);
+
+  // Quick-action prompt chips with `mode: "insert"` (and the "Use as
+  // context" button on completed run cards) bridge through
+  // composer-store: they set a `pendingInsert` keyed to a sessionId;
+  // the matching ChatInput consumes it on mount/effect, appending to
+  // the live textarea value and focusing. Scoped by sessionId so a
+  // stale insert from a now-hidden session doesn't land in the
+  // currently-mounted one.
+  const pendingInsert = useComposerStore((s) => s.pendingInsert);
+  const consumePendingInsert = useComposerStore((s) => s.consumePendingInsert);
+  useEffect(() => {
+    if (pendingInsert === undefined) return;
+    if (pendingInsert.sessionId !== sessionId) return;
+    setText((cur) => {
+      // If the current draft is non-empty and doesn't end on a newline,
+      // separate the inserted text with a blank line so the two
+      // sections don't run together.
+      if (cur.length === 0) return pendingInsert.text;
+      const sep = cur.endsWith("\n") ? "" : "\n\n";
+      return cur + sep + pendingInsert.text;
+    });
+    consumePendingInsert();
+    // Defer focus to the next tick so the textarea has the new value
+    // before the cursor moves to its end.
+    setTimeout(() => {
+      const el = textareaRef.current;
+      if (el === null) return;
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    }, 0);
+  }, [pendingInsert, sessionId, consumePendingInsert]);
 
   // Bang-prefix mode for the visual treatment around the textarea.
   // `!!` runs bash local-only (output stays out of LLM context); `!`

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -29,6 +29,9 @@ import { ChatMarkdown } from "./ChatMarkdown";
 import { CompactionCard } from "./CompactionCard";
 import { DiffBlock } from "./DiffBlock";
 import { SessionTreePanel } from "./SessionTreePanel";
+import { QuickActionsMenu } from "./QuickActionsMenu";
+import { QuickActionRunCard } from "./QuickActionRunCard";
+import { useQuickActionRunsStore } from "../store/quick-actions-store";
 import { parseSubagentDetails, type SubagentResult } from "../lib/subagent-parser";
 
 /**
@@ -99,6 +102,15 @@ export function ChatView({ sessionId }: Props) {
   // map and reading by key would re-run on every map mutation).
   const pendingScrollTarget = useSessionStore((s) => s.pendingScrollByMessageIndex[sessionId]);
   const consumePendingScroll = useSessionStore((s) => s.consumePendingScroll);
+  // Quick-action run cards for THIS session — empty array when none.
+  // The store mutation triggers a re-render which the sticky-bottom
+  // effect picks up automatically, so a new run appearing at the
+  // bottom scrolls into view the same way a new message would.
+  const allRuns = useQuickActionRunsStore((s) => s.runs);
+  const sessionRuns = useMemo(
+    () => allRuns.filter((r) => r.sessionId === sessionId),
+    [allRuns, sessionId],
+  );
 
   const [chatViewType, setChatViewType] = useState<ChatViewType>(readChatViewType);
   const setAndPersistChatViewType = (next: ChatViewType): void => {
@@ -243,55 +255,67 @@ export function ChatView({ sessionId }: Props) {
         {/* Chat-level toolbar. Per-session controls (export, session
             tree, etc.) — pinned above the scroll container so the
             affordances stay reachable from any scroll position. */}
-        <div className="flex items-center justify-end gap-1 border-b border-neutral-800 bg-neutral-900/30 px-3 py-1">
-          {!isMobile && (
-            <div ref={exportMenuRef} className="relative">
-              <button
-                onClick={() => setExportMenuOpen((v) => !v)}
-                aria-haspopup="menu"
-                aria-expanded={exportMenuOpen}
-                className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200"
-                title="Export this conversation"
-              >
-                <Download size={11} />
-                Export
-              </button>
-              {exportMenuOpen && (
-                <div
-                  role="menu"
-                  className="absolute right-0 top-full z-30 mt-1 min-w-[12rem] rounded-md border border-neutral-700 bg-neutral-900 py-1 shadow-xl"
+        <div className="flex items-center justify-between gap-1 border-b border-neutral-800 bg-neutral-900/30 px-3 py-1">
+          {/* Left cluster — quick-action chips. Empty when no actions
+              are defined, in minimal mode with only command chips,
+              or while the store is still loading. The container is
+              always rendered so the right cluster stays anchored
+              right via flex justify-between. */}
+          <div className="flex items-center gap-1">
+            {project !== undefined && (
+              <QuickActionsMenu sessionId={sessionId} projectId={project.id} />
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            {!isMobile && (
+              <div ref={exportMenuRef} className="relative">
+                <button
+                  onClick={() => setExportMenuOpen((v) => !v)}
+                  aria-haspopup="menu"
+                  aria-expanded={exportMenuOpen}
+                  className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200"
+                  title="Export this conversation"
                 >
-                  <button
-                    role="menuitem"
-                    onClick={() => void doExport("markdown")}
-                    className="block w-full px-3 py-1.5 text-left text-xs text-neutral-200 hover:bg-neutral-800"
+                  <Download size={11} />
+                  Export
+                </button>
+                {exportMenuOpen && (
+                  <div
+                    role="menu"
+                    className="absolute right-0 top-full z-30 mt-1 min-w-[12rem] rounded-md border border-neutral-700 bg-neutral-900 py-1 shadow-xl"
                   >
-                    Markdown <span className="text-neutral-500">(.md)</span>
-                  </button>
-                  <button
-                    role="menuitem"
-                    onClick={() => void doExport("jsonl")}
-                    className="block w-full px-3 py-1.5 text-left text-xs text-neutral-200 hover:bg-neutral-800"
-                  >
-                    Raw JSONL <span className="text-neutral-500">(.jsonl)</span>
-                  </button>
-                </div>
-              )}
-            </div>
-          )}
-          {exportError !== undefined && (
-            <span className="text-[10px] text-amber-400 light:text-amber-700" role="status">
-              Export failed: {exportError}
-            </span>
-          )}
-          <button
-            onClick={() => setTreeOpen(true)}
-            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200"
-            title="Open session tree (navigate / fork from any prior point)"
-          >
-            <GitBranch size={11} />
-            Tree
-          </button>
+                    <button
+                      role="menuitem"
+                      onClick={() => void doExport("markdown")}
+                      className="block w-full px-3 py-1.5 text-left text-xs text-neutral-200 hover:bg-neutral-800"
+                    >
+                      Markdown <span className="text-neutral-500">(.md)</span>
+                    </button>
+                    <button
+                      role="menuitem"
+                      onClick={() => void doExport("jsonl")}
+                      className="block w-full px-3 py-1.5 text-left text-xs text-neutral-200 hover:bg-neutral-800"
+                    >
+                      Raw JSONL <span className="text-neutral-500">(.jsonl)</span>
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+            {exportError !== undefined && (
+              <span className="text-[10px] text-amber-400 light:text-amber-700" role="status">
+                Export failed: {exportError}
+              </span>
+            )}
+            <button
+              onClick={() => setTreeOpen(true)}
+              className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200"
+              title="Open session tree (navigate / fork from any prior point)"
+            >
+              <GitBranch size={11} />
+              Tree
+            </button>
+          </div>
         </div>
         {/* Banner sits ABOVE the scroll container so it stays pinned to the top
             of the chat view regardless of how far the user has scrolled into a
@@ -406,6 +430,9 @@ export function ChatView({ sessionId }: Props) {
               <ActiveToolPlaceholder tool={activeTool} />
             )}
             {queued !== undefined && <QueuedMessages queued={queued} />}
+            {sessionRuns.map((run) => (
+              <QuickActionRunCard key={run.runId} run={run} />
+            ))}
           </div>
         </div>
       </div>

--- a/packages/client/src/components/QuickActionRunCard.tsx
+++ b/packages/client/src/components/QuickActionRunCard.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import { Check, Loader2, MessageSquarePlus, Terminal, X } from "lucide-react";
+import { useQuickActionRunsStore, type QuickActionRun } from "../store/quick-actions-store";
+import { useComposerStore } from "../store/composer-store";
+
+interface Props {
+  run: QuickActionRun;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
+/**
+ * Inline "I ran a chip" card. Lives in the chat scroll alongside
+ * agent messages so the user has a visual trail of what they
+ * triggered and what came back — same visual idiom as the existing
+ * tool-execution cards (collapsed details + colored left border for
+ * success/fail).
+ *
+ * `running` state: spinner, abort button.
+ * `done` state: exit code, duration, expand for stdout / stderr,
+ *   "Use as context" button to push the captured output into the
+ *   composer for the next prompt.
+ */
+export function QuickActionRunCard({ run }: Props) {
+  const removeRun = useQuickActionRunsStore((s) => s.removeRun);
+  const setPendingInsert = useComposerStore((s) => s.setPendingInsert);
+  const [expanded, setExpanded] = useState(false);
+
+  const result = run.result;
+  const isRunning = run.status === "running";
+  const isError = run.error !== undefined;
+  const success = result?.success === true && !isError;
+  const exitCode = result?.exitCode ?? null;
+
+  // Left border color encodes the headline result: amber while
+  // running, green on clean success, red on failure (incl. error,
+  // timeout, non-zero exit, abort).
+  const borderClass = isRunning
+    ? "border-l-amber-500 light:border-l-amber-600"
+    : success
+      ? "border-l-emerald-500 light:border-l-emerald-600"
+      : "border-l-red-500 light:border-l-red-600";
+
+  const statusLabel = isRunning
+    ? "running"
+    : isError
+      ? "error"
+      : result?.timedOut === true
+        ? "timed out"
+        : run.status === "aborted"
+          ? "aborted"
+          : exitCode === 0
+            ? "exit 0"
+            : `exit ${exitCode ?? "?"}`;
+
+  // Combined output for the "Use as context" button. Kept simple —
+  // fenced with the action name so the agent has framing without us
+  // doing heavyweight rendering.
+  const buildContextSnippet = (): string => {
+    if (result === undefined) return "";
+    const out: string[] = [`Ran quick action: ${run.actionName}`, ""];
+    if (result.stdout.length > 0) {
+      out.push("```", result.stdout.replace(/\s+$/, ""), "```");
+    }
+    if (result.stderr.length > 0) {
+      out.push("", "stderr:", "```", result.stderr.replace(/\s+$/, ""), "```");
+    }
+    if (result.exitCode !== null && result.exitCode !== 0) {
+      out.push("", `exit code: ${result.exitCode}`);
+    }
+    return out.join("\n");
+  };
+
+  return (
+    <div
+      className={`rounded-lg border border-neutral-800 border-l-4 bg-neutral-900/40 px-3 py-2 text-xs light:border-neutral-300 light:bg-neutral-50 ${borderClass}`}
+    >
+      <div className="flex items-center gap-2">
+        <Terminal size={12} className="text-neutral-500 light:text-neutral-600" />
+        <span className="font-mono text-neutral-300 light:text-neutral-800">{run.actionName}</span>
+        <span className="text-neutral-500 light:text-neutral-600">·</span>
+        {isRunning ? (
+          <span className="flex items-center gap-1 text-amber-400 light:text-amber-700">
+            <Loader2 size={11} className="animate-spin" />
+            {statusLabel}
+          </span>
+        ) : success ? (
+          <span className="flex items-center gap-1 text-emerald-400 light:text-emerald-700">
+            <Check size={11} />
+            {statusLabel}
+          </span>
+        ) : (
+          <span className="flex items-center gap-1 text-red-400 light:text-red-700">
+            <X size={11} />
+            {statusLabel}
+          </span>
+        )}
+        {result !== undefined && (
+          <span className="text-neutral-500 light:text-neutral-600">
+            · {formatDuration(result.durationMs)}
+          </span>
+        )}
+        {result?.truncated === true && (
+          <span
+            className="rounded bg-amber-700/40 px-1 text-[10px] text-amber-100 light:bg-amber-200 light:text-amber-900"
+            title="Output exceeded the per-stream cap and was cut off"
+          >
+            truncated
+          </span>
+        )}
+        <div className="flex-1" />
+        {isRunning ? (
+          <button
+            type="button"
+            onClick={() => {
+              run.abort();
+              // Note: server doesn't expose a per-run abort endpoint
+              // yet — the AbortController only stops us from honouring
+              // the result. v2 can wire a real /abort. Mark "aborted"
+              // optimistically so the card visibly responds.
+              useQuickActionRunsStore.getState().updateRun(run.runId, { status: "aborted" });
+            }}
+            className="rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200 light:text-neutral-600 light:hover:bg-neutral-200"
+            title="Stop waiting on this run (server-side abort coming later)"
+          >
+            Stop
+          </button>
+        ) : (
+          <>
+            {result !== undefined && (result.stdout.length > 0 || result.stderr.length > 0) && (
+              <button
+                type="button"
+                onClick={() => setPendingInsert(run.sessionId, buildContextSnippet())}
+                className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-sky-400 hover:bg-neutral-800 hover:text-sky-200 light:text-sky-700 light:hover:bg-neutral-200 light:hover:text-sky-900"
+                title="Insert the captured output into the composer for your next prompt"
+              >
+                <MessageSquarePlus size={11} />
+                Use as context
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => removeRun(run.runId)}
+              className="rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200 light:text-neutral-500 light:hover:bg-neutral-200 light:hover:text-neutral-900"
+              title="Dismiss"
+            >
+              Dismiss
+            </button>
+          </>
+        )}
+      </div>
+      {(result !== undefined &&
+        (result.stdout.length > 0 || result.stderr.length > 0 || result.exitCode !== 0)) ||
+      isError ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-1 cursor-pointer text-[10px] uppercase tracking-wider text-neutral-500 hover:text-neutral-300 light:text-neutral-600 light:hover:text-neutral-900"
+        >
+          {expanded ? "Hide output" : "Show output"}
+        </button>
+      ) : null}
+      {expanded && (
+        <div className="mt-2 space-y-2">
+          {isError && (
+            <pre className="overflow-auto whitespace-pre-wrap rounded bg-neutral-950 px-2 py-1 font-mono text-[11px] text-red-300 light:bg-red-50 light:text-red-800">
+              {run.error}
+            </pre>
+          )}
+          {result !== undefined && result.stdout.length > 0 && (
+            <div>
+              <div className="mb-0.5 text-[10px] uppercase tracking-wider text-neutral-500 light:text-neutral-600">
+                stdout
+              </div>
+              <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded bg-neutral-950 px-2 py-1 font-mono text-[11px] text-neutral-200 light:bg-white light:text-neutral-800">
+                {result.stdout}
+              </pre>
+            </div>
+          )}
+          {result !== undefined && result.stderr.length > 0 && (
+            <div>
+              <div className="mb-0.5 text-[10px] uppercase tracking-wider text-neutral-500 light:text-neutral-600">
+                stderr
+              </div>
+              <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded bg-neutral-950 px-2 py-1 font-mono text-[11px] text-red-300 light:bg-red-50 light:text-red-800">
+                {result.stderr}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/QuickActionsMenu.tsx
+++ b/packages/client/src/components/QuickActionsMenu.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown, Loader2, MessageSquare, Terminal, Zap } from "lucide-react";
+import { api, ApiError } from "../lib/api-client";
+import type { QuickAction } from "../lib/api-client";
+import {
+  useQuickActionRunsStore,
+  useQuickActionsStore,
+  type QuickActionRun,
+} from "../store/quick-actions-store";
+import { useUiConfigStore } from "../store/ui-config-store";
+import { useSessionStore } from "../store/session-store";
+import { useComposerStore } from "../store/composer-store";
+
+/**
+ * Toolbar chip rendered in `ChatView`'s top bar (left-aligned). Two
+ * action kinds are dispatched here:
+ *
+ *  - command: POST /quick-actions/:id/run with the project id.
+ *    A `QuickActionRun` is pushed into the runs store so the inline
+ *    card in the chat scroll picks it up immediately in `running`
+ *    state, then mutates to `done`/`aborted` when the request
+ *    resolves.
+ *  - prompt: dispatched entirely client-side — either `sendPrompt`
+ *    (mode: "send") or `composerStore.setPendingInsert` (mode:
+ *    "insert"). No server round-trip.
+ *
+ * Command chips are filtered out under MINIMAL_UI. Defense-in-depth
+ * matters: the server `/run` route also returns 403 in that mode.
+ */
+interface Props {
+  sessionId: string;
+  projectId: string;
+}
+
+function isCommandAction(a: QuickAction): boolean {
+  return typeof a.command === "string" && a.command.length > 0;
+}
+
+function isPromptAction(a: QuickAction): boolean {
+  return typeof a.text === "string" && a.text.length > 0;
+}
+
+function randomId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `run-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function QuickActionsMenu({ sessionId, projectId }: Props) {
+  const loaded = useQuickActionsStore((s) => s.loaded);
+  const actions = useQuickActionsStore((s) => s.actions);
+  const minimal = useUiConfigStore((s) => s.minimal);
+  const addRun = useQuickActionRunsStore((s) => s.addRun);
+  const updateRun = useQuickActionRunsStore((s) => s.updateRun);
+  const runs = useQuickActionRunsStore((s) => s.runs);
+  const sendPrompt = useSessionStore((s) => s.sendPrompt);
+  const setPendingInsert = useComposerStore((s) => s.setPendingInsert);
+
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Click-outside close — mirrors the export menu pattern in ChatView.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent): void => {
+      if (menuRef.current === null) return;
+      if (!menuRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // The list the user actually sees: enabled chips, with command-kind
+  // filtered out in minimal mode. Settings still shows them; the menu
+  // hides them.
+  const visible = actions.filter((a) => {
+    if (a.enabled === false) return false;
+    if (minimal && isCommandAction(a)) return false;
+    return true;
+  });
+
+  // Per-action in-flight count for the dropdown row spinner. Counts
+  // include runs from OTHER sessions too — if the user clicked a
+  // chip in session A then switched to B, the row should still hint
+  // that the command is running so they're not surprised by a card
+  // landing in A on return.
+  const inFlightById = new Map<string, number>();
+  let totalInFlight = 0;
+  for (const r of runs) {
+    if (r.status !== "running") continue;
+    totalInFlight += 1;
+    inFlightById.set(r.actionId, (inFlightById.get(r.actionId) ?? 0) + 1);
+  }
+
+  if (!loaded || visible.length === 0) return null;
+
+  const handleCommand = (action: QuickAction): void => {
+    const runId = randomId();
+    const controller = new AbortController();
+    const run: QuickActionRun = {
+      runId,
+      sessionId,
+      actionId: action.id,
+      actionName: action.name,
+      startedAt: Date.now(),
+      status: "running",
+      abort: () => {
+        try {
+          controller.abort();
+        } catch {
+          // ignore
+        }
+      },
+    };
+    addRun(run);
+    void api
+      .runQuickAction(action.id, projectId)
+      .then((result) => {
+        updateRun(runId, { status: controller.signal.aborted ? "aborted" : "done", result });
+      })
+      .catch((err: unknown) => {
+        const message =
+          err instanceof ApiError ? `${err.code}: ${err.message}` : (err as Error).message;
+        updateRun(runId, { status: "done", error: message });
+      });
+  };
+
+  const handlePrompt = (action: QuickAction): void => {
+    const text = action.text ?? "";
+    if (text.length === 0) return;
+    const mode = action.mode ?? "send";
+    if (mode === "insert") {
+      setPendingInsert(sessionId, text);
+    } else {
+      void sendPrompt(sessionId, text);
+    }
+  };
+
+  const onPick = (action: QuickAction): void => {
+    setOpen(false);
+    if (isCommandAction(action)) handleCommand(action);
+    else if (isPromptAction(action)) handlePrompt(action);
+  };
+
+  return (
+    <div ref={menuRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200 light:text-neutral-600 light:hover:bg-neutral-200 light:hover:text-neutral-900"
+        title="Run a saved quick action"
+      >
+        <Zap size={11} />
+        Actions
+        {totalInFlight > 0 && (
+          <span
+            className="ml-0.5 flex items-center gap-0.5 rounded bg-amber-700/40 px-1 text-[9px] normal-case text-amber-100 light:bg-amber-200 light:text-amber-900"
+            title={`${totalInFlight} action${totalInFlight === 1 ? "" : "s"} running`}
+          >
+            <Loader2 size={9} className="animate-spin" />
+            {totalInFlight}
+          </span>
+        )}
+        <ChevronDown size={11} />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute left-0 top-full z-30 mt-1 min-w-[14rem] max-w-[20rem] rounded-md border border-neutral-700 bg-neutral-900 py-1 shadow-xl light:border-neutral-300 light:bg-white"
+        >
+          {visible.map((action) => {
+            const isCmd = isCommandAction(action);
+            const Icon = isCmd ? Terminal : MessageSquare;
+            const running = inFlightById.get(action.id) ?? 0;
+            return (
+              <button
+                key={action.id}
+                role="menuitem"
+                onClick={() => onPick(action)}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-neutral-200 hover:bg-neutral-800 light:text-neutral-800 light:hover:bg-neutral-100"
+                title={
+                  isCmd
+                    ? (action.command ?? "")
+                    : `${action.mode === "insert" ? "Insert" : "Send"}: ${action.text ?? ""}`
+                }
+              >
+                <Icon
+                  size={12}
+                  className={
+                    isCmd
+                      ? "text-amber-400 light:text-amber-700"
+                      : "text-sky-400 light:text-sky-700"
+                  }
+                />
+                <span className="flex-1 truncate">{action.name}</span>
+                {running > 0 && (
+                  <Loader2 size={11} className="animate-spin text-amber-400 light:text-amber-700" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -17,6 +17,7 @@ import { useActiveProject, useProjectStore } from "../store/project-store";
 import { useUiConfigStore } from "../store/ui-config-store";
 import { useUiStore } from "../store/ui-store";
 import { EMPTY_STATUS, useMcpStore } from "../store/mcp-store";
+import { useQuickActionsStore } from "../store/quick-actions-store";
 import { THEME_DEFS, useThemeStore, type ThemeId } from "../lib/theme";
 import { getStoredToken } from "../lib/auth-client";
 import { useAuthStore } from "../store/auth-store";
@@ -29,6 +30,7 @@ type Tab =
   | "skills"
   | "prompts"
   | "systemPrompt"
+  | "quickActions"
   | "appearance"
   | "backup"
   | "general";
@@ -80,6 +82,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
             "prompts",
             "systemPrompt",
             "tools",
+            "quickActions",
             "appearance",
             "backup",
             "general",
@@ -92,6 +95,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
             "skills",
             "prompts",
             "systemPrompt",
+            "quickActions",
             "appearance",
             "backup",
             "general",
@@ -155,11 +159,13 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
                             ? "Prompts"
                             : t === "systemPrompt"
                               ? "System Prompt"
-                              : t === "appearance"
-                                ? "Appearance"
-                                : t === "backup"
-                                  ? "Backup"
-                                  : "General"}
+                              : t === "quickActions"
+                                ? "Quick Actions"
+                                : t === "appearance"
+                                  ? "Appearance"
+                                  : t === "backup"
+                                    ? "Backup"
+                                    : "General"}
               </button>
             ))}
           </div>
@@ -210,6 +216,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           {tab === "skills" && <SkillsTab onError={setError} />}
           {tab === "prompts" && <PromptsTab onError={setError} />}
           {tab === "systemPrompt" && <SystemPromptTab onError={setError} />}
+          {tab === "quickActions" && <QuickActionsTab onError={setError} />}
           {tab === "appearance" && <AppearanceTab />}
           {tab === "backup" && <BackupTab onError={setError} />}
           {tab === "general" && <GeneralTab />}
@@ -1932,6 +1939,375 @@ function SystemPromptTab({ onError }: { onError: (msg: string | undefined) => vo
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+// ---------------- Quick Actions tab ----------------
+
+interface DraftAction {
+  id?: string;
+  name: string;
+  kind: "command" | "prompt";
+  enabled: boolean;
+  command: string;
+  timeoutSec: string;
+  text: string;
+  mode: "send" | "insert";
+}
+
+function emptyActionDraft(kind: "command" | "prompt"): DraftAction {
+  return {
+    name: "",
+    kind,
+    enabled: true,
+    command: "",
+    timeoutSec: "30",
+    text: "",
+    mode: "send",
+  };
+}
+
+function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => void }) {
+  const minimal = useUiConfigStore((s) => s.minimal);
+  const loaded = useQuickActionsStore((s) => s.loaded);
+  const actions = useQuickActionsStore((s) => s.actions);
+  const load = useQuickActionsStore((s) => s.load);
+  const create = useQuickActionsStore((s) => s.create);
+  const update = useQuickActionsStore((s) => s.update);
+  const remove = useQuickActionsStore((s) => s.remove);
+
+  const [draft, setDraft] = useState<DraftAction | undefined>(undefined);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | undefined>(undefined);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    onError(undefined);
+    if (!loaded) void load();
+  }, [load, loaded, onError]);
+
+  const startEdit = (a: (typeof actions)[number]): void => {
+    const isCmd = typeof a.command === "string" && a.command.length > 0;
+    setDraft({
+      id: a.id,
+      name: a.name,
+      kind: isCmd ? "command" : "prompt",
+      enabled: a.enabled !== false,
+      command: a.command ?? "",
+      timeoutSec: String(Math.round((a.timeoutMs ?? 30_000) / 1000)),
+      text: a.text ?? "",
+      mode: a.mode ?? "send",
+    });
+  };
+
+  const save = async (): Promise<void> => {
+    if (draft === undefined) return;
+    const trimmedName = draft.name.trim();
+    if (trimmedName.length === 0) {
+      onError("Name is required");
+      return;
+    }
+    const body: {
+      name: string;
+      enabled?: boolean;
+      command?: string;
+      timeoutMs?: number;
+      text?: string;
+      mode?: "send" | "insert";
+    } = { name: trimmedName, enabled: draft.enabled };
+    if (draft.kind === "command") {
+      const cmd = draft.command.trim();
+      if (cmd.length === 0) {
+        onError("Command is required");
+        return;
+      }
+      body.command = cmd;
+      const secs = Number.parseInt(draft.timeoutSec, 10);
+      if (Number.isFinite(secs) && secs > 0) body.timeoutMs = secs * 1000;
+    } else {
+      const text = draft.text.trim();
+      if (text.length === 0) {
+        onError("Prompt text is required");
+        return;
+      }
+      body.text = text;
+      body.mode = draft.mode;
+    }
+    setBusy(true);
+    try {
+      if (draft.id === undefined) await create(body);
+      else await update(draft.id, body);
+      setDraft(undefined);
+      onError(undefined);
+    } catch (err) {
+      onError(`Save failed: ${errorCode(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doDelete = async (id: string): Promise<void> => {
+    setBusy(true);
+    try {
+      await remove(id);
+      setPendingDeleteId(undefined);
+      if (draft?.id === id) setDraft(undefined);
+    } catch (err) {
+      onError(`Delete failed: ${errorCode(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-neutral-100 light:text-neutral-900">
+          Quick action chips
+        </h2>
+        <p className="mt-1 text-xs text-neutral-400 light:text-neutral-600">
+          One-click buttons on the chat toolbar. Two kinds:{" "}
+          <span className="text-amber-400 light:text-amber-700">command</span> chips run a shell
+          snippet in the active project&apos;s folder;{" "}
+          <span className="text-sky-400 light:text-sky-700">prompt</span> chips either send a
+          templated prompt to the agent or insert it into the composer so you can tweak it before
+          sending. Chips are stored globally (not per-project) — they&apos;re your personal toolbox.
+        </p>
+      </div>
+
+      {minimal && (
+        <div className="rounded border border-amber-700/40 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800">
+          MINIMAL_UI is enabled. Command chips are listed below but are hidden from the toolbar and
+          the server refuses to run them. Prompt chips are unaffected.
+        </div>
+      )}
+
+      <div className="space-y-1">
+        {actions.length === 0 && loaded && (
+          <p className="text-xs italic text-neutral-500 light:text-neutral-600">
+            No chips defined yet. Click &ldquo;New&rdquo; below to add one.
+          </p>
+        )}
+        {actions.map((a) => {
+          const isCmd = typeof a.command === "string" && a.command.length > 0;
+          const hiddenInMinimal = minimal && isCmd;
+          return (
+            <div
+              key={a.id}
+              className={`flex items-center gap-2 rounded border border-neutral-800 bg-neutral-900/40 px-3 py-2 text-xs light:border-neutral-300 light:bg-neutral-50 ${
+                a.enabled === false ? "opacity-60" : ""
+              }`}
+            >
+              <span
+                className={`rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${
+                  isCmd
+                    ? "bg-amber-900/40 text-amber-300 light:bg-amber-100 light:text-amber-900"
+                    : "bg-sky-900/40 text-sky-300 light:bg-sky-100 light:text-sky-900"
+                }`}
+              >
+                {isCmd ? "cmd" : "prompt"}
+              </span>
+              <span className="flex-1 truncate font-medium text-neutral-200 light:text-neutral-900">
+                {a.name}
+              </span>
+              {a.enabled === false && (
+                <span className="text-[10px] uppercase tracking-wider text-neutral-500">
+                  disabled
+                </span>
+              )}
+              {hiddenInMinimal && (
+                <span className="text-[10px] uppercase tracking-wider text-amber-400 light:text-amber-700">
+                  hidden by MINIMAL_UI
+                </span>
+              )}
+              <button
+                onClick={() => startEdit(a)}
+                className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-300 hover:border-neutral-500 light:border-neutral-400 light:text-neutral-700"
+              >
+                Edit
+              </button>
+              {pendingDeleteId === a.id ? (
+                <>
+                  <button
+                    onClick={() => void doDelete(a.id)}
+                    disabled={busy}
+                    className="rounded border border-red-700 px-2 py-0.5 text-[11px] text-red-300 hover:bg-red-900/40 light:border-red-400 light:text-red-700"
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => setPendingDeleteId(undefined)}
+                    className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-400 hover:border-neutral-500 light:border-neutral-400 light:text-neutral-600"
+                  >
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={() => setPendingDeleteId(a.id)}
+                  className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-400 hover:border-red-500 hover:text-red-300 light:border-neutral-400 light:text-neutral-600"
+                >
+                  Delete
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {draft === undefined && (
+        <button
+          onClick={() => setDraft(emptyActionDraft("prompt"))}
+          className="rounded border border-neutral-700 px-3 py-1 text-xs text-neutral-200 hover:border-neutral-500 light:border-neutral-400 light:text-neutral-800"
+        >
+          + New chip
+        </button>
+      )}
+
+      {draft !== undefined && (
+        <div className="space-y-3 rounded border border-neutral-700 bg-neutral-900/60 p-3 light:border-neutral-300 light:bg-white">
+          <div>
+            <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+              Name
+            </label>
+            <input
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              placeholder="e.g. Run tests"
+              className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 light:border-neutral-300 light:bg-white light:text-neutral-900"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+              Kind
+            </label>
+            <div className="flex items-center gap-3 text-xs text-neutral-300 light:text-neutral-800">
+              <label className="flex items-center gap-1.5">
+                <input
+                  type="radio"
+                  checked={draft.kind === "prompt"}
+                  onChange={() => setDraft({ ...draft, kind: "prompt" })}
+                />
+                Prompt
+              </label>
+              <label
+                className={`flex items-center gap-1.5 ${minimal ? "opacity-50" : ""}`}
+                title={
+                  minimal
+                    ? "Command chips are disabled by MINIMAL_UI. The server refuses to run them."
+                    : undefined
+                }
+              >
+                <input
+                  type="radio"
+                  checked={draft.kind === "command"}
+                  disabled={minimal}
+                  onChange={() => setDraft({ ...draft, kind: "command" })}
+                />
+                Command{minimal ? " (disabled by MINIMAL_UI)" : ""}
+              </label>
+            </div>
+          </div>
+          {draft.kind === "command" ? (
+            <>
+              <div>
+                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+                  Command
+                </label>
+                <textarea
+                  value={draft.command}
+                  onChange={(e) => setDraft({ ...draft, command: e.target.value })}
+                  rows={3}
+                  placeholder="npm test"
+                  className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 light:border-neutral-300 light:bg-white light:text-neutral-900"
+                />
+                <p className="mt-1 text-[11px] text-neutral-500 light:text-neutral-600">
+                  Runs in the active project&apos;s folder via <code>/bin/sh -c</code>. Multi-line
+                  is fine (<code>&amp;&amp;</code>, <code>;</code>, etc.). Environment is scrubbed
+                  of pi-forge and provider secrets (same as the integrated terminal).
+                </p>
+              </div>
+              <div>
+                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+                  Timeout (seconds)
+                </label>
+                <input
+                  value={draft.timeoutSec}
+                  onChange={(e) => setDraft({ ...draft, timeoutSec: e.target.value })}
+                  placeholder="30"
+                  className="w-24 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 light:border-neutral-300 light:bg-white light:text-neutral-900"
+                />
+                <p className="mt-1 text-[11px] text-neutral-500 light:text-neutral-600">
+                  Max 300 (five minutes). Past that, use the integrated terminal.
+                </p>
+              </div>
+            </>
+          ) : (
+            <>
+              <div>
+                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+                  Prompt text
+                </label>
+                <textarea
+                  value={draft.text}
+                  onChange={(e) => setDraft({ ...draft, text: e.target.value })}
+                  rows={4}
+                  placeholder="Review the staged changes for security issues."
+                  className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs text-neutral-100 light:border-neutral-300 light:bg-white light:text-neutral-900"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+                  Mode
+                </label>
+                <div className="flex items-center gap-3 text-xs text-neutral-300 light:text-neutral-800">
+                  <label className="flex items-center gap-1.5">
+                    <input
+                      type="radio"
+                      checked={draft.mode === "send"}
+                      onChange={() => setDraft({ ...draft, mode: "send" })}
+                    />
+                    Send immediately
+                  </label>
+                  <label className="flex items-center gap-1.5">
+                    <input
+                      type="radio"
+                      checked={draft.mode === "insert"}
+                      onChange={() => setDraft({ ...draft, mode: "insert" })}
+                    />
+                    Insert into composer
+                  </label>
+                </div>
+              </div>
+            </>
+          )}
+          <div>
+            <label className="flex items-center gap-1.5 text-xs text-neutral-300 light:text-neutral-800">
+              <input
+                type="checkbox"
+                checked={draft.enabled}
+                onChange={(e) => setDraft({ ...draft, enabled: e.target.checked })}
+              />
+              Enabled (visible in the menu)
+            </label>
+          </div>
+          <div className="flex items-center gap-2 border-t border-neutral-800 pt-3 light:border-neutral-300">
+            <button
+              onClick={() => void save()}
+              disabled={busy}
+              className="rounded bg-emerald-700 px-3 py-1 text-xs text-white hover:bg-emerald-600 disabled:opacity-50"
+            >
+              {draft.id === undefined ? "Create" : "Save"}
+            </button>
+            <button
+              onClick={() => setDraft(undefined)}
+              className="rounded border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:border-neutral-500 light:border-neutral-400 light:text-neutral-700"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -11,6 +11,9 @@ import {
   type McpServersResponse,
   type McpSettingsResponse,
   type McpToolSummary,
+  type QuickAction,
+  type QuickActionsResponse,
+  type QuickActionRunResult,
   type Project,
   type BrowseEntry,
   type BrowseResponse,
@@ -534,6 +537,44 @@ function vMcpDelete(value: unknown, status: number): { removed: boolean } {
     fail(status, "expected { removed: boolean }");
   }
   return { removed: value.removed };
+}
+
+function vQuickAction(value: unknown, status: number): QuickAction {
+  if (!isObject(value) || typeof value.id !== "string" || typeof value.name !== "string") {
+    fail(status, "expected QuickAction shape");
+  }
+  return value as unknown as QuickAction;
+}
+
+function vQuickActions(value: unknown, status: number): QuickActionsResponse {
+  if (!isObject(value) || !Array.isArray(value.actions)) {
+    fail(status, "expected { actions: [...] }");
+  }
+  return { actions: value.actions as QuickAction[] };
+}
+
+function vQuickActionRunResult(value: unknown, status: number): QuickActionRunResult {
+  if (
+    !isObject(value) ||
+    typeof value.success !== "boolean" ||
+    typeof value.stdout !== "string" ||
+    typeof value.stderr !== "string" ||
+    typeof value.durationMs !== "number" ||
+    typeof value.timedOut !== "boolean" ||
+    typeof value.truncated !== "boolean"
+  ) {
+    fail(status, "expected QuickActionRunResult shape");
+  }
+  const exitCode = value.exitCode;
+  return {
+    success: value.success,
+    exitCode: typeof exitCode === "number" ? exitCode : null,
+    stdout: value.stdout,
+    stderr: value.stderr,
+    durationMs: value.durationMs,
+    timedOut: value.timedOut,
+    truncated: value.truncated,
+  };
 }
 
 function vAuthSummary(value: unknown, status: number): AuthSummary {
@@ -1418,6 +1459,23 @@ export const api = {
       },
       { method: "DELETE" },
     ),
+  // ---------------- quick actions ----------------
+  listQuickActions: () => request("/api/v1/quick-actions", vQuickActions),
+  createQuickAction: (body: Omit<QuickAction, "id">) =>
+    request("/api/v1/quick-actions", vQuickAction, { method: "POST", body }),
+  updateQuickAction: (id: string, body: Omit<QuickAction, "id">) =>
+    request(`/api/v1/quick-actions/${encodeURIComponent(id)}`, vQuickAction, {
+      method: "PUT",
+      body,
+    }),
+  deleteQuickAction: (id: string) =>
+    request(`/api/v1/quick-actions/${encodeURIComponent(id)}`, vVoid, { method: "DELETE" }),
+  runQuickAction: (id: string, projectId: string) =>
+    request(`/api/v1/quick-actions/${encodeURIComponent(id)}/run`, vQuickActionRunResult, {
+      method: "POST",
+      body: { projectId },
+    }),
+
   listSkills: (projectId: string) =>
     request(
       `/api/v1/config/skills?projectId=${encodeURIComponent(projectId)}`,

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -104,6 +104,40 @@ export interface McpSettingsResponse {
   total: number;
 }
 
+// ---------------- Quick actions ----------------
+
+/**
+ * Discriminator-by-presence (matches `McpServerConfig`): `command` is
+ * set → command action; `text` is set → prompt action. The wire
+ * surface enforces "exactly one of" with a 400 — never both, never
+ * neither.
+ */
+export interface QuickAction {
+  id: string;
+  name: string;
+  enabled?: boolean;
+  // command-only
+  command?: string;
+  timeoutMs?: number;
+  // prompt-only
+  text?: string;
+  mode?: "send" | "insert";
+}
+
+export interface QuickActionsResponse {
+  actions: QuickAction[];
+}
+
+export interface QuickActionRunResult {
+  success: boolean;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  timedOut: boolean;
+  truncated: boolean;
+}
+
 export interface McpToolSummary {
   name: string;
   description: string;

--- a/packages/client/src/store/composer-store.ts
+++ b/packages/client/src/store/composer-store.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+
+/**
+ * One-shot bridge from "something else" (quick-action prompt chips,
+ * the "Use as context" button on run cards, …) into the chat
+ * composer. The `ChatInput` component subscribes via effect: when
+ * `pendingInsert` flips to a non-null value, it appends to its
+ * textarea, focuses, then calls `consumePendingInsert()` so the
+ * same value isn't reinserted on re-render.
+ *
+ * Scoped by sessionId so a stale insert from session A doesn't land
+ * in session B when the user switches tabs before the composer mount
+ * fires.
+ */
+interface PendingInsert {
+  sessionId: string;
+  text: string;
+}
+
+interface ComposerState {
+  pendingInsert: PendingInsert | undefined;
+  setPendingInsert: (sessionId: string, text: string) => void;
+  consumePendingInsert: () => void;
+}
+
+export const useComposerStore = create<ComposerState>((set) => ({
+  pendingInsert: undefined,
+  setPendingInsert: (sessionId, text) => set({ pendingInsert: { sessionId, text } }),
+  consumePendingInsert: () => set({ pendingInsert: undefined }),
+}));

--- a/packages/client/src/store/quick-actions-store.ts
+++ b/packages/client/src/store/quick-actions-store.ts
@@ -1,0 +1,95 @@
+import { create } from "zustand";
+import { api, ApiError } from "../lib/api-client";
+import type { QuickAction, QuickActionRunResult } from "../lib/api-client";
+
+/**
+ * Global quick-action registry — fetched once on app boot and on
+ * settings-panel save. List order from the server = display order
+ * in the chip dropdown.
+ *
+ * Run results are NOT held here: they're owned by `runs-store` so
+ * the chat-view inline card can mount/unmount independently of
+ * whether the menu is open.
+ */
+interface QuickActionsState {
+  loaded: boolean;
+  actions: QuickAction[];
+  error: string | undefined;
+  load: () => Promise<void>;
+  create: (body: Omit<QuickAction, "id">) => Promise<QuickAction>;
+  update: (id: string, body: Omit<QuickAction, "id">) => Promise<QuickAction>;
+  remove: (id: string) => Promise<void>;
+}
+
+export const useQuickActionsStore = create<QuickActionsState>((set, get) => ({
+  loaded: false,
+  actions: [],
+  error: undefined,
+  load: async () => {
+    try {
+      const { actions } = await api.listQuickActions();
+      set({ loaded: true, actions, error: undefined });
+    } catch (err) {
+      const code = err instanceof ApiError ? err.code : (err as Error).message;
+      if (typeof console !== "undefined") {
+        console.warn("[quick-actions] load failed:", code);
+      }
+      // Failure leaves loaded=false so the menu never appears — better
+      // than showing an empty Actions chip that can't be acted on.
+      set({ error: code });
+    }
+  },
+  create: async (body) => {
+    const created = await api.createQuickAction(body);
+    set({ actions: [...get().actions, created] });
+    return created;
+  },
+  update: async (id, body) => {
+    const updated = await api.updateQuickAction(id, body);
+    set({ actions: get().actions.map((a) => (a.id === id ? updated : a)) });
+    return updated;
+  },
+  remove: async (id) => {
+    await api.deleteQuickAction(id);
+    set({ actions: get().actions.filter((a) => a.id !== id) });
+  },
+}));
+
+/**
+ * In-flight + completed runs for the chat view's inline cards. Keyed
+ * by a per-click `runId` (uuid) — NOT by the action id — so two
+ * concurrent clicks of the same chip each get their own card.
+ *
+ * Runs are scoped to a session: switching to a different session
+ * removes the runs from view (still in the store; harmless). The
+ * chat view filters by `sessionId`.
+ */
+export interface QuickActionRun {
+  runId: string;
+  sessionId: string;
+  actionId: string;
+  actionName: string;
+  startedAt: number;
+  status: "running" | "done" | "aborted";
+  result?: QuickActionRunResult;
+  error?: string;
+  abort: () => void;
+}
+
+interface RunsState {
+  runs: QuickActionRun[];
+  addRun: (run: QuickActionRun) => void;
+  updateRun: (runId: string, patch: Partial<QuickActionRun>) => void;
+  removeRun: (runId: string) => void;
+  /** All runs for a session, oldest first (matches scroll order). */
+  runsForSession: (sessionId: string) => QuickActionRun[];
+}
+
+export const useQuickActionRunsStore = create<RunsState>((set, get) => ({
+  runs: [],
+  addRun: (run) => set({ runs: [...get().runs, run] }),
+  updateRun: (runId, patch) =>
+    set({ runs: get().runs.map((r) => (r.runId === runId ? { ...r, ...patch } : r)) }),
+  removeRun: (runId) => set({ runs: get().runs.filter((r) => r.runId !== runId) }),
+  runsForSession: (sessionId) => get().runs.filter((r) => r.sessionId === sessionId),
+}));

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -243,6 +243,16 @@ export const config = Object.freeze({
    */
   systemPromptOverridesFile: join(FORGE_DATA_DIR, "system-prompt-overrides.json"),
   /**
+   * Path to the forge-private quick-actions registry. One flat JSON
+   * array of "chips" the user can click from the chat-view toolbar to
+   * fire either a shell command (run in the current project's cwd) or
+   * a templated prompt (sent to / inserted into the active session).
+   * Global (not per-project) by design — chips are the operator's
+   * personal toolbox, same install-private rationale as the other
+   * forge-owned files.
+   */
+  quickActionsFile: join(FORGE_DATA_DIR, "quick-actions.json"),
+  /**
    * Whether `/api/docs` (Swagger UI + OpenAPI JSON spec) is reachable.
    * Defaults to true so Docker / production deploys keep working without
    * extra config (the README quickstart documents `/api/docs`). When

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -25,6 +25,7 @@ import { gitRoutes } from "./routes/git.js";
 import { execRoutes } from "./routes/exec.js";
 import { exportRoutes } from "./routes/export.js";
 import { mcpRoutes } from "./routes/mcp.js";
+import { quickActionRoutes } from "./routes/quick-actions.js";
 import { searchRoutes } from "./routes/search.js";
 import { terminalRoutes } from "./routes/terminal.js";
 import { disposeAll as disposeAllMcp, loadGlobal as loadGlobalMcp } from "./mcp/manager.js";
@@ -383,6 +384,7 @@ export async function buildServer(): Promise<FastifyInstance> {
       await api.register(execRoutes);
       await api.register(exportRoutes);
       await api.register(mcpRoutes);
+      await api.register(quickActionRoutes);
       await api.register(searchRoutes);
       await api.register(terminalRoutes);
     },

--- a/packages/server/src/quick-actions.ts
+++ b/packages/server/src/quick-actions.ts
@@ -1,0 +1,175 @@
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+import { config } from "./config.js";
+
+/**
+ * Forge-private "quick action" registry — the clickable chips that
+ * live on the chat-view toolbar. Two kinds, presence-discriminated
+ * the same way `McpServerConfig` is (no `kind` field on the wire):
+ *
+ *   - command: `command` is a non-empty string. Runs in the project's
+ *     cwd via `bash -c`, stdout/stderr captured.
+ *   - prompt:  `text` is a non-empty string. Either auto-sends to the
+ *     active session (`mode: "send"`) or prefills the composer
+ *     (`mode: "insert"`).
+ *
+ * Stored as a flat array (not a map) so the file's order = display
+ * order. The route layer is the only validator — this module trusts
+ * the shapes it persists.
+ */
+
+export interface QuickAction {
+  id: string;
+  name: string;
+  enabled?: boolean;
+  // command-only
+  command?: string;
+  timeoutMs?: number;
+  // prompt-only
+  text?: string;
+  mode?: "send" | "insert";
+}
+
+export class QuickActionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`quick action not found: ${id}`);
+    this.name = "QuickActionNotFoundError";
+  }
+}
+
+/** Hard cap on a single command string. Mirrors the system-prompt
+ * addendum cap — large enough for a multi-line shell snippet, small
+ * enough to keep the wire surface bounded. */
+export const MAX_COMMAND_BYTES = 20_000;
+
+/** Hard cap on a single prompt template. Pi compaction lives further
+ * down the stack, but bounding here keeps an accidental megabyte paste
+ * from silently landing in the composer. */
+export const MAX_PROMPT_BYTES = 50_000;
+
+/** Default command timeout (30 s) and absolute ceiling (5 min). A
+ * five-minute build is the upper end of "still feels like a chip";
+ * past that, the user should be using the terminal. */
+export const DEFAULT_TIMEOUT_MS = 30_000;
+export const MAX_TIMEOUT_MS = 300_000;
+
+export function isCommandAction(a: QuickAction): boolean {
+  return typeof a.command === "string" && a.command.length > 0;
+}
+
+export function isPromptAction(a: QuickAction): boolean {
+  return typeof a.text === "string" && a.text.length > 0;
+}
+
+async function ensureDir(): Promise<void> {
+  await mkdir(dirname(config.quickActionsFile), { recursive: true });
+}
+
+async function atomicWrite(actions: QuickAction[]): Promise<void> {
+  await ensureDir();
+  const target = config.quickActionsFile;
+  const tmp = `${target}.${randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(actions, null, 2), { mode: 0o600 });
+  try {
+    await rename(tmp, target);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
+}
+
+function isAction(v: unknown): v is QuickAction {
+  if (typeof v !== "object" || v === null) return false;
+  const r = v as Record<string, unknown>;
+  if (typeof r.id !== "string" || typeof r.name !== "string") return false;
+  const hasCmd = typeof r.command === "string" && r.command.length > 0;
+  const hasText = typeof r.text === "string" && r.text.length > 0;
+  // Drop entries that look corrupted (neither kind, or both) rather
+  // than surfacing them to the route layer, which would have to
+  // re-validate. Strict-on-read keeps the in-memory shape clean.
+  return hasCmd !== hasText;
+}
+
+/**
+ * Serialise all read-modify-write sequences over quick-actions.json
+ * — same pattern as projects.json. Without it, concurrent
+ * POST /quick-actions calls can race the rename().
+ */
+let lock: Promise<unknown> = Promise.resolve();
+function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = lock.then(fn, fn);
+  lock = next.catch(() => undefined);
+  return next;
+}
+
+export async function readQuickActions(): Promise<QuickAction[]> {
+  try {
+    const raw = await readFile(config.quickActionsFile, "utf8");
+    if (raw.trim().length === 0) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isAction);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+export async function getQuickAction(id: string): Promise<QuickAction | undefined> {
+  const list = await readQuickActions();
+  return list.find((a) => a.id === id);
+}
+
+/**
+ * Create a new action. The caller (route layer) is responsible for
+ * shape validation (one-of command/text, byte caps, etc.) — this
+ * function only assigns the id and persists.
+ */
+export async function createQuickAction(input: Omit<QuickAction, "id">): Promise<QuickAction> {
+  return withLock(async () => {
+    const list = await readQuickActions();
+    const action: QuickAction = { ...input, id: randomUUID() };
+    list.push(action);
+    await atomicWrite(list);
+    return action;
+  });
+}
+
+export async function updateQuickAction(
+  id: string,
+  patch: Partial<Omit<QuickAction, "id">>,
+): Promise<QuickAction> {
+  return withLock(async () => {
+    const list = await readQuickActions();
+    const idx = list.findIndex((a) => a.id === id);
+    if (idx === -1) throw new QuickActionNotFoundError(id);
+    const existing = list[idx];
+    if (existing === undefined) throw new QuickActionNotFoundError(id);
+    // Build the merged record explicitly so a switch from command to
+    // prompt (or vice-versa) drops the now-unused fields rather than
+    // carrying them as dead weight. The caller passes the FULL desired
+    // shape on every update; the patch arg is union-typed for ergonomic
+    // partial calls but the route layer always sends the complete form.
+    const merged: QuickAction = { ...existing, ...patch, id };
+    if (typeof patch.command === "string" && patch.command.length > 0) {
+      delete merged.text;
+      delete merged.mode;
+    } else if (typeof patch.text === "string" && patch.text.length > 0) {
+      delete merged.command;
+      delete merged.timeoutMs;
+    }
+    list[idx] = merged;
+    await atomicWrite(list);
+    return merged;
+  });
+}
+
+export async function deleteQuickAction(id: string): Promise<void> {
+  await withLock(async () => {
+    const list = await readQuickActions();
+    const next = list.filter((a) => a.id !== id);
+    if (next.length === list.length) throw new QuickActionNotFoundError(id);
+    await atomicWrite(next);
+  });
+}

--- a/packages/server/src/routes/quick-actions.ts
+++ b/packages/server/src/routes/quick-actions.ts
@@ -1,0 +1,444 @@
+import { spawn } from "node:child_process";
+import type { FastifyPluginAsync, FastifyReply } from "fastify";
+import { config } from "../config.js";
+import { getProject } from "../project-manager.js";
+import { scrubbedEnv } from "../pty-manager.js";
+import {
+  createQuickAction,
+  DEFAULT_TIMEOUT_MS,
+  deleteQuickAction,
+  getQuickAction,
+  isCommandAction,
+  isPromptAction,
+  MAX_COMMAND_BYTES,
+  MAX_PROMPT_BYTES,
+  MAX_TIMEOUT_MS,
+  QuickActionNotFoundError,
+  readQuickActions,
+  updateQuickAction,
+  type QuickAction,
+} from "../quick-actions.js";
+import { errorSchema } from "./_schemas.js";
+
+/**
+ * Wire shape — same on the way in (POST/PUT body) and out
+ * (GET response). Discriminator is presence of `command` vs `text`;
+ * the validator below rejects both/neither with 400.
+ */
+const quickActionSchema = {
+  type: "object",
+  required: ["id", "name"],
+  properties: {
+    id: { type: "string" },
+    name: { type: "string" },
+    enabled: { type: "boolean" },
+    command: { type: "string" },
+    timeoutMs: { type: "integer" },
+    text: { type: "string" },
+    mode: { type: "string", enum: ["send", "insert"] },
+  },
+} as const;
+
+const runResultSchema = {
+  type: "object",
+  required: ["success", "exitCode", "stdout", "stderr", "durationMs", "timedOut", "truncated"],
+  properties: {
+    success: { type: "boolean" },
+    exitCode: { type: ["integer", "null"] },
+    stdout: { type: "string" },
+    stderr: { type: "string" },
+    durationMs: { type: "integer" },
+    timedOut: { type: "boolean" },
+    truncated: { type: "boolean" },
+  },
+} as const;
+
+/** Per-stream output cap. A chip that prints 100 MB of node_modules
+ * paths shouldn't drag the request handler down — truncate and flag
+ * it; the user can re-run in the integrated terminal if they need the
+ * full output. */
+const MAX_OUTPUT_BYTES = 1_000_000;
+
+interface ActionBody {
+  name: string;
+  enabled?: boolean;
+  command?: string;
+  timeoutMs?: number;
+  text?: string;
+  mode?: "send" | "insert";
+}
+
+/**
+ * Normalise + validate one wire body into a QuickAction-shaped patch.
+ * Centralises the one-of discriminator + byte caps so POST and PUT
+ * both produce identical 400s on the same bad input.
+ */
+function validateBody(body: ActionBody, reply: FastifyReply): Omit<QuickAction, "id"> | undefined {
+  const trimmedName = body.name.trim();
+  if (trimmedName.length === 0) {
+    reply.code(400).send({ error: "invalid_name" });
+    return undefined;
+  }
+  const hasCmd = typeof body.command === "string" && body.command.length > 0;
+  const hasText = typeof body.text === "string" && body.text.length > 0;
+  if (hasCmd === hasText) {
+    reply.code(400).send({
+      error: "invalid_action",
+      message: "exactly one of `command` or `text` is required",
+    });
+    return undefined;
+  }
+  const out: Omit<QuickAction, "id"> = { name: trimmedName };
+  if (body.enabled !== undefined) out.enabled = body.enabled;
+  if (hasCmd) {
+    const cmd = body.command!;
+    if (Buffer.byteLength(cmd, "utf8") > MAX_COMMAND_BYTES) {
+      reply.code(400).send({ error: "command_too_large" });
+      return undefined;
+    }
+    out.command = cmd;
+    if (body.timeoutMs !== undefined) {
+      const t = body.timeoutMs;
+      if (!Number.isInteger(t) || t <= 0) {
+        reply.code(400).send({ error: "invalid_timeout" });
+        return undefined;
+      }
+      out.timeoutMs = Math.min(t, MAX_TIMEOUT_MS);
+    }
+  } else {
+    const text = body.text!;
+    if (Buffer.byteLength(text, "utf8") > MAX_PROMPT_BYTES) {
+      reply.code(400).send({ error: "prompt_too_large" });
+      return undefined;
+    }
+    out.text = text;
+    out.mode = body.mode ?? "send";
+  }
+  return out;
+}
+
+function handleError(reply: FastifyReply, err: unknown): FastifyReply {
+  if (err instanceof QuickActionNotFoundError) {
+    return reply.code(404).send({ error: "action_not_found" });
+  }
+  reply.log.error({ err }, "quick-actions route error");
+  return reply.code(500).send({ error: "internal_error" });
+}
+
+/**
+ * Spawn the command under `/bin/sh -c` with a scrubbed env (same
+ * posture as the integrated terminal — no pi-forge / provider
+ * secrets leak into chip output). stdout and stderr are captured
+ * separately so the chat card can render them in distinct blocks.
+ */
+async function runCommand(
+  command: string,
+  cwd: string,
+  timeoutMs: number,
+): Promise<{
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  truncated: boolean;
+}> {
+  return new Promise((resolve) => {
+    const proc = spawn("/bin/sh", ["-c", command], {
+      cwd,
+      env: scrubbedEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let stdoutLen = 0;
+    let stderrLen = 0;
+    let truncated = false;
+    let timedOut = false;
+
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      const remaining = MAX_OUTPUT_BYTES - stdoutLen;
+      if (remaining <= 0) {
+        truncated = true;
+        return;
+      }
+      if (chunk.length > remaining) {
+        stdoutChunks.push(chunk.subarray(0, remaining));
+        stdoutLen += remaining;
+        truncated = true;
+      } else {
+        stdoutChunks.push(chunk);
+        stdoutLen += chunk.length;
+      }
+    });
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      const remaining = MAX_OUTPUT_BYTES - stderrLen;
+      if (remaining <= 0) {
+        truncated = true;
+        return;
+      }
+      if (chunk.length > remaining) {
+        stderrChunks.push(chunk.subarray(0, remaining));
+        stderrLen += remaining;
+        truncated = true;
+      } else {
+        stderrChunks.push(chunk);
+        stderrLen += chunk.length;
+      }
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        // best-effort
+      }
+      // SIGKILL grace — match the exec-route convention.
+      setTimeout(() => {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          // best-effort
+        }
+      }, 2000);
+    }, timeoutMs);
+
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      // Spawn error (ENOENT on `/bin/sh`, etc.) — surface as a failed
+      // run with the error on stderr so the chat card shows it.
+      resolve({
+        exitCode: null,
+        stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+        stderr: err.message,
+        timedOut,
+        truncated,
+      });
+    });
+    proc.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({
+        exitCode: code,
+        stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+        stderr: Buffer.concat(stderrChunks).toString("utf8"),
+        timedOut,
+        truncated,
+      });
+    });
+  });
+}
+
+export const quickActionRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get(
+    "/quick-actions",
+    {
+      schema: {
+        description:
+          "List all quick-action chips. Global (not per-project) — chips " +
+          "are operator-personal, same install-private rationale as the " +
+          "other forge-owned config files.",
+        tags: ["config"],
+        response: {
+          200: {
+            type: "object",
+            required: ["actions"],
+            properties: {
+              actions: { type: "array", items: quickActionSchema },
+            },
+          },
+        },
+      },
+    },
+    async () => ({ actions: await readQuickActions() }),
+  );
+
+  fastify.post<{ Body: ActionBody }>(
+    "/quick-actions",
+    {
+      schema: {
+        description:
+          "Create a quick-action chip. Exactly one of `command` or `text` " +
+          "must be set — presence is the kind discriminator (no `kind` " +
+          "field on the wire, matches the MCP server-config convention). " +
+          "400 on both/neither, 400 on byte-cap overflow.",
+        tags: ["config"],
+        body: {
+          type: "object",
+          required: ["name"],
+          additionalProperties: false,
+          properties: {
+            name: { type: "string", minLength: 1, maxLength: 200 },
+            enabled: { type: "boolean" },
+            command: { type: "string" },
+            timeoutMs: { type: "integer", minimum: 1 },
+            text: { type: "string" },
+            mode: { type: "string", enum: ["send", "insert"] },
+          },
+        },
+        response: {
+          201: quickActionSchema,
+          400: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const validated = validateBody(req.body, reply);
+      if (validated === undefined) return reply;
+      try {
+        const created = await createQuickAction(validated);
+        return reply.code(201).send(created);
+      } catch (err) {
+        return handleError(reply, err);
+      }
+    },
+  );
+
+  fastify.put<{ Params: { id: string }; Body: ActionBody }>(
+    "/quick-actions/:id",
+    {
+      schema: {
+        description:
+          "Replace a quick-action chip. Full record on the body — switching " +
+          "kind (command ↔ prompt) drops the now-unused fields. Same " +
+          "validation rules as POST.",
+        tags: ["config"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          required: ["name"],
+          additionalProperties: false,
+          properties: {
+            name: { type: "string", minLength: 1, maxLength: 200 },
+            enabled: { type: "boolean" },
+            command: { type: "string" },
+            timeoutMs: { type: "integer", minimum: 1 },
+            text: { type: "string" },
+            mode: { type: "string", enum: ["send", "insert"] },
+          },
+        },
+        response: {
+          200: quickActionSchema,
+          400: errorSchema,
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const validated = validateBody(req.body, reply);
+      if (validated === undefined) return reply;
+      try {
+        const updated = await updateQuickAction(req.params.id, validated);
+        return updated;
+      } catch (err) {
+        return handleError(reply, err);
+      }
+    },
+  );
+
+  fastify.delete<{ Params: { id: string } }>(
+    "/quick-actions/:id",
+    {
+      schema: {
+        description: "Delete a quick-action chip.",
+        tags: ["config"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          204: { type: "null" },
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      try {
+        await deleteQuickAction(req.params.id);
+        return reply.code(204).send();
+      } catch (err) {
+        return handleError(reply, err);
+      }
+    },
+  );
+
+  fastify.post<{ Params: { id: string }; Body: { projectId: string } }>(
+    "/quick-actions/:id/run",
+    {
+      schema: {
+        description:
+          "Execute a command-kind quick action in the named project's " +
+          "cwd. Returns captured stdout/stderr and the exit code. The " +
+          "spawned shell inherits a SCRUBBED env (same as the " +
+          "integrated terminal — no pi-forge or provider secrets). " +
+          "Hard-gated under MINIMAL_UI: command runs return 403 " +
+          "`command_actions_disabled_in_minimal` regardless of who " +
+          "is calling. Prompt-kind actions are not executable here " +
+          "(420-style validation error) — those are a pure client " +
+          "concern that route through the composer or sendPrompt.",
+        tags: ["config"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          required: ["projectId"],
+          additionalProperties: false,
+          properties: {
+            projectId: { type: "string", minLength: 1 },
+          },
+        },
+        response: {
+          200: runResultSchema,
+          400: errorSchema,
+          403: errorSchema,
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      // Defense in depth — the client also hides command chips
+      // under MINIMAL_UI, but a stale tab or scripted caller could
+      // still POST here. Refuse at the route.
+      if (config.minimalUi) {
+        return reply.code(403).send({ error: "command_actions_disabled_in_minimal" });
+      }
+      const action = await getQuickAction(req.params.id);
+      if (action === undefined) {
+        return reply.code(404).send({ error: "action_not_found" });
+      }
+      if (isPromptAction(action)) {
+        return reply.code(400).send({
+          error: "not_a_command_action",
+          message: "prompt actions are dispatched client-side, not via this route",
+        });
+      }
+      if (!isCommandAction(action)) {
+        return reply.code(400).send({ error: "invalid_action" });
+      }
+      const project = await getProject(req.body.projectId);
+      if (project === undefined) {
+        return reply.code(404).send({ error: "project_not_found" });
+      }
+      const timeoutMs = Math.min(action.timeoutMs ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
+      const started = Date.now();
+      const result = await runCommand(action.command!, project.path, timeoutMs);
+      const durationMs = Date.now() - started;
+      return {
+        success: result.exitCode === 0 && !result.timedOut,
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        durationMs,
+        timedOut: result.timedOut,
+        truncated: result.truncated,
+      };
+    },
+  );
+};

--- a/tests/test-quick-actions.ts
+++ b/tests/test-quick-actions.ts
@@ -1,0 +1,482 @@
+/**
+ * Quick-actions integration test.
+ *
+ * Verifies:
+ *   - List / create / update / delete round-trip
+ *   - Presence-discriminated kind: both-fields and neither-field → 400
+ *   - Switching kind via PUT drops the now-unused fields
+ *   - Run command-action: stdout captured, cwd is the project root,
+ *     exit code propagated, scrubbed env (no leaked FORGE_TEST_SECRET)
+ *   - Per-stream truncation flag on huge output
+ *   - 404 on unknown action / unknown project
+ *   - Prompt-action returns 400 when posted to /run (client-side concern)
+ *   - MINIMAL_UI=1 → command runs return 403
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+interface JsonResponse {
+  status: number;
+  body: unknown;
+}
+
+async function jget(base: string, path: string): Promise<JsonResponse> {
+  const res = await fetch(`${base}${path}`);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function jsend(
+  base: string,
+  method: "POST" | "PUT" | "PATCH" | "DELETE",
+  path: string,
+  body?: unknown,
+): Promise<JsonResponse> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(`${base}${path}`, init);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+interface ServerModule {
+  buildServer: () => Promise<{
+    listen: (opts: { port: number; host: string }) => Promise<string>;
+    close: () => Promise<void>;
+  }>;
+}
+
+async function bootServer(
+  workspacePath: string,
+  configDir: string,
+  dataDir: string,
+  opts: { minimalUi?: boolean } = {},
+): Promise<{ base: string; close: () => Promise<void> }> {
+  process.env.WORKSPACE_PATH = workspacePath;
+  process.env.PI_CONFIG_DIR = configDir;
+  process.env.FORGE_DATA_DIR = dataDir;
+  process.env.SESSION_DIR = join(workspacePath, ".pi", "sessions");
+  process.env.NODE_ENV = "test";
+  delete process.env.UI_PASSWORD;
+  delete process.env.JWT_SECRET;
+  delete process.env.API_KEY;
+  if (opts.minimalUi === true) {
+    process.env.MINIMAL_UI = "1";
+  } else {
+    delete process.env.MINIMAL_UI;
+  }
+  // The dist module is cached after the first import — re-importing
+  // won't pick up the new env. Tests that need a fresh config call
+  // bootServer in a separate `import()` URL (with a cache-buster
+  // query string), see `bootFresh()`.
+  const serverModule = (await import(
+    `${resolve(repoRoot, "packages/server/dist/index.js")}`
+  )) as unknown as ServerModule;
+  const fastify = await serverModule.buildServer();
+  const base = await fastify.listen({ port: 0, host: "127.0.0.1" });
+  return { base, close: () => fastify.close() };
+}
+
+function pickFreePort(): Promise<number> {
+  return new Promise((resolveFn, rejectFn) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on("error", rejectFn);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === "string") {
+        rejectFn(new Error("failed to acquire free port"));
+        return;
+      }
+      const { port } = addr;
+      srv.close(() => resolveFn(port));
+    });
+  });
+}
+
+async function waitForHealth(url: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(url);
+      if (r.ok) return;
+    } catch {
+      // server not up yet
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`timeout waiting for ${url}`);
+}
+
+/**
+ * Boot the server in a child process so module-load-time env reads
+ * (notably `config.minimalUi`) reflect the env we set. The
+ * in-process `import()` cannot do this for repeat boots — the
+ * dist module is already cached.
+ */
+async function bootSubprocess(
+  workspacePath: string,
+  configDir: string,
+  dataDir: string,
+  opts: { minimalUi?: boolean } = {},
+): Promise<{ base: string; close: () => Promise<void> }> {
+  const serverEntry = resolve(repoRoot, "packages/server/dist/index.js");
+  const port = await pickFreePort();
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    PORT: String(port),
+    LOG_LEVEL: "warn",
+    NODE_ENV: "test",
+    WORKSPACE_PATH: workspacePath,
+    PI_CONFIG_DIR: configDir,
+    FORGE_DATA_DIR: dataDir,
+    SESSION_DIR: join(workspacePath, ".pi", "sessions"),
+    SERVE_CLIENT: "false",
+    UI_PASSWORD: undefined,
+    JWT_SECRET: undefined,
+    API_KEY: undefined,
+    MINIMAL_UI: opts.minimalUi === true ? "1" : undefined,
+  };
+  const child: ChildProcess = spawn(process.execPath, [serverEntry], {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (b) => process.stderr.write(`[subserver] ${String(b)}`));
+  const base = `http://127.0.0.1:${port}`;
+  await waitForHealth(`${base}/api/v1/health`);
+  const close = (): Promise<void> =>
+    new Promise<void>((res) => {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        res();
+        return;
+      }
+      child.once("exit", () => res());
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 2000).unref();
+    });
+  return { base, close };
+}
+
+async function main(): Promise<void> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-qa-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-qa-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-qa-data-"));
+  // Sentinel in env — scrubbedEnv() must drop this when running command
+  // chips. The `report-env` style chip below greps for it; if it shows
+  // up in stdout, the scrub is leaking.
+  process.env.FORGE_TEST_SECRET = "should-not-leak";
+
+  console.log(`[test-quick-actions] WORKSPACE_PATH=${workspacePath}`);
+
+  let serverHandle: { base: string; close: () => Promise<void> } | undefined;
+
+  try {
+    serverHandle = await bootServer(workspacePath, configDir, dataDir);
+    const base = serverHandle.base;
+
+    // 1. Empty list on fresh data dir.
+    {
+      const r = await jget(base, "/api/v1/quick-actions");
+      assert("GET on fresh dir → 200 with empty list", r.status === 200);
+      const body = r.body as { actions: unknown[] };
+      assert("  actions array is empty", Array.isArray(body.actions) && body.actions.length === 0);
+    }
+
+    // 2. Create a project (needed for run-cwd).
+    const projResp = await jsend(base, "POST", "/api/v1/projects", {
+      name: "qa-test",
+      path: workspacePath,
+    });
+    assert("create project → 201", projResp.status === 201);
+    const projectId = (projResp.body as { id: string }).id;
+    const projectPath = (projResp.body as { path: string }).path;
+
+    // 3. Create a command action.
+    let cmdActionId = "";
+    {
+      const r = await jsend(base, "POST", "/api/v1/quick-actions", {
+        name: "List files",
+        command: "ls -1",
+      });
+      assert("POST command action → 201", r.status === 201, JSON.stringify(r.body));
+      const body = r.body as { id: string; name: string; command: string };
+      cmdActionId = body.id;
+      assert("  id assigned", typeof body.id === "string" && body.id.length > 0);
+      assert("  name persisted", body.name === "List files");
+      assert("  command persisted", body.command === "ls -1");
+    }
+
+    // 4. Create a prompt action.
+    let promptActionId = "";
+    {
+      const r = await jsend(base, "POST", "/api/v1/quick-actions", {
+        name: "Plan task",
+        text: "Plan this task step by step.",
+        mode: "insert",
+      });
+      assert("POST prompt action → 201", r.status === 201);
+      const body = r.body as { id: string; text: string; mode: string };
+      promptActionId = body.id;
+      assert("  text persisted", body.text === "Plan this task step by step.");
+      assert("  mode persisted", body.mode === "insert");
+    }
+
+    // 5. List both.
+    {
+      const r = await jget(base, "/api/v1/quick-actions");
+      const body = r.body as { actions: { id: string }[] };
+      assert("GET after creates → 2 actions", body.actions.length === 2);
+    }
+
+    // 6. Validators — neither field set.
+    {
+      const r = await jsend(base, "POST", "/api/v1/quick-actions", { name: "Bad" });
+      assert("POST without command/text → 400", r.status === 400);
+    }
+
+    // 7. Validators — both fields set.
+    {
+      const r = await jsend(base, "POST", "/api/v1/quick-actions", {
+        name: "Bad",
+        command: "ls",
+        text: "do it",
+      });
+      assert("POST with both command and text → 400", r.status === 400);
+    }
+
+    // 8. PUT switches kind cleanly.
+    {
+      const r = await jsend(base, "PUT", `/api/v1/quick-actions/${cmdActionId}`, {
+        name: "List files",
+        text: "List the files for me",
+      });
+      assert("PUT command → prompt → 200", r.status === 200, JSON.stringify(r.body));
+      const body = r.body as { command?: string; text?: string };
+      assert("  command field dropped", body.command === undefined);
+      assert("  text field set", body.text === "List the files for me");
+
+      // Revert to command for the run tests.
+      const back = await jsend(base, "PUT", `/api/v1/quick-actions/${cmdActionId}`, {
+        name: "List files",
+        command: "ls -1",
+        timeoutMs: 5000,
+      });
+      assert("PUT back to command → 200", back.status === 200);
+    }
+
+    // 9. PUT unknown id → 404.
+    {
+      const r = await jsend(base, "PUT", "/api/v1/quick-actions/does-not-exist", {
+        name: "x",
+        command: "ls",
+      });
+      assert("PUT unknown id → 404", r.status === 404);
+    }
+
+    // 10. Run command action.
+    {
+      // Drop a known file in the project root so the ls output is
+      // predictable.
+      const probe = "QUICK_ACTION_PROBE.txt";
+      await (await import("node:fs/promises")).writeFile(join(projectPath, probe), "hi", "utf8");
+      const r = await jsend(base, "POST", `/api/v1/quick-actions/${cmdActionId}/run`, {
+        projectId,
+      });
+      assert("POST /run command action → 200", r.status === 200, JSON.stringify(r.body));
+      const body = r.body as {
+        success: boolean;
+        exitCode: number | null;
+        stdout: string;
+        stderr: string;
+        durationMs: number;
+        timedOut: boolean;
+        truncated: boolean;
+      };
+      assert("  success=true", body.success === true, JSON.stringify(body));
+      assert("  exitCode=0", body.exitCode === 0);
+      assert(
+        "  stdout contains probe filename",
+        body.stdout.includes(probe),
+        `stdout=${body.stdout}`,
+      );
+      assert("  durationMs is a non-negative integer", Number.isInteger(body.durationMs));
+      assert("  timedOut=false", body.timedOut === false);
+      assert("  truncated=false", body.truncated === false);
+    }
+
+    // 11. Run command action with env probe — FORGE_TEST_SECRET must
+    //     NOT appear in the spawned shell's env.
+    {
+      // Create a dedicated chip so we don't conflate with the ls test.
+      const probeAction = await jsend(base, "POST", "/api/v1/quick-actions", {
+        name: "env probe",
+        // Print every env var; the FORGE_TEST_SECRET check below greps.
+        command: "env",
+      });
+      assert("POST env-probe action → 201", probeAction.status === 201);
+      const probeId = (probeAction.body as { id: string }).id;
+      const r = await jsend(base, "POST", `/api/v1/quick-actions/${probeId}/run`, { projectId });
+      assert("POST /run env probe → 200", r.status === 200);
+      const body = r.body as { stdout: string };
+      assert(
+        "  FORGE_TEST_SECRET scrubbed from spawned shell env",
+        !body.stdout.includes("should-not-leak"),
+        `leak in stdout: ${body.stdout.slice(0, 400)}`,
+      );
+      await jsend(base, "DELETE", `/api/v1/quick-actions/${probeId}`);
+    }
+
+    // 12. Unknown project on /run → 404.
+    {
+      const r = await jsend(base, "POST", `/api/v1/quick-actions/${cmdActionId}/run`, {
+        projectId: "00000000-0000-0000-0000-000000000000",
+      });
+      assert("POST /run unknown project → 404", r.status === 404);
+    }
+
+    // 13. Unknown action on /run → 404.
+    {
+      const r = await jsend(base, "POST", "/api/v1/quick-actions/does-not-exist/run", {
+        projectId,
+      });
+      assert("POST /run unknown action → 404", r.status === 404);
+    }
+
+    // 14. Prompt action on /run → 400 (not a command action).
+    {
+      const r = await jsend(base, "POST", `/api/v1/quick-actions/${promptActionId}/run`, {
+        projectId,
+      });
+      assert("POST /run on prompt action → 400", r.status === 400, JSON.stringify(r.body));
+    }
+
+    // 15. Non-zero exit and stderr capture.
+    {
+      const created = await jsend(base, "POST", "/api/v1/quick-actions", {
+        name: "fail",
+        command: "echo to-stderr 1>&2; exit 7",
+      });
+      const id = (created.body as { id: string }).id;
+      const r = await jsend(base, "POST", `/api/v1/quick-actions/${id}/run`, { projectId });
+      const body = r.body as { success: boolean; exitCode: number | null; stderr: string };
+      assert("  non-zero exit → success=false", body.success === false);
+      assert("  exitCode=7", body.exitCode === 7);
+      assert("  stderr captured", body.stderr.includes("to-stderr"));
+      await jsend(base, "DELETE", `/api/v1/quick-actions/${id}`);
+    }
+
+    // 16. On-disk shape — file persisted with the expected fields.
+    {
+      const raw = await readFile(join(dataDir, "quick-actions.json"), "utf8");
+      const parsed = JSON.parse(raw) as { id: string; name: string }[];
+      assert("on-disk file is a JSON array", Array.isArray(parsed));
+      assert(
+        "  contains command action by id",
+        parsed.some((a) => a.id === cmdActionId),
+      );
+      assert(
+        "  contains prompt action by id",
+        parsed.some((a) => a.id === promptActionId),
+      );
+    }
+
+    // 17. Delete.
+    {
+      const r = await jsend(base, "DELETE", `/api/v1/quick-actions/${cmdActionId}`);
+      assert("DELETE command action → 204", r.status === 204);
+      const list = await jget(base, "/api/v1/quick-actions");
+      const body = list.body as { actions: { id: string }[] };
+      assert(
+        "  command action absent after delete",
+        !body.actions.some((a) => a.id === cmdActionId),
+      );
+    }
+
+    // 18. Delete unknown id → 404.
+    {
+      const r = await jsend(base, "DELETE", "/api/v1/quick-actions/does-not-exist");
+      assert("DELETE unknown id → 404", r.status === 404);
+    }
+
+    await serverHandle.close();
+    serverHandle = undefined;
+
+    // 19. MINIMAL_UI=1 — re-boot with the flag and verify /run returns
+    //     403 even for a valid command action. List/create still work
+    //     so settings UI can manage chips for when minimal flips off.
+    {
+      const minDataDir = await mkdtemp(join(tmpdir(), "pi-forge-qa-min-"));
+      const minConfigDir = await mkdtemp(join(tmpdir(), "pi-forge-qa-mincfg-"));
+      const minWs = await mkdtemp(join(tmpdir(), "pi-forge-qa-minws-"));
+      const minHandle = await bootSubprocess(minWs, minConfigDir, minDataDir, {
+        minimalUi: true,
+      });
+      try {
+        const proj = await jsend(minHandle.base, "POST", "/api/v1/projects", {
+          name: "min",
+          path: minWs,
+        });
+        const minProjectId = (proj.body as { id: string }).id;
+        const created = await jsend(minHandle.base, "POST", "/api/v1/quick-actions", {
+          name: "ls",
+          command: "ls",
+        });
+        assert("MINIMAL_UI: create command action still works", created.status === 201);
+        const id = (created.body as { id: string }).id;
+        const run = await jsend(minHandle.base, "POST", `/api/v1/quick-actions/${id}/run`, {
+          projectId: minProjectId,
+        });
+        assert("MINIMAL_UI: /run returns 403", run.status === 403, JSON.stringify(run.body));
+        const err = (run.body as { error: string }).error;
+        assert(
+          "  error code is command_actions_disabled_in_minimal",
+          err === "command_actions_disabled_in_minimal",
+          err,
+        );
+      } finally {
+        await minHandle.close();
+        await rm(minDataDir, { recursive: true, force: true }).catch(() => undefined);
+        await rm(minConfigDir, { recursive: true, force: true }).catch(() => undefined);
+        await rm(minWs, { recursive: true, force: true }).catch(() => undefined);
+      }
+    }
+  } finally {
+    if (serverHandle !== undefined) await serverHandle.close();
+    delete process.env.FORGE_TEST_SECRET;
+    await rm(workspacePath, { recursive: true, force: true }).catch(() => undefined);
+    await rm(configDir, { recursive: true, force: true }).catch(() => undefined);
+    await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-quick-actions] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-quick-actions] PASS");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds quick-action chips to the chat-view toolbar. One left-aligned **Actions** dropdown dispatches saved chips of two kinds (presence-discriminated, matches the MCP server-config convention):

- **command** — runs a shell snippet in the active project's folder via \`/bin/sh -c\` with a scrubbed env (same posture as the integrated terminal; no pi-forge or provider secrets leak). Captured stdout/stderr land in an **inline run card** in the chat scroll — amber while running, green on success, red on failure — with expandable output blocks and a **Use as context** button that pushes the captured output back into the composer for the next prompt.
- **prompt** — dispatched client-side. \`mode: \"send\"\` auto-fires \`sendPrompt\`; \`mode: \"insert\"\` lands in the composer via a new \`composer-store\` bridge (so the user can tweak before sending).

Chips are stored **globally** in \`FORGE_DATA_DIR/quick-actions.json\` — operator-personal, same install-private rationale as the other forge-owned files. A new **Quick Actions** tab in Settings handles CRUD.

## MINIMAL_UI gate (defense in depth, three layers)

- **Server** — \`POST /quick-actions/:id/run\` returns 403 \`command_actions_disabled_in_minimal\` regardless of caller, so a stale tab or scripted client can't bypass.
- **Menu** — command chips are filtered out of the toolbar dropdown.
- **Settings** — the command radio is disabled with an explanatory tooltip; existing command chips still appear in the list with a \"hidden by MINIMAL_UI\" badge so operators can audit/remove them.

Prompt chips are unaffected.

## New surface

| | |
|---|---|
| **Routes** | \`GET / POST / PUT / DELETE /api/v1/quick-actions\`, \`POST /api/v1/quick-actions/:id/run\` (full OpenAPI schemas) |
| **Server modules** | \`quick-actions.ts\` (storage + lock + atomic write), \`routes/quick-actions.ts\` |
| **Client** | \`QuickActionsMenu\`, \`QuickActionRunCard\`, \`quick-actions-store\` (+ in-flight runs store), \`composer-store\` (insert bridge), new Settings tab |
| **Wire shape** | Discriminator by presence — \`command\` ↦ command kind, \`text\` ↦ prompt kind. Both/neither → 400. |

## Defaults and caps

- Command timeout: **30 s** default, **5 min** absolute cap (past that, use the integrated terminal).
- Output: **1 MB per stream**, with a \`truncated\` flag surfaced on the run card.
- Command size: **20 KB**. Prompt text: **50 KB**.

## Test plan

- [x] \`npm run check\` — typecheck + eslint + prettier clean
- [x] \`npm run build\` clean
- [x] \`tests/test-quick-actions.ts\` — 41 assertions, all PASS (CRUD round-trip, on-disk JSON shape, presence-discriminated validation, kind switch via PUT, cwd-is-project-root, stdout capture, non-zero exit + stderr capture, env scrub regression guard, 404s for unknown action/project, prompt-on-/run → 400, MINIMAL_UI → 403)
- [x] Full \`scripts/run-tests.sh --skip pty-reattach,terminal,docker\` — 30/30 PASS (pty-reattach failure is the known fresh-worktree \`posix_spawnp\` issue, unrelated to this branch)
- [ ] Manual smoke: create a command + prompt chip via Settings, fire each from the chat toolbar
- [ ] Manual smoke under \`MINIMAL_UI=1\`: command chip absent from menu, server returns 403 on direct POST