### PR TITLE
chore(release): v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.2.5] — 2026-05-23
+
 ### Added
 
 - **`process` tool — browser-native implementation of the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "workspaces": [
         "packages/*"
       ],
@@ -16925,7 +16925,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -16971,7 +16971,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.74.0",
         "@earendil-works/pi-ai": "0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## v1.2.5 — `process` tool, hover timestamps, honest token accounting, compaction polish

| | |
|---|---|
| **Branch** | `release/v1.2.5` (single `chore(release)` commit, will squash on merge) |
| **Versions** | root + `@pi-forge/server` + `@pi-forge/client` all bumped `1.2.4 → 1.2.5` |
| **Build / check** | clean from the release branch |

### Added

- **`process` tool** — browser-native implementation of [`@aliou/pi-processes`](https://github.com/aliou/pi-processes) (MIT). Lifecycle-managed background processes the agent can `start | list | output | logs | kill | clear | write`, with per-process disk log files + ring-buffer rotation, regex log-watches, and a new right-pane "Processes" tab + chat-input Activity badge. (#149)
- **Hover-revealed message timestamps** — each user / assistant bubble shows wall-clock time next to the role label on hover (fades in via `group-hover`); full date+time in a native `title` tooltip. (#149)

### Changed

- **Tighter MCP tool-result cap** — `MCP_TEXT_CAP_CHARS` lowered from 100,000 chars (≈ 33k real tokens) to 30,000 chars (≈ 10k tokens). One chatty `list_everything` call no longer eats most of a session's context budget in a single round trip. (#150)
- **Context Inspector token heuristic moved chars/4 → chars/3** — all three local estimators now share a single `CHARS_PER_TOKEN` constant. The 4:1 ratio is calibrated for English prose; pi-forge sessions are predominantly code/JSON/diffs where real tokenizers run closer to 3:1. (#150)
- **Chat hides the latest compaction's kept window inside the CompactionCard's expand drawer.** Pi keeps `keepRecentTokens` worth of recent context verbatim; the chat used to render those bubbles inline so compaction looked like it accomplished nothing. Inline render now suppressed; the card's `archivedMessages` still has everything for anyone who wants to expand and scroll back. (#151)

### Fixed

- **Spurious "Reconnecting — server closed stream" banner after large tool results.** SSE bridge's per-client outbound-buffer cap raised from 256 KB to 8 MB — the old ceiling was tripping mid-session on legitimate slow consumers when a `tool_result` for an 11k-token tool output (~80–150 KB on the wire) plus a `message_update` stream piled into the buffer. New stderr log (`sse-client-dropped-backpressure`) makes future occurrences visible instead of silent. (#149)
- **Context Inspector breakdown bar misattributing tool-call args + thinking to "System + tools".** Categorizer was using stale Anthropic-wire block names (`type:"toolUse"` / `input`; `type:"thinking"` reading `text` field) instead of the SDK's actual shape (`type:"toolCall"` / `arguments`; `thinking` field). Fixed at three sites with the same wrong-name pattern. (#150)
- **Agent halts after overflow-driven auto-compaction (weaker models).** Weaker local models (Gemma-class on vLLM) read the structured compaction summary as a status report and respond with prose instead of continuing the work. New in-process pi extension (`compactionContinuationExtension`) hooks the `context` event and appends a one-line imperative nudge when the last message is a `compactionSummary` — sent to the LLM but NOT persisted to the JSONL. No effect on strong models. (#151)
- **"Compacting context…" banner doesn't appear when deployed behind OpenShift's HAProxy router.** The `compaction_start` SSE frame (~150 bytes) sits in HAProxy's response buffer waiting for either a flush threshold or connection close — for the duration of the multi-second compaction LLM call. Fix: emit a one-shot ~2 KB SSE comment-line ("padding flush") immediately after every `compaction_start` write, pushing past HAProxy's default flush threshold. EventSource ignores comment lines silently so the browser sees nothing visible. Heartbeat interval (20s) intentionally unchanged. (#151)

### Test plan

- [x] `npm run check` clean on the release branch
- [x] `npm run build` clean on the release branch
- [ ] CI `npm run test:ci` green
- [ ] Manual smoke (production / OpenShift): trigger a compaction and verify the banner appears within ms instead of after compaction completes

### After merge

```
git checkout main && git pull --ff-only
git tag v1.2.5
git push origin v1.2.5
```

The release workflow takes it from there — multi-arch Docker image, npm publish via the trusted-publisher flow, and the GitHub Release.