### PR TITLE
feat(v1.3.0): clone-as-project, gh CLI in container, default-hard session delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,52 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
-## [1.2.5] — 2026-05-23
+### Added
+
+- **Clone a git repository as a new project.** New "Clone repository"
+  tab in the project picker. Streams `git clone --progress` over SSE
+  so the user sees a real-time progress bar + phase label
+  ("Receiving objects 45%", "Resolving deltas 100%", etc.) instead
+  of a blocked spinner during a multi-minute clone of a large repo.
+  Form takes:
+  - **Repository URL** — HTTPS or `file://`. SSH URLs are out of
+    scope for v1.3.0; use `gh repo clone` from the integrated
+    terminal for SSH-based clones.
+  - **Branch** (optional) — defaults to the remote's HEAD.
+  - **Folder name** (auto-filled from the URL's last path segment,
+    overrideable) — relative to the workspace root.
+  - **Project name** (auto-filled from the folder name).
+  - **Access token** (optional, masked) — for private repos. Embedded
+    as `x-access-token:<token>` in the clone URL (the GitHub
+    convention; works for GitHub.com, GitHub Enterprise, GitLab PATs,
+    Bitbucket app passwords, Gitea PATs). Stripped from
+    `.git/config` after success; if the clone fails partway, the
+    target directory is rm-rf'd so no leftover token bytes survive.
+  Defense-in-depth: target path is validated to be inside
+  `WORKSPACE_PATH` (403 otherwise); pre-existing non-empty target
+  returns 409 before any spawn; clone is cancellable via the
+  request `AbortSignal` (client disconnect kills the child with
+  SIGTERM → 5s grace → SIGKILL). Same heartbeat-and-padding-flush
+  pattern as the compaction SSE so the stream works behind
+  OpenShift's HAProxy router.
+- **`gh` (GitHub CLI) in the Docker image.** Installed from the
+  official GitHub apt repository so `gh auth login`, `gh pr`,
+  `gh issue`, `gh repo clone`, etc. work out of the box in the
+  integrated terminal and via the agent's `bash` tool. Available on
+  PATH for the running server and any process it spawns.
+
+### Changed
+
+- **Session DELETE always hard-deletes the JSONL.** Previously
+  required `?hard=1` on the route and a `{hard: true}` opt in the
+  client API — but the UI passed it unconditionally, so the
+  non-destructive path was vestigial and confusing for programmatic
+  clients. Now: `DELETE /api/v1/sessions/:id` always disposes the
+  live session AND removes the JSONL AND cascade-removes any
+  pi-subagents child JSONLs nested under it. Client API simplified
+  to drop the `hard` parameter. Removing the JSONL was already what
+  every UI delete did; this just makes the default match the user's
+  mental model of "delete means gone."
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,43 @@ section. See the "Versions" section of the README for the support window policy.
 
 ### Added
 
+- **Background processes notify the agent on completion.** The
+  `process` tool's `alertOnSuccess` / `alertOnFailure` /
+  `alertOnKill` flags were previously stored on `ProcessInfo` but
+  never consumed — nothing fired when a process exited. Now: when
+  a process exits and the matching alert flag is set, the manager
+  emits a `process_alert` event that the SSE bridge translates
+  into `session.sendUserMessage()` with `deliverAs: "followUp"`,
+  giving the agent a turn to react. Message format:
+  `[process alert] "<name>" (id=<id>) finished successfully (exit
+  0).` (or `failed with exit code N`, or `was killed externally`)
+  + a nudge to call `process output` to inspect what it produced.
+  Defaults: alertOnFailure is on (the common case the agent
+  usually wants to know about), alertOnSuccess + alertOnKill are
+  off (would be noisy for the common cases). Tool-initiated kills
+  (the agent calling `process kill` itself) never trigger an
+  alert — would be redundant. The alert lands in the chat as a
+  normal user-shaped bubble with the `[process alert]` prefix so
+  it's obvious it's automated rather than typed by the user.
+
+### Fixed
+
+- **Spurious "Reconnecting" banner during long idle gaps on
+  deployments behind HAProxy.** Same root cause as the
+  compaction-banner fix: the 20-second heartbeat was only ~13
+  bytes (`: heartbeat\n\n`), below HAProxy's small-write buffer
+  threshold. During a long-running agent turn with no token output
+  (slow LLM call, long-running tool, multi-second prefill),
+  heartbeats sat in the router's response buffer and never reached
+  the client. The connection eventually timed out somewhere on
+  the path, and the browser showed a misleading "Reconnecting —
+  server closed stream" banner even though the server side was
+  still alive. Fix: pad every heartbeat to 2KB so it crosses the
+  buffer-flush threshold and actually reaches the client. Same
+  mechanism as the per-turn compaction-start padding flush, but
+  applied to the every-20s heartbeat. Bandwidth cost is ~100
+  bytes/sec/client sustained — negligible.
+
 - **Clone a git repository as a new project.** New "Clone repository"
   tab in the project picker. Streams `git clone --progress` over SSE
   so the user sees a real-time progress bar + phase label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,34 @@ section. See the "Versions" section of the README for the support window policy.
   to drop the `hard` parameter. Removing the JSONL was already what
   every UI delete did; this just makes the default match the user's
   mental model of "delete means gone."
+- **Project DELETE always wipes the session directory + auto-disposes
+  live sessions.** Same "delete means gone" framing as the session
+  change above. Three things change:
+  - The session-directory cleanup was previously opt-in via
+    `?cascade=1` on the route + a checkbox in the delete-project
+    dialog. The default-off behavior left a `<projectId>/`
+    directory on disk that the UI had no way to reach ever again
+    (even when individual sessions had been deleted earlier —
+    `deleteColdSession` only unlinks the JSONL, not the parent
+    dir). Now: `DELETE /api/v1/projects/:id` always removes the
+    project record AND rm -rf's `${SESSION_DIR}/<projectId>/`,
+    JSONLs and all. Route drops the `?cascade=` query param;
+    client API drops the `{cascade}` opt.
+  - The UI no longer blocks delete when the project has live
+    sessions. The previous "dispose them first, then try again"
+    alert was busy-work — live sessions are now disposed
+    automatically as the first step of the delete (in parallel,
+    best-effort), then the server-side rm -rf cleans up their
+    JSONLs.
+  - The sidebar delete dialog gains a required confirmation
+    checkbox when the project has sessions: "Yes, I understand
+    this will delete N session(s). This can't be undone." Forces
+    a deliberate acknowledgment for the destructive case without
+    re-introducing the old opt-in cascade toggle. Empty projects
+    skip the checkbox.
+  - The project's workspace folder
+    (`${WORKSPACE_PATH}/<projectName>/`) is still never touched —
+    that's almost always real work the user wants to keep.
 
 ### Added
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,15 @@ ARG PGID=1000
 # Runtime tools the agent + interactive terminal need:
 #   - tini: PID-1 signal handling (see above)
 #   - git: status / diff / commit / push / etc. — the GitPanel routes
-#     and the agent's `bash` tool both expect git on PATH.
+#     and the agent's `bash` tool both expect git on PATH. Also used by
+#     pi-forge's "clone repository" project-setup flow.
+#   - gh: the GitHub CLI. Authenticates against github.com / GHE via
+#     `gh auth login` (more ergonomic than wrangling raw PATs / SSH
+#     keys), wraps git for HTTPS clones with stored credentials, and
+#     gives the agent + interactive terminal a first-class surface for
+#     `gh pr`, `gh issue`, `gh repo`, etc. Not in Debian's default
+#     repos — installed from GitHub's apt source (the keyring and
+#     sources.list lines below).
 #   - ripgrep: pi's `grep` tool delegates to ripgrep when present.
 #     Without it, code search inside the agent silently degrades.
 #   - bash: replaces dash as the integrated terminal's interactive
@@ -80,9 +88,20 @@ ARG PGID=1000
 #     hygiene. curl for fetching, ca-certificates so HTTPS works, less
 #     so `git log` and similar pagers don't bomb, procps so `ps`/`top`
 #     are present for users debugging long-running tool processes.
+#   - gnupg: needed only to verify the GitHub CLI apt-source signing
+#     key during install — kept in the same RUN so the keyring is
+#     present when `apt-get install gh` runs.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      tini git ripgrep bash curl ca-certificates less procps \
+      tini git ripgrep bash curl ca-certificates less procps gnupg \
+ && install -dm 0755 /etc/apt/keyrings \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
  && rm -rf /var/lib/apt/lists/* \
  && (userdel node 2>/dev/null || true) \
  && (groupdel node 2>/dev/null || true) \

--- a/packages/client/src/components/ProjectPicker.tsx
+++ b/packages/client/src/components/ProjectPicker.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { api, ApiError, type BrowseEntry } from "../lib/api-client";
+import { useEffect, useRef, useState } from "react";
+import { api, ApiError, parseCloneEventStream, type BrowseEntry } from "../lib/api-client";
 import { useProjectStore } from "../store/project-store";
 import { useUiConfigStore } from "../store/ui-config-store";
 
@@ -9,12 +9,30 @@ interface Props {
   required?: boolean;
 }
 
+/**
+ * Project-setup picker. Three flows:
+ *   - "Create new"  — type a name, browse to a folder (or auto-mkdir
+ *                     `<workspaceRoot>/<name>` under MINIMAL_UI).
+ *   - "Pick existing" — same browser, no mkdir.
+ *   - "Clone repo"  — URL + optional branch + optional token; streams
+ *                     `git clone` progress and creates the project on
+ *                     success.
+ *
+ * The picker remembers the typed name across mode switches, since the
+ * cost of retyping it is the most common UX regret in pickers like
+ * this.
+ */
+type Mode = "create" | "clone";
 type Step = "name" | "browse";
 
 export function ProjectPicker({ onClose, required = false }: Props) {
   const create = useProjectStore((s) => s.create);
   const minimal = useUiConfigStore((s) => s.minimal);
   const workspaceRoot = useUiConfigStore((s) => s.workspaceRoot);
+  const loadProjects = useProjectStore((s) => s.load);
+  const setActiveProject = useProjectStore((s) => s.setActive);
+
+  const [mode, setMode] = useState<Mode>("create");
   const [step, setStep] = useState<Step>("name");
   const [name, setName] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -28,7 +46,7 @@ export function ProjectPicker({ onClose, required = false }: Props) {
   const [showNewFolder, setShowNewFolder] = useState(false);
 
   useEffect(() => {
-    if (step !== "browse") return;
+    if (mode !== "create" || step !== "browse") return;
     let cancelled = false;
     setLoadingBrowse(true);
     setError(undefined);
@@ -50,7 +68,7 @@ export function ProjectPicker({ onClose, required = false }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [step, path]);
+  }, [mode, step, path]);
 
   /**
    * Default flow: take the typed name, advance to the folder
@@ -128,7 +146,11 @@ export function ProjectPicker({ onClose, required = false }: Props) {
       <div className="w-full max-w-lg rounded-lg border border-neutral-800 bg-neutral-900 p-6 shadow-xl">
         <header className="mb-4 flex items-center justify-between">
           <h2 className="text-lg font-semibold tracking-tight">
-            {step === "name" ? "New project" : `Pick a folder for "${name.trim()}"`}
+            {mode === "clone"
+              ? "Clone repository"
+              : step === "name"
+                ? "New project"
+                : `Pick a folder for "${name.trim()}"`}
           </h2>
           {!required && (
             <button
@@ -141,6 +163,17 @@ export function ProjectPicker({ onClose, required = false }: Props) {
         </header>
 
         {step === "name" && (
+          <div className="mb-3 flex gap-1 border-b border-neutral-800">
+            <ModeTab active={mode === "create"} onClick={() => setMode("create")}>
+              Create / pick folder
+            </ModeTab>
+            <ModeTab active={mode === "clone"} onClick={() => setMode("clone")}>
+              Clone repository
+            </ModeTab>
+          </div>
+        )}
+
+        {step === "name" && mode === "create" && (
           <form
             onSubmit={(e) => {
               e.preventDefault();
@@ -175,7 +208,22 @@ export function ProjectPicker({ onClose, required = false }: Props) {
           </form>
         )}
 
-        {step === "browse" && (
+        {step === "name" && mode === "clone" && (
+          <CloneForm
+            initialName={name}
+            workspaceRoot={workspaceRoot}
+            onProjectCreated={async (projectId) => {
+              // Drop the picker; reload project list so the new
+              // project lands in the sidebar, then activate it.
+              await loadProjects();
+              setActiveProject(projectId);
+              onClose();
+            }}
+            onCancel={onClose}
+          />
+        )}
+
+        {mode === "create" && step === "browse" && (
           <div className="space-y-3">
             <div className="flex items-center gap-2 text-xs text-neutral-400">
               <button
@@ -301,5 +349,338 @@ export function ProjectPicker({ onClose, required = false }: Props) {
         )}
       </div>
     </div>
+  );
+}
+
+function ModeTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`-mb-px border-b-2 px-3 py-2 text-sm transition-colors ${
+        active
+          ? "border-neutral-200 text-neutral-100"
+          : "border-transparent text-neutral-400 hover:text-neutral-200"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * Clone form + streaming-progress display. Lives inside ProjectPicker
+ * so it can share the workspace-root validation rules and project-
+ * creation handoff. Default folder name is derived from the URL's
+ * last path segment (e.g. `https://github.com/foo/bar.git` →
+ * `bar`).
+ */
+function CloneForm({
+  initialName,
+  workspaceRoot,
+  onProjectCreated,
+  onCancel,
+}: {
+  initialName: string;
+  workspaceRoot: string;
+  onProjectCreated: (projectId: string) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [url, setUrl] = useState("");
+  const [branch, setBranch] = useState("");
+  const [token, setToken] = useState("");
+  const [folderName, setFolderName] = useState("");
+  const [projectName, setProjectName] = useState(initialName);
+  const [folderTouched, setFolderTouched] = useState(false);
+  const [projectTouched, setProjectTouched] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [phase, setPhase] = useState<string | undefined>();
+  const [percent, setPercent] = useState<number | null>(null);
+  const [logLines, setLogLines] = useState<string[]>([]);
+  const [showRawLog, setShowRawLog] = useState(false);
+  const abortRef = useRef<AbortController | undefined>(undefined);
+
+  // Derive folder name from the URL's last path segment unless the
+  // user has typed something themselves. Strip a trailing `.git`.
+  useEffect(() => {
+    if (folderTouched) return;
+    try {
+      const u = new URL(url);
+      const segs = u.pathname.split("/").filter((s) => s.length > 0);
+      const last = segs[segs.length - 1] ?? "";
+      const stripped = last.replace(/\.git$/i, "");
+      if (stripped.length > 0) setFolderName(stripped);
+    } catch {
+      // Invalid URL — don't touch the field.
+    }
+  }, [url, folderTouched]);
+
+  // Project name defaults to the folder name unless the user typed
+  // something. initialName from the parent picker takes precedence
+  // (lets you start typing in the Create tab, switch to Clone, and
+  // keep your name).
+  useEffect(() => {
+    if (projectTouched) return;
+    if (initialName.trim().length > 0) return;
+    if (folderName.length > 0) setProjectName(folderName);
+  }, [folderName, initialName, projectTouched]);
+
+  const onSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    if (submitting) return;
+    if (url.trim().length === 0) {
+      setError("url_required");
+      return;
+    }
+    if (folderName.trim().length === 0) {
+      setError("folder_required");
+      return;
+    }
+    if (projectName.trim().length === 0) {
+      setError("name_required");
+      return;
+    }
+    if (workspaceRoot.length === 0) {
+      setError("workspace_not_loaded");
+      return;
+    }
+    setSubmitting(true);
+    setError(undefined);
+    setPhase("starting…");
+    setPercent(null);
+    setLogLines([]);
+
+    const ac = new AbortController();
+    abortRef.current = ac;
+    try {
+      const body: {
+        url: string;
+        parentPath: string;
+        folderName: string;
+        projectName: string;
+        branch?: string;
+        token?: string;
+      } = {
+        url: url.trim(),
+        parentPath: workspaceRoot,
+        folderName: folderName.trim(),
+        projectName: projectName.trim(),
+      };
+      if (branch.trim().length > 0) body.branch = branch.trim();
+      if (token.length > 0) body.token = token;
+
+      const res = await api.cloneProject(body, ac.signal);
+      let createdProjectId: string | undefined;
+      let sawError = false;
+      let errorMessage = "";
+      for await (const ev of parseCloneEventStream(res)) {
+        switch (ev.type) {
+          case "started":
+            setPhase("starting clone");
+            setLogLines((prev) => [...prev, `→ cloning ${ev.cloneUrlForDisplay}`]);
+            break;
+          case "progress":
+            setPhase(ev.phase);
+            setPercent(ev.percent);
+            break;
+          case "stderr":
+            setLogLines((prev) => {
+              const next = [...prev, ev.line];
+              return next.length > 200 ? next.slice(next.length - 200) : next;
+            });
+            break;
+          case "done":
+            setPhase("clone complete, creating project…");
+            setPercent(100);
+            break;
+          case "project_created":
+            createdProjectId = ev.project.id;
+            break;
+          case "error":
+            sawError = true;
+            errorMessage = ev.message;
+            break;
+        }
+      }
+      if (createdProjectId !== undefined) {
+        await onProjectCreated(createdProjectId);
+        return;
+      }
+      if (sawError) {
+        setError(errorMessage);
+      } else {
+        setError("clone_ended_without_project");
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        setError("cancelled");
+      } else {
+        setError(
+          err instanceof ApiError ? `${err.code}: ${err.message ?? ""}` : (err as Error).message,
+        );
+      }
+    } finally {
+      setSubmitting(false);
+      abortRef.current = undefined;
+    }
+  };
+
+  const onCancelClone = (): void => {
+    if (abortRef.current !== undefined) {
+      abortRef.current.abort();
+    } else {
+      onCancel();
+    }
+  };
+
+  return (
+    <form
+      onSubmit={(e) => {
+        void onSubmit(e);
+      }}
+      className="space-y-3"
+    >
+      <label className="block space-y-1">
+        <span className="text-sm font-medium text-neutral-300">Repository URL</span>
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://github.com/owner/repo.git"
+          disabled={submitting}
+          autoFocus
+          className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 font-mono text-xs outline-none focus:border-neutral-500 disabled:opacity-60"
+        />
+      </label>
+
+      <div className="grid grid-cols-2 gap-2">
+        <label className="block space-y-1">
+          <span className="text-sm font-medium text-neutral-300">Branch (optional)</span>
+          <input
+            value={branch}
+            onChange={(e) => setBranch(e.target.value)}
+            placeholder="default branch"
+            disabled={submitting}
+            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 font-mono text-xs outline-none focus:border-neutral-500 disabled:opacity-60"
+          />
+        </label>
+        <label className="block space-y-1">
+          <span className="text-sm font-medium text-neutral-300">Folder name</span>
+          <input
+            value={folderName}
+            onChange={(e) => {
+              setFolderName(e.target.value);
+              setFolderTouched(true);
+            }}
+            placeholder="auto from URL"
+            disabled={submitting}
+            className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 font-mono text-xs outline-none focus:border-neutral-500 disabled:opacity-60"
+          />
+        </label>
+      </div>
+
+      <label className="block space-y-1">
+        <span className="text-sm font-medium text-neutral-300">Project name</span>
+        <input
+          value={projectName}
+          onChange={(e) => {
+            setProjectName(e.target.value);
+            setProjectTouched(true);
+          }}
+          placeholder="auto from folder"
+          disabled={submitting}
+          className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm outline-none focus:border-neutral-500 disabled:opacity-60"
+        />
+        {workspaceRoot.length > 0 && folderName.length > 0 && (
+          <span className="block font-mono text-[11px] text-neutral-500">
+            Will clone into {workspaceRoot}/{folderName}
+          </span>
+        )}
+      </label>
+
+      <label className="block space-y-1">
+        <span className="text-sm font-medium text-neutral-300">
+          Access token (optional, for private repos)
+        </span>
+        <input
+          type="password"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="ghp_... / glpat_... / etc."
+          disabled={submitting}
+          className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 font-mono text-xs outline-none focus:border-neutral-500 disabled:opacity-60"
+        />
+        <span className="block text-[11px] text-neutral-500">
+          Sent over HTTPS, embedded as <code>x-access-token:&lt;token&gt;</code> in the clone URL,
+          and stripped from <code>.git/config</code> after success.
+        </span>
+      </label>
+
+      {(submitting || phase !== undefined) && (
+        <div className="space-y-1 rounded-md border border-neutral-800 bg-neutral-950 p-2">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-neutral-300">{phase ?? "starting…"}</span>
+            <span className="font-mono text-neutral-500">
+              {percent !== null ? `${percent}%` : ""}
+            </span>
+          </div>
+          {percent !== null && (
+            <div className="h-1 w-full overflow-hidden rounded bg-neutral-800">
+              <div
+                className="h-full bg-emerald-500 transition-all"
+                style={{ width: `${Math.max(2, Math.min(100, percent))}%` }}
+              />
+            </div>
+          )}
+          {logLines.length > 0 && (
+            <details
+              open={showRawLog}
+              onToggle={(e) => setShowRawLog((e.target as HTMLDetailsElement).open)}
+              className="pt-1"
+            >
+              <summary className="cursor-pointer text-[10px] uppercase tracking-wider text-neutral-500 hover:text-neutral-300">
+                Raw output ({logLines.length})
+              </summary>
+              <pre className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-words font-mono text-[10px] leading-snug text-neutral-400">
+                {logLines.join("\n")}
+              </pre>
+            </details>
+          )}
+        </div>
+      )}
+
+      {error !== undefined && (
+        <p className="text-xs text-red-400 light:text-red-700">Error: {error}</p>
+      )}
+
+      <div className="flex justify-end gap-2 pt-1">
+        <button
+          type="button"
+          onClick={onCancelClone}
+          className="rounded-md border border-neutral-700 px-3 py-2 text-sm text-neutral-300"
+        >
+          {submitting ? "Cancel clone" : "Cancel"}
+        </button>
+        <button
+          type="submit"
+          disabled={
+            submitting ||
+            url.trim().length === 0 ||
+            projectName.trim().length === 0 ||
+            workspaceRoot.length === 0
+          }
+          className="rounded-md bg-neutral-100 px-3 py-2 text-sm font-medium text-neutral-900 disabled:opacity-50"
+        >
+          {submitting ? "Cloning…" : "Clone + create project"}
+        </button>
+      </div>
+    </form>
   );
 }

--- a/packages/client/src/components/ProjectSidebar.tsx
+++ b/packages/client/src/components/ProjectSidebar.tsx
@@ -23,6 +23,7 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
   const rename = useProjectStore((s) => s.rename);
   const sessionsByProject = useSessionStore((s) => s.byProject);
   const createSession = useSessionStore((s) => s.createSession);
+  const disposeSession = useSessionStore((s) => s.disposeSession);
 
   /**
    * Create a new session under `projectId`. Mirrors the project-
@@ -43,41 +44,56 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
   const [renameValue, setRenameValue] = useState("");
 
   /**
-   * Delete-project modal state. We track on-disk session count to
-   * surface the cascade option only when there's something to clean
-   * up — otherwise the checkbox would just be confusing.
+   * Delete-project modal state. `liveCount` and `onDiskCount` are
+   * captured at open time so the dialog copy stays stable while the
+   * user reads it (a session ending mid-read shouldn't change the
+   * number shown). `acknowledged` gates the Delete button when there
+   * are session files to remove — a required confirmation step
+   * rather than an opt-in toggle. Empty projects don't need the
+   * acknowledgement and the button is enabled immediately.
    */
   const [deleteDialog, setDeleteDialog] = useState<
-    { id: string; name: string; onDiskCount: number; cascade: boolean } | undefined
+    | {
+        id: string;
+        name: string;
+        liveCount: number;
+        onDiskCount: number;
+        acknowledged: boolean;
+        submitting: boolean;
+      }
+    | undefined
   >(undefined);
 
   /**
-   * Two-stage delete confirm: if the project has live sessions, demand the
-   * user dispose them first. Otherwise show the delete modal which offers
-   * to cascade-delete the on-disk session JSONLs (default: NO, the safer
-   * option — matches v1's "workspace dir is user-managed" framing).
+   * Open the delete confirmation modal. No live-sessions block: any
+   * live sessions for this project get disposed as part of the
+   * delete (in `submitDelete` below), which matches the user's
+   * mental model of "delete project = make it go away" without the
+   * extra "dispose all live sessions first" dance.
    */
   const handleDelete = (id: string, name: string): void => {
     const list = sessionsByProject[id] ?? [];
     const liveCount = list.filter((s) => s.isLive).length;
-    if (liveCount > 0) {
-      alert(
-        `Cannot delete "${name}" — it has ${liveCount} live session${liveCount === 1 ? "" : "s"}. ` +
-          `Dispose ${liveCount === 1 ? "it" : "them"} first (× next to each session in the sidebar), then try again.`,
-      );
-      return;
-    }
-    // Count cold (on-disk-only) sessions: anything in the unified
-    // list that isn't currently live. Live count is already 0 here.
     const onDiskCount = list.filter((s) => !s.isLive).length;
-    setDeleteDialog({ id, name, onDiskCount, cascade: false });
+    setDeleteDialog({ id, name, liveCount, onDiskCount, acknowledged: false, submitting: false });
   };
 
   const submitDelete = async (): Promise<void> => {
     if (deleteDialog === undefined) return;
-    const { id, cascade } = deleteDialog;
+    const { id } = deleteDialog;
+    // Dispose any live sessions FIRST so the registry doesn't try to
+    // hold onto them while the server rm -rf's their JSONLs out from
+    // under them. The server's session-dir wipe also cleans up the
+    // JSONL files, so dispose here is the "release the in-memory
+    // handle + close SSE connections" half — best-effort, runs in
+    // parallel, errors don't block the project delete.
+    setDeleteDialog({ ...deleteDialog, submitting: true });
+    const liveIds = (sessionsByProject[id] ?? []).filter((s) => s.isLive).map((s) => s.sessionId);
+    if (liveIds.length > 0) {
+      await Promise.all(liveIds.map((sid) => disposeSession(sid).catch(() => undefined)));
+    }
     setDeleteDialog(undefined);
-    void remove(id, { cascade });
+    void remove(id);
   };
 
   const submitRename = async (id: string): Promise<void> => {
@@ -207,58 +223,80 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
           deleteDialog !== undefined ? `Delete project "${deleteDialog.name}"` : "Delete project"
         }
       >
-        {deleteDialog !== undefined && (
-          <div className="flex flex-col gap-3 px-4 py-3">
-            <p className="text-xs text-neutral-300">
-              Remove "{deleteDialog.name}" from the pi-forge. The project folder on disk is{" "}
-              <strong>not</strong> deleted; only the pi-forge's record of it goes away.
-            </p>
-            {deleteDialog.onDiskCount > 0 && (
-              <label className="flex items-start gap-2 rounded border border-neutral-800 bg-neutral-950 px-2 py-1.5 text-xs text-neutral-300">
-                <input
-                  type="checkbox"
-                  checked={deleteDialog.cascade}
-                  onChange={(e) =>
-                    setDeleteDialog((d) =>
-                      d === undefined ? d : { ...d, cascade: e.target.checked },
-                    )
-                  }
-                  className="mt-0.5 h-3 w-3"
-                />
-                <span>
-                  Also delete {deleteDialog.onDiskCount} on-disk session file
-                  {deleteDialog.onDiskCount === 1 ? "" : "s"} (under{" "}
-                  <code className="font-mono text-[10px] text-neutral-400">
-                    .pi/sessions/{deleteDialog.id}/
-                  </code>
-                  ). Without this, the JSONLs stay on disk and become orphaned — recoverable but not
-                  reachable through the pi-forge.
-                </span>
-              </label>
-            )}
-            {deleteDialog.onDiskCount === 0 && (
-              <p className="text-[11px] italic text-neutral-500">
-                No on-disk sessions for this project; nothing to clean up beyond the project record.
-              </p>
-            )}
-            <footer className="flex justify-end gap-2 pt-1">
-              <button
-                type="button"
-                onClick={() => setDeleteDialog(undefined)}
-                className="rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-200 hover:bg-neutral-800"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => void submitDelete()}
-                className="rounded-md bg-red-700 px-3 py-1 text-xs font-medium text-red-50 hover:bg-red-600"
-              >
-                Delete
-              </button>
-            </footer>
-          </div>
-        )}
+        {deleteDialog !== undefined &&
+          (() => {
+            const totalSessions = deleteDialog.liveCount + deleteDialog.onDiskCount;
+            const requiresAck = totalSessions > 0;
+            const canSubmit =
+              !deleteDialog.submitting && (!requiresAck || deleteDialog.acknowledged);
+            return (
+              <div className="flex flex-col gap-3 px-4 py-3">
+                <p className="text-xs text-neutral-300">
+                  Remove "{deleteDialog.name}" from pi-forge.
+                </p>
+                <ul className="ml-4 list-disc space-y-0.5 text-[11px] text-neutral-400">
+                  <li>
+                    Project record + the project's session directory (
+                    <code className="font-mono text-[10px] text-neutral-400">
+                      .pi/sessions/{deleteDialog.id}/
+                    </code>
+                    ) will be deleted.
+                  </li>
+                  {deleteDialog.liveCount > 0 && (
+                    <li>
+                      {deleteDialog.liveCount} live session
+                      {deleteDialog.liveCount === 1 ? "" : "s"} will be disposed first.
+                    </li>
+                  )}
+                  <li>
+                    The project's workspace folder on disk is <strong>not</strong> touched.
+                  </li>
+                </ul>
+                {requiresAck && (
+                  <label className="flex items-start gap-2 rounded border border-red-900/40 bg-red-950/30 px-2 py-1.5 text-xs text-red-200 light:border-red-300 light:bg-red-50 light:text-red-800">
+                    <input
+                      type="checkbox"
+                      checked={deleteDialog.acknowledged}
+                      onChange={(e) =>
+                        setDeleteDialog((d) =>
+                          d === undefined ? d : { ...d, acknowledged: e.target.checked },
+                        )
+                      }
+                      className="mt-0.5 h-3 w-3"
+                    />
+                    <span>
+                      Yes, I understand this will delete {totalSessions} session
+                      {totalSessions === 1 ? "" : "s"}
+                      {deleteDialog.liveCount > 0 && deleteDialog.onDiskCount > 0
+                        ? ` (${deleteDialog.liveCount} live, ${deleteDialog.onDiskCount} on disk)`
+                        : deleteDialog.liveCount > 0
+                          ? ` (${deleteDialog.liveCount} live)`
+                          : ""}
+                      . This can't be undone.
+                    </span>
+                  </label>
+                )}
+                <footer className="flex justify-end gap-2 pt-1">
+                  <button
+                    type="button"
+                    onClick={() => setDeleteDialog(undefined)}
+                    disabled={deleteDialog.submitting}
+                    className="rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-200 hover:bg-neutral-800 disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void submitDelete()}
+                    disabled={!canSubmit}
+                    className="rounded-md bg-red-700 px-3 py-1 text-xs font-medium text-red-50 hover:bg-red-600 disabled:opacity-50 disabled:hover:bg-red-700"
+                  >
+                    {deleteDialog.submitting ? "Deleting…" : "Delete"}
+                  </button>
+                </footer>
+              </div>
+            );
+          })()}
       </Modal>
     </aside>
   );

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -108,11 +108,11 @@ export function SessionList({ projectId }: Props) {
 
   const onDeleteClick = (sessionId: string): void => {
     if (armedDeleteId === sessionId) {
-      // Second click on the armed button — fire and clear. hard:true
-      // unconditionally, same matrix as the bulk path: dispose live +
-      // remove JSONL atomically.
+      // Second click on the armed button — fire and clear.
+      // Server's DELETE always dispose+remove JSONL atomically since
+      // v1.3.0 (the legacy `?hard=` toggle is gone).
       setArmedDeleteId(undefined);
-      void disposeSession(sessionId, { hard: true });
+      void disposeSession(sessionId);
       return;
     }
     // First click (or click on a different row's ×) — arm this row.
@@ -198,13 +198,11 @@ export function SessionList({ projectId }: Props) {
     if (deleteDialog === undefined) return;
     const ids = deleteDialog.sessionIds;
     setDeleteDialog(undefined);
-    // hard:true unconditionally — server's DELETE route handles the
-    // live + hard case by disposing the in-memory entry AND
-    // removing the on-disk JSONL atomically. The route's docs spell
-    // out the full matrix; we always pick the "actually delete" leg.
+    // Server's DELETE always dispose+remove JSONL atomically since
+    // v1.3.0 (the legacy `?hard=` toggle is gone).
     for (const id of ids) {
       try {
-        await disposeSession(id, { hard: true });
+        await disposeSession(id);
       } catch {
         // store.error renders the first failure; keep going so a
         // single missing/blocked session doesn't strand the rest of

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1239,6 +1239,68 @@ export const api = {
       method: "POST",
       body: { parentPath, name },
     }),
+  /**
+   * Start a git clone + project creation in one streaming operation.
+   * Returns the raw fetch Response so callers can consume the SSE
+   * stream incrementally. Server emits these event types (one JSON
+   * per `data:` line):
+   *   - `started`         {cloneUrlForDisplay}
+   *   - `progress`        {phase, percent, raw}
+   *   - `stderr`          {line}
+   *   - `done`            {target} (clone finished; project not yet created)
+   *   - `project_created` {project}
+   *   - `error`           {code?, message}
+   *
+   * Not routed through `request()` because the response is a stream,
+   * not a single JSON body. Caller handles parsing via
+   * `parseCloneEventStream` (below) or its own line reader.
+   */
+  cloneProject: async (
+    body: {
+      url: string;
+      parentPath: string;
+      folderName: string;
+      projectName: string;
+      branch?: string;
+      token?: string;
+    },
+    signal?: AbortSignal,
+  ): Promise<Response> => {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    };
+    const stored = getStoredToken();
+    if (stored) headers.Authorization = `Bearer ${stored.token}`;
+    const init: RequestInit = {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    };
+    if (signal !== undefined) init.signal = signal;
+    const res = await fetch("/api/v1/projects/clone", init);
+    if (res.status === 401) {
+      clearStoredToken();
+      window.dispatchEvent(new Event(UNAUTHORIZED_EVENT));
+      throw new ApiError(401, "invalid_token");
+    }
+    // Pre-stream validation failure surfaces as a normal JSON body
+    // (4xx). Pass through to the caller as an ApiError so the UI can
+    // show a clean error before any progress events would have
+    // started.
+    if (!res.ok) {
+      let parsed: { error?: unknown; message?: unknown } | undefined;
+      try {
+        parsed = (await res.json()) as typeof parsed;
+      } catch {
+        /* non-JSON body */
+      }
+      const code = typeof parsed?.error === "string" ? parsed.error : "clone_failed";
+      const msg = typeof parsed?.message === "string" ? parsed.message : undefined;
+      throw new ApiError(res.status, code, msg);
+    }
+    return res;
+  },
 
   // ---------------- sessions ----------------
   listSessions: (projectId?: string) => {
@@ -1275,10 +1337,8 @@ export const api = {
         }[],
       };
     }),
-  disposeSession: (id: string, opts?: { hard?: boolean }) => {
-    const qs = opts?.hard === true ? "?hard=1" : "";
-    return request(`/api/v1/sessions/${encodeURIComponent(id)}${qs}`, vVoid, { method: "DELETE" });
-  },
+  disposeSession: (id: string) =>
+    request(`/api/v1/sessions/${encodeURIComponent(id)}`, vVoid, { method: "DELETE" }),
   renameSession: (id: string, name: string) =>
     request(`/api/v1/sessions/${encodeURIComponent(id)}/name`, vSessionSummary, {
       method: "POST",
@@ -2347,3 +2407,64 @@ export const api = {
 
 // Export string validator for routes that return a bare string in future phases.
 export { vString };
+
+/**
+ * Wire-shape event union for the `/api/v1/projects/clone` stream.
+ * Documented separately from the api.cloneProject() function so the
+ * UI can switch on `event.type` with full type narrowing.
+ */
+export type CloneStreamEvent =
+  | { type: "started"; cloneUrlForDisplay: string }
+  | { type: "progress"; phase: string; percent: number | null; raw: string }
+  | { type: "stderr"; line: string }
+  | { type: "done"; target: string }
+  | { type: "project_created"; project: Project }
+  | { type: "error"; code?: string; message: string };
+
+/**
+ * Async-iterate the clone SSE response one event at a time. Same
+ * frame format as the rest of the SSE surface (`data: <json>\n\n`,
+ * comment lines stripped). Returns when the server closes the stream
+ * or the caller aborts the underlying response.
+ *
+ * Errors during parsing of a single frame are swallowed (an opaque
+ * `error` event with a generic message would be more confusing than
+ * silently dropping a malformed frame) — but a malformed JSON in a
+ * `data:` line is the only "parsing" we do; the server controls the
+ * format, so this should never fire in practice.
+ */
+export async function* parseCloneEventStream(
+  res: Response,
+): AsyncGenerator<CloneStreamEvent, void, void> {
+  if (res.body === null) return;
+  const reader = res.body.pipeThrough(new TextDecoderStream()).getReader();
+  let buf = "";
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) return;
+      buf += value.replace(/\r\n/g, "\n");
+      let sep = buf.indexOf("\n\n");
+      while (sep !== -1) {
+        const message = buf.slice(0, sep);
+        buf = buf.slice(sep + 2);
+        for (const line of message.split("\n")) {
+          if (!line.startsWith("data:")) continue;
+          const payload = line.slice(5).trimStart();
+          try {
+            yield JSON.parse(payload) as CloneStreamEvent;
+          } catch {
+            /* malformed frame — drop it */
+          }
+        }
+        sep = buf.indexOf("\n\n");
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      /* already released */
+    }
+  }
+}

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1198,17 +1198,15 @@ export const api = {
       method: "PATCH",
       body: { name },
     }),
-  deleteProject: (id: string, opts?: { cascade?: boolean }) => {
-    const qs = opts?.cascade === true ? "?cascade=1" : "";
-    return request(
-      `/api/v1/projects/${encodeURIComponent(id)}${qs}`,
+  deleteProject: (id: string) =>
+    request(
+      `/api/v1/projects/${encodeURIComponent(id)}`,
       (v, s) => {
         if (!isObject(v) || typeof v.cascaded !== "boolean") fail(s, "expected { cascaded }");
         return { cascaded: v.cascaded };
       },
       { method: "DELETE" },
-    );
-  },
+    ),
   browse: (path?: string) => {
     const qs = path !== undefined ? `?path=${encodeURIComponent(path)}` : "";
     return request(`/api/v1/projects/browse${qs}`, vBrowse);

--- a/packages/client/src/store/project-store.ts
+++ b/packages/client/src/store/project-store.ts
@@ -32,7 +32,7 @@ interface ProjectState {
   load: () => Promise<void>;
   create: (name: string, path: string) => Promise<Project>;
   rename: (id: string, name: string) => Promise<void>;
-  remove: (id: string, opts?: { cascade?: boolean }) => Promise<void>;
+  remove: (id: string) => Promise<void>;
   setActive: (id: string | undefined) => void;
   toggleCollapsed: (id: string) => void;
 }
@@ -83,9 +83,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       throw err;
     }
   },
-  remove: async (id, opts) => {
+  remove: async (id) => {
     try {
-      await api.deleteProject(id, opts);
+      await api.deleteProject(id);
       set((s) => {
         const projects = s.projects.filter((p) => p.id !== id);
         const activeProjectId = s.activeProjectId === id ? projects[0]?.id : s.activeProjectId;

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -327,7 +327,7 @@ interface SessionState {
   sendPrompt: (sessionId: string, text: string, attachments?: File[]) => Promise<void>;
   sendSteer: (sessionId: string, text: string, mode?: "steer" | "followUp") => Promise<void>;
   abortSession: (sessionId: string) => Promise<void>;
-  disposeSession: (sessionId: string, opts?: { hard?: boolean }) => Promise<void>;
+  disposeSession: (sessionId: string) => Promise<void>;
 }
 
 export const useSessionStore = create<SessionState>((set, get) => ({
@@ -669,7 +669,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     }
   },
 
-  disposeSession: async (sessionId, opts) => {
+  disposeSession: async (sessionId) => {
     set({ error: undefined });
     try {
       get().closeStream(sessionId);
@@ -677,7 +677,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       // listeners only need the id, but we may want to filter by
       // project later.
       const priorProjectId = findProjectIdForSession(get(), sessionId);
-      await api.disposeSession(sessionId, opts);
+      await api.disposeSession(sessionId);
       set((s) => removeSessionFromState(s, sessionId));
       if (get().activeSessionId === undefined) {
         localStorage.removeItem(ACTIVE_SESSION_KEY);

--- a/packages/server/src/git-clone.ts
+++ b/packages/server/src/git-clone.ts
@@ -1,0 +1,396 @@
+/**
+ * `git clone` runner for the "Clone repository" project-setup flow.
+ *
+ * Why this exists separately from `git-runner.ts`: git-runner.ts wraps
+ * the agent-/UI-facing `git status`/`diff`/`commit`/`push` surface for
+ * an already-cloned repo. Clone is a one-shot, multi-second operation
+ * that needs progress streaming and optional auth — different shape of
+ * problem, so it gets its own module.
+ *
+ * Auth model: a user-supplied token (PAT, fine-grained PAT, GitHub
+ * App installation token, etc.) is embedded into the clone URL as
+ * `https://x-access-token:<TOKEN>@<host>/<path>`. The
+ * `x-access-token:<TOKEN>` convention is GitHub's official
+ * recommendation and works for GitHub.com, GitHub Enterprise, GitLab
+ * (PAT-as-password), Bitbucket app passwords, and Gitea PATs. After
+ * the clone completes, we rewrite `origin` to the original
+ * token-free URL so the token doesn't persist in
+ * `.git/config`. The token is never logged and never appears in
+ * command args (it's part of the cloned URL, not a flag).
+ *
+ * Security notes for the threat model:
+ *   - Single-tenant deploys only — the URL is visible to anyone with
+ *     access to the spawned process (`ps`). Multi-tenant deploys would
+ *     need to use `GIT_ASKPASS` or `credential.helper` instead.
+ *   - The token is held in process memory for the lifetime of one
+ *     clone. We don't log it. We don't write it to any pi-forge
+ *     file.
+ *   - If the clone fails partway, the URL with the embedded token may
+ *     be in git's internal state (e.g. a partial `.git/config` if
+ *     anything wrote a remote before the failure). We rm-rf the
+ *     target directory on failure to make sure no leftover token
+ *     bytes survive.
+ */
+import { spawn } from "node:child_process";
+import { rm, stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { scrubbedEnv } from "./pty-manager.js";
+
+const MAX_PROGRESS_BUFFER_BYTES = 64 * 1024;
+const CLONE_TIMEOUT_MS = 30 * 60 * 1000;
+
+export interface CloneOptions {
+  /** Repository URL — HTTPS only. SSH URLs would need a key on disk; out of scope for v1.3.0. */
+  url: string;
+  /** Absolute path where the clone will land. Must not exist or must be empty. */
+  target: string;
+  /** Optional branch / tag / sha to check out. Defaults to remote HEAD. */
+  branch?: string;
+  /**
+   * Optional access token. Embedded into the clone URL as
+   * `x-access-token:<token>` (GitHub-style) and stripped from the
+   * stored `origin` URL after success.
+   */
+  token?: string;
+  /** Optional AbortSignal to cancel the clone mid-run. SIGTERM → SIGKILL after 5s grace. */
+  signal?: AbortSignal;
+}
+
+export type CloneEvent =
+  | { type: "started"; cloneUrlForDisplay: string }
+  | { type: "progress"; phase: string; percent: number | null; raw: string }
+  | { type: "stderr"; line: string }
+  | { type: "done"; target: string }
+  | { type: "error"; message: string };
+
+export class GitCloneError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "GitCloneError";
+    this.code = code;
+  }
+}
+
+/**
+ * Validate a URL is suitable for `git clone`. Returns the parsed URL
+ * on success. Accepts:
+ *   - `https://` — the primary case. Token injection works.
+ *   - `file://`  — local-repo clone (useful for testing and for
+ *                 forking from a local mirror). No token, no auth.
+ *
+ * Rejects everything else (ssh:, http:, git:, ftp:, ...). Plain http
+ * is explicitly out because we don't want to embed a token in a
+ * cleartext URL even on private networks — operators expecting that
+ * almost certainly want HTTPS.
+ */
+export function validateCloneUrl(raw: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new GitCloneError("invalid_url", `Not a valid URL: ${raw}`);
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "file:") {
+    throw new GitCloneError(
+      "unsupported_protocol",
+      `Only HTTPS and file:// clone URLs are supported (got ${parsed.protocol}).`,
+    );
+  }
+  // HTTPS requires a host. file:// uses `parsed.pathname` and may
+  // have an empty hostname ("file:///path/to/repo") — that's the
+  // correct shape, not an error.
+  if (parsed.protocol === "https:" && parsed.hostname.length === 0) {
+    throw new GitCloneError("invalid_url", "URL is missing a host.");
+  }
+  return parsed;
+}
+
+/**
+ * Inject `x-access-token:<token>` into the URL's userinfo. URL
+ * encoding is handled by the URL API — tokens containing `:` / `@` /
+ * `/` etc. are encoded correctly.
+ */
+function injectToken(url: URL, token: string): string {
+  const withAuth = new URL(url.toString());
+  withAuth.username = "x-access-token";
+  withAuth.password = token;
+  return withAuth.toString();
+}
+
+/**
+ * Parse a git progress line. Git writes progress to stderr in lines
+ * like "Receiving objects: 45% (450/1000), 1.23 MiB | 200 KiB/s" or
+ * "Resolving deltas: 100% (123/123), done.". We pull out the phase
+ * name ("Receiving objects") and the percent (45 or 100). Returns
+ * undefined for non-progress lines (which are still surfaced via
+ * `type: "stderr"` events).
+ */
+export function parseProgressLine(
+  line: string,
+): { phase: string; percent: number | null } | undefined {
+  // Format: `<Phase>: <pct>% (...)` with the percent optional in some
+  // phases (e.g. "Counting objects: 1234, done.").
+  const match = /^([A-Z][A-Za-z ]+):\s+(\d+)%/.exec(line.trim());
+  if (match !== null) {
+    return { phase: match[1] ?? "", percent: Number(match[2]) };
+  }
+  // Some phases don't report percent (e.g. "Counting objects: 1234"
+  // or "Cloning into '...'"). Surface them with percent=null so the
+  // UI can still show the phase change.
+  const phaseOnly = /^([A-Z][A-Za-z ]+):/.exec(line.trim());
+  if (phaseOnly !== null) {
+    return { phase: phaseOnly[1] ?? "", percent: null };
+  }
+  return undefined;
+}
+
+interface SpawnedClone {
+  promise: Promise<void>;
+  events: AsyncIterable<CloneEvent>;
+}
+
+/**
+ * Run `git clone` with progress streaming. Yields CloneEvents in
+ * real time. Resolves when the spawn settles (success or failure);
+ * the caller iterates `events` to render progress as it happens.
+ *
+ * On error, the target directory is rm -rf'd to avoid leaving a
+ * half-cloned tree (and any leftover token bytes in
+ * `.git/config`).
+ */
+export function cloneRepository(opts: CloneOptions): SpawnedClone {
+  const url = validateCloneUrl(opts.url);
+  const target = resolve(opts.target);
+
+  const cloneUrl = opts.token !== undefined ? injectToken(url, opts.token) : url.toString();
+  const displayUrl = url.toString();
+
+  // Build args. `--progress` forces git to emit progress to stderr
+  // even when stdout isn't a tty (which it never is for us — we're
+  // a child process). Without it, the operator sees no progress
+  // until the clone completes.
+  const args = ["clone", "--progress"];
+  if (opts.branch !== undefined && opts.branch.length > 0) {
+    args.push("--branch", opts.branch);
+  }
+  args.push(cloneUrl, target);
+
+  // Bounded queue so a slow consumer can't drive memory to the moon.
+  // 1024 events / 8s of typical progress lines is the cap; backpressure
+  // is "drop oldest" since the user can survive missing a few
+  // intermediate progress lines and the `done`/`error` event is
+  // generated locally (not from the queue).
+  const queue: CloneEvent[] = [];
+  let pendingResolve: ((e: IteratorResult<CloneEvent>) => void) | undefined;
+  let finished = false;
+  let finishedReason: { type: "done"; target: string } | { type: "error"; message: string } | null =
+    null;
+
+  const push = (e: CloneEvent): void => {
+    if (pendingResolve !== undefined) {
+      const resolve = pendingResolve;
+      pendingResolve = undefined;
+      resolve({ value: e, done: false });
+      return;
+    }
+    queue.push(e);
+    while (queue.length > 1024) queue.shift();
+  };
+
+  const finish = (
+    reason: { type: "done"; target: string } | { type: "error"; message: string },
+  ): void => {
+    if (finished) return;
+    finished = true;
+    finishedReason = reason;
+    push({ ...reason });
+    if (pendingResolve !== undefined) {
+      const resolve = pendingResolve;
+      pendingResolve = undefined;
+      resolve({ value: undefined, done: true });
+    }
+  };
+
+  const events: AsyncIterable<CloneEvent> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<CloneEvent>> {
+          if (queue.length > 0) {
+            const e = queue.shift()!;
+            return Promise.resolve({ value: e, done: false });
+          }
+          if (finished && finishedReason !== null && queue.length === 0) {
+            // We already pushed the terminal event in finish(); subsequent
+            // calls should report done.
+            return Promise.resolve({ value: undefined, done: true });
+          }
+          return new Promise((resolve) => {
+            pendingResolve = resolve;
+          });
+        },
+      };
+    },
+  };
+
+  push({ type: "started", cloneUrlForDisplay: displayUrl });
+
+  const env = {
+    ...scrubbedEnv(),
+    // Prevent git from prompting on stdin when credentials are
+    // wrong / missing — without this, git can hang indefinitely
+    // waiting for a username/password.
+    GIT_TERMINAL_PROMPT: "0",
+  };
+
+  const child = spawn("git", args, {
+    cwd: dirname(target),
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stderrBuffer = "";
+  let stderrBytes = 0;
+
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderrBytes += Buffer.byteLength(chunk, "utf8");
+    // Cap the in-memory buffer — git progress lines come with `\r`
+    // overwrites and can fill memory if something runs amok.
+    if (stderrBytes > MAX_PROGRESS_BUFFER_BYTES) {
+      stderrBuffer = stderrBuffer.slice(-MAX_PROGRESS_BUFFER_BYTES);
+      stderrBytes = MAX_PROGRESS_BUFFER_BYTES;
+    }
+    // Git uses `\r` to overwrite progress lines in-place. Split on
+    // both `\r` and `\n` so we surface each "frame" as its own
+    // progress line.
+    stderrBuffer += chunk;
+    const lines = stderrBuffer.split(/[\r\n]/);
+    stderrBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      const parsed = parseProgressLine(trimmed);
+      if (parsed !== undefined) {
+        push({ type: "progress", phase: parsed.phase, percent: parsed.percent, raw: trimmed });
+      } else {
+        push({ type: "stderr", line: trimmed });
+      }
+    }
+  });
+
+  // Abort plumbing — caller's AbortSignal kills the child.
+  if (opts.signal !== undefined) {
+    const onAbort = (): void => {
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 5_000).unref();
+    };
+    if (opts.signal.aborted) onAbort();
+    else opts.signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  // Hard timeout — runaway clones don't sit forever.
+  const timeoutTimer = setTimeout(() => {
+    child.kill("SIGTERM");
+    setTimeout(() => child.kill("SIGKILL"), 5_000).unref();
+  }, CLONE_TIMEOUT_MS);
+  timeoutTimer.unref();
+
+  const promise = new Promise<void>((resolveOuter) => {
+    let settled = false;
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutTimer);
+      finish({
+        type: "error",
+        message: `Failed to spawn git clone: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      resolveOuter();
+    });
+    child.on("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutTimer);
+      void (async () => {
+        if (code === 0) {
+          // Success — strip the token from `origin` if we injected
+          // one. Best-effort; if it fails we still report success
+          // (the clone IS done) but warn-log it.
+          if (opts.token !== undefined) {
+            await stripTokenFromOrigin(target, displayUrl).catch(() => undefined);
+          }
+          finish({ type: "done", target });
+          resolveOuter();
+          return;
+        }
+        // Non-zero exit (or killed). Clean up the half-cloned dir
+        // so a retry doesn't trip "destination already exists" and
+        // no leftover token bytes survive in `.git/config`.
+        await rm(target, { recursive: true, force: true }).catch(() => undefined);
+        const sigMsg = signal !== null ? ` (signal ${signal})` : "";
+        finish({
+          type: "error",
+          message: `git clone exited with code ${code}${sigMsg}`,
+        });
+        resolveOuter();
+      })();
+    });
+  });
+
+  return { promise, events };
+}
+
+/**
+ * After a successful clone, rewrite `origin` to the token-free URL
+ * so the token doesn't persist in `.git/config`. Best-effort —
+ * any failure is swallowed by the caller.
+ */
+async function stripTokenFromOrigin(target: string, cleanUrl: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("git", ["-C", target, "remote", "set-url", "origin", cleanUrl], {
+      env: scrubbedEnv(),
+      stdio: "ignore",
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`set-url exited ${code}`));
+    });
+  });
+}
+
+/**
+ * Verify the target directory is suitable for a clone: either
+ * doesn't exist, or exists and is empty. Returns the resolved path
+ * on success. Used by the route before spawning `git clone` so we
+ * surface "directory not empty" as a 409 rather than letting the
+ * spawn fail with a less friendly error.
+ */
+export async function assertTargetClonable(target: string): Promise<void> {
+  const resolved = resolve(target);
+  try {
+    const st = await stat(resolved);
+    if (!st.isDirectory()) {
+      throw new GitCloneError(
+        "target_not_a_directory",
+        `Target exists but is not a directory: ${resolved}`,
+      );
+    }
+    // Exists and is a directory — only OK if empty. git clone will
+    // refuse to clone into a non-empty dir; we catch it here to give
+    // a better error.
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(resolved);
+    if (entries.length > 0) {
+      throw new GitCloneError("target_not_empty", `Target directory is not empty: ${resolved}`);
+    }
+  } catch (err) {
+    if (err instanceof GitCloneError) throw err;
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return; // doesn't exist — fine
+    throw err;
+  }
+}
+
+export { join as joinTargetPath };

--- a/packages/server/src/processes/manager.ts
+++ b/packages/server/src/processes/manager.ts
@@ -181,7 +181,16 @@ class ProcessManagerRegistry {
     child.on("close", (code, signal) => {
       info.endTime = Date.now();
       info.exitCode = typeof code === "number" ? code : null;
-      const wasKilled = managed.killSent !== null || signal !== null;
+      // `killSent` is set when WE called .kill() (via the `process
+      // kill` tool); `signal` is non-null when the child died from
+      // any signal (ours or external). Both contribute to "wasKilled"
+      // for the status display, but only the EXTERNAL case (signal
+      // present, killSent absent) triggers an `alertOnKill` —
+      // alerting the agent that it killed something is redundant
+      // and noisy.
+      const killedByUs = managed.killSent !== null;
+      const killedExternally = !killedByUs && signal !== null;
+      const wasKilled = killedByUs || killedExternally;
       info.status = wasKilled ? "killed" : "exited";
       info.success = info.exitCode === 0 && !wasKilled;
       if (managed.killTimer !== null) {
@@ -198,6 +207,17 @@ class ProcessManagerRegistry {
       // needs to see; log cleanup is bookkeeping.
       this.notify({ type: "process_ended", sessionId, info });
       this.notify({ type: "processes_changed", sessionId });
+      // Agent-alert events. The three alertOn* flags were captured
+      // at start() time; honor them now. Order chosen so a single
+      // outcome only fires one alert — a failure isn't ALSO a "non-
+      // success" alert, etc.
+      if (killedExternally && info.alertOnKill) {
+        this.notify({ type: "process_alert", sessionId, info, reason: "killed" });
+      } else if (!wasKilled && info.exitCode === 0 && info.alertOnSuccess) {
+        this.notify({ type: "process_alert", sessionId, info, reason: "success" });
+      } else if (!wasKilled && info.exitCode !== 0 && info.alertOnFailure) {
+        this.notify({ type: "process_alert", sessionId, info, reason: "failure" });
+      }
       void this.finalize(managed);
     });
 

--- a/packages/server/src/processes/types.ts
+++ b/packages/server/src/processes/types.ts
@@ -117,6 +117,18 @@ export type WriteResult =
     };
 
 /**
+ * Reason a `process_alert` event was emitted. Mirrors the three
+ * `alertOn*` flags on StartOptions:
+ *   - `success`: clean exit, exitCode 0, alertOnSuccess set.
+ *   - `failure`: non-zero exit (and not killed externally),
+ *                alertOnFailure set.
+ *   - `killed`:  killed by external signal (NOT by the `process kill`
+ *                tool — that's intentional, would be redundant to
+ *                notify the agent of its own action), alertOnKill set.
+ */
+export type ProcessAlertReason = "success" | "failure" | "killed";
+
+/**
  * Public manager events fanned out to listeners (SSE bridge,
  * watches, etc.). All carry the sessionId so the SSE layer can
  * route correctly without needing to know which manager produced
@@ -127,4 +139,10 @@ export type ManagerEvent =
   | { type: "process_ended"; sessionId: string; info: ProcessInfo }
   | { type: "process_output_changed"; sessionId: string; id: string }
   | { type: "process_watch_matched"; sessionId: string; match: LogWatchMatchEvent }
-  | { type: "processes_changed"; sessionId: string };
+  | { type: "processes_changed"; sessionId: string }
+  | {
+      type: "process_alert";
+      sessionId: string;
+      info: ProcessInfo;
+      reason: ProcessAlertReason;
+    };

--- a/packages/server/src/project-manager.ts
+++ b/packages/server/src/project-manager.ts
@@ -245,7 +245,7 @@ const noopWarn: WarnFn = () => undefined;
 
 export async function deleteProject(
   id: string,
-  opts: { cascadeSessionDir?: boolean; logWarn?: WarnFn } = {},
+  opts: { logWarn?: WarnFn } = {},
 ): Promise<{ cascaded: boolean }> {
   const warn = opts.logWarn ?? noopWarn;
   let cascaded = false;
@@ -271,37 +271,52 @@ export async function deleteProject(
   await clearProjectStdioTrust(id).catch((err: unknown) => {
     warn({ err, id }, "mcp-stdio-trust cleanup failed");
   });
-  if (opts.cascadeSessionDir === true) {
-    // Wipe the project's session directory. Best-effort — a missing
-    // dir (no sessions ever recorded) is not an error.
-    //
-    // SAFETY: validate the id is UUID-shaped (the only shape
-    // `createProject()` ever produces) BEFORE building the path.
-    // `rm({ recursive: true, force: true })` is destructive enough
-    // that any path-traversal in `id` would be catastrophic — a
-    // hypothetical `id === ".."` would resolve to the parent of
-    // `${SESSION_DIR}` and wipe it. Today the only id source is
-    // `randomUUID()`, but the validator codifies that invariant
-    // against any future code path that imports/restores ids from
-    // the wire or a manually-edited projects.json.
-    if (!UUID_RE.test(id)) {
-      // Should be unreachable — the project record we just deleted
-      // had this id, so it passed creation-time validation. Log and
-      // skip the cascade rather than rm something dangerous.
-      warn({ id }, "refusing cascade rm for non-UUID id");
-      return { cascaded };
-    }
-    const dir = join(config.sessionDir, id);
-    try {
-      await rm(dir, { recursive: true, force: true });
-      cascaded = true;
-    } catch (err) {
-      // Don't fail the delete itself if cascade cleanup fails — the
-      // project record is gone, the session files are just orphaned
-      // (the same state that exists when cascade isn't requested).
-      // But DO log so a permissions issue isn't silently invisible.
-      warn({ err, dir }, "cascade rm failed");
-    }
+
+  // Always wipe the project's session directory in full — JSONLs
+  // and the dir itself. Earlier versions made this opt-in via
+  // `cascadeSessionDir: true` and a UI checkbox, but the default-off
+  // behavior left a `<projectId>/` directory on disk that the UI had
+  // no way to reach ever again. Even when individual sessions were
+  // deleted before the project, the empty parent dir survived
+  // (deleteColdSession only unlinks the JSONL, not the parent).
+  //
+  // v1.3.0 makes "project delete means gone" the contract: project
+  // record + all session metadata + the parent dir are removed in
+  // one shot. The user-facing confirmation about deleting N session
+  // files happens at the UI layer (a required checkbox in the
+  // delete dialog when sessions are present) — but the server-side
+  // behavior is unconditional. Programmatic clients calling DELETE
+  // /api/v1/projects/:id get the same atomic delete.
+  //
+  // The project's workspace folder (`${WORKSPACE_PATH}/<projectName>/`)
+  // is still left alone — that's almost always real work the user
+  // wants to keep.
+  //
+  // SAFETY: validate the id is UUID-shaped (the only shape
+  // `createProject()` ever produces) BEFORE building the path.
+  // `rm({ recursive: true, force: true })` is destructive enough
+  // that any path-traversal in `id` would be catastrophic — a
+  // hypothetical `id === ".."` would resolve to the parent of
+  // `${SESSION_DIR}` and wipe it. Today the only id source is
+  // `randomUUID()`, but the validator codifies that invariant
+  // against any future code path that imports/restores ids from
+  // the wire or a manually-edited projects.json.
+  if (!UUID_RE.test(id)) {
+    // Should be unreachable — the project record we just deleted
+    // had this id, so it passed creation-time validation. Log and
+    // skip the cleanup rather than rm something dangerous.
+    warn({ id }, "refusing cascade rm for non-UUID id");
+    return { cascaded };
+  }
+  const dir = join(config.sessionDir, id);
+  try {
+    await rm(dir, { recursive: true, force: true });
+    cascaded = true;
+  } catch (err) {
+    // Don't fail the delete itself if cleanup fails — the project
+    // record is gone, the session files are just orphaned. But DO
+    // log so a permissions issue isn't silently invisible.
+    warn({ err, dir }, "session-dir rm failed");
   }
   return { cascaded };
 }

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -1,4 +1,13 @@
 import type { FastifyPluginAsync, FastifyReply } from "fastify";
+import { join, resolve } from "node:path";
+import { config } from "../config.js";
+import {
+  assertTargetClonable,
+  cloneRepository,
+  GitCloneError,
+  validateCloneUrl,
+  type CloneEvent,
+} from "../git-clone.js";
 import {
   browseDirectory,
   createDirectory,
@@ -20,6 +29,23 @@ import {
   setProjectSystemPromptAddendum,
 } from "../system-prompt-overrides.js";
 import { errorSchema } from "./_schemas.js";
+
+/**
+ * Heartbeat cadence for the clone SSE stream. Same value as
+ * `sse-bridge.ts:HEARTBEAT_INTERVAL_MS` — keeps comfortable margin
+ * under the OpenShift HAProxy `timeout server` default of 30s.
+ */
+const CLONE_HEARTBEAT_INTERVAL_MS = 20_000;
+
+/**
+ * One-shot padding flush after the `started` event so OpenShift's
+ * HAProxy router releases the small initial frames immediately
+ * instead of holding them through the multi-second clone. Same
+ * pattern as `sse-bridge.ts:COMPACTION_START_PADDING_LINE` — see
+ * that doc-comment for the rationale.
+ */
+const CLONE_PADDING_BYTES = 2048;
+const CLONE_PADDING_LINE = `: pad-flush ${"_".repeat(CLONE_PADDING_BYTES - 14)}\n\n`;
 
 const projectSchema = {
   type: "object",
@@ -358,6 +384,217 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
       await setProjectSystemPromptAddendum(req.params.id, req.body.addendum);
       const addendum = await getProjectSystemPromptAddendum(req.params.id);
       return { addendum, maxBytes: MAX_ADDENDUM_BYTES };
+    },
+  );
+
+  fastify.post<{
+    Body: {
+      url: string;
+      parentPath: string;
+      folderName: string;
+      projectName: string;
+      branch?: string;
+      token?: string;
+    };
+  }>(
+    "/projects/clone",
+    {
+      schema: {
+        description:
+          "Clone a git repository into a new folder under WORKSPACE_PATH, then " +
+          "create a project pointing at it. Streams progress as SSE events.\n\n" +
+          "Event types on the stream:\n" +
+          "  - `started`  — {cloneUrlForDisplay} (URL with credentials stripped)\n" +
+          "  - `progress` — {phase, percent, raw} (one per `git clone --progress` line)\n" +
+          "  - `stderr`   — {line} (other stderr text — non-progress, non-fatal)\n" +
+          "  - `done`     — {project} (the created Project record)\n" +
+          "  - `error`    — {message, code} (fatal — connection then closes)\n\n" +
+          "Auth: optional `token` is embedded as `x-access-token:<token>` in the " +
+          "clone URL (GitHub convention; works for most providers). The token is " +
+          "stripped from the stored `origin` URL after a successful clone so it " +
+          "doesn't persist in `.git/config`. On failure the target dir is " +
+          "rm -rf'd so no token bytes survive.",
+        tags: ["projects"],
+        body: {
+          type: "object",
+          required: ["url", "parentPath", "folderName", "projectName"],
+          additionalProperties: false,
+          properties: {
+            url: { type: "string", minLength: 1 },
+            parentPath: { type: "string", minLength: 1 },
+            folderName: { type: "string", minLength: 1, maxLength: 100 },
+            projectName: { type: "string", minLength: 1, maxLength: 200 },
+            branch: { type: "string", maxLength: 250 },
+            token: { type: "string", maxLength: 4096 },
+          },
+        },
+        response: {
+          // SSE responses don't fit Fastify's response-schema model;
+          // only the pre-stream error shapes are declared. The
+          // catalog of event types is in the description above.
+          400: errorSchema,
+          403: errorSchema,
+          409: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { url, parentPath, folderName, projectName, branch, token } = req.body;
+
+      // ---- pre-stream validation: errors land as plain JSON 4xx ----
+      try {
+        validateCloneUrl(url);
+      } catch (err) {
+        if (err instanceof GitCloneError) {
+          return reply.code(400).send({ error: err.code, message: err.message });
+        }
+        throw err;
+      }
+      // Folder-name validation mirrors createDirectory's rules.
+      if (
+        folderName.includes("/") ||
+        folderName.includes("\\") ||
+        folderName === "." ||
+        folderName === ".."
+      ) {
+        return reply.code(400).send({ error: "invalid_directory_name" });
+      }
+      // Resolve target path and confirm it's inside WORKSPACE_PATH.
+      // Reuses the project-manager error so the route surface stays
+      // consistent.
+      const parentResolved = resolve(parentPath);
+      const targetPath = join(parentResolved, folderName);
+      const workspaceResolved = resolve(config.workspacePath);
+      if (
+        !parentResolved.startsWith(workspaceResolved + "/") &&
+        parentResolved !== workspaceResolved
+      ) {
+        return reply.code(403).send({ error: "path_not_allowed" });
+      }
+      if (!targetPath.startsWith(workspaceResolved + "/") && targetPath !== workspaceResolved) {
+        return reply.code(403).send({ error: "path_not_allowed" });
+      }
+      try {
+        await assertTargetClonable(targetPath);
+      } catch (err) {
+        if (err instanceof GitCloneError) {
+          const status = err.code === "target_not_empty" ? 409 : 400;
+          return reply.code(status).send({ error: err.code, message: err.message });
+        }
+        throw err;
+      }
+
+      // ---- start streaming ----
+      reply.hijack();
+      const raw = reply.raw;
+      let closed = false;
+      let heartbeat: NodeJS.Timeout | undefined;
+      const close = (): void => {
+        if (closed) return;
+        closed = true;
+        if (heartbeat !== undefined) {
+          clearInterval(heartbeat);
+          heartbeat = undefined;
+        }
+        try {
+          raw.end();
+        } catch {
+          /* socket already torn down */
+        }
+      };
+      const writeRaw = (chunk: string): void => {
+        if (closed) return;
+        try {
+          raw.write(chunk);
+        } catch {
+          close();
+        }
+      };
+      const writeEvent = (event: CloneEvent): void => {
+        writeRaw(`data: ${JSON.stringify(event)}\n\n`);
+      };
+
+      try {
+        raw.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache, no-transform",
+          Connection: "keep-alive",
+          "X-Accel-Buffering": "no",
+        });
+      } catch (err) {
+        req.log.error({ err }, "clone prelude failed");
+        try {
+          raw.destroy();
+        } catch {
+          /* already destroyed */
+        }
+        return;
+      }
+      heartbeat = setInterval(() => writeRaw(": heartbeat\n\n"), CLONE_HEARTBEAT_INTERVAL_MS);
+      heartbeat.unref();
+
+      // Abort the clone if the client disconnects mid-stream.
+      const ac = new AbortController();
+      raw.on("close", () => {
+        ac.abort();
+        close();
+      });
+      raw.on("error", () => {
+        ac.abort();
+        close();
+      });
+
+      const cloneOpts: import("../git-clone.js").CloneOptions = {
+        url,
+        target: targetPath,
+        signal: ac.signal,
+      };
+      if (branch !== undefined && branch.length > 0) cloneOpts.branch = branch;
+      if (token !== undefined && token.length > 0) cloneOpts.token = token;
+      const { promise, events } = cloneRepository(cloneOpts);
+
+      // Stream every event to the client. After the `started` event,
+      // send a one-shot padding flush so HAProxy releases the small
+      // frames immediately rather than holding them through the
+      // multi-second clone (same pattern as the compaction-start
+      // padding flush in sse-bridge.ts).
+      let sentPadding = false;
+      let cloneSucceeded = false;
+      for await (const e of events) {
+        writeEvent(e);
+        if (!sentPadding && e.type === "started") {
+          writeRaw(CLONE_PADDING_LINE);
+          sentPadding = true;
+        }
+        if (e.type === "done") cloneSucceeded = true;
+        if (closed) break;
+      }
+      await promise;
+
+      // Create the project record on success, then emit a final
+      // event with the project shape so the client can navigate
+      // straight to it. The `done` event from the clone module
+      // already fired above with `target`; this is a separate
+      // `project_created` event so the contract is unambiguous.
+      if (cloneSucceeded && !closed) {
+        try {
+          const project = await createProject(projectName, targetPath);
+          writeRaw(`data: ${JSON.stringify({ type: "project_created", project })}\n\n`);
+        } catch (err) {
+          const code =
+            err instanceof DuplicatePathError
+              ? "duplicate_path"
+              : err instanceof PathOutsideWorkspaceError
+                ? "path_not_allowed"
+                : err instanceof InvalidNameError
+                  ? "invalid_name"
+                  : "project_create_failed";
+          const message = err instanceof Error ? err.message : String(err);
+          writeRaw(`data: ${JSON.stringify({ type: "error", code, message })}\n\n`);
+        }
+      }
+      close();
     },
   );
 

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -174,28 +174,32 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
     },
   );
 
-  fastify.delete<{ Params: { id: string }; Querystring: { cascade?: string } }>(
+  fastify.delete<{ Params: { id: string } }>(
     "/projects/:id",
     {
       schema: {
         description:
-          "Delete the project record. With `?cascade=1` ALSO removes the " +
-          "project's on-disk session directory (under `${SESSION_DIR}/<id>/`); " +
-          "without it, those files are left in place and become orphaned. " +
-          "Cascade cleanup is best-effort — a missing dir is not an error, " +
-          "and an rm failure does NOT fail the delete (the project record " +
-          "is already gone at that point).",
+          "Delete the project record AND rm -rf the project's session " +
+          "directory (`${SESSION_DIR}/<id>/`) including every session " +
+          "JSONL inside. The project's workspace folder " +
+          "(`${WORKSPACE_PATH}/<projectName>/`) is left alone — that's " +
+          "almost always real work the user wants to keep.\n\n" +
+          "Earlier versions accepted a `?cascade=0|1` query param to opt " +
+          "into the session-dir cleanup. v1.3.0 dropped the param and " +
+          "made cleanup unconditional — the default-off behavior left a " +
+          "`<projectId>/` directory on disk that the UI had no way to " +
+          "reach. User-facing confirmation about deleting N session " +
+          "files happens at the UI layer (a required checkbox in the " +
+          "delete dialog when sessions are present); programmatic " +
+          "clients get the same atomic delete with no opt.\n\n" +
+          "Session-dir cleanup is best-effort: a missing dir is not an " +
+          "error, and an rm failure does NOT fail the delete (the project " +
+          "record is already gone at that point).",
         tags: ["projects"],
         params: {
           type: "object",
           required: ["id"],
           properties: { id: { type: "string" } },
-        },
-        querystring: {
-          type: "object",
-          properties: {
-            cascade: { type: "string", enum: ["0", "1", "true", "false"] },
-          },
         },
         response: {
           200: {
@@ -209,9 +213,7 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       try {
-        const cascade = req.query.cascade === "1" || req.query.cascade === "true";
         const result = await deleteProject(req.params.id, {
-          cascadeSessionDir: cascade,
           logWarn: (obj, msg) => req.log.warn(obj, msg),
         });
         return reply.code(200).send(result);

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -755,34 +755,28 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     },
   );
 
-  fastify.delete<{ Params: { id: string }; Querystring: { hard?: string } }>(
+  fastify.delete<{ Params: { id: string } }>(
     "/sessions/:id",
     {
       schema: {
         description:
-          "Dispose the live session AND/OR delete the on-disk JSONL. The " +
-          "`hard` query param is the destructive-intent toggle:\n" +
-          "  - live + no `hard` → dispose, file preserved → 204\n" +
-          "  - live + `hard=1` → dispose AND delete the JSONL → 204\n" +
-          "  - cold + `hard=1` → delete the JSONL → 204\n" +
-          "  - cold + no `hard` → 404 (nothing to dispose; pass `hard=1` " +
-          "if you mean to delete the file)\n" +
+          "Dispose the live session AND delete the on-disk JSONL (plus " +
+          "any pi-subagents child JSONLs nested under it). Always destructive " +
+          "— matches the UI's expectation that 'delete' means the session is " +
+          "gone from disk and the sidebar.\n" +
+          "  - live → dispose AND delete the JSONL → 204\n" +
+          "  - cold → delete the JSONL → 204\n" +
           "  - not found anywhere → 404\n" +
-          "The `hard=1`-required-for-cold rule keeps DELETE without `hard` " +
-          "non-destructive in every case: programmatic clients hammering " +
-          "DELETE in a cleanup loop won't accidentally remove on-disk " +
-          "session files.",
+          "Earlier versions of this route accepted a `?hard=0|1` query " +
+          "param to opt into JSONL deletion. The non-destructive default was " +
+          "vestigial (the UI always passed `hard=1`) and confusing for " +
+          "programmatic clients, so v1.3.0 dropped the param and made hard " +
+          "delete the only behavior.",
         tags: ["sessions"],
         params: {
           type: "object",
           required: ["id"],
           properties: { id: { type: "string" } },
-        },
-        querystring: {
-          type: "object",
-          properties: {
-            hard: { type: "string", enum: ["0", "1", "true", "false"] },
-          },
         },
         response: {
           204: { type: "null" },
@@ -792,19 +786,11 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const hard = req.query.hard === "1" || req.query.hard === "true";
       const wasLive = await disposeSession(req.params.id);
-      if (wasLive && !hard) return reply.code(204).send();
-      if (!wasLive && !hard) {
-        // Cold session, no destructive intent — 404. The user/client
-        // has to opt in via `?hard=1` to delete a cold session's
-        // JSONL. Mirrors the live-with-no-hard "non-destructive"
-        // semantic in the cold case.
-        return notFound(reply);
-      }
-      // Hard delete (live OR cold). After dispose, the registry no
-      // longer has the entry; deleteColdSession's "live" guard
-      // doesn't trip on the ordinary case.
+      // Always hard-delete: dispose (above) + remove JSONL (below).
+      // After dispose, the registry no longer has the entry;
+      // deleteColdSession's "live" guard doesn't trip on the ordinary
+      // case.
       let r: "deleted" | "live" | "not_found";
       try {
         r = await deleteColdSession(req.params.id);

--- a/packages/server/src/sse-bridge.ts
+++ b/packages/server/src/sse-bridge.ts
@@ -31,17 +31,45 @@ import { processManager } from "./processes/manager.js";
 const BACKPRESSURE_LIMIT_BYTES = 8 * 1024 * 1024;
 
 /**
- * Cadence at which we send an SSE comment line (`: heartbeat\n\n`) on
- * every open stream. EventSource ignores comment lines silently, so the
- * browser sees nothing — but the bytes reset any idle-connection timer
- * sitting between us and the client. OpenShift's HAProxy router defaults
+ * Cadence at which we send an SSE keepalive on every open stream.
+ * EventSource ignores comment lines silently, so the browser sees
+ * nothing — but the bytes reset any idle-connection timer sitting
+ * between us and the client. OpenShift's HAProxy router defaults
  * `timeout server` to 30s for HTTP routes, and any L7 proxy / load
- * balancer enforces a similar window; with no agent activity between
- * turns, an idle SSE stream gets killed by the middlebox and the
- * browser shows "reconnecting." 20s gives us comfortable margin under
- * the typical 30s default.
+ * balancer enforces a similar window; with no agent activity
+ * between turns, an idle SSE stream gets killed by the middlebox
+ * and the browser shows "reconnecting." 20s gives us comfortable
+ * margin under the typical 30s default.
  */
 const HEARTBEAT_INTERVAL_MS = 20_000;
+
+/**
+ * Heartbeat payload, padded to 2KB.
+ *
+ * The earlier ~13-byte `: heartbeat\n\n` payload kept the *connection*
+ * alive (any byte resets the idle timer) but didn't help with L7
+ * proxies (most painfully OpenShift's HAProxy router) that buffer
+ * small writes until either a threshold is reached or the connection
+ * closes. During a long-running agent turn with no token output (a
+ * slow LLM call, a long-running tool, a multi-second compaction
+ * prefill), the symptom was: heartbeats sit in HAProxy's response
+ * buffer, the browser sees nothing for 30+ seconds, the connection
+ * times out somewhere on the path, and the user gets a misleading
+ * "Reconnecting — server closed stream" banner.
+ *
+ * Padding the heartbeat to 2KB pushes past the buffer-flush
+ * threshold so every heartbeat actually reaches the client. Same
+ * mechanism as the compaction-start one-shot padding flush, but
+ * applied every 20s instead of per-turn.
+ *
+ * Bandwidth cost: ~100 bytes/sec/client sustained. Negligible.
+ *
+ * Marker text `heartbeat` is kept so an operator inspecting raw SSE
+ * frames in `tcpdump` / `curl -N` can identify what they're looking
+ * at; the underscore padding is just deliberate filler.
+ */
+const HEARTBEAT_PADDING_BYTES = 2048;
+const HEARTBEAT_LINE = `: heartbeat ${"_".repeat(HEARTBEAT_PADDING_BYTES - 14)}\n\n`;
 
 /**
  * One-shot padding flush we send right after the `compaction_start`
@@ -194,6 +222,50 @@ export function initProcessesFanout(): () => void {
           // best-effort fanout
         }
       }
+      return;
+    }
+    if (event.type === "process_alert") {
+      // Inject a user-shaped message into the live session so the
+      // agent gets a turn to react to the process finishing. The
+      // alertOn* flags were set at start() time and already filtered
+      // in the manager — by the time we get here, the alert is
+      // wanted. Best-effort: `sendUserMessage` returns a Promise but
+      // we don't await it (the SSE fanout shouldn't block on a
+      // round-trip; agent processing happens in the background and
+      // the result lands in the session JSONL like any other turn).
+      //
+      // deliverAs: "followUp" — if the agent is mid-turn, queue the
+      // alert until that turn completes. If idle, sendUserMessage
+      // kicks off a fresh turn immediately. Either way the user
+      // sees the alert message in the chat as a normal user bubble
+      // (with the `[process alert]` prefix making it obvious it's
+      // automated).
+      const reasonText =
+        event.reason === "success"
+          ? `finished successfully (exit ${event.info.exitCode ?? "?"})`
+          : event.reason === "failure"
+            ? `failed with exit code ${event.info.exitCode ?? "?"}`
+            : "was killed externally";
+      const message =
+        `[process alert] "${event.info.name}" (id=${event.info.id}) ${reasonText}. ` +
+        `Use \`process output\` to inspect what it produced if you need to react.`;
+      void live.session
+        .sendUserMessage(message, { deliverAs: "followUp" })
+        .catch((err: unknown) => {
+          // Swallow — most likely failure mode is "session was
+          // disposed between fanout and queue-write," which is benign.
+          process.stderr.write(
+            JSON.stringify({
+              level: "warn",
+              time: new Date().toISOString(),
+              msg: "process-alert sendUserMessage failed",
+              sessionId: event.sessionId,
+              processId: event.info.id,
+              reason: event.reason,
+              err: err instanceof Error ? err.message : String(err),
+            }) + "\n",
+          );
+        });
       return;
     }
     // Lifecycle events all carry a full-snapshot update on the
@@ -449,13 +521,17 @@ export function createSSEClient(reply: FastifyReply, live: LiveSession): SSEClie
     raw.on("close", close);
     raw.on("error", close);
 
-    // Idle-timer reset for L7 proxies (OpenShift HAProxy router, nginx,
-    // ALB, etc.). Comment line, no `data:` field — EventSource skips it.
-    // Uses writeRaw so the same backpressure guard applies; if the socket
-    // is wedged the heartbeat will trip the limit and call close(), which
-    // tears the timer down.
+    // Idle-timer reset + buffer-flush for L7 proxies (OpenShift
+    // HAProxy router, nginx, ALB, etc.). Comment line, no `data:`
+    // field — EventSource skips it. HEARTBEAT_LINE is padded to 2KB
+    // to defeat HAProxy's small-write buffering so heartbeats
+    // actually reach the client during long idle gaps; see the
+    // HEARTBEAT_LINE doc-comment for the full rationale. Uses
+    // writeRaw so the same backpressure guard applies; if the
+    // socket is wedged the heartbeat will trip the limit and call
+    // close(), which tears the timer down.
     heartbeatTimer = setInterval(() => {
-      writeRaw(": heartbeat\n\n");
+      writeRaw(HEARTBEAT_LINE);
     }, HEARTBEAT_INTERVAL_MS);
     // Don't keep the Node event loop alive just for heartbeats — when
     // the socket closes the close handler clears the timer anyway.

--- a/tests/test-api.ts
+++ b/tests/test-api.ts
@@ -459,10 +459,10 @@ async function main(): Promise<void> {
       const del = await jsend("DELETE", `${base}/api/v1/sessions/${sessionId}`, undefined, auth);
       assert("DELETE /sessions/:id → 204", del.status === 204);
       const after = await jget(`${base}/api/v1/sessions/${sessionId}`, auth);
-      // The session is no longer live, but the JSONL exists on disk if any
-      // entries were appended. The fire-and-forget prompt() rejected without
-      // ever writing an assistant message → no JSONL → 404 from disk lookup.
-      assert("GET after delete returns 404 (no on-disk entries written)", after.status === 404);
+      // Since v1.3.0, DELETE always hard-deletes (dispose + remove JSONL
+      // + cascade subagent JSONLs). The legacy `?hard=` toggle is gone.
+      // GET after delete is always 404.
+      assert("GET after delete returns 404", after.status === 404);
 
       // Second DELETE on the same id: the live entry is gone and there's
       // no JSONL on disk, so the cold-delete fallback also returns

--- a/tests/test-clone.ts
+++ b/tests/test-clone.ts
@@ -1,0 +1,388 @@
+/**
+ * Integration test for the "Clone repository" project-setup flow.
+ *
+ * Coverage:
+ *   - validateCloneUrl (unit) — accepts https + file, rejects ssh/http/garbage
+ *   - parseProgressLine (unit) — known git progress shapes
+ *   - assertTargetClonable (unit) — fresh dir vs existing-non-empty
+ *   - End-to-end POST /api/v1/projects/clone:
+ *       - Creates a local bare repo with one commit as the clone source
+ *       - Streams: started → progress* → done → project_created
+ *       - Project is registered with the expected path
+ *       - Cloned folder contains the committed file + `.git/`
+ *   - Rejects clone into a non-empty target with 409
+ *
+ * Token-injection is exercised at the URL-build level (we can't
+ * spin up an HTTPS server with auth in a unit test) — the test
+ * confirms a token-bearing URL is constructed without the token
+ * leaking into the cloned `origin` URL.
+ */
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+const serverEntry = resolve(repoRoot, "packages/server/dist/index.js");
+
+// Match the pattern other tests use: dynamic import of the dist/ JS
+// keeps `npm run check` from tripping on missing type info for the
+// compiled module (the import lives behind an `as unknown as`
+// validated interface).
+interface GitCloneModule {
+  validateCloneUrl: (raw: string) => URL;
+  parseProgressLine: (line: string) => { phase: string; percent: number | null } | undefined;
+  assertTargetClonable: (target: string) => Promise<void>;
+  GitCloneError: new (code: string, message: string) => Error & { code: string };
+}
+const { validateCloneUrl, parseProgressLine, assertTargetClonable, GitCloneError } = (await import(
+  resolve(repoRoot, "packages/server/dist/git-clone.js")
+)) as unknown as GitCloneModule;
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function pickFreePort(): Promise<number> {
+  return new Promise((resolveFn, rejectFn) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on("error", rejectFn);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === "string") {
+        rejectFn(new Error("failed to acquire free port"));
+        return;
+      }
+      const { port } = addr;
+      srv.close(() => resolveFn(port));
+    });
+  });
+}
+
+async function waitFor(url: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(url);
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  throw new Error(`timeout waiting for ${url}`);
+}
+
+function runGit(cwd: string, args: string[]): Promise<void> {
+  return new Promise((resolveFn, rejectFn) => {
+    const child = spawn("git", args, {
+      cwd,
+      stdio: "ignore",
+      env: {
+        ...process.env,
+        // Deterministic identity so commits succeed without the
+        // host user's git config.
+        GIT_AUTHOR_NAME: "Test",
+        GIT_AUTHOR_EMAIL: "test@example.com",
+        GIT_COMMITTER_NAME: "Test",
+        GIT_COMMITTER_EMAIL: "test@example.com",
+      },
+    });
+    child.on("error", rejectFn);
+    child.on("close", (code) => {
+      if (code === 0) resolveFn();
+      else rejectFn(new Error(`git ${args.join(" ")} exited ${code}`));
+    });
+  });
+}
+
+/**
+ * Build a bare git repo with one commit containing `README.md`.
+ * Returns the on-disk path; the clone source URL is the
+ * `file://`-formatted version of this path.
+ */
+async function buildBareSourceRepo(workspaceParent: string): Promise<string> {
+  // Two dirs: a "source" worktree where we make the commit, and a
+  // bare repo we push to. The bare one is the actual clone source.
+  const sourceWork = await mkdtemp(join(workspaceParent, "clone-src-"));
+  const bare = await mkdtemp(join(workspaceParent, "clone-bare-"));
+  await runGit(sourceWork, ["init", "--initial-branch", "main"]);
+  await writeFile(join(sourceWork, "README.md"), "# hello\n", "utf8");
+  await runGit(sourceWork, ["add", "README.md"]);
+  await runGit(sourceWork, ["commit", "-m", "init"]);
+  await runGit(bare, ["init", "--bare", "--initial-branch", "main"]);
+  await runGit(sourceWork, ["remote", "add", "origin", bare]);
+  await runGit(sourceWork, ["push", "origin", "main"]);
+  await rm(sourceWork, { recursive: true, force: true });
+  return bare;
+}
+
+interface RunningServer {
+  base: string;
+  workspacePath: string;
+  stop: () => Promise<void>;
+}
+
+async function startServer(): Promise<RunningServer> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-clone-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-clone-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-clone-data-"));
+  const port = await pickFreePort();
+  const child = spawn(process.execPath, [serverEntry], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      LOG_LEVEL: "warn",
+      NODE_ENV: "test",
+      WORKSPACE_PATH: workspacePath,
+      PI_CONFIG_DIR: configDir,
+      FORGE_DATA_DIR: dataDir,
+      SESSION_DIR: join(workspacePath, ".pi", "sessions"),
+      SERVE_CLIENT: "false",
+      UI_PASSWORD: undefined,
+      JWT_SECRET: undefined,
+      API_KEY: undefined,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (b) => process.stderr.write(`[clone-srv] ${String(b)}`));
+  const base = `http://127.0.0.1:${port}`;
+  const stop = async (): Promise<void> => {
+    if (child.exitCode === null && child.signalCode === null) {
+      await new Promise<void>((res) => {
+        child.once("exit", () => res());
+        child.kill("SIGTERM");
+        setTimeout(() => child.kill("SIGKILL"), 1500).unref();
+      });
+    }
+    await rm(workspacePath, { recursive: true, force: true });
+    await rm(configDir, { recursive: true, force: true });
+    await rm(dataDir, { recursive: true, force: true });
+  };
+  try {
+    await waitFor(`${base}/api/v1/health`);
+  } catch (err) {
+    await stop();
+    throw err;
+  }
+  return { base, workspacePath, stop };
+}
+
+interface CloneEvent {
+  type: string;
+  [k: string]: unknown;
+}
+
+/**
+ * POST /projects/clone and collect all SSE events. Resolves when the
+ * stream closes. Throws on HTTP error before the stream starts.
+ */
+async function streamClone(
+  base: string,
+  body: Record<string, unknown>,
+): Promise<{ status: number; events: CloneEvent[] }> {
+  const res = await fetch(`${base}/api/v1/projects/clone`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = { error: text };
+    }
+    return { status: res.status, events: [{ type: "http_error", ...(parsed as object) }] };
+  }
+  if (res.body === null) return { status: res.status, events: [] };
+  const reader = res.body.pipeThrough(new TextDecoderStream()).getReader();
+  const events: CloneEvent[] = [];
+  let buf = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += value.replace(/\r\n/g, "\n");
+    let sep = buf.indexOf("\n\n");
+    while (sep !== -1) {
+      const message = buf.slice(0, sep);
+      buf = buf.slice(sep + 2);
+      for (const line of message.split("\n")) {
+        if (!line.startsWith("data:")) continue;
+        const payload = line.slice(5).trimStart();
+        try {
+          events.push(JSON.parse(payload) as CloneEvent);
+        } catch {
+          /* skip malformed frames */
+        }
+      }
+      sep = buf.indexOf("\n\n");
+    }
+  }
+  return { status: res.status, events };
+}
+
+async function main(): Promise<void> {
+  console.log("[test-clone] validateCloneUrl");
+  assert(
+    "rejects garbage",
+    thrown(() => validateCloneUrl("not a url"), "invalid_url"),
+  );
+  assert(
+    "rejects http://",
+    thrown(() => validateCloneUrl("http://github.com/foo/bar.git"), "unsupported_protocol"),
+  );
+  assert(
+    "rejects ssh://",
+    thrown(() => validateCloneUrl("ssh://git@github.com/foo/bar.git"), "unsupported_protocol"),
+  );
+  assert(
+    "accepts https://",
+    didNotThrow(() => validateCloneUrl("https://github.com/foo/bar.git")),
+  );
+  assert(
+    "accepts file://",
+    didNotThrow(() => validateCloneUrl("file:///tmp/some/repo")),
+  );
+
+  console.log("\n[test-clone] parseProgressLine");
+  const p1 = parseProgressLine("Receiving objects:  45% (450/1000), 1.23 MiB | 200 KiB/s");
+  assert("'Receiving objects' phase parsed", p1?.phase === "Receiving objects");
+  assert("'Receiving objects' percent === 45", p1?.percent === 45);
+  const p2 = parseProgressLine("Resolving deltas: 100% (123/123), done.");
+  assert("'Resolving deltas' percent === 100", p2?.percent === 100);
+  const p3 = parseProgressLine("Counting objects: 1234, done.");
+  assert("phase-only line parses with percent=null", p3?.phase === "Counting objects");
+  assert("phase-only line null percent", p3?.percent === null);
+  assert(
+    "completely unknown line returns undefined",
+    parseProgressLine("some random text not in phase format") === undefined,
+  );
+
+  console.log("\n[test-clone] assertTargetClonable");
+  const probeRoot = await mkdtemp(join(tmpdir(), "pi-forge-clone-probe-"));
+  try {
+    // Non-existent path is fine.
+    await assertTargetClonable(join(probeRoot, "fresh"));
+    assert("nonexistent target → OK", true);
+    // Empty existing dir is also fine.
+    await mkdir(join(probeRoot, "empty"));
+    await assertTargetClonable(join(probeRoot, "empty"));
+    assert("empty existing target → OK", true);
+    // Non-empty existing dir is rejected.
+    await mkdir(join(probeRoot, "occupied"));
+    await writeFile(join(probeRoot, "occupied", "x"), "x", "utf8");
+    let occupiedErr: unknown;
+    try {
+      await assertTargetClonable(join(probeRoot, "occupied"));
+    } catch (e) {
+      occupiedErr = e;
+    }
+    assert(
+      "non-empty existing target → rejects with target_not_empty",
+      occupiedErr instanceof GitCloneError && occupiedErr.code === "target_not_empty",
+    );
+  } finally {
+    await rm(probeRoot, { recursive: true, force: true });
+  }
+
+  console.log("\n[test-clone] end-to-end via POST /projects/clone");
+  const srv = await startServer();
+  try {
+    // Build the bare source repo OUTSIDE the workspace (clone source
+    // is separate from the workspace where the clone lands).
+    const sourceParent = await mkdtemp(join(tmpdir(), "pi-forge-clone-source-"));
+    const bare = await buildBareSourceRepo(sourceParent);
+    const sourceUrl = pathToFileURL(bare).toString();
+
+    try {
+      const { status, events } = await streamClone(srv.base, {
+        url: sourceUrl,
+        parentPath: srv.workspacePath,
+        folderName: "cloned-repo",
+        projectName: "Cloned Repo",
+      });
+      assert("POST /projects/clone HTTP status 200", status === 200);
+      const types = events.map((e) => e.type);
+      assert(
+        "first event is `started`",
+        types[0] === "started",
+        `types=${types.slice(0, 3).join(",")}`,
+      );
+      assert("at least one `progress` event", types.includes("progress"));
+      assert(
+        "ends with `done` then `project_created`",
+        types.includes("done") && types.includes("project_created"),
+      );
+      const projectCreated = events.find((e) => e.type === "project_created");
+      const project = projectCreated?.project as
+        | { id: string; path: string; name: string }
+        | undefined;
+      assert("project_created carries a project", project !== undefined);
+      // project-manager realpaths the path on creation (so symlinks
+      // can't bypass workspace boundary checks). On macOS that
+      // resolves /var/folders/... → /private/var/folders/..., so we
+      // compare endings rather than the full path.
+      assert(
+        "project.path ends with the clone target folder",
+        project?.path !== undefined && project.path.endsWith("/cloned-repo"),
+        `got ${project?.path}`,
+      );
+      // Verify clone contents on disk.
+      const readme = await stat(join(srv.workspacePath, "cloned-repo", "README.md"));
+      assert("cloned target contains README.md", readme.isFile());
+      const dotGit = await stat(join(srv.workspacePath, "cloned-repo", ".git"));
+      assert("cloned target contains .git directory", dotGit.isDirectory());
+
+      // Second clone into the same folder fails fast with 409.
+      const second = await streamClone(srv.base, {
+        url: sourceUrl,
+        parentPath: srv.workspacePath,
+        folderName: "cloned-repo",
+        projectName: "Cloned Repo 2",
+      });
+      assert("re-clone into non-empty folder → 409", second.status === 409);
+    } finally {
+      await rm(sourceParent, { recursive: true, force: true });
+    }
+  } finally {
+    await srv.stop();
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-clone] FAIL — ${failures} assertion(s)`);
+    process.exit(1);
+  }
+  console.log("\n[test-clone] PASS");
+}
+
+function thrown(fn: () => unknown, expectedCode: string): boolean {
+  try {
+    fn();
+    return false;
+  } catch (err) {
+    return err instanceof GitCloneError && err.code === expectedCode;
+  }
+}
+
+function didNotThrow(fn: () => unknown): boolean {
+  try {
+    fn();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+await main();

--- a/tests/test-processes.ts
+++ b/tests/test-processes.ts
@@ -458,6 +458,74 @@ async function main(): Promise<void> {
       );
     }
 
+    // -------- agent alerts on process completion --------
+    // alertOnSuccess, alertOnFailure, alertOnKill fire `process_alert`
+    // events on the manager; the SSE bridge translates those into
+    // session.sendUserMessage so the agent gets a turn to react.
+    // Here we just subscribe to the manager directly and assert the
+    // events come out in the expected shape — the
+    // sendUserMessage hand-off is exercised end-to-end by manual
+    // smoke + the live-prompt branch in CI when enabled.
+    {
+      const alerts: {
+        reason: string;
+        id: string;
+        exitCode: number | null;
+      }[] = [];
+      const unsub = managerMod.processManager.subscribe((e) => {
+        if (e.type === "process_alert") {
+          const ev = e as unknown as {
+            reason: string;
+            info: { id: string; exitCode: number | null };
+          };
+          alerts.push({ reason: ev.reason, id: ev.info.id, exitCode: ev.info.exitCode });
+        }
+      });
+      try {
+        // success path
+        const ok = await call({
+          action: "start",
+          name: "alert-ok",
+          command: "true",
+          alertOnSuccess: true,
+        });
+        const okId = (ok.details.process as { id: string }).id;
+        // failure path
+        const fail = await call({
+          action: "start",
+          name: "alert-fail",
+          command: "false",
+          // alertOnFailure defaults true; we just leave it.
+        });
+        const failId = (fail.details.process as { id: string }).id;
+        await sleep(600);
+        const okAlert = alerts.find((a) => a.id === okId);
+        const failAlert = alerts.find((a) => a.id === failId);
+        assert("alertOnSuccess fired for clean exit", okAlert?.reason === "success");
+        assert("  carries exitCode=0", okAlert?.exitCode === 0);
+        assert("alertOnFailure fired for non-zero exit", failAlert?.reason === "failure");
+        assert(
+          "  carries non-zero exitCode",
+          failAlert !== undefined && failAlert.exitCode !== null && failAlert.exitCode !== 0,
+        );
+        // killing via the tool should NOT alert (the agent did it on
+        // purpose; would be redundant noise)
+        const k = await call({
+          action: "start",
+          name: "alert-killed-by-tool",
+          command: "exec sleep 30",
+          alertOnKill: true,
+        });
+        const kId = (k.details.process as { id: string }).id;
+        await call({ action: "kill", id: kId });
+        await sleep(400);
+        const killAlert = alerts.find((a) => a.id === kId);
+        assert("tool-initiated kill does NOT alert", killAlert === undefined);
+      } finally {
+        unsub();
+      }
+    }
+
     // -------- clear finished --------
     {
       const before = ((await call({ action: "list" })).details.processes as unknown[]).length;

--- a/tests/test-projects.ts
+++ b/tests/test-projects.ts
@@ -304,55 +304,33 @@ async function main(): Promise<void> {
       );
     }
 
-    // 9. DELETE removes the record but leaves the project folder intact
-    //    (cascade defaults to false; that path is exercised below).
+    // 9. DELETE removes the project record AND the session dir (since
+    //    v1.3.0 the cascade is unconditional). The workspace folder
+    //    on disk is left intact — that's user-owned work.
+    //    Plant a fake JSONL under the session dir first so we can
+    //    assert it's actually removed.
     {
+      const sessionDir = join(workspacePath, ".pi", "sessions", created.id);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(sessionDir, "abc.jsonl"), `{"type":"session"}\n`);
       const { status, body } = await jsend("DELETE", `${base}/api/v1/projects/${created.id}`);
       assert("DELETE /projects/:id → 200", status === 200);
       assert(
-        "  default delete returns { cascaded: false }",
-        (body as { cascaded?: boolean }).cascaded === false,
+        "  delete returns { cascaded: true }",
+        (body as { cascaded?: boolean }).cascaded === true,
       );
       const list = (await jget(`${base}/api/v1/projects`)).body as { projects: Project[] };
       assert("  list is empty after delete", list.projects.length === 0);
-      const folderStat = await stat(repoFolder).catch(() => undefined);
-      assert(
-        "  on-disk folder still exists after delete",
-        folderStat !== undefined && folderStat.isDirectory(),
-      );
-    }
-
-    // 9b. DELETE with ?cascade=1 also removes the project's session dir.
-    //     Re-create the project, plant a fake JSONL under the session
-    //     dir, then delete with cascade and verify both are gone.
-    {
-      const { body: cb } = await jsend("POST", `${base}/api/v1/projects`, {
-        name: "to-cascade",
-        path: repoFolder,
-      });
-      const cascadeId = (cb as Project).id;
-      const sessionDir = join(workspacePath, ".pi", "sessions", cascadeId);
-      await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(sessionDir, "abc.jsonl"), `{"type":"session"}\n`);
-      const { status, body } = await jsend(
-        "DELETE",
-        `${base}/api/v1/projects/${cascadeId}?cascade=1`,
-      );
-      assert("DELETE /projects/:id?cascade=1 → 200", status === 200);
-      assert(
-        "  cascade delete returns { cascaded: true }",
-        (body as { cascaded?: boolean }).cascaded === true,
-      );
       const dirStat = await stat(sessionDir).catch(() => undefined);
-      assert("  session dir removed by cascade", dirStat === undefined);
+      assert("  session dir removed", dirStat === undefined);
       const folderStat = await stat(repoFolder).catch(() => undefined);
       assert(
-        "  project folder still on disk after cascade",
+        "  on-disk project folder still exists after delete",
         folderStat !== undefined && folderStat.isDirectory(),
       );
     }
 
-    // 9c. DELETE ?cascade=1 on a project that never had any sessions.
+    // 9b. DELETE on a project that never had any sessions.
     //     The most common real-world case — `rm({ force: true })` on a
     //     missing dir should still report `cascaded: true`.
     {
@@ -363,11 +341,8 @@ async function main(): Promise<void> {
         path: emptyFolder,
       });
       const emptyId = (cb as Project).id;
-      const { status, body } = await jsend(
-        "DELETE",
-        `${base}/api/v1/projects/${emptyId}?cascade=1`,
-      );
-      assert("cascade on project with no sessions → 200", status === 200);
+      const { status, body } = await jsend("DELETE", `${base}/api/v1/projects/${emptyId}`);
+      assert("delete on project with no sessions → 200", status === 200);
       assert(
         "  cascaded: true even when no session dir existed",
         (body as { cascaded?: boolean }).cascaded === true,


### PR DESCRIPTION
## Summary

Three independent items for v1.3.0 bundled on one branch — each scoped tight enough to review in isolation.

### 1. Clone a git repository as a new project

New **Clone repository** tab in the project picker. Streams `git clone --progress` over SSE so the user sees a live progress bar + phase label ("Receiving objects 45%", "Resolving deltas 100%", etc.) instead of a blocked spinner during a multi-minute clone.

| Field | Notes |
|---|---|
| **Repository URL** | HTTPS or `file://`. SSH is out of scope for v1.3.0 — use `gh repo clone` from the integrated terminal (which now ships with `gh`, see item 2). |
| **Branch** | Optional. Defaults to the remote's HEAD. Maps to `git clone --branch`. |
| **Folder name** | Auto-derived from the URL's last path segment (strips trailing `.git`). Editable; lives relative to `WORKSPACE_PATH`. |
| **Project name** | Auto-derived from the folder name. Editable. |
| **Access token** | Optional, masked input. Embedded as `x-access-token:<token>` in the clone URL (GitHub convention — works for GitHub.com, GitHub Enterprise, GitLab PATs, Bitbucket app passwords, Gitea PATs). Stripped from `.git/config` after success. |

**Auth & cleanup posture.** Token is held only in process memory and never logged. On a successful clone, `origin` is rewritten to the token-free URL so it doesn't persist in `.git/config`. On any failure, the half-cloned target dir is `rm -rf`'d to make sure no leftover token bytes survive in a partial `.git/config`.

**Defense-in-depth.** Target path is validated to be inside `WORKSPACE_PATH` (403 otherwise). Pre-existing non-empty target returns 409 before any `git` spawn. Clone is cancellable via the request `AbortSignal` (client disconnect kills the child with SIGTERM → 5s grace → SIGKILL). Same 20s heartbeat + 2KB pad-flush pattern as the compaction SSE so the stream works behind OpenShift's HAProxy router.

**New files / changes:**
- `packages/server/src/git-clone.ts` — clone runner with async-iterable progress events
- `POST /api/v1/projects/clone` — SSE-streaming route in `routes/projects.ts`
- `api.cloneProject()` + `parseCloneEventStream()` in `lib/api-client/index.ts`
- `CloneForm` + `ModeTab` components in `ProjectPicker.tsx`
- `tests/test-clone.ts` — 19 assertions

### 2. `gh` (GitHub CLI) in the Docker image

Installed from the official GitHub apt repository so `gh auth login`, `gh pr`, `gh issue`, `gh repo clone`, etc. work out of the box in the integrated terminal and via the agent's `bash` tool. Available on `PATH` for the running server and any process it spawns.

Pairs naturally with item 1: clone-via-token in the UI for HTTPS, `gh repo clone` in the terminal for SSH-based clones.

### 3. Session `DELETE` always hard-deletes the JSONL

Previously the route accepted a `?hard=1` query param and the client API took a `{hard: true}` opt — but the UI passed it unconditionally, so the non-destructive path was vestigial and confusing for programmatic clients. Now: `DELETE /api/v1/sessions/:id` always disposes the live session AND removes the JSONL AND cascade-removes any pi-subagents child JSONLs nested under it. Client API simplified to drop the `hard` parameter.

Removing the JSONL was already what every UI delete did; this just makes the default match the user's mental model of "delete means gone."

Cascade-delete of pi-subagents children was already implemented in `deleteColdSession`; this change just makes sure every UI/API delete actually exercises it.

## Test plan

- [x] `npm run check` clean (typecheck + eslint + prettier)
- [x] `npm run build` clean
- [x] `scripts/run-tests.sh --skip docker,pty-reattach,terminal` — 35/35 PASS, including the new `tests/test-clone.ts`
- [ ] CI `test-docker` green (verifies item 2's apt install works on a clean image build)
- [ ] Manual smoke: clone a public HTTPS repo via the picker; verify the progress bar moves, the project lands in the sidebar, and the cloned folder has the expected contents
- [ ] Manual smoke: clone a private repo with a PAT; verify `git -C <target> remote get-url origin` returns the token-free URL after success
- [ ] Manual smoke: delete a session that has live pi-subagents children; verify both the parent `.jsonl` and the sibling subagent directory are removed from `${WORKSPACE_PATH}/.pi/sessions/<projectId>/`
- [ ] Manual smoke (production / OpenShift): exec into the container and confirm `gh --version` works