### PR TITLE
fix(inspector): honest token accounting + tighter MCP cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,54 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Changed
+
+- **Tighter MCP tool-result cap.** `MCP_TEXT_CAP_CHARS` lowered
+  from 100,000 chars (≈ 33k real tokens) to 30,000 chars (≈ 10k
+  tokens). The old ceiling let one chatty `list_everything` call
+  dump 30k+ real tokens into a single round trip — most of a
+  session's usable context budget — and triggered compaction far
+  earlier than the operator expects. 10k tokens is the practical
+  upper bound for a single tool response; anything bigger should
+  be paginated, filtered, or written to disk for the agent to
+  `read` incrementally. The 60/40 head/tail split and the
+  truncation marker the agent reads stay the same; only the cap
+  moved. Test suite reads the constant dynamically, so it
+  auto-adapted.
+- **Context Inspector token heuristic moved from chars/4 → chars/3.**
+  All three local estimators (`categorizeContext` for the breakdown
+  bar, `estimateTokens` for the per-row badge, the per-turn `New`
+  delta) now share a single `CHARS_PER_TOKEN` constant. The textbook
+  4:1 ratio comes from English prose; pi-forge sessions are
+  predominantly tool-call JSON, code, diffs, and search results,
+  where real tokenizers run closer to 3:1. Empirically the 4:1
+  estimate was under-counting tool-result-heavy turns by 20–40%,
+  making the inspector's breakdown bar disagree with the
+  authoritative `usage.input` total in the top context-window bar.
+  The authoritative count is unchanged (still pulled from the
+  SDK's `getContextUsage().tokens`); only the local estimates that
+  *bucket* it across categories shift.
+
+### Fixed
+
+- **Context Inspector breakdown bar misattributing tool-call args
+  and thinking content to "System + tools".** The categorizer's
+  message walk was using stale Anthropic-wire block names
+  (`type:"toolUse"`, `input` field; `type:"thinking"` reading `text`
+  field) instead of the SDK's actual shape (`type:"toolCall"`,
+  `arguments`; `type:"thinking"`, `thinking`). Result: the
+  `toolCalls` and `thinking` buckets were always 0, and because
+  `systemAndTools` is computed as a residual (`actualTotalTokens −
+  messageTotal`), every byte those buckets should have held leaked
+  into "System + tools" instead. End-effect: a tool-call turn made
+  "System + tools" and "Tool results" appear to bump together,
+  which looked like the SDK was double-counting the tool result —
+  it wasn't. Fixed the categorizer plus two render-time sites
+  (`extractPreview` and `renderExpanded`) that had the same
+  wrong-name pattern, so tool calls now also show up in the
+  inspector's one-line previews and the click-to-expand detail
+  view rather than being silently invisible.
+
 ## [1.2.4] — 2026-05-22
 
 ### Added

--- a/packages/client/src/components/ContextInspectorPanel.tsx
+++ b/packages/client/src/components/ContextInspectorPanel.tsx
@@ -5,6 +5,22 @@ import { api, ApiError, type ContextTurn, type SessionContextResponse } from "..
 import { useSessionStore } from "../store/session-store";
 
 /**
+ * Chars-per-token estimate used by every local approximation in this
+ * panel (the breakdown bar, the per-row badge, the per-turn "New"
+ * delta). The textbook "4 chars per token" comes from English prose;
+ * the inspector's job is to bucket *what's actually in the context*,
+ * and that's predominantly tool-call JSON, code, diffs, and search
+ * results — content where real tokenizers are denser. Empirically 3.0
+ * lands much closer for pi-forge sessions than 4.0 did (4.0 made
+ * tool-result-heavy turns visibly under-count by 20–40%). All three
+ * callsites read this constant so the breakdown bar, the row badge,
+ * and the "New" column stay consistent with each other; the
+ * authoritative count still comes from the SDK's `usage.input` and
+ * shows on the top context-window bar separately.
+ */
+const CHARS_PER_TOKEN = 3;
+
+/**
  * Phase 16 — Context & Token Inspector.
  *
  * Right-pane tab showing the messages the agent will send to the
@@ -243,7 +259,7 @@ function TokenSummary({
 
       {/* Per-category breakdown — what's *actually* taking up the
           window, derived client-side from the current message array.
-          Estimates are ~chars/4 (same heuristic as estimateTokens).
+          Estimates are ~chars/3 (same heuristic as estimateTokens).
           The SDK doesn't ship a categorized breakdown, so this is
           best-effort and may differ from the provider's true count. */}
       <ContextBreakdown breakdown={breakdown} contextWindow={cu.contextWindow} />
@@ -397,7 +413,7 @@ function ContextBreakdown({
     <div>
       <div className="mb-1 flex items-center justify-between text-[10px] text-neutral-400">
         <span>What&rsquo;s in the context</span>
-        <span className="text-neutral-600" title="Sum of category estimates (~chars/4)">
+        <span className="text-neutral-600" title="Sum of category estimates (~chars/3)">
           ~{formatTokens(total)} tok
           {contextWindow > 0 && (
             <span className="ml-1">({((total / contextWindow) * 100).toFixed(1)}%)</span>
@@ -447,9 +463,10 @@ function ContextBreakdown({
 
 /**
  * Walk the messages array and bucket text into context categories.
- * Token estimate is the same ~chars/4 heuristic estimateTokens
- * uses — provider-specific tokenizers would be more accurate, but
- * the per-turn `usage` data above carries the authoritative numbers.
+ * Token estimate is the same ~chars/CHARS_PER_TOKEN heuristic that
+ * `estimateTokens` uses — provider-specific tokenizers would be
+ * more accurate, but the per-turn `usage` data above carries the
+ * authoritative numbers.
  * This breakdown answers "where did the tokens go?", which is a
  * relative question that survives the heuristic.
  *
@@ -491,20 +508,35 @@ function categorizeContext(
       }
     } else if (role === "assistant" && Array.isArray(content)) {
       for (const c of content) {
-        const o = c as { type?: unknown; text?: unknown; input?: unknown };
+        // Block types per @earendil-works/pi-ai's types.d.ts:
+        // TextContent     {type:"text",     text:string}
+        // ThinkingContent {type:"thinking", thinking:string}   ← NOT `text`
+        // ToolCall        {type:"toolCall", arguments:object}  ← NOT `toolUse`/`input`
+        // Earlier revisions of this categorizer used the wire-level
+        // Anthropic shape (`toolUse`/`input`), which silently zeroed
+        // out the toolCalls + thinking buckets and made every byte
+        // they should have held leak into `systemAndTools` (the
+        // residual). End-effect: a tool-call turn made it look like
+        // the SDK was double-counting the tool result.
+        const o = c as {
+          type?: unknown;
+          text?: unknown;
+          thinking?: unknown;
+          arguments?: unknown;
+        };
         if (o.type === "text" && typeof o.text === "string") {
           asstTextChars += o.text.length;
-        } else if (o.type === "thinking" && typeof o.text === "string") {
-          thinkingChars += o.text.length;
-        } else if (o.type === "toolUse") {
+        } else if (o.type === "thinking" && typeof o.thinking === "string") {
+          thinkingChars += o.thinking.length;
+        } else if (o.type === "toolCall") {
           // Tool args go through the LLM as a JSON-encoded string;
           // measuring the JSON length is closer to the truth than
           // measuring raw character counts of object values.
           try {
-            toolCallChars += JSON.stringify(o.input ?? {}).length;
+            toolCallChars += JSON.stringify(o.arguments ?? {}).length;
           } catch {
             // circular ref → estimate via toString
-            toolCallChars += String(o.input ?? "").length;
+            toolCallChars += String(o.arguments ?? "").length;
           }
         }
       }
@@ -523,11 +555,13 @@ function categorizeContext(
       }
     }
   }
-  // 4 chars / token is the conventional rule of thumb. Image rough
-  // estimate at 1500 tok/image — between Anthropic's ~1200 (1024px
-  // square) and OpenAI's ~1700 (high-detail). Same number used in
-  // estimateTokens for consistency; both undercount large images.
-  const tokens = (chars: number): number => Math.ceil(chars / 4);
+  // CHARS_PER_TOKEN is tuned for code/JSON-heavy pi-forge sessions;
+  // see the constant's docstring at the top of the file. Image
+  // rough estimate at 1500 tok/image — between Anthropic's ~1200
+  // (1024px square) and OpenAI's ~1700 (high-detail). Same numbers
+  // used in `estimateTokens` for consistency; both undercount large
+  // images.
+  const tokens = (chars: number): number => Math.ceil(chars / CHARS_PER_TOKEN);
   const userPrompts = tokens(userChars);
   const assistantText = tokens(asstTextChars);
   const thinking = tokens(thinkingChars);
@@ -585,7 +619,7 @@ function TurnsTable({
             <th className="pr-2 text-left font-normal">Model</th>
             <th
               className="pr-2 text-right font-normal"
-              title="Estimated new tokens this turn — user message + tool results since the prior assistant turn (~chars/4 estimate). Distinct from Prompt."
+              title="Estimated new tokens this turn — user message + tool results since the prior assistant turn (~chars/3 estimate). Distinct from Prompt."
             >
               New
             </th>
@@ -931,20 +965,21 @@ function extractPreview(message: Record<string, unknown>, showThinking: boolean)
   if (!Array.isArray(content)) return "";
   const parts: string[] = [];
   for (const c of content) {
-    const o = c as { type?: unknown; text?: unknown; name?: unknown };
+    const o = c as { type?: unknown; text?: unknown; thinking?: unknown; name?: unknown };
     if (o.type === "thinking" && !showThinking) continue;
     if (o.type === "text" && typeof o.text === "string") parts.push(o.text);
-    else if (o.type === "thinking" && typeof o.text === "string")
-      parts.push(`[thinking] ${o.text}`);
-    else if (o.type === "toolUse" && typeof o.name === "string") parts.push(`[tool: ${o.name}]`);
+    else if (o.type === "thinking" && typeof o.thinking === "string")
+      parts.push(`[thinking] ${o.thinking}`);
+    else if (o.type === "toolCall" && typeof o.name === "string") parts.push(`[tool: ${o.name}]`);
   }
   return parts.join(" ").slice(0, 200);
 }
 
 /**
- * Rough token estimate: ~4 chars per token. Used in the row badge
- * as an at-a-glance signal; the real per-turn counts come from
- * the SDK's usage field rendered in TurnsTable. Image constant
+ * Rough token estimate using CHARS_PER_TOKEN (see top-of-file
+ * docstring for why 3 and not 4). Used in the row badge as an
+ * at-a-glance signal; the real per-turn counts come from the
+ * SDK's usage field rendered in TurnsTable. Image constant
  * matches `categorizeContext` for consistency (1500 tok/image:
  * between Anthropic's ~1200 and OpenAI's ~1700 high-detail).
  */
@@ -953,7 +988,7 @@ function estimateTokens(message: Record<string, unknown>): number {
   const u = message.usage as { totalTokens?: unknown } | undefined;
   if (u !== undefined && typeof u.totalTokens === "number") return u.totalTokens;
   const content = message.content;
-  if (typeof content === "string") return Math.ceil(content.length / 4);
+  if (typeof content === "string") return Math.ceil(content.length / CHARS_PER_TOKEN);
   if (!Array.isArray(content)) return 0;
   let chars = 0;
   let images = 0;
@@ -962,7 +997,7 @@ function estimateTokens(message: Record<string, unknown>): number {
     if (typeof o.text === "string") chars += o.text.length;
     if (o.type === "image") images += 1;
   }
-  return Math.ceil(chars / 4) + images * 1500;
+  return Math.ceil(chars / CHARS_PER_TOKEN) + images * 1500;
 }
 
 /**
@@ -978,8 +1013,9 @@ function estimateTokens(message: Record<string, unknown>): number {
  * turns' "new" only includes content between consecutive assistant
  * messages.
  *
- * Uses the same ~chars/4 heuristic as `estimateTokens` and
- * `categorizeContext` so the three numbers tell a consistent story.
+ * Uses the same ~chars/CHARS_PER_TOKEN heuristic as
+ * `estimateTokens` and `categorizeContext` so the three numbers
+ * tell a consistent story.
  * This is a UX-grade estimate; the per-turn `Prompt` column shows
  * the provider's authoritative input number alongside.
  */
@@ -1033,9 +1069,16 @@ function renderExpanded(
     return (
       <>
         {content.map((c, i) => {
-          const o = c as { type?: unknown; text?: unknown; name?: unknown; input?: unknown };
+          const o = c as {
+            type?: unknown;
+            text?: unknown;
+            thinking?: unknown;
+            name?: unknown;
+            arguments?: unknown;
+          };
           if (o.type === "thinking" && !showThinking) return null;
           if (o.type === "text" || o.type === "thinking") {
+            const body = o.type === "thinking" ? o.thinking : o.text;
             return (
               <pre
                 key={`${index}-${i}`}
@@ -1043,18 +1086,18 @@ function renderExpanded(
                   o.type === "thinking" ? "italic text-neutral-500" : "text-neutral-200"
                 }`}
               >
-                {String(o.text ?? "")}
+                {String(body ?? "")}
               </pre>
             );
           }
-          if (o.type === "toolUse") {
+          if (o.type === "toolCall") {
             return (
               <div key={`${index}-${i}`} className="rounded border border-neutral-800 p-2">
                 <p className="mb-1 text-[10px] text-neutral-500">
                   tool call: <span className="font-mono">{String(o.name ?? "unknown")}</span>
                 </p>
                 <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words font-mono text-[10px] text-neutral-300">
-                  {jsonish(o.input)}
+                  {jsonish(o.arguments)}
                 </pre>
               </div>
             );

--- a/packages/server/src/mcp/tool-bridge.ts
+++ b/packages/server/src/mcp/tool-bridge.ts
@@ -145,13 +145,19 @@ export function mcpResultToAgentResult(res: unknown): AgentToolResult<unknown> {
 
 /**
  * Default cap on the total *text* size (across all text blocks) of an
- * MCP tool result, in characters. ~100k chars ≈ ~25k tokens via the
- * standard chars/4 heuristic the SDK uses elsewhere — large enough
- * that almost no legitimate single tool call hits it, small enough
- * that one accidental "list everything" doesn't blow a 200k context
- * window. Image blocks are passed through untouched (truncating
- * base64 mid-byte breaks the image; image tokens are
- * provider-specific anyway and not measured here).
+ * MCP tool result, in characters. 30k chars ≈ 10k tokens at the
+ * code/JSON chars/3 ratio (the older 4:1 estimate was tuned for
+ * prose and systematically under-counted real tool output by
+ * 20–40%). The earlier 100k-char (≈ 33k-token) cap let one chatty
+ * `list_everything` call dump 30k+ real tokens into context, eating
+ * most of a session's usable budget in a single round trip and
+ * triggering compaction far earlier than the operator expects. 10k
+ * tokens is the practical upper bound for a *single* tool round
+ * trip — anything bigger should be paginated, filtered, or written
+ * to disk for the agent to `read` incrementally. Image blocks are
+ * passed through untouched (truncating base64 mid-byte breaks the
+ * image; image tokens are provider-specific anyway and not measured
+ * here).
  *
  * Split: 60% head + 40% tail. Head usually carries summary / total /
  * schema context that the agent needs to interpret the rest; tail
@@ -166,7 +172,7 @@ export function mcpResultToAgentResult(res: unknown): AgentToolResult<unknown> {
  * No per-tool override yet — add when a real workload needs a higher
  * or lower cap. Hardcoded constant is the deliberate first cut.
  */
-export const MCP_TEXT_CAP_CHARS = 100_000;
+export const MCP_TEXT_CAP_CHARS = 30_000;
 export const MCP_TEXT_HEAD_RATIO = 0.6;
 
 export type ContentBlock =


### PR DESCRIPTION
## Summary

Three related fixes that all come back to the inspector under-counting real context tokens. End result: the breakdown bar gives an honest split that lines up with the SDK's authoritative `usage.input`, and the MCP truncation cap is tight enough that one chatty tool call can't eat a whole session's context budget in a single round trip.

### 1. Categorizer was using stale SDK block names

The message walk was checking for `type:"toolUse"` with field `input` (Anthropic wire shape) and `type:"thinking"` reading the `text` field. The SDK actually emits `type:"toolCall"` with `arguments` and `type:"thinking"` with `thinking`.

Net effect: the `toolCalls` and `thinking` buckets were always 0. Because `systemAndTools` is computed as a residual (`actualTotalTokens − messageTotal`), every byte those buckets should have held leaked into "System + tools" instead. End-user impression: a tool-call turn made "System + tools" and "Tool results" both bump together — which looked like the SDK was double-counting the tool result. It wasn't; the tool-call args were just being mis-attributed.

Fixed at three sites with the same wrong-name pattern: `categorizeContext` (the breakdown bar), `extractPreview` (one-line previews in the message list), and `renderExpanded` (the click-to-expand detail view). Tool calls now show up in all three.

### 2. chars-per-token heuristic moved 4 → 3

The textbook 4:1 ratio is calibrated for English prose. pi-forge sessions are predominantly tool-call JSON, code, diffs, and search results — content where real tokenizers run closer to 3:1.

Empirically the 4:1 estimate was under-counting tool-result-heavy turns by 20–40%, making the breakdown bar disagree visibly with the top context-window number. Moved all three local estimators (`categorizeContext`, `estimateTokens`, `computeNewDeltas`) onto a single `CHARS_PER_TOKEN = 3` constant at the top of the file so they stay consistent with each other.

**The authoritative number on the top context-window bar is unchanged** — it still comes from the SDK's `getContextUsage().tokens`, which pulls from the LLM's actual `usage.input`. Only the local heuristics that *bucket* it across categories shift.

### 3. `MCP_TEXT_CAP_CHARS` tightened 100,000 → 30,000

At the honest 3:1 ratio, 30k chars ≈ 10k tokens — the practical upper bound for a single tool round trip. The old 100k-char ceiling was ~33k real tokens, large enough that one chatty `list_everything` call could dump most of a session's usable budget into context in a single round trip and trigger compaction far earlier than the operator expects. Anything bigger should be paginated, filtered, or written to disk for the agent to `read` incrementally.

The 60/40 head/tail split and the truncation marker the agent reads are unchanged; only the cap moved.

## Test plan

- [x] `npm run check` clean (typecheck + eslint + prettier)
- [x] `npm run build` clean
- [x] `tests/test-mcp-truncation.ts` — 23 assertions PASS against the new cap (test reads `MCP_TEXT_CAP_CHARS` dynamically, auto-adapted)
- [ ] Manual smoke: fire a tool call with tiny args + large response; verify only "Tool results" goes up in the breakdown, "System + tools" stays flat
- [ ] Manual smoke: verify the breakdown bar sum lines up with the top context-window total within ~5%
- [ ] Manual smoke: trigger an MCP tool that returns >30k chars; verify truncation marker appears and the agent's next turn references it