### PR TITLE
feat(pwa): mobile popovers, scrollable settings tabs, dark log-link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,29 @@ section. See the "Versions" section of the README for the support window policy.
 
 ### Fixed
 
+- **"Full stdout/stderr log" buttons on a process navigated the
+  current tab as a side-effect of opening the new one.** The
+  `window.open(blobUrl, "_blank", ...)` call ran AFTER `await
+  fetch(...)`, so by the time it fired the user-gesture chain was
+  broken and the popup blocker kicked in. The fallback path then
+  `window.location.assign(blobUrl)`'d, navigating the current tab.
+  When the user clicked "allow" on the popup-blocker prompt the
+  new tab opened too — hence "opens in a new tab AND changes the
+  current tab." Fix: open the new tab synchronously to about:blank
+  inside the click handler (counts as user-initiated, popup
+  blocker stays quiet), then navigate it once the fetch resolves.
+  If the synchronous open is still blocked (strictest popup
+  configs), surface a clear "popup blocked" error instead of
+  stealing the current tab. Additionally, the log content is now
+  wrapped in a minimal HTML document with explicit dark CSS and a
+  meaningful `<title>` — the prior single-step open landed on
+  whatever the browser's default plain-text rendering happened to
+  be (Chrome auto-dark, Safari/Firefox white), and the new
+  about:blank-then-navigate sequence broke that heuristic and
+  consistently showed white. The HTML wrapper makes the rendering
+  deterministic (dark by default, respects
+  `prefers-color-scheme: light`), gives the tab a useful label,
+  and softens line wrapping.
 - **Settings modal tab strip overflowed on narrow viewports.**
   With 10+ tabs the strip ran off the right edge of the modal —
   visible on mobile PWA, small desktop windows, and the iPad

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ section. See the "Versions" section of the README for the support window policy.
 
 ### Added
 
+- **Mobile-only quick-list popovers for processes and todos on
+  the chat-input footer badges.** The chat-input badges for
+  running processes and todos route to right-pane panels on
+  desktop (the existing behavior, unchanged). On mobile (narrow
+  viewport detected via `useIsMobile`) the right pane stays
+  collapsed and the same right-pane auto-expand logic in
+  App.tsx is `!isMobile`-gated, so routing to it from the badge
+  used to be a dead-end interaction. The mobile path now opens a
+  small floating popover anchored above the badge, showing the
+  list inline — the popover IS the panel for the mobile case.
+  Outside-click and Escape close it. The processes popover
+  surfaces live runtime (updates per second while open), pid,
+  status badge, and an inline Kill button; the todos popover
+  renders the checklist with status glyphs and strikethrough for
+  completed items, skipping soft-deleted tombstones. Width clamps
+  to the viewport via `max-w-[calc(100vw-1rem)]`.
+
+### Fixed
+
+- **Settings modal tab strip overflowed on narrow viewports.**
+  With 10+ tabs the strip ran off the right edge of the modal —
+  visible on mobile PWA, small desktop windows, and the iPad
+  split-view layout. The tabs are now wrapped in a horizontally
+  scrollable container with `overflow-x-auto`, `min-w-0` so the
+  flex item can actually shrink, and `shrink-0` /
+  `whitespace-nowrap` on each tab so labels stay intact under
+  scroll. The trailing controls (API Docs / Close) stay fixed to
+  the right.
+
 - **Background processes notify the agent on completion.** The
   `process` tool's `alertOnSuccess` / `alertOnFailure` /
   `alertOnKill` flags were previously stored on `ProcessInfo` but

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -24,6 +24,7 @@ import { useUiStore } from "../store/ui-store";
 import { useComposerStore } from "../store/composer-store";
 import { deriveCounts, selectTodoState, useTodoStore } from "../store/todo-store";
 import { countRunning, selectProcesses, useProcessesStore } from "../store/processes-store";
+import { ProcessesPopover, TodosPopover } from "./InputPopovers";
 
 /**
  * Pull the user's prior prompts out of the session message history,
@@ -256,6 +257,10 @@ export function ChatInput({ sessionId }: Props) {
   // renders the panel as a bottom strip of whatever tab is showing.
   const todoState = useTodoStore((s) => selectTodoState(s, sessionId));
   const todoCounts = deriveCounts(todoState);
+  // todoPanelOpen drives the active-button highlight on desktop
+  // (where the badge toggles the bottom-strip right-pane panel).
+  // On mobile the popover replaces that interaction — the badge
+  // opens the popover instead.
   const todoPanelOpen = useUiStore((s) => s.todoPanelOpen);
   const setTodoPanelOpen = useUiStore((s) => s.setTodoPanelOpen);
 
@@ -268,6 +273,17 @@ export function ChatInput({ sessionId }: Props) {
   const sessionProcesses = useProcessesStore((s) => selectProcesses(s, sessionId));
   const runningProcesses = countRunning(sessionProcesses);
   const openProcessesTab = useUiStore((s) => s.openProcessesTab);
+
+  // Popovers anchored to the chat-input footer badges. Each is a
+  // small floating panel that shows the list directly, instead of
+  // navigating away to the right-pane tab (which is often
+  // collapsed on narrow viewports — mobile PWA in particular).
+  // The popover's footer link is the way to reach the full panel
+  // for deeper drill-down.
+  const [processesPopoverOpen, setProcessesPopoverOpen] = useState(false);
+  const [todosPopoverOpen, setTodosPopoverOpen] = useState(false);
+  const processesButtonRef = useRef<HTMLButtonElement>(null);
+  const todosButtonRef = useRef<HTMLButtonElement>(null);
 
   // ----- @-completion (file references in the chat input) -----
   // The popover is "open" when `acToken` is set; that happens whenever
@@ -1545,50 +1561,102 @@ export function ChatInput({ sessionId }: Props) {
                   <RotateCcw size={12} />
                 </button>
               )}
-              {/* Processes shortcut — only renders when the
-                  session has ≥1 running process. Clicking
-                  switches the right-pane tab to "processes" and
-                  auto-opens the right pane if collapsed (via
-                  ui-store → App.tsx effect). */}
+              {/* Processes shortcut. Desktop: clicking opens the
+                  right-pane Processes tab (auto-expands the pane
+                  if collapsed via App.tsx). Mobile: clicking
+                  opens a small floating popover anchored to the
+                  button — the right pane is usually collapsed
+                  there and routing to it would mean a full
+                  navigation away from the chat input. The
+                  popover's "Open full panel →" footer link
+                  preserves access to the deeper view. */}
               {runningProcesses > 0 && (
-                <button
-                  type="button"
-                  onClick={() => openProcessesTab()}
-                  className="flex items-center gap-1 rounded px-1.5 py-1 text-[11px] text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200 light:text-neutral-600 light:hover:bg-neutral-200 light:hover:text-neutral-900"
-                  title={`${runningProcesses} background process(es) running — view processes panel`}
-                  aria-label="View processes panel"
-                >
-                  <Activity size={12} className="text-emerald-400 light:text-emerald-700" />
-                  <span>{runningProcesses}</span>
-                </button>
+                <div className="relative">
+                  <button
+                    ref={processesButtonRef}
+                    type="button"
+                    onClick={() => {
+                      if (isMobile) setProcessesPopoverOpen((v) => !v);
+                      else openProcessesTab();
+                    }}
+                    className={`flex items-center gap-1 rounded px-1.5 py-1 text-[11px] ${
+                      isMobile && processesPopoverOpen
+                        ? "bg-neutral-800 text-neutral-100 light:bg-neutral-200 light:text-neutral-900"
+                        : "text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200 light:text-neutral-600 light:hover:bg-neutral-200 light:hover:text-neutral-900"
+                    }`}
+                    title={
+                      isMobile
+                        ? `${runningProcesses} background process(es) running — show list`
+                        : `${runningProcesses} background process(es) running — view processes panel`
+                    }
+                    aria-label={isMobile ? "Show processes list" : "View processes panel"}
+                    aria-expanded={isMobile ? processesPopoverOpen : undefined}
+                  >
+                    <Activity size={12} className="text-emerald-400 light:text-emerald-700" />
+                    <span>{runningProcesses}</span>
+                  </button>
+                  {isMobile && (
+                    <ProcessesPopover
+                      open={processesPopoverOpen}
+                      onClose={() => setProcessesPopoverOpen(false)}
+                      anchorRef={processesButtonRef}
+                      sessionId={sessionId}
+                    />
+                  )}
+                </div>
               )}
-              {/* Todo toggle — only renders when the session has
-                  todos. Clicking opens the bottom-strip panel in
-                  the right pane (App auto-opens the pane if
-                  collapsed). */}
+              {/* Todo toggle. Desktop: clicking toggles the
+                  bottom-strip todo panel in the right pane.
+                  Mobile: clicking opens the popover with the
+                  task list. Same rationale as processes — see
+                  the comment above. */}
               {todoCounts.total > 0 && (
-                <button
-                  type="button"
-                  onClick={() => setTodoPanelOpen(!todoPanelOpen)}
-                  className={`flex items-center gap-1 rounded px-1.5 py-1 text-[11px] ${
-                    todoPanelOpen
-                      ? "bg-amber-900/40 text-amber-200 light:bg-amber-100 light:text-amber-900"
-                      : "text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200 light:text-neutral-600 light:hover:bg-neutral-200 light:hover:text-neutral-900"
-                  }`}
-                  title={
-                    todoPanelOpen
-                      ? "Hide todo panel"
-                      : `Show todo panel (${todoCounts.completed}/${todoCounts.total} done${
-                          todoCounts.inProgress > 0 ? `, ${todoCounts.inProgress} in progress` : ""
-                        })`
-                  }
-                  aria-pressed={todoPanelOpen}
-                >
-                  <ListChecks size={12} />
-                  <span>
-                    {todoCounts.completed}/{todoCounts.total}
-                  </span>
-                </button>
+                <div className="relative">
+                  <button
+                    ref={todosButtonRef}
+                    type="button"
+                    onClick={() => {
+                      if (isMobile) setTodosPopoverOpen((v) => !v);
+                      else setTodoPanelOpen(!todoPanelOpen);
+                    }}
+                    className={`flex items-center gap-1 rounded px-1.5 py-1 text-[11px] ${
+                      (isMobile ? todosPopoverOpen : todoPanelOpen)
+                        ? "bg-amber-900/40 text-amber-200 light:bg-amber-100 light:text-amber-900"
+                        : "text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200 light:text-neutral-600 light:hover:bg-neutral-200 light:hover:text-neutral-900"
+                    }`}
+                    title={
+                      isMobile
+                        ? `Tasks: ${todoCounts.completed}/${todoCounts.total} done${
+                            todoCounts.inProgress > 0
+                              ? `, ${todoCounts.inProgress} in progress`
+                              : ""
+                          }`
+                        : todoPanelOpen
+                          ? "Hide todo panel"
+                          : `Show todo panel (${todoCounts.completed}/${todoCounts.total} done${
+                              todoCounts.inProgress > 0
+                                ? `, ${todoCounts.inProgress} in progress`
+                                : ""
+                            })`
+                    }
+                    aria-label={isMobile ? "Show tasks list" : "Toggle todo panel"}
+                    aria-expanded={isMobile ? todosPopoverOpen : undefined}
+                    aria-pressed={isMobile ? undefined : todoPanelOpen}
+                  >
+                    <ListChecks size={12} />
+                    <span>
+                      {todoCounts.completed}/{todoCounts.total}
+                    </span>
+                  </button>
+                  {isMobile && (
+                    <TodosPopover
+                      open={todosPopoverOpen}
+                      onClose={() => setTodosPopoverOpen(false)}
+                      anchorRef={todosButtonRef}
+                      sessionId={sessionId}
+                    />
+                  )}
+                </div>
               )}
             </div>
           )}

--- a/packages/client/src/components/InputPopovers.tsx
+++ b/packages/client/src/components/InputPopovers.tsx
@@ -1,0 +1,334 @@
+/**
+ * Floating popovers anchored to the chat-input footer badges for
+ * processes and todos. **Mobile-only.** On desktop the badges keep
+ * their original behavior (route to right-pane Processes tab / open
+ * the bottom-strip todo panel); the right pane only auto-expands
+ * `!isMobile` (see App.tsx), and there's no useful "open full
+ * panel" interaction on mobile — these popovers ARE the panel for
+ * the mobile case.
+ *
+ * Shared mechanics:
+ *   - Click-outside / Escape closes.
+ *   - Anchored above the trigger button, right-aligned.
+ *   - Capped height with overflow scroll for long lists.
+ *   - Width clamps to the viewport so the popover doesn't overflow.
+ */
+import { useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+import { api, ApiError } from "../lib/api-client";
+import {
+  LIVE_STATUSES,
+  selectProcesses,
+  useProcessesStore,
+  type ProcessInfo,
+} from "../store/processes-store";
+import { selectTodoState, useTodoStore, type Task } from "../store/todo-store";
+
+/**
+ * Common shell: outside-click + Escape close, positioned above the
+ * trigger. The trigger's bounding rect is captured by the caller
+ * via `anchorRef` (see ChatInput.tsx). We use absolute positioning
+ * within a wrapping container (the chat-input footer is positioned
+ * relative for this purpose).
+ */
+function PopoverShell({
+  open,
+  onClose,
+  anchorRef,
+  title,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  anchorRef: React.RefObject<HTMLElement | null>;
+  title: string;
+  children: React.ReactNode;
+}) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent): void => {
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      // Clicks on the trigger button itself are the caller's
+      // toggle — don't double-close.
+      if (anchorRef.current?.contains(target) === true) return;
+      if (popoverRef.current?.contains(target) === true) return;
+      onClose();
+    };
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open, onClose, anchorRef]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={popoverRef}
+      role="dialog"
+      aria-label={title}
+      // `bottom-full` parks the popover ABOVE the button (the chat-
+      // input badges live at the bottom of the input footer, so the
+      // popover would otherwise need to extend below the input
+      // bezel). `right-0` right-aligns to the button — works for
+      // both processes and todos since they're both on the right
+      // edge of the footer.
+      className="absolute bottom-full right-0 z-30 mb-1 w-72 max-w-[calc(100vw-1rem)] overflow-hidden rounded-md border border-neutral-700 bg-neutral-900 shadow-xl light:border-neutral-300 light:bg-white"
+    >
+      <header className="flex items-center justify-between gap-2 border-b border-neutral-800 px-3 py-2 text-[11px] uppercase tracking-wider text-neutral-400 light:border-neutral-200 light:text-neutral-500">
+        <span>{title}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded p-0.5 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200 light:hover:bg-neutral-100 light:hover:text-neutral-700"
+          aria-label="Close"
+        >
+          <X size={12} />
+        </button>
+      </header>
+      <div className="max-h-72 overflow-y-auto">{children}</div>
+    </div>
+  );
+}
+
+function formatRuntime(startTime: number, endTime: number | null): string {
+  const end = endTime ?? Date.now();
+  const secs = Math.max(0, Math.floor((end - startTime) / 1000));
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ${secs % 60}s`;
+  return `${Math.floor(secs / 3600)}h ${Math.floor((secs % 3600) / 60)}m`;
+}
+
+function StatusBadge({ status }: { status: ProcessInfo["status"] }) {
+  // Colors mirror ProcessesPanel for visual consistency between the
+  // popover and the full-panel view.
+  const cls =
+    status === "running"
+      ? "bg-emerald-900/40 text-emerald-200 light:bg-emerald-100 light:text-emerald-800"
+      : status === "terminating" || status === "terminate_timeout"
+        ? "bg-amber-900/40 text-amber-200 light:bg-amber-100 light:text-amber-800"
+        : status === "killed"
+          ? "bg-red-900/40 text-red-200 light:bg-red-100 light:text-red-800"
+          : "bg-neutral-800 text-neutral-300 light:bg-neutral-200 light:text-neutral-700";
+  return (
+    <span className={`rounded px-1 py-0.5 text-[9px] uppercase tracking-wider ${cls}`}>
+      {status}
+    </span>
+  );
+}
+
+export function ProcessesPopover({
+  open,
+  onClose,
+  anchorRef,
+  sessionId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  anchorRef: React.RefObject<HTMLElement | null>;
+  sessionId: string | undefined;
+}) {
+  const processes = useProcessesStore((s) => selectProcesses(s, sessionId));
+  // Show live processes at top, finished after a divider. Most of
+  // the time only running matters; we keep finished accessible so a
+  // user who tapped after a process exited can still see "yes, it
+  // ended" without leaving the input.
+  const live = processes.filter((p) => LIVE_STATUSES.has(p.status));
+  const finished = processes.filter((p) => !LIVE_STATUSES.has(p.status));
+
+  // Live runtime updates: re-render once per second while the
+  // popover is open and there's at least one live process. Cheap
+  // (just bumps a counter) and only runs while visible.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!open || live.length === 0) return;
+    const id = window.setInterval(() => setTick((t) => t + 1), 1000);
+    return () => window.clearInterval(id);
+  }, [open, live.length]);
+
+  const [killingId, setKillingId] = useState<string | undefined>();
+  const onKill = async (id: string): Promise<void> => {
+    if (sessionId === undefined) return;
+    setKillingId(id);
+    try {
+      await api.killProcess(sessionId, id);
+    } catch {
+      // Errors surface in the chat-input error banner via the
+      // calling component if needed; for the popover, the SSE
+      // update will reflect actual status soon either way. Keep
+      // the popover quiet.
+    } finally {
+      setKillingId(undefined);
+    }
+  };
+
+  return (
+    <PopoverShell
+      open={open}
+      onClose={onClose}
+      anchorRef={anchorRef}
+      title={`Processes (${live.length} running)`}
+    >
+      {processes.length === 0 ? (
+        <p className="px-3 py-3 text-xs italic text-neutral-500">No processes.</p>
+      ) : (
+        <ul className="divide-y divide-neutral-800 light:divide-neutral-200">
+          {live.map((p) => (
+            <ProcessRow
+              key={p.id}
+              process={p}
+              busy={killingId === p.id}
+              onKill={() => void onKill(p.id)}
+            />
+          ))}
+          {finished.length > 0 && live.length > 0 && (
+            <li className="bg-neutral-950 px-3 py-1 text-[10px] uppercase tracking-wider text-neutral-500 light:bg-neutral-100">
+              Finished
+            </li>
+          )}
+          {finished.map((p) => (
+            <ProcessRow key={p.id} process={p} busy={false} />
+          ))}
+        </ul>
+      )}
+    </PopoverShell>
+  );
+}
+
+function ProcessRow({
+  process,
+  busy,
+  onKill,
+}: {
+  process: ProcessInfo;
+  busy: boolean;
+  onKill?: () => void;
+}) {
+  const isLive = LIVE_STATUSES.has(process.status);
+  return (
+    <li className="flex items-start justify-between gap-2 px-3 py-2 text-xs">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate font-medium text-neutral-200 light:text-neutral-800">
+            {process.name}
+          </span>
+          <StatusBadge status={process.status} />
+        </div>
+        <div className="mt-0.5 flex items-center gap-2 text-[10px] text-neutral-500">
+          <span>pid {process.pid}</span>
+          <span>·</span>
+          <span>{formatRuntime(process.startTime, process.endTime)}</span>
+          {process.exitCode !== null && (
+            <>
+              <span>·</span>
+              <span>exit {process.exitCode}</span>
+            </>
+          )}
+        </div>
+      </div>
+      {isLive && onKill !== undefined && (
+        <button
+          type="button"
+          onClick={onKill}
+          disabled={busy}
+          className="shrink-0 rounded border border-red-800 px-1.5 py-0.5 text-[10px] text-red-300 hover:bg-red-900/40 disabled:opacity-50 light:border-red-300 light:text-red-700 light:hover:bg-red-50"
+          title="Kill this process"
+        >
+          {busy ? "…" : "Kill"}
+        </button>
+      )}
+    </li>
+  );
+}
+
+function TaskStatusGlyph({ status }: { status: Task["status"] }) {
+  // Plain Unicode glyphs — no icon dependency, render at any DPI,
+  // copy/paste meaningful. ProgressIcon-style: ●○◐✓.
+  const ch =
+    status === "completed"
+      ? "✓"
+      : status === "in_progress"
+        ? "◐"
+        : status === "deleted"
+          ? "×"
+          : "○";
+  const cls =
+    status === "completed"
+      ? "text-emerald-400 light:text-emerald-700"
+      : status === "in_progress"
+        ? "text-amber-400 light:text-amber-700"
+        : status === "deleted"
+          ? "text-neutral-600 light:text-neutral-400"
+          : "text-neutral-500";
+  return <span className={`inline-block w-4 text-center ${cls}`}>{ch}</span>;
+}
+
+export function TodosPopover({
+  open,
+  onClose,
+  anchorRef,
+  sessionId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  anchorRef: React.RefObject<HTMLElement | null>;
+  sessionId: string | undefined;
+}) {
+  const todoState = useTodoStore((s) => selectTodoState(s, sessionId));
+  // Skip soft-deleted tombstones in the popover — they exist in
+  // state for branch-replay consistency but aren't useful at-a-
+  // glance. The full panel keeps them visible behind a toggle.
+  const visible = todoState.tasks.filter((t) => t.status !== "deleted");
+  const completed = visible.filter((t) => t.status === "completed").length;
+  const inProgress = visible.filter((t) => t.status === "in_progress").length;
+
+  return (
+    <PopoverShell
+      open={open}
+      onClose={onClose}
+      anchorRef={anchorRef}
+      title={
+        visible.length === 0
+          ? "Tasks"
+          : `Tasks · ${completed}/${visible.length}${inProgress > 0 ? ` · ${inProgress} in progress` : ""}`
+      }
+    >
+      {visible.length === 0 ? (
+        <p className="px-3 py-3 text-xs italic text-neutral-500">No tasks.</p>
+      ) : (
+        <ul className="divide-y divide-neutral-800 light:divide-neutral-200">
+          {visible.map((t) => (
+            <li key={t.id} className="flex items-start gap-2 px-3 py-2 text-xs">
+              <TaskStatusGlyph status={t.status} />
+              <span
+                className={`min-w-0 flex-1 ${
+                  t.status === "completed"
+                    ? "text-neutral-500 line-through light:text-neutral-400"
+                    : "text-neutral-200 light:text-neutral-800"
+                }`}
+              >
+                {t.subject}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </PopoverShell>
+  );
+}
+
+/**
+ * `ApiError` is imported for the same reason as in ProcessesPanel:
+ * the kill route can fail with a typed error. We currently swallow
+ * silently in the popover for noise reasons, but keep the import
+ * so a future "show error inline" change is one line away.
+ */
+void ApiError;

--- a/packages/client/src/components/ProcessesPanel.tsx
+++ b/packages/client/src/components/ProcessesPanel.tsx
@@ -423,6 +423,22 @@ function formatRuntime(start: number, end: number | null): string {
  * loading the whole file into memory first. Acceptable for log
  * files capped at 10 MB by the server's rotation policy.
  */
+/**
+ * Minimal HTML entity escape for embedding raw log text inside a
+ * `<pre>` tag in the new-tab document. Handles the four characters
+ * that can break out of `<pre>` content (`&` first, then `<`, `>`,
+ * and quotes — quotes matter inside the `<title>`). Tab and
+ * newline pass through unchanged so the log layout is preserved.
+ */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function FullLogLink({
   sessionId,
   processId,
@@ -434,41 +450,100 @@ function FullLogLink({
 }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | undefined>(undefined);
-  const onClick = async (): Promise<void> => {
+  const onClick = (): void => {
+    // Open the new tab SYNCHRONOUSLY in the click handler so the
+    // browser counts it as user-initiated and doesn't trigger the
+    // popup blocker. We point it at about:blank first, fetch the
+    // log in the background, then navigate the already-open tab
+    // to the blob URL when the bytes are ready.
+    //
+    // The earlier implementation called window.open AFTER `await
+    // fetch(...)` — by then the user-gesture chain was broken, the
+    // popup got blocked, and the fallback (window.location.assign)
+    // navigated the CURRENT tab. The user then saw both:
+    // (a) the current tab go to the log file, (b) the popup
+    // blocker prompt let them open the new tab anyway. Hence
+    // "opens in a new tab, but also changes the current tab."
+    //
+    // `noopener` / `noreferrer` are intentionally omitted: both
+    // cause window.open to return null, breaking our ability to
+    // navigate the new tab afterward. The opened content is plain
+    // text from our own server (the log file blob), with no JS
+    // running in it, so `window.opener` accessibility from the
+    // new tab is a non-issue here.
+    const newTab = window.open("about:blank", "_blank");
+    if (newTab === null) {
+      // Even the synchronous open got blocked (some strict popup
+      // configurations). Surface the failure rather than the
+      // earlier behavior of stealing the current tab.
+      setErr("popup blocked — allow popups for this site");
+      return;
+    }
     setBusy(true);
     setErr(undefined);
-    try {
-      const url = api.processLogFileUrl(sessionId, processId, stream);
-      const stored = getStoredToken();
-      const headers: Record<string, string> = {};
-      if (stored !== undefined) headers.Authorization = `Bearer ${stored.token}`;
-      const res = await fetch(url, { headers });
-      if (!res.ok) {
-        setErr(`${res.status} ${res.statusText}`);
-        return;
+    void (async () => {
+      try {
+        const url = api.processLogFileUrl(sessionId, processId, stream);
+        const stored = getStoredToken();
+        const headers: Record<string, string> = {};
+        if (stored !== undefined) headers.Authorization = `Bearer ${stored.token}`;
+        const res = await fetch(url, { headers });
+        if (!res.ok) {
+          newTab.close();
+          setErr(`${res.status} ${res.statusText}`);
+          return;
+        }
+        const text = await res.text();
+        // Wrap the log in a minimal dark-themed HTML document
+        // instead of serving raw text/plain. Two reasons:
+        //
+        //   1. Plain text/plain rendering varies wildly by browser:
+        //      Chrome may apply auto-dark, Safari/Firefox usually
+        //      don't. The previous single-step window.open(blobUrl)
+        //      happened to land on whatever the browser's default
+        //      for the user's color scheme was, which was dark for
+        //      most users — but the about:blank-then-navigate
+        //      sequence breaks that heuristic and ends up showing
+        //      a white page. Wrapping in HTML with explicit CSS
+        //      makes the rendering deterministic and matches the
+        //      app's dark posture.
+        //   2. Bonus: better typography (monospace, soft wrap, line
+        //      numbers possible later), and the <title> shows the
+        //      stream + process id in the tab strip instead of an
+        //      opaque `blob:...` URL.
+        const title = `${stream} — ${processId}`;
+        const html =
+          `<!doctype html><html><head><meta charset="utf-8">` +
+          `<title>${escapeHtml(title)}</title>` +
+          `<meta name="color-scheme" content="dark light">` +
+          `<style>` +
+          `html,body{margin:0;padding:0;background:#0a0a0a;color:#e5e5e5;` +
+          `font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;` +
+          `font-size:13px;line-height:1.5;tab-size:4}` +
+          `@media (prefers-color-scheme: light){html,body{background:#fafafa;color:#171717}}` +
+          `pre{margin:0;padding:1rem;white-space:pre-wrap;word-break:break-word}` +
+          `</style></head><body><pre>${escapeHtml(text)}</pre></body></html>`;
+        const blob = new Blob([html], { type: "text/html;charset=utf-8" });
+        const blobUrl = URL.createObjectURL(blob);
+        // Navigate the already-open tab to the blob. `location =`
+        // (rather than `location.replace`) leaves a single
+        // about:blank entry in that tab's history, which is the
+        // expected back-button behavior.
+        newTab.location.href = blobUrl;
+        // Revoke after the new tab has had time to load it.
+        setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
+      } catch (e) {
+        newTab.close();
+        setErr(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusy(false);
       }
-      const blob = await res.blob();
-      const blobUrl = URL.createObjectURL(blob);
-      // Open in a new tab. The blob URL is short-lived: revoke
-      // after a generous delay so the new tab has time to load
-      // it but we don't leak the buffer forever.
-      const w = window.open(blobUrl, "_blank", "noopener,noreferrer");
-      if (w === null) {
-        // Popup blocked — fall back to navigating the current
-        // tab (the user can use back to return).
-        window.location.assign(blobUrl);
-      }
-      setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(false);
-    }
+    })();
   };
   return (
     <button
       type="button"
-      onClick={() => void onClick()}
+      onClick={onClick}
       disabled={busy}
       className="text-sky-400 hover:underline disabled:opacity-50 light:text-sky-700"
       title={err}

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -134,43 +134,53 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
         // chat for screen real estate.
         className="flex h-full max-h-[720px] w-full max-w-6xl flex-col overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950 shadow-2xl"
       >
-        <header className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
-          <div className="flex items-center gap-1">
-            {visibleTabs.map((t) => (
-              <button
-                key={t}
-                onClick={() => setTab(t)}
-                className={`rounded px-3 py-1 text-xs ${
-                  tab === t
-                    ? "bg-neutral-800 text-neutral-100"
-                    : "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
-                }`}
-              >
-                {t === "providers"
-                  ? "Providers"
-                  : t === "agent"
-                    ? "Agent"
-                    : t === "mcp"
-                      ? "MCP"
-                      : t === "tools"
-                        ? "Tools"
-                        : t === "skills"
-                          ? "Skills"
-                          : t === "prompts"
-                            ? "Prompts"
-                            : t === "systemPrompt"
-                              ? "System Prompt"
-                              : t === "quickActions"
-                                ? "Quick Actions"
-                                : t === "appearance"
-                                  ? "Appearance"
-                                  : t === "backup"
-                                    ? "Backup"
-                                    : "General"}
-              </button>
-            ))}
+        <header className="flex items-center gap-3 border-b border-neutral-800 px-4 py-3">
+          {/* Horizontally scrollable tab strip. With 10+ tabs the strip
+              overflows on narrow viewports (mobile, small windows) —
+              the modal itself is up to max-w-6xl but real-world phones
+              clamp it to the viewport width. `min-w-0` lets the
+              container actually shrink so `overflow-x-auto` activates;
+              `shrink-0` on each tab keeps labels intact when the user
+              scrolls. The trailing controls (API Docs / Close) stay
+              fixed to the right via `gap-3` on the header. */}
+          <div className="-mx-1 min-w-0 flex-1 overflow-x-auto px-1">
+            <div className="flex min-w-max items-center gap-1">
+              {visibleTabs.map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setTab(t)}
+                  className={`shrink-0 whitespace-nowrap rounded px-3 py-1 text-xs ${
+                    tab === t
+                      ? "bg-neutral-800 text-neutral-100"
+                      : "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
+                  }`}
+                >
+                  {t === "providers"
+                    ? "Providers"
+                    : t === "agent"
+                      ? "Agent"
+                      : t === "mcp"
+                        ? "MCP"
+                        : t === "tools"
+                          ? "Tools"
+                          : t === "skills"
+                            ? "Skills"
+                            : t === "prompts"
+                              ? "Prompts"
+                              : t === "systemPrompt"
+                                ? "System Prompt"
+                                : t === "quickActions"
+                                  ? "Quick Actions"
+                                  : t === "appearance"
+                                    ? "Appearance"
+                                    : t === "backup"
+                                      ? "Backup"
+                                      : "General"}
+                </button>
+              ))}
+            </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             <button
               onClick={() => {
                 // Carry the user's current token over to the swagger


### PR DESCRIPTION
## Summary

Three PWA / mobile-UX items bundled on one branch.

### 1. Settings tabs scroll horizontally on narrow viewports

The Settings modal's tab strip has crept to 10+ tabs (Providers, Agent, MCP, Tools, Skills, Prompts, System Prompt, Quick Actions, Appearance, Backup, General). On mobile PWA, small desktop windows, and the iPad split-view layout, the strip ran off the right edge with no scroll affordance and no wrap.

Fix: wrap the tab strip in `overflow-x-auto` with `min-w-0` (so the flex item can actually shrink) and `shrink-0` / `whitespace-nowrap` on each tab (so labels stay intact under scroll). The trailing controls (API Docs / Close) stay pinned to the right via `gap-3` on the header. Desktop layout unchanged when the tabs already fit.

### 2. Mobile-only quick-list popovers for the chat-input processes & todos badges

Both badges route to right-pane panels on desktop — that behavior is unchanged. On mobile (`useIsMobile` → true) the right pane stays collapsed and the auto-expand logic in `App.tsx` is `!isMobile`-gated, so routing to it from the badge was a dead-end interaction.

The mobile path now opens a small floating popover anchored above the badge:

| Popover | Content |
|---|---|
| **Processes** | Live processes at the top (name, status badge, pid, runtime that ticks every second while open, inline Kill button). Finished processes after a divider with exit code. |
| **Todos** | Checklist with status glyphs (`✓ ◐ × ○`) and strikethrough for completed items. Skips soft-deleted tombstones. |

Outside-click and Escape close. Width clamps to viewport via `max-w-[calc(100vw-1rem)]`. No "Open full panel →" link — the popover IS the panel for the mobile case.

### 3. "Full stdout/stderr log" button fixes

Two issues with one button, both fixed:

- **Used to navigate the current tab as a side-effect of opening the new one.** `window.open(blobUrl, "_blank")` ran after `await fetch(...)`, the user-gesture chain was broken, popup blocker fired, and the fallback `window.location.assign(blobUrl)` stole the current tab. Fix: open the new tab synchronously to `about:blank` inside the click handler (counts as user-initiated, popup blocker stays quiet), then navigate the already-open tab once the fetch resolves. If even the synchronous open is blocked, surface a "popup blocked" error instead of stealing the current tab.
- **New tab rendered white instead of dark.** The single-step `window.open(blobUrl)` used to land on the browser's default `text/plain` rendering — Chrome's auto-dark heuristic kicked in for most users; the about:blank-then-navigate sequence broke that heuristic. Fix: wrap the log content in a minimal dark-themed HTML document with explicit CSS, a `<title>` of `<stream> — <processId>` (so the tab label is meaningful instead of `blob:...`), and `prefers-color-scheme: light` for light-mode users.

## Test plan

- [x] `npm run check` clean (typecheck + eslint + prettier)
- [x] `npm run build` clean
- [x] `scripts/run-tests.sh --skip docker,pty-reattach,terminal` — 35/35 PASS (no test-suite changes; this is all UI)
- [ ] Manual smoke (desktop): Settings → verify tab strip still fits + lays out normally; confirm processes badge still routes to the Processes right-pane tab; confirm todos badge still toggles the bottom-strip panel
- [ ] Manual smoke (mobile / narrow viewport): Settings → swipe tab strip to confirm horizontal scroll; tap processes badge → confirm popover opens with live runtime + Kill button; tap todos badge → confirm popover opens with checklist
- [ ] Manual smoke: click "full stdout log" on a running process; verify (a) the current tab DOES NOT change, (b) the new tab opens with dark background, and (c) the tab label reads `stdout — <processId>`