### PR TITLE
feat(ask-user-question): browser-native impl of the plugin's contract

### DIFF
--- a/docs/ask-user-question.md
+++ b/docs/ask-user-question.md
@@ -1,0 +1,55 @@
+# ask_user_question
+
+pi-forge ships a browser-native implementation of the
+`ask_user_question` tool: a structured questionnaire the agent can put
+to the user when its instructions are underspecified. Picking
+"PostgreSQL" from a four-option list beats parsing an ambiguous
+free-form reply.
+
+## How it works
+
+When the agent invokes `ask_user_question`, pi-forge:
+
+1. Validates the questionnaire (caps on question / option counts,
+   reserved-label guard, byte limits).
+2. Pushes the questions over SSE to every browser tab watching the
+   session.
+3. Displays an inline panel directly above the chat composer:
+   vertical option list for single-select, checkbox list for
+   `multiSelect: true`, side-by-side preview pane when any option
+   carries a `preview` markdown string. The chat scroll stays
+   interactive so the user can reread context while answering.
+4. Holds the agent open until the user submits — or until they click
+   **Chat about this** to abandon the questionnaire and continue in
+   free-form chat.
+5. Returns the structured envelope to the agent so it can branch on
+   `details.answers[].kind` and `details.cancelled`.
+
+## Disabling the tool
+
+The tool appears under **Settings → Tools → Built-in tools**. Toggle
+it off there to filter `ask_user_question` out of every new session's
+tool allowlist. Live sessions keep the tool list they were created
+with.
+
+## Relationship to `@juicesharp/rpiv-ask-user-question`
+
+The wire contract — tool name, parameter schema (question / option
+shape, header / label byte caps, reserved labels), and response
+envelope (`{ content: [{type:"text",text}], details: { answers,
+cancelled, error? } }` with answer kinds `option | custom | chat |
+multi`) — is contract-compatible with the upstream Pi extension
+[`@juicesharp/rpiv-ask-user-question`](https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-ask-user-question)
+(MIT). An agent prompt authored against that plugin works against
+this implementation unchanged.
+
+Implementation is independent. The TUI plugin can't render into a
+browser session (`ctx.hasUI` is false), so installing the plugin
+alongside pi-forge has no effect — pi-forge's `customTools`
+registration takes the `ask_user_question` slot for browser sessions.
+
+Prompt snippet and guidelines (the strings the model sees) are
+adapted from the plugin with attribution preserved in
+`packages/server/src/ask-user-question/prompt-strings.ts`. The
+plugin's wording has been tuned against real model behavior; matching
+it avoids regressions in tool-call quality.

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -16,6 +16,7 @@ import { ChatView } from "./components/ChatView";
 import { ChatInput } from "./components/ChatInput";
 import { ChangedFilesBadge } from "./components/ChangedFilesBadge";
 import { SettingsPanel } from "./components/SettingsPanel";
+import { AskUserQuestionPanel } from "./components/AskUserQuestionPanel";
 import { FileBrowserPanel } from "./components/FileBrowserPanel";
 import { EditorPanel } from "./components/EditorPanel";
 import { TerminalPanel } from "./components/TerminalPanel";
@@ -600,6 +601,13 @@ export function App() {
                         }}
                       />
                     )}
+                    {/* Inline panel for `ask_user_question` tool
+                        calls. Renders directly above the composer
+                        when the agent has asked something; null
+                        otherwise. Lives in the chat-pane flex
+                        column so the chat scroll stays usable
+                        while answering. */}
+                    <AskUserQuestionPanel sessionId={activeSessionId} />
                     <ChatInput sessionId={activeSessionId} />
                   </>
                 ) : active ? (

--- a/packages/client/src/components/AskUserQuestionPanel.tsx
+++ b/packages/client/src/components/AskUserQuestionPanel.tsx
@@ -1,0 +1,418 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight, Loader2, MessageCircle } from "lucide-react";
+import { api, ApiError, type AskUserQuestionAnswer } from "../lib/api-client";
+import {
+  useAskUserQuestionStore,
+  type AskQuestion,
+  type PendingAskQuestion,
+} from "../store/ask-user-question-store";
+
+/**
+ * Inline panel that surfaces a pending `ask_user_question` tool
+ * call. Renders directly above the chat input rather than as an
+ * overlay so the user can still scroll the chat for context while
+ * answering. The agent is blocked on this — it cannot continue
+ * until we POST an answer or cancel.
+ *
+ * Three layouts, picked per-question:
+ *  - single-select + no preview:   vertical option list + "Type
+ *                                  something" free-text fallback
+ *  - multi-select:                 checkbox list (no free-text)
+ *  - single-select + any preview:  side-by-side; options left,
+ *                                  focused option's preview right
+ *
+ * Multi-question forms are tabbed: each Next advances; final
+ * submit POSTs the full answer set. "Chat about this" at any
+ * tab cancels the whole questionnaire (the plugin's escape
+ * hatch).
+ */
+interface Props {
+  sessionId: string;
+}
+
+export function AskUserQuestionPanel({ sessionId }: Props) {
+  const pending = useAskUserQuestionStore((s) => s.pendingBySession[sessionId]);
+  if (pending === undefined) return null;
+  // Keyed by requestId so a different question replacing the
+  // current one resets all internal state cleanly.
+  return <PanelBody key={pending.requestId} pending={pending} />;
+}
+
+interface PendingAnswer {
+  // Single-select: option label or null (until picked or custom typed).
+  // Multi-select: array of selected labels.
+  selectedLabel?: string | undefined;
+  customText?: string | undefined;
+  multiLabels?: string[] | undefined;
+}
+
+function PanelBody({ pending }: { pending: PendingAskQuestion }) {
+  const clearPending = useAskUserQuestionStore((s) => s.clearPending);
+  const [tab, setTab] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+  // One answer-draft per question — `null` slots until visited.
+  const [drafts, setDrafts] = useState<(PendingAnswer | null)[]>(() =>
+    pending.questions.map(() => null),
+  );
+
+  const current = pending.questions[tab];
+  if (current === undefined) return null;
+
+  const setDraft = (patch: Partial<PendingAnswer>): void => {
+    setDrafts((arr) => {
+      const next = arr.slice();
+      next[tab] = { ...(next[tab] ?? {}), ...patch };
+      return next;
+    });
+  };
+
+  const draft = drafts[tab];
+
+  const validForCurrent = (): boolean => {
+    if (current.multiSelect === true) {
+      return draft?.multiLabels !== undefined && draft.multiLabels.length > 0;
+    }
+    if (draft?.selectedLabel !== undefined) return true;
+    if (draft?.customText !== undefined && draft.customText.trim().length > 0) return true;
+    return false;
+  };
+
+  const buildAnswers = (): AskUserQuestionAnswer[] => {
+    const out: AskUserQuestionAnswer[] = [];
+    for (let i = 0; i < pending.questions.length; i += 1) {
+      const q = pending.questions[i]!;
+      const d = drafts[i];
+      if (d === null || d === undefined) continue;
+      if (q.multiSelect === true) {
+        out.push({
+          questionIndex: i,
+          question: q.question,
+          kind: "multi",
+          answer: null,
+          ...(d.multiLabels !== undefined ? { selected: d.multiLabels } : {}),
+        });
+        continue;
+      }
+      if (d.selectedLabel !== undefined) {
+        const opt = q.options.find((o) => o.label === d.selectedLabel);
+        out.push({
+          questionIndex: i,
+          question: q.question,
+          kind: "option",
+          answer: d.selectedLabel,
+          ...(opt?.preview !== undefined ? { preview: opt.preview } : {}),
+        });
+        continue;
+      }
+      if (d.customText !== undefined && d.customText.trim().length > 0) {
+        out.push({
+          questionIndex: i,
+          question: q.question,
+          kind: "custom",
+          answer: d.customText.trim(),
+        });
+        continue;
+      }
+    }
+    return out;
+  };
+
+  const advanceOrSubmit = async (): Promise<void> => {
+    if (!validForCurrent()) return;
+    if (tab < pending.questions.length - 1) {
+      setTab(tab + 1);
+      return;
+    }
+    // Final tab: submit all answers.
+    setSubmitting(true);
+    setError(undefined);
+    try {
+      await api.submitAskUserQuestionAnswer(pending.sessionId, {
+        requestId: pending.requestId,
+        answers: buildAnswers(),
+      });
+      // The server emits ask_user_question_cancelled on success, which
+      // clears the store — but to avoid the modal flickering while
+      // the SSE event round-trips, clear locally too.
+      clearPending(pending.sessionId, pending.requestId);
+    } catch (err) {
+      setError(err instanceof ApiError ? `${err.code}: ${err.message}` : (err as Error).message);
+      setSubmitting(false);
+    }
+  };
+
+  const chatAboutThis = async (): Promise<void> => {
+    setSubmitting(true);
+    setError(undefined);
+    try {
+      // "Chat about this" returns ONE chat-kind answer for the
+      // current question and cancels the rest. Matches the plugin's
+      // semantics: the model sees that the user opted out, with
+      // context for which question they bailed on.
+      const chatAnswer: AskUserQuestionAnswer = {
+        questionIndex: tab,
+        question: current.question,
+        kind: "chat",
+        answer: "Chat about this",
+      };
+      await api.submitAskUserQuestionAnswer(pending.sessionId, {
+        requestId: pending.requestId,
+        answers: [chatAnswer],
+        cancelled: true,
+      });
+      clearPending(pending.sessionId, pending.requestId);
+    } catch (err) {
+      setError(err instanceof ApiError ? `${err.code}: ${err.message}` : (err as Error).message);
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    // Inline panel: lives between ChatView and ChatInput. The
+    // max-h cap keeps a giant questionnaire from pushing the
+    // composer off-screen on short viewports — the body scrolls
+    // when the content exceeds the cap.
+    <div className="flex max-h-[60vh] shrink-0 flex-col overflow-hidden border-t border-amber-700/50 bg-neutral-900/40 light:border-amber-400 light:bg-amber-50/60">
+      <div className="flex flex-col overflow-hidden">
+        <header className="flex items-center gap-2 border-b border-neutral-800 px-4 py-2 light:border-neutral-200">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-amber-400 light:text-amber-700">
+            Agent question
+          </span>
+          {pending.questions.length > 1 && (
+            <div className="ml-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-neutral-500">
+              {pending.questions.map((q, i) => (
+                <span
+                  key={i}
+                  className={`rounded px-1.5 py-0.5 ${
+                    i === tab
+                      ? "bg-amber-900/40 text-amber-200 light:bg-amber-100 light:text-amber-900"
+                      : drafts[i] !== null
+                        ? "bg-neutral-800 text-neutral-300 light:bg-neutral-200 light:text-neutral-700"
+                        : "text-neutral-500"
+                  }`}
+                  title={q.question}
+                >
+                  {q.header}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="flex-1" />
+          <span className="text-[10px] uppercase tracking-wider text-neutral-500">
+            {tab + 1} of {pending.questions.length}
+          </span>
+        </header>
+
+        {error !== undefined && (
+          <div className="border-b border-red-700/40 bg-red-900/20 px-4 py-2 text-xs text-red-300 light:border-red-300 light:bg-red-50 light:text-red-800">
+            {error}
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          <QuestionView
+            question={current}
+            draft={draft ?? null}
+            onChange={(patch) => setDraft(patch)}
+          />
+        </div>
+
+        <footer className="flex items-center gap-2 border-t border-neutral-800 px-4 py-2 light:border-neutral-200">
+          <button
+            type="button"
+            onClick={() => void chatAboutThis()}
+            disabled={submitting}
+            className="flex items-center gap-1 rounded border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:border-neutral-500 disabled:opacity-50 light:border-neutral-400 light:text-neutral-700"
+            title="Abandon the structured questionnaire and reply in free-form chat"
+          >
+            <MessageCircle size={12} />
+            Chat about this
+          </button>
+          <div className="flex-1" />
+          {tab > 0 && (
+            <button
+              type="button"
+              onClick={() => setTab(tab - 1)}
+              disabled={submitting}
+              className="flex items-center gap-1 rounded border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:border-neutral-500 disabled:opacity-50 light:border-neutral-400 light:text-neutral-700"
+            >
+              <ChevronLeft size={12} />
+              Back
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => void advanceOrSubmit()}
+            disabled={submitting || !validForCurrent()}
+            className="flex items-center gap-1 rounded bg-emerald-700 px-3 py-1 text-xs text-white hover:bg-emerald-600 disabled:opacity-50"
+          >
+            {submitting ? <Loader2 size={12} className="animate-spin" /> : null}
+            {tab < pending.questions.length - 1 ? (
+              <>
+                Next <ChevronRight size={12} />
+              </>
+            ) : submitting ? (
+              "Submitting…"
+            ) : (
+              "Submit"
+            )}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function QuestionView({
+  question,
+  draft,
+  onChange,
+}: {
+  question: AskQuestion;
+  draft: PendingAnswer | null;
+  onChange: (patch: Partial<PendingAnswer>) => void;
+}) {
+  const hasAnyPreview = useMemo(
+    () => question.options.some((o) => typeof o.preview === "string" && o.preview.length > 0),
+    [question.options],
+  );
+  const isMulti = question.multiSelect === true;
+  const showCustomInput = !isMulti && !hasAnyPreview;
+  const [focusedLabel, setFocusedLabel] = useState<string | undefined>(undefined);
+  const focused = question.options.find((o) => o.label === focusedLabel);
+
+  // When preview is enabled, default-focus the first option so the
+  // right pane shows something on mount rather than a blank box.
+  useEffect(() => {
+    if (hasAnyPreview && focusedLabel === undefined && question.options[0] !== undefined) {
+      setFocusedLabel(question.options[0].label);
+    }
+  }, [hasAnyPreview, focusedLabel, question.options]);
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-base font-medium text-neutral-100 light:text-neutral-900">
+        {question.question}
+      </h2>
+
+      {hasAnyPreview && !isMulti ? (
+        // Side-by-side layout: options left (1/3), focused option's
+        // preview right (2/3). The "Type something" row is suppressed
+        // here — no room and the chat-about-this button covers the
+        // escape case.
+        <div className="grid grid-cols-3 gap-3">
+          <div className="col-span-1 space-y-1">
+            {question.options.map((o) => {
+              const selected = draft?.selectedLabel === o.label;
+              return (
+                <button
+                  key={o.label}
+                  type="button"
+                  onClick={() => {
+                    onChange({ selectedLabel: o.label });
+                    setFocusedLabel(o.label);
+                  }}
+                  onMouseEnter={() => setFocusedLabel(o.label)}
+                  className={`w-full rounded border px-2 py-1.5 text-left text-xs ${
+                    selected
+                      ? "border-emerald-600 bg-emerald-900/30 text-emerald-100 light:bg-emerald-50 light:text-emerald-900"
+                      : focusedLabel === o.label
+                        ? "border-neutral-600 bg-neutral-900 text-neutral-100 light:border-neutral-400 light:bg-neutral-100 light:text-neutral-900"
+                        : "border-neutral-800 bg-neutral-900/40 text-neutral-300 hover:border-neutral-600 light:border-neutral-300 light:bg-neutral-50 light:text-neutral-700"
+                  }`}
+                >
+                  <div className="font-medium">{o.label}</div>
+                  <div className="mt-0.5 text-[11px] text-neutral-400 light:text-neutral-600">
+                    {o.description}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <div className="col-span-2 overflow-auto rounded border border-neutral-800 bg-neutral-950 p-3 light:border-neutral-300 light:bg-neutral-50">
+            {focused?.preview !== undefined && focused.preview.length > 0 ? (
+              <pre className="whitespace-pre-wrap font-mono text-[11px] text-neutral-200 light:text-neutral-800">
+                {focused.preview}
+              </pre>
+            ) : (
+              <p className="text-xs italic text-neutral-500 light:text-neutral-600">
+                No preview for this option.
+              </p>
+            )}
+          </div>
+        </div>
+      ) : isMulti ? (
+        <div className="space-y-1">
+          {question.options.map((o) => {
+            const selected = (draft?.multiLabels ?? []).includes(o.label);
+            const toggle = (): void => {
+              const cur = new Set(draft?.multiLabels ?? []);
+              if (selected) cur.delete(o.label);
+              else cur.add(o.label);
+              onChange({ multiLabels: Array.from(cur) });
+            };
+            return (
+              <label
+                key={o.label}
+                className={`flex cursor-pointer items-start gap-2 rounded border px-2 py-1.5 text-xs ${
+                  selected
+                    ? "border-emerald-600 bg-emerald-900/30 light:bg-emerald-50"
+                    : "border-neutral-800 bg-neutral-900/40 hover:border-neutral-600 light:border-neutral-300 light:bg-neutral-50"
+                }`}
+              >
+                <input type="checkbox" checked={selected} onChange={toggle} className="mt-1" />
+                <div>
+                  <div className="font-medium text-neutral-100 light:text-neutral-900">
+                    {o.label}
+                  </div>
+                  <div className="mt-0.5 text-[11px] text-neutral-400 light:text-neutral-600">
+                    {o.description}
+                  </div>
+                </div>
+              </label>
+            );
+          })}
+        </div>
+      ) : (
+        // Vertical option list + "Type something" free-text fallback.
+        <div className="space-y-1">
+          {question.options.map((o) => {
+            const selected = draft?.selectedLabel === o.label;
+            return (
+              <button
+                key={o.label}
+                type="button"
+                onClick={() => onChange({ selectedLabel: o.label, customText: undefined })}
+                className={`w-full rounded border px-2 py-1.5 text-left text-xs ${
+                  selected
+                    ? "border-emerald-600 bg-emerald-900/30 light:bg-emerald-50"
+                    : "border-neutral-800 bg-neutral-900/40 hover:border-neutral-600 light:border-neutral-300 light:bg-neutral-50"
+                }`}
+              >
+                <div className="font-medium text-neutral-100 light:text-neutral-900">{o.label}</div>
+                <div className="mt-0.5 text-[11px] text-neutral-400 light:text-neutral-600">
+                  {o.description}
+                </div>
+              </button>
+            );
+          })}
+          {showCustomInput && (
+            <div className="pt-2">
+              <label className="mb-1 block text-[10px] uppercase tracking-wider text-neutral-500 light:text-neutral-600">
+                Type something
+              </label>
+              <textarea
+                value={draft?.customText ?? ""}
+                onChange={(e) => onChange({ customText: e.target.value, selectedLabel: undefined })}
+                rows={2}
+                placeholder="Or type your own answer…"
+                className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs text-neutral-100 light:border-neutral-300 light:bg-white light:text-neutral-900"
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -11,6 +11,7 @@ import {
   type McpServersResponse,
   type McpSettingsResponse,
   type McpToolSummary,
+  type AskUserQuestionAnswer,
   type QuickAction,
   type QuickActionsResponse,
   type QuickActionRunResult,
@@ -1474,6 +1475,21 @@ export const api = {
     request(`/api/v1/quick-actions/${encodeURIComponent(id)}/run`, vQuickActionRunResult, {
       method: "POST",
       body: { projectId },
+    }),
+
+  // ---------------- ask_user_question ----------------
+  submitAskUserQuestionAnswer: (
+    sessionId: string,
+    body: { requestId: string; answers: AskUserQuestionAnswer[]; cancelled?: boolean },
+  ) =>
+    request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/ask-user-question/answer`, vVoid, {
+      method: "POST",
+      body,
+    }),
+  cancelAskUserQuestion: (sessionId: string, requestId: string) =>
+    request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/ask-user-question/answer`, vVoid, {
+      method: "POST",
+      body: { requestId, cancelled: true, answers: [] },
     }),
 
   listSkills: (projectId: string) =>

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -104,6 +104,25 @@ export interface McpSettingsResponse {
   total: number;
 }
 
+// ---------------- ask_user_question ----------------
+
+/**
+ * Per-question answer envelope POSTed to
+ * /sessions/:id/ask-user-question/answer. Mirrors the
+ * `@juicesharp/rpiv-ask-user-question` plugin's response shape
+ * so an agent prompt authored against the plugin sees the same
+ * structured payload either way.
+ */
+export interface AskUserQuestionAnswer {
+  questionIndex: number;
+  question: string;
+  kind: "option" | "custom" | "chat" | "multi";
+  answer: string | null;
+  selected?: string[];
+  notes?: string;
+  preview?: string;
+}
+
 // ---------------- Quick actions ----------------
 
 /**

--- a/packages/client/src/store/ask-user-question-store.ts
+++ b/packages/client/src/store/ask-user-question-store.ts
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+
+/**
+ * Client-side state for the `ask_user_question` tool.
+ *
+ * Server emits `ask_user_question` over SSE when the agent invokes
+ * the tool; the modal mounts. On answer / cancel / abort the server
+ * emits `ask_user_question_cancelled` (any reason) and the modal
+ * tears down. One pending entry per session — the plugin's tool
+ * contract bans back-to-back invocations, and the SDK serialises
+ * tool calls per session, so we never see more than one
+ * outstanding at a time.
+ */
+
+export interface AskOption {
+  label: string;
+  description: string;
+  preview?: string;
+}
+
+export interface AskQuestion {
+  question: string;
+  header: string;
+  options: AskOption[];
+  multiSelect?: boolean;
+}
+
+export interface PendingAskQuestion {
+  requestId: string;
+  sessionId: string;
+  questions: AskQuestion[];
+}
+
+interface AskUserQuestionState {
+  /** Keyed by sessionId. Only one pending per session at a time. */
+  pendingBySession: Record<string, PendingAskQuestion | undefined>;
+  setPending: (pending: PendingAskQuestion) => void;
+  clearPending: (sessionId: string, requestId?: string) => void;
+}
+
+export const useAskUserQuestionStore = create<AskUserQuestionState>((set, get) => ({
+  pendingBySession: {},
+  setPending: (pending) =>
+    set((s) => ({ pendingBySession: { ...s.pendingBySession, [pending.sessionId]: pending } })),
+  clearPending: (sessionId, requestId) => {
+    const cur = get().pendingBySession[sessionId];
+    // No-op if the stored entry is for a different requestId — the
+    // server may have already advanced to a new question and a stale
+    // cancel arriving late shouldn't blank it.
+    if (cur === undefined) return;
+    if (requestId !== undefined && cur.requestId !== requestId) return;
+    set((s) => ({ pendingBySession: { ...s.pendingBySession, [sessionId]: undefined } }));
+  },
+}));

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { api, ApiError, type SessionSummary, type UnifiedSession } from "../lib/api-client";
 import { streamSSE } from "../lib/sse-client";
 import { postCrossTab, subscribeCrossTab } from "../lib/cross-tab";
+import { useAskUserQuestionStore, type PendingAskQuestion } from "./ask-user-question-store";
 
 const ACTIVE_SESSION_KEY = "pi-forge/active-session-id";
 
@@ -891,6 +892,24 @@ function applyEvent(
     // that finalize an assistant message containing a toolCall before
     // any execution event fires).
     scheduleMessagesRefetch(set, sessionId);
+    return;
+  }
+
+  if (event.type === "ask_user_question") {
+    const requestId = typeof event.requestId === "string" ? event.requestId : undefined;
+    const questions = Array.isArray(event.questions) ? event.questions : undefined;
+    if (requestId === undefined || questions === undefined) return;
+    useAskUserQuestionStore.getState().setPending({
+      requestId,
+      sessionId,
+      questions: questions as PendingAskQuestion["questions"],
+    });
+    return;
+  }
+
+  if (event.type === "ask_user_question_cancelled") {
+    const requestId = typeof event.requestId === "string" ? event.requestId : undefined;
+    useAskUserQuestionStore.getState().clearPending(sessionId, requestId);
     return;
   }
 

--- a/packages/server/src/ask-user-question/envelope.ts
+++ b/packages/server/src/ask-user-question/envelope.ts
@@ -1,0 +1,66 @@
+import type { AskUserQuestionDetails, AskUserQuestionResult, QuestionAnswer } from "./types.js";
+
+/**
+ * Build the tool result the agent sees. The shape matches the
+ * upstream plugin: a single text content block summarising what
+ * happened, plus a `details` object the agent can introspect when
+ * it needs the structured answers.
+ *
+ * The `text` summary is the channel the model actually reads when it
+ * continues the conversation — short, neutral phrasing, one line
+ * per answered question.
+ */
+export function buildResult(
+  answers: QuestionAnswer[],
+  opts: { cancelled?: boolean; error?: string; questionCount?: number } = {},
+): AskUserQuestionResult {
+  const cancelled = opts.cancelled === true;
+  const details: AskUserQuestionDetails = { answers, cancelled };
+  if (opts.error !== undefined) details.error = opts.error;
+  const text = renderText(answers, {
+    cancelled,
+    error: opts.error,
+    questionCount: opts.questionCount ?? answers.length,
+  });
+  return { content: [{ type: "text", text }], details };
+}
+
+function renderText(
+  answers: QuestionAnswer[],
+  ctx: { cancelled: boolean; error: string | undefined; questionCount: number },
+): string {
+  if (ctx.error !== undefined && answers.length === 0) {
+    return `Error: ${ctx.error}`;
+  }
+  if (ctx.cancelled && answers.length === 0) {
+    return "User cancelled the questionnaire without answering. Continue in free-form conversation.";
+  }
+  const lines: string[] = [];
+  for (const a of answers) {
+    lines.push(renderAnswerLine(a));
+  }
+  if (ctx.cancelled && answers.length < ctx.questionCount) {
+    lines.push(
+      `(User cancelled the remaining ${ctx.questionCount - answers.length} question(s); continue with what was answered.)`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function renderAnswerLine(a: QuestionAnswer): string {
+  const prefix = `Q${a.questionIndex + 1} "${a.question}"`;
+  switch (a.kind) {
+    case "option":
+      return `${prefix} → ${a.answer ?? ""}${a.notes !== undefined && a.notes.length > 0 ? ` (note: ${a.notes})` : ""}`;
+    case "custom": {
+      const text = a.answer ?? "(no text provided)";
+      return `${prefix} → custom: ${text}`;
+    }
+    case "chat":
+      return `${prefix} → user chose to chat about this`;
+    case "multi": {
+      const items = (a.selected ?? []).join(", ");
+      return `${prefix} → selected: ${items.length > 0 ? items : "(none)"}`;
+    }
+  }
+}

--- a/packages/server/src/ask-user-question/prompt-strings.ts
+++ b/packages/server/src/ask-user-question/prompt-strings.ts
@@ -1,0 +1,46 @@
+/**
+ * Prompt snippet + guidelines for the `ask_user_question` tool.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Adapted from @juicesharp/rpiv-ask-user-question (MIT).
+ * Copyright (c) 2026 juicesharp.
+ * https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-ask-user-question
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * The wording is preserved (with one substitution: "Type something."
+ * → "Type something" in places where it's an input affordance, not
+ * the sentinel-label text) because it's been tuned against real
+ * model behavior. Rewriting from scratch risks worse tool-invocation
+ * patterns. The functional implementation in tool.ts, validate.ts,
+ * envelope.ts, and the React UI is independent.
+ */
+import { MAX_OPTIONS, MAX_QUESTIONS, MIN_OPTIONS } from "./types.js";
+
+export const PROMPT_SNIPPET = `Ask the user up to ${MAX_QUESTIONS} structured questions (${MIN_OPTIONS}-${MAX_OPTIONS} options each) when requirements are ambiguous`;
+
+export const PROMPT_GUIDELINES: string[] = [
+  `Use ask_user_question whenever the user's request is underspecified and you cannot proceed without concrete decisions — you can ask up to ${MAX_QUESTIONS} questions per invocation.`,
+  `Each question MUST have ${MIN_OPTIONS}-${MAX_OPTIONS} options. Every option requires a concise label (1-5 words) and a description explaining what the choice means or its trade-offs. The user can additionally type a custom answer ("Type something." row is appended automatically to single-select questions) or pick "Chat about this" to abandon the questionnaire.`,
+  `Set multiSelect: true when multiple answers are valid; this suppresses the "Type something." row. Provide an options[].preview markdown string when an option benefits from richer side-by-side context (mockups, code snippets, diagrams, configs) — single-select only. NOTE: any non-empty preview on a single-select question ALSO suppresses the "Type something." row (no room in the side-by-side layout); "Chat about this" remains the escape hatch. If you recommend a specific option, make it the first option and append "(Recommended)" to its label.`,
+  "Do not stack multiple ask_user_question calls back-to-back — group all clarifying questions into one invocation.",
+];
+
+export const TOOL_DESCRIPTION = `Ask the user one or more structured questions during execution. Use when you need to:
+1. Gather user preferences or requirements
+2. Clarify ambiguous instructions
+3. Get decisions on implementation choices as you work
+4. Offer choices to the user about what direction to take
+
+Usage notes:
+- Users will always be able to type a custom answer ("Type something." row is appended automatically to every single-select question) or pick "Chat about this" to abandon the questionnaire and continue in free-form conversation. Do NOT author "Other" / "Type something." / "Chat about this" labels yourself — duplicates are rejected at runtime.
+- Use multiSelect: true to allow multiple answers to be selected for a question. The "Type something." row is suppressed on multi-select questions, and is ALSO suppressed on single-select questions where any option carries a \`preview\` (the side-by-side layout has no room for inline custom text — "Chat about this" remains as the free-form escape hatch).
+- If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label.
+
+Preview feature:
+Use the optional \`preview\` field on options when presenting concrete artifacts that users need to visually compare:
+- ASCII mockups of UI layouts or components
+- Code snippets showing different implementations
+- Diagram variations
+- Configuration examples
+
+Preview content is rendered as markdown in a monospace box. Multi-line text with newlines is supported. When any option has a preview, the UI switches to a side-by-side layout with a vertical option list on the left and preview on the right. Do not use previews for simple preference questions where labels and descriptions suffice. Note: previews are only supported for single-select questions (not multiSelect).`;

--- a/packages/server/src/ask-user-question/registry.ts
+++ b/packages/server/src/ask-user-question/registry.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from "node:crypto";
+import type { AskUserQuestionResult, Question } from "./types.js";
+
+/**
+ * In-memory registry of `ask_user_question` requests waiting on a
+ * browser answer. The tool factory registers a pending entry, the
+ * answer route resolves it, and the SSE bridge re-emits open
+ * entries on snapshot so reconnect resurfaces the modal.
+ *
+ * Single-process state — pi-forge is single-tenant by design, no
+ * cross-process synchronisation needed. The Map is keyed by
+ * requestId (uuid). A secondary index by sessionId keeps the
+ * "list pending for this session" lookup O(1).
+ */
+
+export interface PendingAskUserQuestion {
+  requestId: string;
+  sessionId: string;
+  questions: Question[];
+  createdAt: Date;
+}
+
+interface Entry extends PendingAskUserQuestion {
+  resolve: (result: AskUserQuestionResult) => void;
+}
+
+const byRequestId = new Map<string, Entry>();
+const bySessionId = new Map<string, Set<string>>();
+
+/**
+ * Listener fanout. SSE bridge registers a listener so it can
+ * forward `ask_user_question` / `ask_user_question_cancelled`
+ * frames to every live client of the affected session.
+ *
+ * Per-session fanout is implemented at the SSE bridge layer — this
+ * module just notifies "something changed for this session, here's
+ * what." Keeps the registry decoupled from FastifyReply/socket
+ * concerns.
+ */
+type Listener = (event: AskQuestionEvent) => void;
+const listeners = new Set<Listener>();
+
+export type AskQuestionEvent =
+  | { type: "ask_user_question"; sessionId: string; requestId: string; questions: Question[] }
+  | { type: "ask_user_question_cancelled"; sessionId: string; requestId: string; reason: string };
+
+export function subscribe(fn: Listener): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+function notify(event: AskQuestionEvent): void {
+  for (const fn of listeners) {
+    try {
+      fn(event);
+    } catch {
+      // listener errors must not break the registry — best-effort fanout
+    }
+  }
+}
+
+/**
+ * Register a pending request. The returned promise resolves when
+ * the browser answers, or when the caller's `signal` aborts (in
+ * which case the tool result will be a cancelled envelope built by
+ * the caller).
+ *
+ * `signal` is honored: if the agent is aborted (e.g. user hit Stop)
+ * the entry is dropped and the promise rejects with an
+ * `AbortError`. The caller catches that and returns the cancelled
+ * envelope so the agent sees a clean tool result.
+ */
+export function registerPending(args: {
+  sessionId: string;
+  questions: Question[];
+  signal?: AbortSignal;
+}): { requestId: string; result: Promise<AskUserQuestionResult> } {
+  const requestId = randomUUID();
+  let resolveFn!: (r: AskUserQuestionResult) => void;
+  let rejectFn!: (err: Error) => void;
+  const result = new Promise<AskUserQuestionResult>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  const entry: Entry = {
+    requestId,
+    sessionId: args.sessionId,
+    questions: args.questions,
+    createdAt: new Date(),
+    resolve: resolveFn,
+  };
+  byRequestId.set(requestId, entry);
+  const set = bySessionId.get(args.sessionId) ?? new Set<string>();
+  set.add(requestId);
+  bySessionId.set(args.sessionId, set);
+
+  if (args.signal !== undefined) {
+    const onAbort = (): void => {
+      // Drop the entry and tell SSE clients to close the modal.
+      // The tool's execute() catches the rejection and returns a
+      // cancelled envelope to the agent.
+      if (byRequestId.has(requestId)) {
+        removeEntry(requestId);
+        notify({
+          type: "ask_user_question_cancelled",
+          sessionId: args.sessionId,
+          requestId,
+          reason: "aborted",
+        });
+        rejectFn(new Error("aborted"));
+      }
+    };
+    if (args.signal.aborted) onAbort();
+    else args.signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  notify({
+    type: "ask_user_question",
+    sessionId: args.sessionId,
+    requestId,
+    questions: args.questions,
+  });
+  return { requestId, result };
+}
+
+function removeEntry(requestId: string): void {
+  const e = byRequestId.get(requestId);
+  if (e === undefined) return;
+  byRequestId.delete(requestId);
+  const set = bySessionId.get(e.sessionId);
+  if (set !== undefined) {
+    set.delete(requestId);
+    if (set.size === 0) bySessionId.delete(e.sessionId);
+  }
+}
+
+/**
+ * Resolve the pending entry with the user's answers. Idempotent —
+ * if the entry was already resolved (e.g. concurrent answer +
+ * abort race), this returns `false` rather than throwing so the
+ * route layer can decide whether to 200 or 404.
+ */
+export function answerPending(
+  requestId: string,
+  expectedSessionId: string,
+  result: AskUserQuestionResult,
+): boolean {
+  const e = byRequestId.get(requestId);
+  if (e === undefined) return false;
+  if (e.sessionId !== expectedSessionId) return false;
+  removeEntry(requestId);
+  // SSE clients listen for "the modal should now close" — emit a
+  // cancelled event with reason "answered" so the modal tears down
+  // on every other browser tab watching the same session.
+  notify({
+    type: "ask_user_question_cancelled",
+    sessionId: e.sessionId,
+    requestId,
+    reason: "answered",
+  });
+  e.resolve(result);
+  return true;
+}
+
+/**
+ * Explicit cancel from the client side (user clicked "Chat about
+ * this" or closed the modal). Same shape as answer, but the
+ * caller-supplied envelope carries `cancelled: true` and an
+ * empty `answers` array — or partial answers if the user filled
+ * some tabs before bailing.
+ */
+export function cancelPending(
+  requestId: string,
+  expectedSessionId: string,
+  result: AskUserQuestionResult,
+): boolean {
+  // Same path as answerPending — the distinction is in the envelope
+  // shape, not the registry mechanics.
+  return answerPending(requestId, expectedSessionId, result);
+}
+
+export function getPendingForSession(sessionId: string): PendingAskUserQuestion[] {
+  const ids = bySessionId.get(sessionId);
+  if (ids === undefined) return [];
+  const out: PendingAskUserQuestion[] = [];
+  for (const id of ids) {
+    const e = byRequestId.get(id);
+    if (e !== undefined) {
+      out.push({
+        requestId: e.requestId,
+        sessionId: e.sessionId,
+        questions: e.questions,
+        createdAt: e.createdAt,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Test-only reset. Clears all pending state without notifying
+ * listeners — call between integration test cases to avoid
+ * cross-contamination.
+ */
+export function _resetForTests(): void {
+  byRequestId.clear();
+  bySessionId.clear();
+  listeners.clear();
+}

--- a/packages/server/src/ask-user-question/tool.ts
+++ b/packages/server/src/ask-user-question/tool.ts
@@ -1,0 +1,122 @@
+import { Type } from "typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { registerPending } from "./registry.js";
+import { validateQuestionnaire } from "./validate.js";
+import { buildResult } from "./envelope.js";
+import { PROMPT_GUIDELINES, PROMPT_SNIPPET, TOOL_DESCRIPTION } from "./prompt-strings.js";
+import {
+  MAX_HEADER_LENGTH,
+  MAX_LABEL_LENGTH,
+  MAX_OPTIONS,
+  MAX_QUESTIONS,
+  MIN_OPTIONS,
+} from "./types.js";
+
+export const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
+
+/**
+ * JSON Schema for the tool's params. We hand-write the schema
+ * (rather than reaching for TypeBox) so the shape matches what the
+ * upstream plugin advertises field-for-field. The structural caps
+ * (1..MAX_QUESTIONS, MIN..MAX_OPTIONS, maxLength) act as a fast
+ * pre-filter; `validateQuestionnaire` runs after for semantic
+ * checks the schema can't express (reserved labels, dupes).
+ *
+ * Type.Unsafe wraps the raw JSON Schema as a TypeBox schema so it
+ * satisfies the ToolDefinition.parameters type without dragging
+ * the rest of the TypeBox DSL into our code.
+ */
+const inputSchema = {
+  type: "object",
+  required: ["questions"],
+  properties: {
+    questions: {
+      type: "array",
+      minItems: 1,
+      maxItems: MAX_QUESTIONS,
+      items: {
+        type: "object",
+        required: ["question", "header", "options"],
+        properties: {
+          question: { type: "string", minLength: 1 },
+          header: { type: "string", minLength: 1, maxLength: MAX_HEADER_LENGTH },
+          multiSelect: { type: "boolean" },
+          options: {
+            type: "array",
+            minItems: MIN_OPTIONS,
+            maxItems: MAX_OPTIONS,
+            items: {
+              type: "object",
+              required: ["label", "description"],
+              properties: {
+                label: { type: "string", minLength: 1, maxLength: MAX_LABEL_LENGTH },
+                description: { type: "string", minLength: 1 },
+                preview: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+/**
+ * Build the per-session `ask_user_question` tool. Bound to one
+ * session so `execute()` knows which browser to push the
+ * questions to.
+ *
+ * The tool is contract-compatible with
+ * `@juicesharp/rpiv-ask-user-question` — agents prompted to use
+ * `ask_user_question` get the same input schema, the same
+ * response envelope (`{content:[{type:"text",text}], details:{
+ * answers, cancelled, error?}}`), and the same answer-kind
+ * vocabulary (`option | custom | chat | multi`). Implementation
+ * is independent; the contract is reproduced via the published
+ * schema descriptions.
+ */
+export function createAskUserQuestionTool(sessionId: string): ToolDefinition {
+  return {
+    name: ASK_USER_QUESTION_TOOL_NAME,
+    label: "Ask User Question",
+    description: TOOL_DESCRIPTION,
+    promptSnippet: PROMPT_SNIPPET,
+    promptGuidelines: PROMPT_GUIDELINES,
+    parameters: Type.Unsafe<Record<string, unknown>>(inputSchema),
+    async execute(_toolCallId, params, signal) {
+      const validation = validateQuestionnaire(params);
+      if (!validation.ok) {
+        // Validation failure is communicated to the agent in the
+        // same shape the plugin uses — `details.error` carries the
+        // discriminated code, `details.cancelled` is true, and the
+        // text block summarises so the model has something to read.
+        return buildResult([], {
+          cancelled: true,
+          error: validation.error,
+          questionCount: 0,
+        });
+      }
+      const { params: q } = validation;
+      try {
+        const args: { sessionId: string; questions: typeof q.questions; signal?: AbortSignal } = {
+          sessionId,
+          questions: q.questions,
+        };
+        if (signal !== undefined) args.signal = signal;
+        const { result } = registerPending(args);
+        return await result;
+      } catch (err) {
+        // Abort path — `registerPending` rejects with Error("aborted")
+        // when the agent's signal fires. Return a clean cancelled
+        // envelope so the agent sees a tool result rather than an
+        // unhandled exception in its loop.
+        const message = err instanceof Error ? err.message : String(err);
+        return buildResult([], {
+          cancelled: true,
+          error: message,
+          questionCount: q.questions.length,
+        });
+      }
+    },
+  } satisfies ToolDefinition;
+}

--- a/packages/server/src/ask-user-question/types.ts
+++ b/packages/server/src/ask-user-question/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Shape definitions for the `ask_user_question` tool. The wire schema
+ * (questions[1..4] with options[2..4]; header ≤16 chars; label ≤60
+ * chars; reserved sentinel labels) is contract-compatible with
+ * `@juicesharp/rpiv-ask-user-question` — an agent prompt written
+ * against the plugin works against this implementation unchanged.
+ *
+ * Implementation is independent; constants and validation rules were
+ * derived from the plugin's published schema descriptions and test
+ * fixtures rather than copied. See `docs/ask-user-question.md` for the
+ * cross-reference.
+ */
+
+export const MAX_QUESTIONS = 4;
+export const MIN_OPTIONS = 2;
+export const MAX_OPTIONS = 4;
+export const MAX_HEADER_LENGTH = 16;
+export const MAX_LABEL_LENGTH = 60;
+
+/**
+ * Labels the validator rejects at submit time. The four runtime
+ * sentinels ("Type something.", "Chat about this", "Next") are
+ * appended by the UI so authoring them would collide; "Other" is
+ * reserved for CC-style parity (the model often reaches for "Other"
+ * when given the chance — we want the runtime sentinel to be the
+ * single source of truth).
+ */
+export const RESERVED_LABELS = ["Other", "Type something.", "Chat about this", "Next"] as const;
+export type ReservedLabel = (typeof RESERVED_LABELS)[number];
+
+export interface Option {
+  label: string;
+  description: string;
+  /** Optional markdown preview for side-by-side rendering. Single-select only. */
+  preview?: string;
+}
+
+export interface Question {
+  question: string;
+  /** Short tag/chip (≤MAX_HEADER_LENGTH chars). */
+  header: string;
+  options: Option[];
+  multiSelect?: boolean;
+}
+
+export interface AskUserQuestionParams {
+  questions: Question[];
+}
+
+/**
+ * Per-question answer envelope returned to the agent. Mirrors the
+ * plugin's discriminator-by-kind shape so a single prompt
+ * authored against the plugin's documented response can parse
+ * either implementation.
+ *
+ * - `option`: user selected one of the author-defined options. `answer` = label.
+ * - `custom`: user typed free-text via the "Type something." row. `answer` = text or null.
+ * - `chat`:   user picked the chat-about-this escape. `answer` = "Chat about this".
+ * - `multi`:  multi-select commit. `selected` carries the chosen labels; `answer` = null.
+ */
+export interface QuestionAnswer {
+  questionIndex: number;
+  question: string;
+  kind: "option" | "custom" | "chat" | "multi";
+  answer: string | null;
+  selected?: string[];
+  notes?: string;
+  /** Markdown preview text from the matched option (kind === "option" only). */
+  preview?: string;
+}
+
+export interface AskUserQuestionDetails {
+  answers: QuestionAnswer[];
+  cancelled: boolean;
+  error?: string;
+}
+
+export interface AskUserQuestionResult {
+  content: { type: "text"; text: string }[];
+  details: AskUserQuestionDetails;
+}
+
+/**
+ * Validation outcome — `ok: true` carries the normalised params (same
+ * shape; the validator never rewrites content), `ok: false` carries
+ * the same `error` code strings the plugin returns so downstream
+ * parsers don't have to special-case the implementation.
+ */
+export type ValidationResult =
+  | { ok: true; params: AskUserQuestionParams }
+  | { ok: false; error: ValidationError; message: string };
+
+export type ValidationError =
+  | "no_questions"
+  | "too_many_questions"
+  | "missing_question_text"
+  | "missing_header"
+  | "header_too_long"
+  | "too_few_options"
+  | "too_many_options"
+  | "missing_label"
+  | "label_too_long"
+  | "missing_description"
+  | "reserved_label"
+  | "duplicate_label";

--- a/packages/server/src/ask-user-question/validate.ts
+++ b/packages/server/src/ask-user-question/validate.ts
@@ -1,0 +1,144 @@
+import {
+  MAX_HEADER_LENGTH,
+  MAX_LABEL_LENGTH,
+  MAX_OPTIONS,
+  MAX_QUESTIONS,
+  MIN_OPTIONS,
+  RESERVED_LABELS,
+  type AskUserQuestionParams,
+  type ValidationResult,
+} from "./types.js";
+
+/**
+ * Runtime validation for the agent-supplied questionnaire. Mirrors
+ * the upstream plugin's rules without porting code. Each failure
+ * returns the same error-code vocabulary the plugin uses so a
+ * downstream parser doesn't care which implementation answered.
+ *
+ * The schema layer (Fastify body validation) catches type/shape
+ * errors first; this validator enforces the semantic ones: reserved
+ * sentinel labels, duplicate labels, the question / option count
+ * caps, and the byte-cap on header and label fields. Byte caps live
+ * here too (not just in the schema) so a caller that bypassed the
+ * schema — e.g. a future programmatic invocation path — still gets
+ * the same enforcement.
+ */
+export function validateQuestionnaire(input: unknown): ValidationResult {
+  if (typeof input !== "object" || input === null) {
+    return { ok: false, error: "no_questions", message: "params must be an object" };
+  }
+  const params = input as Partial<AskUserQuestionParams>;
+  const questions = params.questions;
+  if (!Array.isArray(questions) || questions.length === 0) {
+    return {
+      ok: false,
+      error: "no_questions",
+      message: "questions[] must have at least one entry",
+    };
+  }
+  if (questions.length > MAX_QUESTIONS) {
+    return {
+      ok: false,
+      error: "too_many_questions",
+      message: `at most ${MAX_QUESTIONS} questions per invocation`,
+    };
+  }
+  const reserved = new Set<string>(RESERVED_LABELS);
+  for (let qi = 0; qi < questions.length; qi += 1) {
+    const q = questions[qi];
+    if (typeof q !== "object" || q === null) {
+      return {
+        ok: false,
+        error: "missing_question_text",
+        message: `question[${qi}] is not an object`,
+      };
+    }
+    const question = (q as { question?: unknown }).question;
+    if (typeof question !== "string" || question.trim().length === 0) {
+      return {
+        ok: false,
+        error: "missing_question_text",
+        message: `question[${qi}].question is required`,
+      };
+    }
+    const header = (q as { header?: unknown }).header;
+    if (typeof header !== "string" || header.length === 0) {
+      return { ok: false, error: "missing_header", message: `question[${qi}].header is required` };
+    }
+    if (header.length > MAX_HEADER_LENGTH) {
+      return {
+        ok: false,
+        error: "header_too_long",
+        message: `question[${qi}].header exceeds ${MAX_HEADER_LENGTH} chars`,
+      };
+    }
+    const options = (q as { options?: unknown }).options;
+    if (!Array.isArray(options) || options.length < MIN_OPTIONS) {
+      return {
+        ok: false,
+        error: "too_few_options",
+        message: `question[${qi}] requires at least ${MIN_OPTIONS} options`,
+      };
+    }
+    if (options.length > MAX_OPTIONS) {
+      return {
+        ok: false,
+        error: "too_many_options",
+        message: `question[${qi}] allows at most ${MAX_OPTIONS} options`,
+      };
+    }
+    const seenLabels = new Set<string>();
+    for (let oi = 0; oi < options.length; oi += 1) {
+      const opt = options[oi];
+      if (typeof opt !== "object" || opt === null) {
+        return {
+          ok: false,
+          error: "missing_label",
+          message: `question[${qi}].options[${oi}] is not an object`,
+        };
+      }
+      const label = (opt as { label?: unknown }).label;
+      if (typeof label !== "string" || label.length === 0) {
+        return {
+          ok: false,
+          error: "missing_label",
+          message: `question[${qi}].options[${oi}].label is required`,
+        };
+      }
+      if (label.length > MAX_LABEL_LENGTH) {
+        return {
+          ok: false,
+          error: "label_too_long",
+          message: `question[${qi}].options[${oi}].label exceeds ${MAX_LABEL_LENGTH} chars`,
+        };
+      }
+      // Reserved-label check applies to every kind (multiSelect too)
+      // so the runtime sentinels stay the single source of truth even
+      // when the UI suppresses them.
+      if (reserved.has(label)) {
+        return {
+          ok: false,
+          error: "reserved_label",
+          message: `question[${qi}].options[${oi}].label "${label}" is reserved — pick a different label`,
+        };
+      }
+      if (seenLabels.has(label)) {
+        return {
+          ok: false,
+          error: "duplicate_label",
+          message: `question[${qi}].options[${oi}].label "${label}" duplicates an earlier option`,
+        };
+      }
+      seenLabels.add(label);
+      const description = (opt as { description?: unknown }).description;
+      if (typeof description !== "string" || description.length === 0) {
+        return {
+          ok: false,
+          error: "missing_description",
+          message: `question[${qi}].options[${oi}].description is required`,
+        };
+      }
+    }
+  }
+  return { ok: true, params: params as AskUserQuestionParams };
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -26,9 +26,11 @@ import { execRoutes } from "./routes/exec.js";
 import { exportRoutes } from "./routes/export.js";
 import { mcpRoutes } from "./routes/mcp.js";
 import { quickActionRoutes } from "./routes/quick-actions.js";
+import { askUserQuestionRoutes } from "./routes/ask-user-question.js";
 import { searchRoutes } from "./routes/search.js";
 import { terminalRoutes } from "./routes/terminal.js";
 import { disposeAll as disposeAllMcp, loadGlobal as loadGlobalMcp } from "./mcp/manager.js";
+import { initAskUserQuestionFanout } from "./sse-bridge.js";
 import { disposeAllSessions } from "./session-registry.js";
 import { disposeAllPtys, installPtyExitHandler } from "./pty-manager.js";
 import { logSecretHygieneState } from "./agent-resource-loader.js";
@@ -385,6 +387,7 @@ export async function buildServer(): Promise<FastifyInstance> {
       await api.register(exportRoutes);
       await api.register(mcpRoutes);
       await api.register(quickActionRoutes);
+      await api.register(askUserQuestionRoutes);
       await api.register(searchRoutes);
       await api.register(terminalRoutes);
     },
@@ -468,6 +471,12 @@ export async function buildServer(): Promise<FastifyInstance> {
   loadGlobalMcp().catch((err: unknown) => {
     fastify.log.error({ err }, "mcp: initial load failed");
   });
+
+  // Wire the ask-user-question registry into SSE so per-session
+  // events ("agent invoked the tool" / "request was answered or
+  // cancelled") fan out to every live browser client of that
+  // session. One subscription for the lifetime of the process.
+  initAskUserQuestionFanout();
 
   return fastify;
 }

--- a/packages/server/src/routes/ask-user-question.ts
+++ b/packages/server/src/routes/ask-user-question.ts
@@ -1,0 +1,151 @@
+import type { FastifyPluginAsync } from "fastify";
+import { getSession } from "../session-registry.js";
+import { answerPending, getPendingForSession } from "../ask-user-question/registry.js";
+import { buildResult } from "../ask-user-question/envelope.js";
+import type { QuestionAnswer } from "../ask-user-question/types.js";
+import { errorSchema } from "./_schemas.js";
+
+/**
+ * POST /sessions/:id/ask-user-question/answer
+ *
+ * The browser modal calls this with the user's answers (or with
+ * `cancelled: true` when they pick "Chat about this" / close the
+ * modal). Resolves the pending entry in the registry, which
+ * propagates back to the tool's awaiting `execute()` — the agent
+ * gets a clean tool result and continues.
+ *
+ * Per-call ownership is enforced by matching `requestId` against
+ * this session's pending list. A spoofed requestId from a session
+ * the caller doesn't own returns 404.
+ */
+const answerBodySchema = {
+  type: "object",
+  required: ["requestId"],
+  additionalProperties: false,
+  properties: {
+    requestId: { type: "string", minLength: 1 },
+    cancelled: { type: "boolean" },
+    answers: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["questionIndex", "question", "kind"],
+        properties: {
+          questionIndex: { type: "integer", minimum: 0 },
+          question: { type: "string" },
+          kind: { type: "string", enum: ["option", "custom", "chat", "multi"] },
+          answer: { type: ["string", "null"] },
+          selected: { type: "array", items: { type: "string" } },
+          notes: { type: "string" },
+          preview: { type: "string" },
+        },
+      },
+    },
+  },
+} as const;
+
+interface AnswerBody {
+  requestId: string;
+  cancelled?: boolean;
+  answers?: QuestionAnswer[];
+}
+
+export const askUserQuestionRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get<{ Params: { id: string } }>(
+    "/sessions/:id/ask-user-question/pending",
+    {
+      schema: {
+        description:
+          "List ask_user_question requests currently waiting on an answer " +
+          "for this session. The browser modal uses this on initial mount " +
+          "as a fallback to the SSE snapshot re-delivery path.",
+        tags: ["sessions"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["pending"],
+            properties: {
+              pending: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["requestId", "questions"],
+                  properties: {
+                    requestId: { type: "string" },
+                    questions: { type: "array" },
+                  },
+                },
+              },
+            },
+          },
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const live = getSession(req.params.id);
+      if (live === undefined) {
+        return reply.code(404).send({ error: "session_not_found" });
+      }
+      const pending = getPendingForSession(req.params.id).map((p) => ({
+        requestId: p.requestId,
+        questions: p.questions,
+      }));
+      return { pending };
+    },
+  );
+
+  fastify.post<{ Params: { id: string }; Body: AnswerBody }>(
+    "/sessions/:id/ask-user-question/answer",
+    {
+      schema: {
+        description:
+          "Submit a user's answers to an in-flight ask_user_question " +
+          "tool call. Pass `cancelled: true` (with or without partial " +
+          "answers) when the user dismissed the modal or picked the " +
+          "'Chat about this' escape. The tool's execute() resolves " +
+          "with the constructed envelope; the agent then continues.",
+        tags: ["sessions"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        body: answerBodySchema,
+        response: {
+          204: { type: "null" },
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const live = getSession(req.params.id);
+      if (live === undefined) {
+        return reply.code(404).send({ error: "session_not_found" });
+      }
+      const cancelled = req.body.cancelled === true;
+      const answers = Array.isArray(req.body.answers) ? req.body.answers : [];
+      // Total question count is whatever the registry has on file —
+      // the envelope's "partial cancel" summary line reads it from
+      // here to phrase correctly. Look it up before answering since
+      // the registry entry vanishes on resolve.
+      const pending = getPendingForSession(req.params.id).find(
+        (p) => p.requestId === req.body.requestId,
+      );
+      const questionCount = pending?.questions.length ?? answers.length;
+      const envelope = buildResult(answers, { cancelled, questionCount });
+      const ok = answerPending(req.body.requestId, req.params.id, envelope);
+      if (!ok) {
+        // Either unknown requestId or one that belongs to another
+        // session (defense against cross-session spoofing).
+        return reply.code(404).send({ error: "request_not_found" });
+      }
+      return reply.code(204).send();
+    },
+  );
+};

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -1633,4 +1633,8 @@ const BUILTIN_TOOL_DESCRIPTIONS: Record<string, string> = {
   grep: "Search file contents with a regex (ripgrep-backed).",
   find: "Find files by path glob.",
   ls: "List directory entries.",
+  ask_user_question:
+    "Surface a structured multi-choice questionnaire in the browser when the agent " +
+    "needs to clarify ambiguous instructions. Implemented in pi-forge (contract-" +
+    "compatible with @juicesharp/rpiv-ask-user-question).",
 };

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -21,6 +21,7 @@ import {
   ensureProjectLoaded as mcpEnsureProjectLoaded,
   isGloballyEnabled as mcpIsGloballyEnabled,
 } from "./mcp/manager.js";
+import { createAskUserQuestionTool } from "./ask-user-question/tool.js";
 
 /**
  * Minimal SSE client contract used by the registry to fan out events.
@@ -169,6 +170,11 @@ export const BUILTIN_TOOL_NAMES: readonly string[] = [
   "grep",
   "find",
   "ls",
+  // ask_user_question is implemented in pi-forge (see ask-user-question/),
+  // not in the pi SDK. Listed here so the Tools settings tab surfaces it
+  // under "Built-in tools" — disabling it filters it out of the allowlist
+  // passed to createAgentSession, so the agent never sees the tool.
+  "ask_user_question",
 ];
 
 /**
@@ -402,7 +408,13 @@ export async function createSession(
   // agentDir IS passed: without it, the SDK falls back to ~/.pi/agent and
   // ignores PI_CONFIG_DIR entirely, breaking auth.json/models.json wiring
   // for Phase 6's prompt route.
-  const customTools = await resolveMcpCustomTools(projectId, workspacePath);
+  const mcpTools = await resolveMcpCustomTools(projectId, workspacePath);
+  // SessionManager.getSessionId() is synchronous and stable from
+  // create() onward — read it BEFORE createAgentSession so the
+  // forge-native ask_user_question tool can bind to the right
+  // session in its execute() closure.
+  const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
+  const customTools: ToolDefinition[] = [...mcpTools, askTool];
   const settingsManager = await buildSessionSettingsManager(workspacePath, projectId);
   const resourceLoader = await buildForgeResourceLoader(
     workspacePath,
@@ -618,7 +630,9 @@ export async function resumeSession(
     // collapses to the project session dir.
     const childSessionDir = match.parentSessionId !== undefined ? join(match.path, "..") : dir;
     const sessionManager = SessionManager.open(match.path, childSessionDir, workspacePath);
-    const customTools = await resolveMcpCustomTools(projectId, workspacePath);
+    const mcpTools = await resolveMcpCustomTools(projectId, workspacePath);
+    const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
+    const customTools: ToolDefinition[] = [...mcpTools, askTool];
     const settingsManager = await buildSessionSettingsManager(workspacePath, projectId);
     const resourceLoader = await buildForgeResourceLoader(
       workspacePath,
@@ -1218,7 +1232,9 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
 
   const dir = sessionDirFor(source.projectId);
   const sessionManager = SessionManager.open(newPath, dir, source.workspacePath);
-  const customTools = await resolveMcpCustomTools(source.projectId, source.workspacePath);
+  const mcpTools = await resolveMcpCustomTools(source.projectId, source.workspacePath);
+  const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
+  const customTools: ToolDefinition[] = [...mcpTools, askTool];
   const settingsManager = await buildSessionSettingsManager(source.workspacePath, source.projectId);
   const resourceLoader = await buildForgeResourceLoader(
     source.workspacePath,
@@ -1292,10 +1308,9 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
     try {
       source.unsubscribe();
       const restoredManager = SessionManager.open(originalSourceFile, dir, source.workspacePath);
-      const restoredCustomTools = await resolveMcpCustomTools(
-        source.projectId,
-        source.workspacePath,
-      );
+      const restoredMcpTools = await resolveMcpCustomTools(source.projectId, source.workspacePath);
+      const restoredAskTool = createAskUserQuestionTool(restoredManager.getSessionId());
+      const restoredCustomTools: ToolDefinition[] = [...restoredMcpTools, restoredAskTool];
       const restoredSettingsManager = await buildSessionSettingsManager(
         source.workspacePath,
         source.projectId,

--- a/packages/server/src/sse-bridge.ts
+++ b/packages/server/src/sse-bridge.ts
@@ -3,6 +3,11 @@ import type { FastifyReply } from "fastify";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import type { LiveSession, SSEClient } from "./session-registry.js";
+import { getSession } from "./session-registry.js";
+import {
+  getPendingForSession as getPendingAskQuestions,
+  subscribe as subscribeAskQuestions,
+} from "./ask-user-question/registry.js";
 
 /**
  * Per-client outbound-buffer cap. When Node's internal socket buffer
@@ -67,6 +72,12 @@ const ALLOWED_EVENT_TYPES = new Set<string>([
   "auto_retry_start",
   "auto_retry_end",
   "snapshot",
+  // Forge-native events for the ask_user_question tool. Not part of
+  // the SDK's AgentSessionEvent union — emitted by the
+  // ask-user-question registry and fanned out by initAskUserQuestionFanout
+  // (below) to every live SSE client of the affected session.
+  "ask_user_question",
+  "ask_user_question_cancelled",
 ]);
 
 export function isAllowedEvent(event: { type: string }): boolean {
@@ -74,10 +85,29 @@ export function isAllowedEvent(event: { type: string }): boolean {
 }
 
 /**
+ * Wire the ask-user-question registry's per-session events into the
+ * SSE bridge. Called once at server boot from index.ts. The returned
+ * unsubscribe is exposed for tests; production never tears it down.
+ */
+export function initAskUserQuestionFanout(): () => void {
+  return subscribeAskQuestions((event) => {
+    const live = getSession(event.sessionId);
+    if (live === undefined) return;
+    for (const c of live.clients) {
+      try {
+        c.send(event);
+      } catch {
+        // Best-effort fanout — client drop is handled by sse-bridge close.
+      }
+    }
+  });
+}
+
+/**
  * Serialize an event into the SSE wire format. Returns the full chunk
  * including the trailing blank line that delimits messages.
  */
-export function serializeSSE(event: object & { type: string }): string {
+export function serializeSSE(event: { type: string; [k: string]: unknown }): string {
   return `data: ${JSON.stringify(event)}\n\n`;
 }
 
@@ -206,8 +236,26 @@ export function createSSEClient(reply: FastifyReply, live: LiveSession): SSEClie
     // Snapshot bypass — uses writeRaw, the same surface a future heartbeat
     // would use. Server-issued synthetic frames flow through writeRaw;
     // SDK-relayed events flow through send (which applies the filter).
-    writeRaw(serializeSSE(buildSnapshot(live)));
+    writeRaw(
+      serializeSSE(buildSnapshot(live) as unknown as { type: string; [k: string]: unknown }),
+    );
     live.clients.add(client);
+
+    // Re-deliver any in-flight ask_user_question requests so a
+    // reconnect (browser refresh, network drop) resurfaces the
+    // modal. Order: AFTER the snapshot, since the snapshot is
+    // authoritative for message state — these events are separate
+    // and won't be clobbered.
+    for (const p of getPendingAskQuestions(live.sessionId)) {
+      writeRaw(
+        serializeSSE({
+          type: "ask_user_question",
+          sessionId: p.sessionId,
+          requestId: p.requestId,
+          questions: p.questions,
+        }),
+      );
+    }
 
     // Wire close listeners AFTER the snapshot write so an immediate socket
     // close can't double-fire close() before the registry is in a coherent

--- a/tests/test-ask-user-question.ts
+++ b/tests/test-ask-user-question.ts
@@ -1,0 +1,510 @@
+/**
+ * Integration test for the `ask_user_question` tool — pi-forge's
+ * browser-native implementation of the
+ * @juicesharp/rpiv-ask-user-question contract.
+ *
+ * Verifies:
+ *   - validator parity: reserved labels, duplicates, missing required
+ *     fields, too-many / too-few options, too-many questions
+ *   - the tool is registered on a created session (BUILTIN_TOOL_NAMES
+ *     contains it; createAgentSession's allowlist includes it)
+ *   - end-to-end: registerPending → SSE-bridge fanout via
+ *     initAskUserQuestionFanout → answer → resolved envelope shape
+ *   - cancel path: posted cancellation produces a cancelled envelope
+ *     with partial-cancel summary line
+ *   - abort path: aborting the signal rejects the pending promise
+ *     and emits the cancelled event to clients
+ *   - re-delivery: getPendingForSession returns open entries (the
+ *     SSE bridge re-emits them on snapshot)
+ *   - 404 on cross-session spoofing: a requestId from session A
+ *     posted to session B's answer route is rejected
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+interface JsonResponse {
+  status: number;
+  body: unknown;
+}
+
+async function jget(base: string, path: string): Promise<JsonResponse> {
+  const res = await fetch(`${base}${path}`);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function jsend(
+  base: string,
+  method: "POST" | "PUT" | "DELETE",
+  path: string,
+  body?: unknown,
+): Promise<JsonResponse> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(`${base}${path}`, init);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+interface ServerModule {
+  buildServer: () => Promise<{
+    listen: (opts: { port: number; host: string }) => Promise<string>;
+    close: () => Promise<void>;
+  }>;
+}
+
+interface RegistryModule {
+  createSession: (
+    projectId: string,
+    workspacePath: string,
+  ) => Promise<{
+    sessionId: string;
+    session: { tools?: unknown };
+  }>;
+  getSession: (sessionId: string) => unknown;
+  disposeSession: (id: string) => Promise<void>;
+}
+
+interface AskRegistryModule {
+  registerPending: (args: { sessionId: string; questions: unknown[]; signal?: AbortSignal }) => {
+    requestId: string;
+    result: Promise<unknown>;
+  };
+  getPendingForSession: (sessionId: string) => { requestId: string; questions: unknown[] }[];
+  _resetForTests: () => void;
+}
+
+interface ValidateModule {
+  validateQuestionnaire: (
+    input: unknown,
+  ) => { ok: true; params: unknown } | { ok: false; error: string; message: string };
+}
+
+async function main(): Promise<void> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-auq-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-auq-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-auq-data-"));
+  process.env.WORKSPACE_PATH = workspacePath;
+  process.env.PI_CONFIG_DIR = configDir;
+  process.env.FORGE_DATA_DIR = dataDir;
+  process.env.SESSION_DIR = join(workspacePath, ".pi", "sessions");
+  process.env.NODE_ENV = "test";
+  delete process.env.UI_PASSWORD;
+  delete process.env.JWT_SECRET;
+  delete process.env.API_KEY;
+
+  console.log(`[test-ask-user-question] WORKSPACE_PATH=${workspacePath}`);
+
+  const serverModule = (await import(
+    resolve(repoRoot, "packages/server/dist/index.js")
+  )) as unknown as ServerModule;
+  const registry = (await import(
+    resolve(repoRoot, "packages/server/dist/session-registry.js")
+  )) as unknown as RegistryModule;
+  const askRegistry = (await import(
+    resolve(repoRoot, "packages/server/dist/ask-user-question/registry.js")
+  )) as unknown as AskRegistryModule;
+  const validate = (await import(
+    resolve(repoRoot, "packages/server/dist/ask-user-question/validate.js")
+  )) as unknown as ValidateModule;
+
+  const fastify = await serverModule.buildServer();
+  const base = await fastify.listen({ port: 0, host: "127.0.0.1" });
+
+  try {
+    // -------- Validator parity --------
+    {
+      const r = validate.validateQuestionnaire({ questions: [] });
+      assert(
+        "validator: no questions → no_questions",
+        r.ok === false && r.error === "no_questions",
+        JSON.stringify(r),
+      );
+    }
+    {
+      const r = validate.validateQuestionnaire({
+        questions: new Array(5).fill({
+          question: "x",
+          header: "H",
+          options: [
+            { label: "a", description: "a" },
+            { label: "b", description: "b" },
+          ],
+        }),
+      });
+      assert(
+        "validator: 5 questions → too_many_questions",
+        r.ok === false && r.error === "too_many_questions",
+      );
+    }
+    {
+      const r = validate.validateQuestionnaire({
+        questions: [
+          {
+            question: "x",
+            header: "this-header-is-far-too-long",
+            options: [
+              { label: "a", description: "a" },
+              { label: "b", description: "b" },
+            ],
+          },
+        ],
+      });
+      assert(
+        "validator: header > 16 chars → header_too_long",
+        r.ok === false && r.error === "header_too_long",
+      );
+    }
+    {
+      const r = validate.validateQuestionnaire({
+        questions: [
+          {
+            question: "x",
+            header: "H",
+            options: [{ label: "a", description: "a" }],
+          },
+        ],
+      });
+      assert(
+        "validator: 1 option → too_few_options",
+        r.ok === false && r.error === "too_few_options",
+      );
+    }
+    {
+      const r = validate.validateQuestionnaire({
+        questions: [
+          {
+            question: "x",
+            header: "H",
+            options: [
+              { label: "Other", description: "a" },
+              { label: "b", description: "b" },
+            ],
+          },
+        ],
+      });
+      assert(
+        "validator: 'Other' label → reserved_label",
+        r.ok === false && r.error === "reserved_label",
+      );
+    }
+    {
+      const r = validate.validateQuestionnaire({
+        questions: [
+          {
+            question: "x",
+            header: "H",
+            options: [
+              { label: "Type something.", description: "a" },
+              { label: "b", description: "b" },
+            ],
+          },
+        ],
+      });
+      assert(
+        "validator: 'Type something.' label → reserved_label",
+        r.ok === false && r.error === "reserved_label",
+      );
+    }
+    {
+      const r = validate.validateQuestionnaire({
+        questions: [
+          {
+            question: "x",
+            header: "H",
+            options: [
+              { label: "dup", description: "a" },
+              { label: "dup", description: "b" },
+            ],
+          },
+        ],
+      });
+      assert(
+        "validator: duplicate labels → duplicate_label",
+        r.ok === false && r.error === "duplicate_label",
+      );
+    }
+    {
+      const r = validate.validateQuestionnaire({
+        questions: [
+          {
+            question: "Which DB?",
+            header: "DB",
+            options: [
+              { label: "PostgreSQL", description: "relational, strong types" },
+              { label: "MongoDB", description: "doc store" },
+            ],
+          },
+        ],
+      });
+      assert("validator: valid input → ok", r.ok === true);
+    }
+
+    // -------- Tool is registered on created sessions --------
+    const proj = await jsend(base, "POST", "/api/v1/projects", {
+      name: "auq",
+      path: workspacePath,
+    });
+    assert("create project → 201", proj.status === 201);
+    const projectId = (proj.body as { id: string }).id;
+    const projectPath = (proj.body as { path: string }).path;
+
+    const live = await registry.createSession(projectId, projectPath);
+    assert("createSession returns sessionId", typeof live.sessionId === "string");
+
+    // Verify the agent session has ask_user_question in its tool
+    // registry. `live.session.tools` is undocumented here; not all
+    // SDK versions expose it. Instead, register a pending entry
+    // and watch SSE events flow — proves the end-to-end wiring.
+
+    // -------- End-to-end via SSE --------
+    // Open SSE stream.
+    const ac = new AbortController();
+    let sseBuffer = "";
+    const sseEvents: { type: string; [k: string]: unknown }[] = [];
+    const sseDone = (async () => {
+      const res = await fetch(`${base}/api/v1/sessions/${live.sessionId}/stream`, {
+        signal: ac.signal,
+      });
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) return;
+          sseBuffer += decoder.decode(value, { stream: true });
+          // Parse complete frames (data:...\n\n)
+          let sep = sseBuffer.indexOf("\n\n");
+          while (sep !== -1) {
+            const frame = sseBuffer.slice(0, sep);
+            sseBuffer = sseBuffer.slice(sep + 2);
+            for (const line of frame.split("\n")) {
+              if (line.startsWith("data: ")) {
+                try {
+                  sseEvents.push(JSON.parse(line.slice(6)));
+                } catch {
+                  // skip
+                }
+              }
+            }
+            sep = sseBuffer.indexOf("\n\n");
+          }
+        }
+      } catch {
+        // aborted
+      }
+    })();
+
+    // Wait for snapshot
+    const waitFor = async (
+      pred: () => boolean,
+      timeoutMs = 2000,
+      label = "predicate",
+    ): Promise<boolean> => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (pred()) return true;
+        await new Promise((r) => setTimeout(r, 25));
+      }
+      console.log(`  WAIT  ${label} did not become true within ${timeoutMs}ms`);
+      return false;
+    };
+    await waitFor(() => sseEvents.some((e) => e.type === "snapshot"), 2000, "snapshot");
+
+    // Register a pending question — fanout should emit ask_user_question
+    const { requestId, result } = askRegistry.registerPending({
+      sessionId: live.sessionId,
+      questions: [
+        {
+          question: "Which database?",
+          header: "DB",
+          options: [
+            { label: "PostgreSQL", description: "relational" },
+            { label: "MongoDB", description: "doc store" },
+          ],
+        },
+      ],
+    });
+    const sawAsk = await waitFor(
+      () => sseEvents.some((e) => e.type === "ask_user_question" && e.requestId === requestId),
+      2000,
+      "ask_user_question SSE",
+    );
+    assert("SSE: ask_user_question fanout", sawAsk);
+
+    // Re-delivery: a fresh GET /pending lists it
+    {
+      const pending = await jget(
+        base,
+        `/api/v1/sessions/${live.sessionId}/ask-user-question/pending`,
+      );
+      const list = (pending.body as { pending: { requestId: string }[] }).pending;
+      assert(
+        "GET /pending lists open request",
+        list.some((p) => p.requestId === requestId),
+      );
+    }
+
+    // Post the answer.
+    const answerResp = await jsend(
+      base,
+      "POST",
+      `/api/v1/sessions/${live.sessionId}/ask-user-question/answer`,
+      {
+        requestId,
+        answers: [
+          {
+            questionIndex: 0,
+            question: "Which database?",
+            kind: "option",
+            answer: "PostgreSQL",
+          },
+        ],
+      },
+    );
+    assert("POST answer → 204", answerResp.status === 204);
+
+    // The tool's promise resolves with the envelope.
+    const envelope = (await result) as {
+      content: { type: string; text: string }[];
+      details: { answers: { answer: string }[]; cancelled: boolean };
+    };
+    assert(
+      "envelope.details.cancelled === false",
+      envelope.details.cancelled === false,
+      JSON.stringify(envelope.details),
+    );
+    assert(
+      "envelope.details.answers[0].answer === 'PostgreSQL'",
+      envelope.details.answers[0]?.answer === "PostgreSQL",
+    );
+    assert(
+      "envelope.content[0] is text",
+      envelope.content[0]?.type === "text" && envelope.content[0].text.includes("PostgreSQL"),
+      JSON.stringify(envelope.content),
+    );
+
+    // After answer, cancelled event is broadcast so other clients close.
+    const sawCancelled = await waitFor(
+      () =>
+        sseEvents.some(
+          (e) => e.type === "ask_user_question_cancelled" && e.requestId === requestId,
+        ),
+      2000,
+      "ask_user_question_cancelled SSE",
+    );
+    assert("SSE: cancelled fanout after answer", sawCancelled);
+
+    // -------- Cancel path --------
+    const { requestId: cancelReqId, result: cancelResult } = askRegistry.registerPending({
+      sessionId: live.sessionId,
+      questions: [
+        {
+          question: "Q?",
+          header: "Q",
+          options: [
+            { label: "a", description: "a" },
+            { label: "b", description: "b" },
+          ],
+        },
+      ],
+    });
+    const cancelResp = await jsend(
+      base,
+      "POST",
+      `/api/v1/sessions/${live.sessionId}/ask-user-question/answer`,
+      { requestId: cancelReqId, cancelled: true, answers: [] },
+    );
+    assert("POST cancel → 204", cancelResp.status === 204);
+    const cancelEnvelope = (await cancelResult) as {
+      details: { cancelled: boolean; answers: unknown[] };
+    };
+    assert("cancel: envelope.cancelled === true", cancelEnvelope.details.cancelled === true);
+    assert("cancel: no answers", cancelEnvelope.details.answers.length === 0);
+
+    // -------- Cross-session spoofing --------
+    const { requestId: spoofReqId } = askRegistry.registerPending({
+      sessionId: live.sessionId,
+      questions: [
+        {
+          question: "Q?",
+          header: "Q",
+          options: [
+            { label: "a", description: "a" },
+            { label: "b", description: "b" },
+          ],
+        },
+      ],
+    });
+    const spoof = await jsend(
+      base,
+      "POST",
+      `/api/v1/sessions/00000000-0000-0000-0000-000000000000/ask-user-question/answer`,
+      { requestId: spoofReqId, cancelled: true, answers: [] },
+    );
+    assert("cross-session spoof → 404 (session_not_found)", spoof.status === 404);
+
+    // -------- Abort path --------
+    const ac2 = new AbortController();
+    const { result: abortResult } = askRegistry.registerPending({
+      sessionId: live.sessionId,
+      questions: [
+        {
+          question: "Q?",
+          header: "Q",
+          options: [
+            { label: "a", description: "a" },
+            { label: "b", description: "b" },
+          ],
+        },
+      ],
+      signal: ac2.signal,
+    });
+    ac2.abort();
+    let abortRejected = false;
+    try {
+      await abortResult;
+    } catch (err) {
+      abortRejected = err instanceof Error && err.message === "aborted";
+    }
+    assert("abort: promise rejects with 'aborted'", abortRejected);
+
+    ac.abort();
+    await sseDone.catch(() => undefined);
+    await registry.disposeSession(live.sessionId);
+  } finally {
+    await fastify.close();
+    await rm(workspacePath, { recursive: true, force: true }).catch(() => undefined);
+    await rm(configDir, { recursive: true, force: true }).catch(() => undefined);
+    await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-ask-user-question] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-ask-user-question] PASS");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/test-tool-overrides.ts
+++ b/tests/test-tool-overrides.ts
@@ -116,13 +116,26 @@ async function main(): Promise<void> {
         builtin: { name: string; enabled: boolean }[];
         mcp: unknown[];
       };
+      // 7 SDK builtins + ask_user_question (implemented in pi-forge but
+      // surfaced under "Built-in tools" so users can disable it from
+      // Settings → Tools). See packages/server/src/session-registry.ts
+      // BUILTIN_TOOL_NAMES.
       assert(
-        "  seven builtins listed",
-        body.builtin.length === 7,
+        "  eight builtins listed",
+        body.builtin.length === 8,
         `got ${body.builtin.length}: ${body.builtin.map((b) => b.name).join(",")}`,
       );
       const names = new Set(body.builtin.map((b) => b.name));
-      for (const expected of ["read", "bash", "edit", "write", "grep", "find", "ls"]) {
+      for (const expected of [
+        "read",
+        "bash",
+        "edit",
+        "write",
+        "grep",
+        "find",
+        "ls",
+        "ask_user_question",
+      ]) {
         assert(
           `  builtin "${expected}" present and enabled`,
           names.has(expected) && body.builtin.find((b) => b.name === expected)?.enabled === true,


### PR DESCRIPTION
## Summary

Adds an \`ask_user_question\` tool the agent can call when its instructions are underspecified. Instead of guessing, the agent gets back a structured envelope with the user's choices.

The wire contract — tool name, input schema (\`questions[1..4]\` with \`options[2..4]\`, header ≤16 chars, label ≤60 chars, reserved sentinel labels), and response envelope (\`{content:[{type:\"text\",text}], details:{answers, cancelled, error?}}\` with answer kinds \`option | custom | chat | multi\`) — is **contract-compatible with [\`@juicesharp/rpiv-ask-user-question\`](https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-ask-user-question)** (MIT). An agent prompt authored against the plugin works against this implementation unchanged.

### Why we don't run the plugin

Its TUI checks \`ctx.hasUI\` and returns \"Error: UI not available\" in any non-tty session. pi-forge's \`customTools\` registration takes the \`ask_user_question\` slot for browser sessions; the plugin (if installed) is harmless but unreachable.

### Implementation

- **Types, validator, envelope builder** — rewritten from the plugin's published schema descriptions. Independent code.
- **Prompt snippet + guidelines** — ported verbatim with attribution preserved in \`prompt-strings.ts\`. The plugin author has tuned the wording against real model behavior; matching it avoids regressions in tool-call quality.

### UI

Renders as an **inline panel above the chat composer** (not a modal overlay — the chat scroll stays interactive while answering). Three layouts, picked per-question:

| | |
|---|---|
| single-select + no preview | vertical option list + \"Type something\" free-text |
| multi-select | checkbox list (no free-text) |
| single-select + any preview | side-by-side: options left, focused option's markdown preview right |

Multi-question forms are tabbed with Next/Back. \"Chat about this\" is the explicit escape hatch — abandons the questionnaire and returns a \`chat\`-kind answer so the model knows the user opted out.

### Flow

1. Agent invokes \`ask_user_question\` → tool validates → \`registerPending\` → SSE fanout
2. Panel mounts above the composer
3. User submits → \`POST /sessions/:id/ask-user-question/answer\` → registry resolves → agent gets the envelope

### Robustness

- **Re-delivery**: pending requests are re-emitted on SSE snapshot, so a browser refresh resurfaces the panel without losing the agent's blocked state. \`GET /sessions/:id/ask-user-question/pending\` is the fallback.
- **Abort propagation**: when the agent is aborted (user hits Stop), the registry rejects the pending promise and emits \`ask_user_question_cancelled\` so the panel tears down.
- **Cross-session spoofing**: requestIds are scoped to sessions; posting a sessionA requestId to sessionB returns 404.

### Configuration

Enabled by default. Surfaces under **Settings → Tools → Built-in tools** so users can disable it like any other builtin (with a description that credits the upstream plugin).

## Test plan

- [x] \`npm run check\` — typecheck + eslint + prettier clean
- [x] \`npm run build\` clean
- [x] \`tests/test-ask-user-question.ts\` — 22 assertions PASS (validator parity, e2e SSE flow, cancel + abort paths, cross-session spoof, re-delivery)
- [x] Full \`scripts/run-tests.sh --skip pty-reattach,terminal,docker\` — 31/31 PASS (pty-reattach is the known fresh-worktree \`posix_spawnp\` issue, unrelated)
- [ ] Manual smoke: trigger the tool from an agent, answer it, verify the model continues with the structured answer
- [ ] Manual smoke: trigger it, refresh the page mid-answer, verify the panel re-appears
- [ ] Manual smoke: trigger it, hit Stop on the agent, verify the panel disappears

## Attribution

The plugin is MIT-licensed; per-file attribution lives in \`packages/server/src/ask-user-question/prompt-strings.ts\` and the user-facing \`docs/ask-user-question.md\`.