### PR TITLE
feat(orchestration): supervisor sessions can spawn, observe, and coordinate workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,89 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Added
+
+- **Session orchestration — one session can spawn, observe, and
+  coordinate other sessions.** Off by default; the operator opts
+  in with `ORCHESTRATION_ENABLED=true`, and each session that
+  should act as a supervisor opts in separately via the chat-view
+  `Orch` toggle. Hard-disabled under MINIMAL_UI regardless of the
+  env flag.
+
+  Topology: strict hub-and-spoke at depth=1. A supervisor session
+  gets a new `orchestrate_*` tool group; workers do not, so they
+  have no way to talk to each other. Workers cannot themselves
+  become supervisors (no fork-bombs by buggy prompts). Same-
+  project only — cross-project orchestration is intentionally out
+  of scope for v1.
+
+  Tool surface (8 tools, supervisor-only):
+  - `orchestrate_spawn_worker` — create a new worker session in
+    the same project. `name` is required so the picker stays
+    legible when several workers run in parallel. Optional
+    `contextSummary` parameter prepends a handoff summary to the
+    worker's initial prompt.
+  - `orchestrate_list_workers` — current state of every linked
+    worker (streaming / idle / cold) with message counts.
+  - `orchestrate_read_worker` — fetch the most recent messages
+    from a worker's transcript (auto-resumes cold workers).
+    Default `limit` is 1 — the worker's single latest message is
+    enough context for most supervisor decisions, and bigger
+    pulls burn the supervisor's own context window. Messages are
+    serialized into the tool-result *text* as a readable
+    transcript (per-message role + extracted text + tool_use
+    names + tool_result previews); the supervisor LLM cannot see
+    fields placed only in `details`, so the read tools have to
+    encode their payload into the content.
+  - `orchestrate_send_to_worker` — inject a message into a
+    worker's prompt stream as `prompt | steer | followUp`.
+    Tagged `[supervisor:<id>]` in the worker's transcript.
+  - `orchestrate_interrupt_worker` — abort a worker's current
+    turn.
+  - `orchestrate_kill_worker` — dispose the worker session,
+    optionally also delete the .jsonl from disk.
+  - `orchestrate_detach_worker` — drop the supervisor↔worker
+    link; the worker continues as a standalone session.
+  - `orchestrate_read_inbox` — drain pending worker events
+    (ended / asked / retry-failed / process-alert / deleted).
+
+  Wake-up: worker events route into a per-supervisor inbox queue
+  (`${FORGE_DATA_DIR}/orchestrator-inbox.json`, FIFO-capped at
+  200 / supervisor). When the supervisor is live and idle, a
+  `[orchestration]` system prompt is injected so the agent
+  starts a new turn that processes the inbox via
+  `orchestrate_read_inbox`. If the supervisor is mid-turn, the
+  push skips and the items wait — recovery fires another push
+  when the supervisor's own `agent_end` lands.
+
+  Safety:
+  - Per-supervisor live-worker cap (default 8, configurable via
+    `ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR`).
+  - Every orchestration tool that names a workerId verifies
+    ownership against the store first — a supervisor cannot
+    touch another supervisor's workers by id-guessing.
+  - Worker spawn/kill events route through the existing webhooks
+    event bridge AND the orchestration inbox in parallel — the
+    two systems are independent.
+  - Audit trail is `process.stderr` JSON-line logs
+    (`orchestration-inbox-enqueued`, `orchestration-wake-
+    delivered`, etc.) — no separate audit-log UI by design,
+    operators tail container logs.
+
+  UI: a `Orch` toggle button in the chat-view toolbar (visible
+  only when the instance flag is on) opens the per-session
+  Orchestration panel. Standalone sessions get an "Enable
+  supervisor mode" button; supervisors see their workers list
+  with detach / kill / resume controls and an inbox-history
+  drawer; workers see a back-link to their supervisor. The
+  panel polls every 4s while open. Enable / disable rebuild
+  the live AgentSession in-place (same SessionManager, new
+  `customTools`, SSE clients stay attached) so the
+  orchestrate_* tools appear or disappear immediately — no
+  reconnect, no risk of a pre-prompt session being lost to
+  the cold-resume 404 race or a post-prompt session hitting
+  the dispose tombstone's 410.
+
 ### Changed
 
 - **Clone-repository project setup gains an "Allow self-signed /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,17 @@ pi-forge/
 │   │   │   │   ├── event-bridge.ts      # SDK/forge events → dispatcher
 │   │   │   │   ├── init.ts              # Boot-time wiring of ask-user-question + processes
 │   │   │   │   └── types.ts             # WebhookConfig, DeliveryRecord, event union
+│   │   │   ├── orchestration/            # Session-as-supervisor / session-as-worker (opt-in)
+│   │   │   │   ├── store.ts             # session-orchestration.json + orchestrator-inbox.json
+│   │   │   │   ├── tools.ts             # orchestrate_* ToolDefinition factory (8 tools)
+│   │   │   │   ├── inbox.ts             # PUSH wakeup when supervisor idle + PULL drain
+│   │   │   │   ├── event-bridge.ts      # Worker SDK/forge events → supervisor inbox
+│   │   │   │   ├── init.ts              # Boot-time wiring of ask-user-question + processes
+│   │   │   │   ├── config.ts            # ORCHESTRATION_ENABLED env + fanout cap
+│   │   │   │   └── types.ts             # InboxItem, SupervisorRecord, WorkerRecord
 │   │   │   └── routes/                  # auth, config, control, exec, files, git, health,
 │   │   │                                #   mcp, projects, prompt, sessions, stream, terminal,
-│   │   │                                #   webhooks, _schemas (shared JSON schemas)
+│   │   │                                #   webhooks, orchestration, _schemas (shared schemas)
 │   │   └── package.json
 │   └── client/                          # React + Vite frontend (TypeScript)
 │       ├── index.html                   # Viewport meta + theme-color (dark default; updated by theme.ts)
@@ -451,6 +459,8 @@ route handlers).
 | `prompts-overrides.json` | Per-project pi-prompt enable/disable patterns | `prompt-overrides.ts` |
 | `webhooks.json` | Webhook configs (HMAC secrets stored here — mode 0600) | `webhooks/store.ts` |
 | `webhook-deliveries.json` | Rolling delivery history (cap 100 / webhook) | `webhooks/store.ts` |
+| `session-orchestration.json` | Supervisor opt-in + supervisor↔worker links (mode 0600) | `orchestration/store.ts` |
+| `orchestrator-inbox.json` | Per-supervisor pending event queue (cap 200 / supervisor) | `orchestration/store.ts` |
 | `jwt-secret` | Auto-generated HS256 signing key (mode 0600) | `config.ts` (`loadOrGenerateJwtSecret`) |
 | `password-hash` | scrypt hash of the user's persisted password (mode 0600) | `auth.ts` (`persistPassword`) |
 

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -33,6 +33,8 @@ import { QuickActionsMenu } from "./QuickActionsMenu";
 import { QuickActionRunCard } from "./QuickActionRunCard";
 import { useQuickActionRunsStore } from "../store/quick-actions-store";
 import { parseSubagentDetails, type SubagentResult } from "../lib/subagent-parser";
+import { OrchestrationPanel } from "./OrchestrationPanel";
+import { useUiConfigStore } from "../store/ui-config-store";
 
 /**
  * Per-ChatView diff view-type preference. Each diff-rendering surface
@@ -127,6 +129,8 @@ export function ChatView({ sessionId }: Props) {
   // regardless of how far the user has scrolled.
   const project = useActiveProject();
   const [treeOpen, setTreeOpen] = useState(false);
+  const [orchOpen, setOrchOpen] = useState(false);
+  const orchestrationEnabled = useUiConfigStore((s) => s.orchestrationEnabled);
 
   // Conversation export menu (Markdown / Raw JSONL). Hidden on mobile —
   // the file-download flow is desktop-shaped (browser save dialog,
@@ -315,8 +319,28 @@ export function ChatView({ sessionId }: Props) {
               <GitBranch size={11} />
               Tree
             </button>
+            {orchestrationEnabled && (
+              <button
+                onClick={() => setOrchOpen((v) => !v)}
+                aria-pressed={orchOpen}
+                className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider hover:bg-neutral-800 ${
+                  orchOpen
+                    ? "bg-neutral-800 text-violet-300"
+                    : "text-neutral-400 hover:text-neutral-200"
+                }`}
+                title="Orchestration — supervisor / worker controls"
+              >
+                <Users size={11} />
+                Orch
+              </button>
+            )}
           </div>
         </div>
+        {orchOpen && orchestrationEnabled && (
+          <div className="border-b border-neutral-800 bg-neutral-900/40 px-3 py-2">
+            <OrchestrationPanel sessionId={sessionId} onClose={() => setOrchOpen(false)} />
+          </div>
+        )}
         {/* Banner sits ABOVE the scroll container so it stays pinned to the top
             of the chat view regardless of how far the user has scrolled into a
             long session. Earlier we rendered it inside the scroll container,

--- a/packages/client/src/components/OrchestrationPanel.tsx
+++ b/packages/client/src/components/OrchestrationPanel.tsx
@@ -1,0 +1,500 @@
+import { useEffect, useState } from "react";
+import { Loader2, RefreshCw, Users, X } from "lucide-react";
+import {
+  api,
+  ApiError,
+  type InboxItemType,
+  type InboxItemWire,
+  type SessionLink,
+  type WorkerSummary,
+} from "../lib/api-client";
+import { useUiConfigStore } from "../store/ui-config-store";
+import { useSessionStore } from "../store/session-store";
+
+interface Props {
+  sessionId: string;
+  /** Optional close handler — when set, a close button renders in the
+   *  header so the panel can be dismissed from inside (used by the
+   *  ChatView dropdown integration). */
+  onClose?: () => void;
+}
+
+/**
+ * Per-session orchestration controls. Renders nothing when
+ * orchestration is disabled on this server. Otherwise shows the
+ * session's role (supervisor / worker / standalone) with appropriate
+ * controls:
+ *
+ *   - standalone: button to enable supervisor mode
+ *   - supervisor: worker list + inbox history + disable button
+ *   - worker:     supervisor back-link
+ *
+ * Side effects (enable/disable/kill/detach) reload the link state
+ * after the mutation so the UI stays in sync with the store.
+ *
+ * The supervisor's worker list polls every 4s while the panel is
+ * mounted. Idle UI overhead is small — one cheap HTTP call.
+ */
+export function OrchestrationPanel({ sessionId, onClose }: Props) {
+  const orchestrationEnabled = useUiConfigStore((s) => s.orchestrationEnabled);
+  const [link, setLink] = useState<SessionLink | undefined>(undefined);
+  const [workers, setWorkers] = useState<WorkerSummary[]>([]);
+  const [inbox, setInbox] = useState<InboxItemWire[]>([]);
+  const [showInbox, setShowInbox] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const reload = async (): Promise<void> => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const l = await api.getSessionLink(sessionId);
+      setLink(l);
+      if (l.role === "supervisor") {
+        const w = await api.listSupervisorWorkers(sessionId);
+        setWorkers(w.workers);
+        const i = await api.listSupervisorInbox(sessionId);
+        setInbox(i.items);
+      } else {
+        setWorkers([]);
+        setInbox([]);
+      }
+    } catch (err) {
+      setError(err instanceof ApiError ? err.code : (err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!orchestrationEnabled) return;
+    void reload();
+    // Poll for live worker state. 4s — fast enough to feel live,
+    // slow enough not to spam the server. Aligns with the cadence
+    // the webhooks deliveries panel uses.
+    const t = setInterval(() => {
+      void reload();
+    }, 4_000);
+    return () => clearInterval(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orchestrationEnabled, sessionId]);
+
+  if (!orchestrationEnabled) return null;
+
+  const role = link?.role ?? "standalone";
+
+  return (
+    <div className="rounded-md border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 p-3 text-sm">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 font-medium">
+          <Users size={14} />
+          <span>Orchestration</span>
+          <RoleBadge role={role} />
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => {
+              void reload();
+            }}
+            title="Refresh"
+            className="p-1 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100"
+          >
+            {loading ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+          </button>
+          {onClose !== undefined && (
+            <button
+              type="button"
+              onClick={onClose}
+              title="Close"
+              className="p-1 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100"
+            >
+              <X size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error !== undefined && (
+        <div className="mt-2 rounded bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300 px-2 py-1 text-xs">
+          {error}
+        </div>
+      )}
+
+      {role === "standalone" && (
+        <StandaloneControls
+          sessionId={sessionId}
+          busy={busy}
+          setBusy={setBusy}
+          setError={setError}
+          onAfter={reload}
+        />
+      )}
+      {role === "supervisor" && link !== undefined && (
+        <SupervisorControls
+          link={link}
+          workers={workers}
+          inbox={inbox}
+          showInbox={showInbox}
+          setShowInbox={setShowInbox}
+          busy={busy}
+          setBusy={setBusy}
+          setError={setError}
+          onAfter={reload}
+        />
+      )}
+      {role === "worker" && link !== undefined && <WorkerControls link={link} />}
+    </div>
+  );
+}
+
+function RoleBadge({ role }: { role: "supervisor" | "worker" | "standalone" }) {
+  const styles =
+    role === "supervisor"
+      ? "bg-violet-100 text-violet-800 dark:bg-violet-900/40 dark:text-violet-200"
+      : role === "worker"
+        ? "bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200"
+        : "bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300";
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${styles}`}>
+      {role === "supervisor" ? "Supervisor" : role === "worker" ? "Worker" : "Standalone"}
+    </span>
+  );
+}
+
+function StandaloneControls({
+  sessionId,
+  busy,
+  setBusy,
+  setError,
+  onAfter,
+}: {
+  sessionId: string;
+  busy: boolean;
+  setBusy: (b: boolean) => void;
+  setError: (s: string | undefined) => void;
+  onAfter: () => Promise<void>;
+}) {
+  const onEnable = async (): Promise<void> => {
+    setBusy(true);
+    setError(undefined);
+    try {
+      // Server-side: enable rebuilds the live AgentSession in-place
+      // so the orchestrate_* tools become available immediately. The
+      // SSE connection stays attached — no client-side reconnect
+      // needed, no flicker, no risk of losing a pre-prompt session
+      // to the cold-resume 404 race.
+      await api.enableSupervisor(sessionId);
+      await onAfter();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.code : (err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <div className="mt-2 space-y-2">
+      <p className="text-xs text-zinc-600 dark:text-zinc-400">
+        This session is standalone. Enable supervisor mode to give this session the{" "}
+        <code className="text-xs">orchestrate_*</code> tools — letting it spawn, observe, and
+        coordinate other worker sessions in the same project.
+      </p>
+      <button
+        type="button"
+        onClick={() => {
+          void onEnable();
+        }}
+        disabled={busy}
+        className="rounded bg-violet-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-violet-500 disabled:opacity-50"
+      >
+        {busy ? "Enabling…" : "Enable supervisor mode"}
+      </button>
+      <p className="text-[11px] text-zinc-500 dark:text-zinc-400">
+        The agent's tool list refreshes immediately — no reload needed.
+      </p>
+    </div>
+  );
+}
+
+function SupervisorControls({
+  link,
+  workers,
+  inbox,
+  showInbox,
+  setShowInbox,
+  busy,
+  setBusy,
+  setError,
+  onAfter,
+}: {
+  link: SessionLink;
+  workers: WorkerSummary[];
+  inbox: InboxItemWire[];
+  showInbox: boolean;
+  setShowInbox: (b: boolean) => void;
+  busy: boolean;
+  setBusy: (b: boolean) => void;
+  setError: (s: string | undefined) => void;
+  onAfter: () => Promise<void>;
+}) {
+  const openSession = useSessionStore((s) => s.setActiveSession);
+
+  const onDisable = async (): Promise<void> => {
+    if (!confirm("Disable supervisor mode? Linked workers become standalone sessions.")) return;
+    setBusy(true);
+    setError(undefined);
+    try {
+      // Server-side: disable rebuilds the live AgentSession in-place
+      // so the orchestrate_* tools vanish from its tool surface
+      // without an SSE reconnect.
+      await api.disableSupervisor(link.sessionId);
+      await onAfter();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.code : (err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDetach = async (workerId: string): Promise<void> => {
+    setBusy(true);
+    setError(undefined);
+    try {
+      await api.detachWorker(link.sessionId, workerId);
+      await onAfter();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.code : (err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onKill = async (workerId: string): Promise<void> => {
+    if (!confirm(`Kill worker ${workerId.slice(0, 8)}? (Transcript stays on disk.)`)) return;
+    setBusy(true);
+    setError(undefined);
+    try {
+      await api.killWorker(link.sessionId, workerId);
+      await onAfter();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.code : (err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onResume = async (workerId: string): Promise<void> => {
+    setBusy(true);
+    setError(undefined);
+    try {
+      await api.resumeWorker(link.sessionId, workerId);
+      await onAfter();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.code : (err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onClearInbox = async (): Promise<void> => {
+    if (!confirm("Clear inbox history?")) return;
+    setBusy(true);
+    setError(undefined);
+    try {
+      await api.clearSupervisorInbox(link.sessionId);
+      await onAfter();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.code : (err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const pendingCount = link.pendingInbox ?? 0;
+
+  return (
+    <div className="mt-2 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="text-xs text-zinc-600 dark:text-zinc-400">
+          {workers.length} worker{workers.length === 1 ? "" : "s"}
+          {pendingCount > 0 ? (
+            <span className="ml-2 rounded bg-amber-200 dark:bg-amber-700/50 text-amber-900 dark:text-amber-100 px-1.5 py-0.5">
+              {pendingCount} pending inbox
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            void onDisable();
+          }}
+          disabled={busy}
+          className="rounded text-xs text-zinc-600 dark:text-zinc-400 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 px-1.5 py-0.5"
+        >
+          Disable supervisor mode
+        </button>
+      </div>
+      {workers.length === 0 ? (
+        <p className="text-xs italic text-zinc-500 dark:text-zinc-400">
+          No workers yet. The agent can spawn one with{" "}
+          <code className="text-xs">orchestrate_spawn_worker</code>.
+        </p>
+      ) : (
+        <ul className="divide-y divide-zinc-200 dark:divide-zinc-800 rounded border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950">
+          {workers.map((w) => (
+            <li key={w.workerId} className="flex items-center gap-2 px-2 py-1.5">
+              <StateDot state={w.state ?? (w.isLive ? "idle" : "cold")} />
+              <button
+                type="button"
+                onClick={() => openSession(w.workerId)}
+                className="flex-1 text-left truncate text-xs hover:underline"
+                title={w.workerId}
+              >
+                <span className="font-medium">{w.name ?? w.workerId.slice(0, 8)}</span>
+                {w.messageCount !== undefined && (
+                  <span className="ml-1 text-zinc-500">({w.messageCount} msgs)</span>
+                )}
+              </button>
+              <div className="flex items-center gap-1">
+                {!w.isLive && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void onResume(w.workerId);
+                    }}
+                    disabled={busy}
+                    className="text-[11px] text-zinc-600 dark:text-zinc-400 hover:text-violet-700 dark:hover:text-violet-300 disabled:opacity-50 px-1 py-0.5"
+                  >
+                    Resume
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    void onDetach(w.workerId);
+                  }}
+                  disabled={busy}
+                  className="text-[11px] text-zinc-600 dark:text-zinc-400 hover:text-amber-700 dark:hover:text-amber-300 disabled:opacity-50 px-1 py-0.5"
+                  title="Detach (worker continues as standalone)"
+                >
+                  Detach
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void onKill(w.workerId);
+                  }}
+                  disabled={busy}
+                  className="text-[11px] text-zinc-600 dark:text-zinc-400 hover:text-red-700 dark:hover:text-red-300 disabled:opacity-50 px-1 py-0.5"
+                  title="Kill (dispose live session; transcript stays on disk)"
+                >
+                  Kill
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <details open={showInbox} onToggle={(e) => setShowInbox(e.currentTarget.open)}>
+        <summary className="cursor-pointer text-xs text-zinc-600 dark:text-zinc-400 select-none">
+          Inbox history ({inbox.length}) {pendingCount > 0 && `— ${pendingCount} pending`}
+        </summary>
+        {inbox.length === 0 ? (
+          <p className="text-xs italic text-zinc-500 dark:text-zinc-400 mt-1">No inbox items.</p>
+        ) : (
+          <div className="mt-1 space-y-1">
+            <ul className="divide-y divide-zinc-200 dark:divide-zinc-800 rounded border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 max-h-48 overflow-auto">
+              {inbox.map((item) => (
+                <InboxRow key={item.id} item={item} />
+              ))}
+            </ul>
+            <button
+              type="button"
+              onClick={() => {
+                void onClearInbox();
+              }}
+              disabled={busy}
+              className="text-[11px] text-zinc-500 dark:text-zinc-400 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50"
+            >
+              Clear inbox
+            </button>
+          </div>
+        )}
+      </details>
+    </div>
+  );
+}
+
+function InboxRow({ item }: { item: InboxItemWire }) {
+  const label = inboxTypeLabel(item.type);
+  return (
+    <li className="flex items-baseline gap-2 px-2 py-1 text-xs">
+      <span
+        className={`rounded px-1 py-0.5 ${
+          item.delivered
+            ? "bg-zinc-200 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+            : "bg-amber-200 text-amber-900 dark:bg-amber-700/40 dark:text-amber-200"
+        }`}
+      >
+        {label}
+      </span>
+      <span className="font-mono text-zinc-500" title={item.workerId}>
+        {item.workerId.slice(0, 8)}
+      </span>
+      <span className="text-zinc-500 ml-auto">
+        {new Date(item.occurredAt).toLocaleTimeString()}
+      </span>
+    </li>
+  );
+}
+
+function inboxTypeLabel(t: InboxItemType): string {
+  switch (t) {
+    case "worker.ended":
+      return "ended";
+    case "worker.ask_user":
+      return "asked";
+    case "worker.auto_retry_failed":
+      return "retry failed";
+    case "worker.process_alert":
+      return "process";
+    case "worker.deleted":
+      return "deleted";
+  }
+}
+
+function WorkerControls({ link }: { link: SessionLink }) {
+  const openSession = useSessionStore((s) => s.setActiveSession);
+  const supervisorId = link.supervisorId;
+  if (supervisorId === undefined) return null;
+  return (
+    <div className="mt-2 text-xs text-zinc-600 dark:text-zinc-400">
+      Owned by supervisor{" "}
+      <button
+        type="button"
+        onClick={() => openSession(supervisorId)}
+        className="font-mono underline hover:text-violet-700 dark:hover:text-violet-300"
+        title={supervisorId}
+      >
+        {supervisorId.slice(0, 8)}
+      </button>
+      {link.spawnedFrom !== undefined && link.spawnedFrom.mode === "summary" && (
+        <span className="ml-2 italic">(handoff with context summary)</span>
+      )}
+    </div>
+  );
+}
+
+function StateDot({ state }: { state: "streaming" | "idle" | "cold" }) {
+  const cls =
+    state === "streaming"
+      ? "bg-emerald-500 animate-pulse"
+      : state === "idle"
+        ? "bg-sky-500"
+        : "bg-zinc-400";
+  return (
+    <span className={`inline-block h-2 w-2 rounded-full ${cls}`} title={state} aria-label={state} />
+  );
+}

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -141,11 +141,16 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
   const version = typeof value.version === "string" ? value.version : "unknown";
   const passwordAuthEnabled =
     typeof value.passwordAuthEnabled === "boolean" ? value.passwordAuthEnabled : true;
+  // Default to false on older servers — orchestration is gated by
+  // an explicit env flag, so absence === disabled.
+  const orchestrationEnabled =
+    typeof value.orchestrationEnabled === "boolean" ? value.orchestrationEnabled : false;
   return {
     minimal: value.minimal,
     workspaceRoot: value.workspaceRoot,
     version,
     passwordAuthEnabled,
+    orchestrationEnabled,
   };
 }
 
@@ -743,6 +748,168 @@ function vTodoList(value: unknown, status: number): TodoListResponse {
     fail(status, "expected { tasks: [...], nextId: number }");
   }
   return { tasks: value.tasks as TodoTask[], nextId: value.nextId };
+}
+
+// ---- orchestration ----
+
+export type SessionRole = "supervisor" | "worker" | "standalone";
+
+export interface OrchestrationConfig {
+  enabled: boolean;
+  maxWorkersPerSupervisor: number;
+  maxDepth: number;
+  /** Empty string when enabled; otherwise the disable reason. */
+  disabledReason: "" | "minimal_ui_disabled" | "orchestration_disabled";
+}
+
+export interface SessionLink {
+  sessionId: string;
+  role: SessionRole;
+  /** Worker only — supervisor's session id. */
+  supervisorId?: string;
+  /** Supervisor only — list of worker session ids. */
+  workerIds?: string[];
+  /** Supervisor only — count of inbox items not yet drained by the
+   *  supervisor's LLM via orchestrate_read_inbox. */
+  pendingInbox?: number;
+  /** Supervisor only — ISO timestamp. */
+  enabledAt?: string;
+  /** Worker only — ISO timestamp. */
+  spawnedAt?: string;
+  /** Worker only — back-reference to handoff source. */
+  spawnedFrom?: { sessionId: string; mode: "fresh" | "summary" };
+}
+
+export interface WorkerSummary {
+  workerId: string;
+  isLive: boolean;
+  isStreaming?: boolean;
+  state?: "streaming" | "idle" | "cold";
+  name?: string;
+  lastActivityAt?: string;
+  messageCount?: number;
+  projectId?: string;
+  spawnedAt?: string;
+  spawnedFrom?: { sessionId: string; mode: string };
+}
+
+export type InboxItemType =
+  | "worker.ended"
+  | "worker.ask_user"
+  | "worker.auto_retry_failed"
+  | "worker.process_alert"
+  | "worker.deleted";
+
+export interface InboxItemWire {
+  id: string;
+  type: InboxItemType;
+  workerId: string;
+  occurredAt: string;
+  data: Record<string, unknown>;
+  delivered: boolean;
+}
+
+function vOrchestrationConfig(value: unknown, status: number): OrchestrationConfig {
+  if (
+    !isObject(value) ||
+    typeof value.enabled !== "boolean" ||
+    typeof value.maxWorkersPerSupervisor !== "number" ||
+    typeof value.maxDepth !== "number" ||
+    typeof value.disabledReason !== "string"
+  ) {
+    fail(status, "expected orchestration config");
+  }
+  return {
+    enabled: value.enabled,
+    maxWorkersPerSupervisor: value.maxWorkersPerSupervisor,
+    maxDepth: value.maxDepth,
+    disabledReason: value.disabledReason as OrchestrationConfig["disabledReason"],
+  };
+}
+
+function vSessionLink(value: unknown, status: number): SessionLink {
+  if (!isObject(value) || typeof value.sessionId !== "string" || typeof value.role !== "string") {
+    fail(status, "expected session link");
+  }
+  const role = value.role as SessionRole;
+  if (role !== "supervisor" && role !== "worker" && role !== "standalone") {
+    fail(status, "bad session role");
+  }
+  const out: SessionLink = { sessionId: value.sessionId, role };
+  if (typeof value.supervisorId === "string") out.supervisorId = value.supervisorId;
+  if (Array.isArray(value.workerIds)) {
+    out.workerIds = value.workerIds.filter((s): s is string => typeof s === "string");
+  }
+  if (typeof value.pendingInbox === "number") out.pendingInbox = value.pendingInbox;
+  if (typeof value.enabledAt === "string") out.enabledAt = value.enabledAt;
+  if (typeof value.spawnedAt === "string") out.spawnedAt = value.spawnedAt;
+  if (isObject(value.spawnedFrom) && typeof value.spawnedFrom.sessionId === "string") {
+    const mode = value.spawnedFrom.mode;
+    if (mode === "fresh" || mode === "summary") {
+      out.spawnedFrom = { sessionId: value.spawnedFrom.sessionId, mode };
+    }
+  }
+  return out;
+}
+
+function vWorkerSummaryList(value: unknown, status: number): { workers: WorkerSummary[] } {
+  if (!isObject(value) || !Array.isArray(value.workers)) {
+    fail(status, "expected { workers: [...] }");
+  }
+  const workers: WorkerSummary[] = [];
+  for (const raw of value.workers) {
+    if (!isObject(raw) || typeof raw.workerId !== "string" || typeof raw.isLive !== "boolean") {
+      continue;
+    }
+    const w: WorkerSummary = { workerId: raw.workerId, isLive: raw.isLive };
+    if (typeof raw.isStreaming === "boolean") w.isStreaming = raw.isStreaming;
+    if (raw.state === "streaming" || raw.state === "idle" || raw.state === "cold") {
+      w.state = raw.state;
+    }
+    if (typeof raw.name === "string") w.name = raw.name;
+    if (typeof raw.lastActivityAt === "string") w.lastActivityAt = raw.lastActivityAt;
+    if (typeof raw.messageCount === "number") w.messageCount = raw.messageCount;
+    if (typeof raw.projectId === "string") w.projectId = raw.projectId;
+    if (typeof raw.spawnedAt === "string") w.spawnedAt = raw.spawnedAt;
+    if (
+      isObject(raw.spawnedFrom) &&
+      typeof raw.spawnedFrom.sessionId === "string" &&
+      typeof raw.spawnedFrom.mode === "string"
+    ) {
+      w.spawnedFrom = { sessionId: raw.spawnedFrom.sessionId, mode: raw.spawnedFrom.mode };
+    }
+    workers.push(w);
+  }
+  return { workers };
+}
+
+function vInboxList(value: unknown, status: number): { items: InboxItemWire[] } {
+  if (!isObject(value) || !Array.isArray(value.items)) {
+    fail(status, "expected { items: [...] }");
+  }
+  const items: InboxItemWire[] = [];
+  for (const raw of value.items) {
+    if (
+      !isObject(raw) ||
+      typeof raw.id !== "string" ||
+      typeof raw.type !== "string" ||
+      typeof raw.workerId !== "string" ||
+      typeof raw.occurredAt !== "string" ||
+      !isObject(raw.data) ||
+      typeof raw.delivered !== "boolean"
+    ) {
+      continue;
+    }
+    items.push({
+      id: raw.id,
+      type: raw.type as InboxItemType,
+      workerId: raw.workerId,
+      occurredAt: raw.occurredAt,
+      data: raw.data,
+      delivered: raw.delivered,
+    });
+  }
+  return { items };
 }
 
 function vAuthSummary(value: unknown, status: number): AuthSummary {
@@ -1794,6 +1961,62 @@ export const api = {
     ),
   listWebhookDeliveries: (id: string) =>
     request(`/api/v1/webhooks/${encodeURIComponent(id)}/deliveries`, vDeliveryList),
+
+  // ---------------- orchestration ----------------
+  /**
+   * Fetch the instance-level orchestration config — whether the
+   * feature is enabled, the per-supervisor fanout cap, and (if
+   * disabled) the reason. Cheap to call on every supervisor view
+   * since this is purely env-derived.
+   */
+  orchestrationConfig: () => request("/api/v1/orchestration/config", vOrchestrationConfig),
+  getSessionLink: (sessionId: string) =>
+    request(`/api/v1/orchestration/sessions/${encodeURIComponent(sessionId)}`, vSessionLink),
+  enableSupervisor: (sessionId: string) =>
+    request(
+      `/api/v1/orchestration/sessions/${encodeURIComponent(sessionId)}/enable`,
+      vSessionLink,
+      { method: "POST" },
+    ),
+  disableSupervisor: (sessionId: string) =>
+    request(`/api/v1/orchestration/sessions/${encodeURIComponent(sessionId)}/disable`, vVoid, {
+      method: "POST",
+    }),
+  listSupervisorWorkers: (sessionId: string) =>
+    request(
+      `/api/v1/orchestration/sessions/${encodeURIComponent(sessionId)}/workers`,
+      vWorkerSummaryList,
+    ),
+  listSupervisorInbox: (sessionId: string) =>
+    request(`/api/v1/orchestration/sessions/${encodeURIComponent(sessionId)}/inbox`, vInboxList),
+  clearSupervisorInbox: (sessionId: string) =>
+    request(`/api/v1/orchestration/sessions/${encodeURIComponent(sessionId)}/inbox/clear`, vVoid, {
+      method: "POST",
+    }),
+  detachWorker: (supervisorId: string, workerId: string) =>
+    request(
+      `/api/v1/orchestration/sessions/${encodeURIComponent(supervisorId)}/workers/${encodeURIComponent(workerId)}/detach`,
+      vVoid,
+      { method: "POST" },
+    ),
+  killWorker: (supervisorId: string, workerId: string) =>
+    request(
+      `/api/v1/orchestration/sessions/${encodeURIComponent(supervisorId)}/workers/${encodeURIComponent(workerId)}/kill`,
+      (v, s) => {
+        if (!isObject(v) || typeof v.wasLive !== "boolean") fail(s, "expected { wasLive }");
+        return { wasLive: v.wasLive };
+      },
+      { method: "POST" },
+    ),
+  resumeWorker: (supervisorId: string, workerId: string) =>
+    request(
+      `/api/v1/orchestration/sessions/${encodeURIComponent(supervisorId)}/workers/${encodeURIComponent(workerId)}/resume`,
+      (v, s) => {
+        if (!isObject(v) || typeof v.resumed !== "boolean") fail(s, "expected { resumed }");
+        return { resumed: v.resumed };
+      },
+      { method: "POST" },
+    ),
 
   listSkills: (projectId: string) =>
     request(

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -271,6 +271,13 @@ export interface UiConfigResponse {
    * hides the password section in that case.
    */
   passwordAuthEnabled: boolean;
+  /**
+   * True when the server has `ORCHESTRATION_ENABLED=true` AND is
+   * NOT in MINIMAL_UI mode. Controls whether the supervisor-mode
+   * toggle and Workers panel render at all. Defaults to false on
+   * older servers (forward-compatible).
+   */
+  orchestrationEnabled: boolean;
 }
 
 export interface UnifiedSession {

--- a/packages/client/src/store/ui-config-store.ts
+++ b/packages/client/src/store/ui-config-store.ts
@@ -29,6 +29,13 @@ interface UiConfigState {
    * flashing the form away on first paint.
    */
   passwordAuthEnabled: boolean;
+  /**
+   * True when the server has session orchestration available
+   * (ORCHESTRATION_ENABLED set AND not MINIMAL_UI). Default false —
+   * orchestration is an opt-in feature; rendering its UI on a
+   * server that doesn't have it on would be confusing.
+   */
+  orchestrationEnabled: boolean;
   /** Last load error (sticky until a retry succeeds), for diagnostics. */
   error: string | undefined;
   load: () => Promise<void>;
@@ -40,6 +47,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
   workspaceRoot: "",
   version: "",
   passwordAuthEnabled: true,
+  orchestrationEnabled: false,
   error: undefined,
   load: async () => {
     try {
@@ -50,6 +58,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
         workspaceRoot: cfg.workspaceRoot,
         version: cfg.version,
         passwordAuthEnabled: cfg.passwordAuthEnabled,
+        orchestrationEnabled: cfg.orchestrationEnabled,
         error: undefined,
       });
     } catch (err) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -35,6 +35,11 @@ import { disposeAll as disposeAllMcp, loadGlobal as loadGlobalMcp } from "./mcp/
 import { initAskUserQuestionFanout, initProcessesFanout, initTodoFanout } from "./sse-bridge.js";
 import { webhookRoutes } from "./routes/webhooks.js";
 import { initAskUserQuestionWebhookBridge, initProcessesWebhookBridge } from "./webhooks/init.js";
+import { orchestrationRoutes } from "./routes/orchestration.js";
+import {
+  initOrchestrationAskUserQuestionBridge,
+  initOrchestrationProcessesBridge,
+} from "./orchestration/init.js";
 import { disposeAllSessions } from "./session-registry.js";
 import { disposeAllPtys, installPtyExitHandler } from "./pty-manager.js";
 import { logSecretHygieneState } from "./agent-resource-loader.js";
@@ -395,6 +400,7 @@ export async function buildServer(): Promise<FastifyInstance> {
       await api.register(todoRoutes);
       await api.register(processesRoutes);
       await api.register(webhookRoutes);
+      await api.register(orchestrationRoutes);
       await api.register(searchRoutes);
       await api.register(terminalRoutes);
     },
@@ -496,6 +502,14 @@ export async function buildServer(): Promise<FastifyInstance> {
   // channel.
   initAskUserQuestionWebhookBridge();
   initProcessesWebhookBridge();
+
+  // Orchestration bridges for the same forge-native event channels.
+  // Per-AgentSession events (agent_end, auto_retry_end) are wired
+  // directly inside session-registry's subscribe handler — those
+  // need the LiveSession context at construction time. These two
+  // singleton-channel sources are subscribed once at boot.
+  initOrchestrationAskUserQuestionBridge();
+  initOrchestrationProcessesBridge();
 
   return fastify;
 }

--- a/packages/server/src/orchestration/config.ts
+++ b/packages/server/src/orchestration/config.ts
@@ -1,0 +1,63 @@
+/**
+ * Runtime config for the orchestration feature.
+ *
+ * Instance-level kill switch + tunable limits. Read fresh on every
+ * call (no caching) so changing env requires only a process restart,
+ * not a code edit. Defaults are safe — orchestration is OFF by
+ * default; the operator opts in with `ORCHESTRATION_ENABLED=true`.
+ *
+ * MINIMAL_UI is a HARD gate (checked separately in routes + tool
+ * registration): even with `ORCHESTRATION_ENABLED=true`, a deployment
+ * running under MINIMAL_UI never surfaces orchestration. Same posture
+ * as the webhooks mutation gate, applied to BOTH routes AND the
+ * agent-facing tool surface.
+ */
+import { config } from "../config.js";
+import { DEFAULT_MAX_WORKERS_PER_SUPERVISOR } from "./types.js";
+
+function readBoolEnv(key: string, fallback: boolean): boolean {
+  const raw = process.env[key];
+  if (raw === undefined || raw === "") return fallback;
+  const v = raw.toLowerCase();
+  if (["1", "true", "yes", "on"].includes(v)) return true;
+  if (["0", "false", "no", "off"].includes(v)) return false;
+  return fallback;
+}
+
+function readIntEnv(key: string, fallback: number, min: number, max: number): number {
+  const raw = process.env[key];
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < min || n > max) return fallback;
+  return n;
+}
+
+/**
+ * True when orchestration tools may surface AND the REST routes may
+ * accept mutations. Combines the instance-level env flag with the
+ * MINIMAL_UI hard gate — under MINIMAL_UI, orchestration is OFF
+ * regardless of the env flag.
+ */
+export function isOrchestrationEnabled(): boolean {
+  if (config.minimalUi) return false;
+  return readBoolEnv("ORCHESTRATION_ENABLED", false);
+}
+
+/**
+ * Reason string for the disabled state — surfaced in 403 responses
+ * so the operator/user gets a precise diagnostic instead of a
+ * generic "disabled."
+ */
+export function orchestrationDisabledReason(): "minimal_ui_disabled" | "orchestration_disabled" {
+  if (config.minimalUi) return "minimal_ui_disabled";
+  return "orchestration_disabled";
+}
+
+export function maxWorkersPerSupervisor(): number {
+  return readIntEnv(
+    "ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR",
+    DEFAULT_MAX_WORKERS_PER_SUPERVISOR,
+    1,
+    100,
+  );
+}

--- a/packages/server/src/orchestration/event-bridge.ts
+++ b/packages/server/src/orchestration/event-bridge.ts
@@ -1,0 +1,150 @@
+/**
+ * Bridges forge-side event channels into the supervisor inbox.
+ *
+ * Four event sources feed the inbox (mirroring the webhooks bridge):
+ *
+ *   AgentSession events (per-session subscribe in session-registry):
+ *     - `agent_end`        → inbox `worker.ended`
+ *     - `auto_retry_end` (success=false) → inbox `worker.auto_retry_failed`
+ *
+ *   ask-user-question registry (forge-native):
+ *     - `ask_user_question` → inbox `worker.ask_user`
+ *
+ *   processManager (forge-native):
+ *     - `process_alert`     → inbox `worker.process_alert`
+ *
+ *   session-registry lifecycle (sessions DELETE route):
+ *     - cold/hot delete    → inbox `worker.deleted`
+ *
+ * All bridges are fire-and-forget. Each one looks up the supervisor
+ * via `getSupervisorIdForWorker` and skips silently if the source
+ * session isn't a registered worker — by far the steady state, since
+ * the same SDK event subscriber fires for every live session, not
+ * just orchestrated ones.
+ */
+import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import type { ProcessAlertReason, ProcessInfo } from "../processes/types.js";
+import type { Question } from "../ask-user-question/types.js";
+import { bridgeWorkerEvent } from "./inbox.js";
+
+interface LastAssistantSummary {
+  stopReason?: string;
+  errorMessage?: string;
+  text?: string;
+}
+
+function findLastAssistant(messages: readonly unknown[]): LastAssistantSummary | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i] as { role?: string } | undefined;
+    if (m?.role !== "assistant") continue;
+    const a = m as {
+      stopReason?: string;
+      errorMessage?: string;
+      content?: unknown;
+    };
+    const text = extractAssistantText(a.content);
+    const out: LastAssistantSummary = {};
+    if (a.stopReason !== undefined) out.stopReason = a.stopReason;
+    if (a.errorMessage !== undefined) out.errorMessage = a.errorMessage;
+    if (text !== undefined) out.text = text;
+    return out;
+  }
+  return undefined;
+}
+
+function extractAssistantText(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  const parts: string[] = [];
+  for (const c of content) {
+    const o = c as { type?: string; text?: string };
+    if (o.type === "text" && typeof o.text === "string") parts.push(o.text);
+  }
+  if (parts.length === 0) return undefined;
+  // Cap to 600 chars in the inbox payload — the supervisor LLM
+  // sees this as a quick summary; if it wants more it calls
+  // `orchestrate_read_worker`. Bigger payloads bloat the inbox
+  // file and the supervisor's tool-result context.
+  const joined = parts.join("\n");
+  return joined.length > 600 ? `${joined.slice(0, 600)}…` : joined;
+}
+
+/**
+ * Called from `session-registry.makeSubscribeHandler` for every
+ * AgentSessionEvent on every live session. Filters for the two SDK
+ * events that map to inbox items; everything else is ignored.
+ */
+export async function bridgeWorkerAgentEvent(
+  meta: { sessionId: string; session: AgentSession },
+  event: AgentSessionEvent,
+): Promise<void> {
+  const e = event as unknown as {
+    type: string;
+    message?: { stopReason?: string; errorMessage?: string };
+    success?: boolean;
+    finalError?: string;
+    attempt?: number;
+    maxAttempts?: number;
+  };
+  if (e.type === "agent_end") {
+    const messages = meta.session.messages;
+    const lastAssistant = findLastAssistant(messages);
+    const errorMessage =
+      (meta.session as unknown as { errorMessage?: string }).errorMessage ??
+      lastAssistant?.errorMessage;
+    await bridgeWorkerEvent(meta.sessionId, "worker.ended", {
+      stopReason: lastAssistant?.stopReason ?? null,
+      errorMessage: errorMessage ?? null,
+      assistantTextPreview: lastAssistant?.text ?? null,
+    });
+    return;
+  }
+  if (e.type === "auto_retry_end" && e.success === false) {
+    await bridgeWorkerEvent(meta.sessionId, "worker.auto_retry_failed", {
+      attempt: e.attempt ?? null,
+      maxAttempts: e.maxAttempts ?? null,
+      finalError: e.finalError ?? null,
+    });
+    return;
+  }
+}
+
+export async function bridgeWorkerAskUserQuestion(
+  sessionId: string,
+  questions: readonly Question[],
+  requestId: string,
+): Promise<void> {
+  await bridgeWorkerEvent(sessionId, "worker.ask_user", {
+    requestId,
+    questionCount: questions.length,
+    // Keep the inbox payload tight — preview is the first question's
+    // header so the supervisor sees enough to decide whether to read
+    // the worker's transcript. Full question detail is in the
+    // worker's session, fetched via orchestrate_read_worker.
+    firstQuestionHeader: questions[0]?.header ?? null,
+    firstQuestionText: questions[0]?.question ?? null,
+  });
+}
+
+export async function bridgeWorkerProcessAlert(
+  sessionId: string,
+  info: ProcessInfo,
+  reason: ProcessAlertReason,
+): Promise<void> {
+  await bridgeWorkerEvent(sessionId, "worker.process_alert", {
+    reason,
+    processId: info.id,
+    name: info.name,
+    pid: info.pid,
+    exitCode: info.exitCode,
+    success: info.success,
+  });
+}
+
+export async function bridgeWorkerDeleted(
+  sessionId: string,
+  meta: { wasLive: boolean },
+): Promise<void> {
+  await bridgeWorkerEvent(sessionId, "worker.deleted", {
+    wasLive: meta.wasLive,
+  });
+}

--- a/packages/server/src/orchestration/inbox.ts
+++ b/packages/server/src/orchestration/inbox.ts
@@ -1,0 +1,219 @@
+/**
+ * Inbox surface — the bridge between worker events and supervisor
+ * wake-up. Wraps the raw inbox queue (in `store.ts`) with the
+ * "fire a prompt at an idle supervisor" mechanism that makes
+ * "session A watches session B" actually work without polling.
+ *
+ * Design:
+ *   1. PULL primary: supervisor's LLM calls `orchestrate_read_inbox`
+ *      to drain pending items. Items stay in the file (cap-evicted)
+ *      so the REST UI can show recent activity even after the LLM
+ *      consumed them.
+ *   2. PUSH secondary: when an event enqueues AND the supervisor
+ *      session is live AND idle (not currently streaming), we fire
+ *      a tiny `[orchestration]` prompt at the supervisor so it
+ *      starts a new turn that surfaces the items. If the supervisor
+ *      is busy, the push skips — the items wait on the queue, and
+ *      the supervisor's next prompt will see them via
+ *      `orchestrate_read_inbox`.
+ *   3. Recovery: when the supervisor's own `agent_end` fires (i.e.
+ *      it just became idle), we check for pending items and PUSH
+ *      again if any. Closes the "supervisor finished a turn but
+ *      didn't call read_inbox" gap.
+ *
+ * All PUSH paths are best-effort: the queue is the source of truth.
+ * A missed wake-up means the supervisor sees the items on its next
+ * turn, not that the items vanish.
+ */
+import { getSession } from "../session-registry.js";
+import {
+  enqueueInboxItem,
+  getSupervisorIdForWorker,
+  pendingInboxCount,
+  readPendingInbox,
+} from "./store.js";
+import type { InboxEventType, InboxItem } from "./types.js";
+
+/**
+ * Per-supervisor "already pushed once for this idle window" flag.
+ * Without this, every inbox enqueue while the supervisor is briefly
+ * idle would fire a fresh `prompt()` — the supervisor's first push
+ * starts a turn, but the SDK may not flip isStreaming to true
+ * immediately (it's set after the first message_start event), so a
+ * second enqueue 1ms later would still see "idle" and fire a
+ * duplicate prompt. The flag is cleared in two places:
+ *   - On the supervisor's own `agent_end` (handled in
+ *     `notifySupervisorIdle` below) — the supervisor's turn finished
+ *     and the next idle window is a new wake-up opportunity.
+ *   - On supervisor dispose (handled in session-registry) — clear
+ *     so a re-resumed session can wake again.
+ */
+const pendingWakePush = new Set<string>();
+
+/**
+ * Per-supervisor sequence number for wake-up prompts. Surfaces in
+ * stderr logs to make it possible to grep "how many times have we
+ * pushed to supervisor X today" without parsing timestamps.
+ */
+const wakeCounters = new Map<string, number>();
+
+function nextWakeCounter(supervisorId: string): number {
+  const n = (wakeCounters.get(supervisorId) ?? 0) + 1;
+  wakeCounters.set(supervisorId, n);
+  return n;
+}
+
+function logInbox(level: "info" | "warn", payload: Record<string, unknown>): void {
+  process.stderr.write(
+    `${JSON.stringify({ level, time: new Date().toISOString(), ...payload })}\n`,
+  );
+}
+
+/**
+ * Decide whether the live supervisor session is "idle" — i.e.,
+ * not currently mid-turn. The SDK exposes `isStreaming`; that's a
+ * stable proxy for "the agent loop is producing output right now."
+ * A session that has never prompted is also idle.
+ */
+function isSupervisorIdle(supervisorId: string): boolean {
+  const live = getSession(supervisorId);
+  if (live === undefined) return false; // not live → no idle to push to
+  // SDK exposes isStreaming as a getter on AgentSession.
+  return live.session.isStreaming === false;
+}
+
+/**
+ * Build the wake-up prompt text. Kept short — the prompt's only job
+ * is to nudge the supervisor LLM to call `orchestrate_read_inbox`.
+ * The bracket marker is also what the client UI uses to style the
+ * message distinctly from a user message (recognised by the
+ * `OrchestrationWakePrefix` constant exported below).
+ */
+export const ORCHESTRATION_WAKE_PREFIX = "[orchestration]";
+
+function buildWakeText(pendingCount: number): string {
+  return (
+    `${ORCHESTRATION_WAKE_PREFIX} ${pendingCount} pending worker event(s). ` +
+    `Call \`orchestrate_read_inbox\` to inspect, then decide whether to ` +
+    `\`orchestrate_read_worker\`, \`orchestrate_send_to_worker\`, or take no action.`
+  );
+}
+
+/**
+ * Attempt to wake the supervisor with a tiny system-style prompt.
+ * No-op if the supervisor is offline, busy, or already has an
+ * in-flight push for this idle window.
+ *
+ * Returns true if a prompt was actually fired (used by tests).
+ */
+async function tryWakeSupervisor(supervisorId: string): Promise<boolean> {
+  const live = getSession(supervisorId);
+  if (live === undefined) return false;
+  if (!isSupervisorIdle(supervisorId)) return false;
+  if (pendingWakePush.has(supervisorId)) return false;
+  const pending = await pendingInboxCount(supervisorId);
+  if (pending === 0) return false;
+
+  pendingWakePush.add(supervisorId);
+  const seq = nextWakeCounter(supervisorId);
+  const text = buildWakeText(pending);
+  // Fire-and-forget. The SDK's session.prompt is async; we let it
+  // run in the background so the event-bridge caller (often the
+  // hot path of an AgentSessionEvent subscriber) returns
+  // immediately. Errors are surfaced via stderr — most likely
+  // cause is "no model configured on the supervisor session," in
+  // which case the supervisor is unusable for orchestration
+  // regardless and the operator needs to see why.
+  live.session
+    .prompt(text)
+    .then(() => {
+      logInbox("info", {
+        msg: "orchestration-wake-delivered",
+        supervisorId,
+        pending,
+        seq,
+      });
+    })
+    .catch((err: unknown) => {
+      logInbox("warn", {
+        msg: "orchestration-wake-failed",
+        supervisorId,
+        pending,
+        seq,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    });
+  return true;
+}
+
+/**
+ * Public entry point: a worker session emitted an interesting
+ * event, route it to the right supervisor's inbox and try to
+ * wake the supervisor.
+ *
+ * Silently skips when the worker isn't linked to a supervisor —
+ * happens transiently when a worker is being detached/disposed,
+ * and is the expected steady-state for non-orchestrated sessions
+ * (the event bridge currently calls this for every session's
+ * events, then filters here).
+ */
+export async function bridgeWorkerEvent(
+  workerId: string,
+  type: InboxEventType,
+  data: Record<string, unknown>,
+): Promise<InboxItem | undefined> {
+  const supervisorId = await getSupervisorIdForWorker(workerId);
+  if (supervisorId === undefined) return undefined;
+  const item = await enqueueInboxItem(supervisorId, {
+    type,
+    workerId,
+    occurredAt: new Date().toISOString(),
+    data,
+  });
+  logInbox("info", {
+    msg: "orchestration-inbox-enqueued",
+    supervisorId,
+    workerId,
+    type,
+    itemId: item.id,
+  });
+  // Best-effort wake-up. tryWake handles its own debounce + offline
+  // checks. We DON'T await — the worker event handler that called
+  // us shouldn't block on the supervisor's LLM round-trip.
+  void tryWakeSupervisor(supervisorId);
+  return item;
+}
+
+/**
+ * Called from session-registry when a supervisor's own session
+ * emits `agent_end` — i.e., the supervisor just became idle.
+ * Clears the per-idle-window dedupe flag and re-pushes if pending
+ * items accumulated during the just-finished turn.
+ *
+ * This closes the "supervisor finished a turn without reading the
+ * inbox" gap: if the supervisor's LLM ignored a prior wake-up (or
+ * the wake-up arrived after the supervisor was already mid-turn),
+ * this gives it one more nudge before going truly idle.
+ */
+export async function notifySupervisorIdle(supervisorId: string): Promise<void> {
+  pendingWakePush.delete(supervisorId);
+  void tryWakeSupervisor(supervisorId);
+}
+
+/**
+ * Called from session-registry when a supervisor session is
+ * disposed. Drops the dedupe flag so a future re-resume of the
+ * same id can wake again from scratch.
+ */
+export function notifySupervisorDisposed(supervisorId: string): void {
+  pendingWakePush.delete(supervisorId);
+  wakeCounters.delete(supervisorId);
+}
+
+/**
+ * Drain a supervisor's pending inbox items and mark them delivered.
+ * The tool-side wrapper for `orchestrate_read_inbox`.
+ */
+export async function drainInbox(supervisorId: string): Promise<InboxItem[]> {
+  return readPendingInbox(supervisorId, { markDelivered: true });
+}

--- a/packages/server/src/orchestration/init.ts
+++ b/packages/server/src/orchestration/init.ts
@@ -1,0 +1,38 @@
+/**
+ * Boot-time wiring of the orchestration event bridge to the
+ * forge-native singleton event channels (ask-user-question, processes).
+ *
+ * Per-AgentSession events (agent_end, auto_retry_end) are dispatched
+ * from inside `session-registry.makeSubscribeHandler` — those need
+ * the LiveSession context at construction time. session-registry
+ * also calls `notifySupervisorIdle` on supervisor agent_end and
+ * `notifySupervisorDisposed` on supervisor dispose.
+ *
+ * The DELETE-side `worker.deleted` event is fired from the sessions
+ * DELETE route, alongside the existing webhook `session_deleted`
+ * fan-out.
+ *
+ * No instance-level guard here: the subscribers are cheap (filter
+ * to "is the event source a registered worker?" then route). The
+ * actual gating against `isOrchestrationEnabled()` happens at tool
+ * registration and route entry — events still need to be observed
+ * so a session that becomes a worker mid-stream gets its later
+ * events picked up.
+ */
+import { subscribe as subscribeAskQuestions } from "../ask-user-question/registry.js";
+import { processManager } from "../processes/manager.js";
+import { bridgeWorkerAskUserQuestion, bridgeWorkerProcessAlert } from "./event-bridge.js";
+
+export function initOrchestrationAskUserQuestionBridge(): () => void {
+  return subscribeAskQuestions((event) => {
+    if (event.type !== "ask_user_question") return;
+    void bridgeWorkerAskUserQuestion(event.sessionId, event.questions, event.requestId);
+  });
+}
+
+export function initOrchestrationProcessesBridge(): () => void {
+  return processManager.subscribe((event) => {
+    if (event.type !== "process_alert") return;
+    void bridgeWorkerProcessAlert(event.sessionId, event.info, event.reason);
+  });
+}

--- a/packages/server/src/orchestration/store.ts
+++ b/packages/server/src/orchestration/store.ts
@@ -1,0 +1,398 @@
+/**
+ * Disk-backed persistence for orchestration metadata.
+ *
+ * Two files in `${FORGE_DATA_DIR}/`:
+ *   - `session-orchestration.json` — supervisor opt-in + supervisor↔worker links
+ *   - `orchestrator-inbox.json`    — per-supervisor pending event queue
+ *
+ * Separate files so the chatty inbox writes don't fight the rare
+ * topology mutations. Same atomic-write + in-process lock pattern as
+ * `webhooks/store.ts` and `project-manager.ts`. Single-tenant /
+ * single-process assumption — cross-process safety would need a real
+ * file lock.
+ *
+ * Mode 0600 on both: the link file has no secrets but the inbox can
+ * carry assistant-message previews (which can contain anything the
+ * agent has been working on); both should be unreadable to other
+ * users on shared boxes.
+ */
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { config } from "../config.js";
+import {
+  emptyInboxStore,
+  emptyStore,
+  type InboxItem,
+  type InboxStore,
+  isInboxEventType,
+  MAX_INBOX_ITEMS,
+  ORCHESTRATION_VERSION,
+  type OrchestrationStore,
+  type SupervisorRecord,
+  type WorkerRecord,
+} from "./types.js";
+
+const STORE_FILE = (): string => join(config.forgeDataDir, "session-orchestration.json");
+const INBOX_FILE = (): string => join(config.forgeDataDir, "orchestrator-inbox.json");
+
+async function ensureDir(): Promise<void> {
+  await mkdir(config.forgeDataDir, { recursive: true });
+}
+
+async function atomicWriteJson(target: string, data: unknown, mode: number): Promise<void> {
+  await ensureDir();
+  const tmp = `${target}.${randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  try {
+    await chmod(tmp, mode);
+    await rename(tmp, target);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
+}
+
+// ---- session-orchestration.json (topology) ----
+
+let storeLock: Promise<unknown> = Promise.resolve();
+function withStoreLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = storeLock.then(fn, fn);
+  storeLock = next.catch(() => undefined);
+  return next;
+}
+
+function isSupervisorRecord(v: unknown): v is SupervisorRecord {
+  if (typeof v !== "object" || v === null) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.enabledAt === "string" &&
+    Array.isArray(r.workerIds) &&
+    r.workerIds.every((id) => typeof id === "string")
+  );
+}
+
+function isWorkerRecord(v: unknown): v is WorkerRecord {
+  if (typeof v !== "object" || v === null) return false;
+  const r = v as Record<string, unknown>;
+  if (typeof r.supervisorId !== "string" || typeof r.spawnedAt !== "string") return false;
+  if (r.spawnedFrom !== undefined) {
+    const sf = r.spawnedFrom as Record<string, unknown>;
+    if (typeof sf.sessionId !== "string") return false;
+    if (sf.mode !== "fresh" && sf.mode !== "summary") return false;
+  }
+  return true;
+}
+
+async function readStoreFile(): Promise<OrchestrationStore> {
+  await ensureDir();
+  try {
+    const raw = await readFile(STORE_FILE(), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return emptyStore();
+    const r = parsed as Record<string, unknown>;
+    const supervisors: Record<string, SupervisorRecord> = {};
+    const workers: Record<string, WorkerRecord> = {};
+    if (typeof r.supervisors === "object" && r.supervisors !== null) {
+      for (const [id, rec] of Object.entries(r.supervisors as Record<string, unknown>)) {
+        if (isSupervisorRecord(rec)) supervisors[id] = rec;
+      }
+    }
+    if (typeof r.workers === "object" && r.workers !== null) {
+      for (const [id, rec] of Object.entries(r.workers as Record<string, unknown>)) {
+        if (isWorkerRecord(rec)) workers[id] = rec;
+      }
+    }
+    return { version: ORCHESTRATION_VERSION, supervisors, workers };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return emptyStore();
+    throw err;
+  }
+}
+
+async function writeStoreFile(s: OrchestrationStore): Promise<void> {
+  await atomicWriteJson(STORE_FILE(), s, 0o600);
+}
+
+export async function readStore(): Promise<OrchestrationStore> {
+  return readStoreFile();
+}
+
+/**
+ * Mark a session as a supervisor. Idempotent — calling on an
+ * already-enabled session updates nothing. Rejects if the session
+ * is currently registered as a worker (depth=1 limit).
+ */
+export class OrchestrationError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "OrchestrationError";
+  }
+}
+
+export async function enableSupervisor(sessionId: string): Promise<SupervisorRecord> {
+  return withStoreLock(async () => {
+    const s = await readStoreFile();
+    if (s.workers[sessionId] !== undefined) {
+      throw new OrchestrationError(
+        "depth_limit_exceeded",
+        `Session ${sessionId} is a worker and cannot become a supervisor (depth=1).`,
+      );
+    }
+    const existing = s.supervisors[sessionId];
+    if (existing !== undefined) return existing;
+    const rec: SupervisorRecord = {
+      enabledAt: new Date().toISOString(),
+      workerIds: [],
+    };
+    s.supervisors[sessionId] = rec;
+    await writeStoreFile(s);
+    return rec;
+  });
+}
+
+/**
+ * Remove a session's supervisor mode. Detaches every worker so they
+ * become standalone (their session records are left alone on disk).
+ * No-op if the session wasn't a supervisor.
+ */
+export async function disableSupervisor(sessionId: string): Promise<void> {
+  await withStoreLock(async () => {
+    const s = await readStoreFile();
+    const rec = s.supervisors[sessionId];
+    if (rec === undefined) return;
+    for (const workerId of rec.workerIds) {
+      delete s.workers[workerId];
+    }
+    delete s.supervisors[sessionId];
+    await writeStoreFile(s);
+  });
+}
+
+/**
+ * Register a new worker session under a supervisor. Caller is
+ * responsible for actually creating the session (via createSession
+ * in session-registry); this just records the link. Rejects if the
+ * supervisor doesn't exist or the worker is already linked
+ * elsewhere. Concurrency-safe (single store lock).
+ */
+export async function registerWorker(opts: {
+  supervisorId: string;
+  workerId: string;
+  spawnedFrom?: { sessionId: string; mode: "fresh" | "summary" };
+}): Promise<void> {
+  await withStoreLock(async () => {
+    const s = await readStoreFile();
+    const sup = s.supervisors[opts.supervisorId];
+    if (sup === undefined) {
+      throw new OrchestrationError(
+        "supervisor_not_found",
+        `No supervisor record for ${opts.supervisorId}.`,
+      );
+    }
+    if (s.workers[opts.workerId] !== undefined) {
+      throw new OrchestrationError(
+        "worker_already_linked",
+        `Worker ${opts.workerId} is already linked to a supervisor.`,
+      );
+    }
+    if (s.supervisors[opts.workerId] !== undefined) {
+      throw new OrchestrationError(
+        "depth_limit_exceeded",
+        `Session ${opts.workerId} is already a supervisor; cannot also be a worker.`,
+      );
+    }
+    sup.workerIds.push(opts.workerId);
+    const wrec: WorkerRecord = {
+      supervisorId: opts.supervisorId,
+      spawnedAt: new Date().toISOString(),
+    };
+    if (opts.spawnedFrom !== undefined) wrec.spawnedFrom = opts.spawnedFrom;
+    s.workers[opts.workerId] = wrec;
+    await writeStoreFile(s);
+  });
+}
+
+/**
+ * Drop a worker's link to its supervisor. Idempotent — no-op if the
+ * worker wasn't registered. Used by `orchestrate_detach_worker`
+ * and as the cleanup step when a worker is killed.
+ */
+export async function unregisterWorker(workerId: string): Promise<void> {
+  await withStoreLock(async () => {
+    const s = await readStoreFile();
+    const wrec = s.workers[workerId];
+    if (wrec === undefined) return;
+    const sup = s.supervisors[wrec.supervisorId];
+    if (sup !== undefined) {
+      sup.workerIds = sup.workerIds.filter((id) => id !== workerId);
+    }
+    delete s.workers[workerId];
+    await writeStoreFile(s);
+  });
+}
+
+/**
+ * Resolve the supervisor ID for a worker session, or undefined if
+ * the session isn't a registered worker. Read-only — no lock
+ * needed because we tolerate stale reads (the event bridge reads
+ * this on every event and just skips when the link has been torn
+ * down mid-flight).
+ */
+export async function getSupervisorIdForWorker(workerId: string): Promise<string | undefined> {
+  const s = await readStoreFile();
+  return s.workers[workerId]?.supervisorId;
+}
+
+export async function isSupervisor(sessionId: string): Promise<boolean> {
+  const s = await readStoreFile();
+  return s.supervisors[sessionId] !== undefined;
+}
+
+export async function isWorker(sessionId: string): Promise<boolean> {
+  const s = await readStoreFile();
+  return s.workers[sessionId] !== undefined;
+}
+
+export async function getWorkerIds(supervisorId: string): Promise<string[]> {
+  const s = await readStoreFile();
+  return [...(s.supervisors[supervisorId]?.workerIds ?? [])];
+}
+
+export async function getWorkerRecord(workerId: string): Promise<WorkerRecord | undefined> {
+  const s = await readStoreFile();
+  return s.workers[workerId];
+}
+
+// ---- orchestrator-inbox.json (queue) ----
+
+let inboxLock: Promise<unknown> = Promise.resolve();
+function withInboxLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = inboxLock.then(fn, fn);
+  inboxLock = next.catch(() => undefined);
+  return next;
+}
+
+function isInboxItem(v: unknown): v is InboxItem {
+  if (typeof v !== "object" || v === null) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.id === "string" &&
+    isInboxEventType(r.type) &&
+    typeof r.workerId === "string" &&
+    typeof r.occurredAt === "string" &&
+    typeof r.data === "object" &&
+    r.data !== null &&
+    typeof r.delivered === "boolean"
+  );
+}
+
+async function readInboxFile(): Promise<InboxStore> {
+  await ensureDir();
+  try {
+    const raw = await readFile(INBOX_FILE(), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return emptyInboxStore();
+    const r = parsed as Record<string, unknown>;
+    const inboxes: Record<string, InboxItem[]> = {};
+    if (typeof r.inboxes === "object" && r.inboxes !== null) {
+      for (const [supId, items] of Object.entries(r.inboxes as Record<string, unknown>)) {
+        if (Array.isArray(items)) {
+          inboxes[supId] = items.filter(isInboxItem);
+        }
+      }
+    }
+    return { version: ORCHESTRATION_VERSION, inboxes };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return emptyInboxStore();
+    throw err;
+  }
+}
+
+async function writeInboxFile(s: InboxStore): Promise<void> {
+  await atomicWriteJson(INBOX_FILE(), s, 0o600);
+}
+
+/**
+ * Append an inbox item for the supervisor. FIFO-evicts items beyond
+ * `MAX_INBOX_ITEMS`. Caller is responsible for resolving the
+ * supervisor ID (via `getSupervisorIdForWorker`) — this is a raw
+ * write that doesn't check the topology.
+ */
+export async function enqueueInboxItem(
+  supervisorId: string,
+  item: Omit<InboxItem, "id" | "delivered">,
+): Promise<InboxItem> {
+  return withInboxLock(async () => {
+    const s = await readInboxFile();
+    const existing = s.inboxes[supervisorId] ?? [];
+    const full: InboxItem = { id: randomUUID(), delivered: false, ...item };
+    existing.push(full);
+    // FIFO trim from the front so the most recent N stay.
+    const trimmed =
+      existing.length > MAX_INBOX_ITEMS
+        ? existing.slice(existing.length - MAX_INBOX_ITEMS)
+        : existing;
+    s.inboxes[supervisorId] = trimmed;
+    await writeInboxFile(s);
+    return full;
+  });
+}
+
+/**
+ * Read pending (undelivered) items for the supervisor. Optionally
+ * mark them delivered as part of the same lock window so the
+ * agent-facing tool can advance the cursor atomically.
+ *
+ * Returns the items in chronological order (oldest first) — the
+ * supervisor LLM should process them in arrival order so a "ended"
+ * event after an "ask_user" doesn't get acted on first.
+ */
+export async function readPendingInbox(
+  supervisorId: string,
+  opts: { markDelivered?: boolean } = {},
+): Promise<InboxItem[]> {
+  return withInboxLock(async () => {
+    const s = await readInboxFile();
+    const items = s.inboxes[supervisorId] ?? [];
+    const pending = items.filter((it) => !it.delivered);
+    if (opts.markDelivered === true && pending.length > 0) {
+      for (const it of pending) it.delivered = true;
+      s.inboxes[supervisorId] = items;
+      await writeInboxFile(s);
+    }
+    return pending.map((it) => ({ ...it }));
+  });
+}
+
+/**
+ * Return ALL inbox items for the supervisor (delivered + pending),
+ * newest first. Powers the REST UI; capped by the per-supervisor
+ * FIFO already, so safe to send wholesale.
+ */
+export async function readAllInbox(supervisorId: string): Promise<InboxItem[]> {
+  const s = await readInboxFile();
+  const items = s.inboxes[supervisorId] ?? [];
+  return items.slice().reverse();
+}
+
+export async function pendingInboxCount(supervisorId: string): Promise<number> {
+  const s = await readInboxFile();
+  const items = s.inboxes[supervisorId] ?? [];
+  return items.filter((it) => !it.delivered).length;
+}
+
+/**
+ * Drop a supervisor's inbox entirely. Called when supervisor mode
+ * is disabled or the supervisor session is deleted.
+ */
+export async function clearInbox(supervisorId: string): Promise<void> {
+  await withInboxLock(async () => {
+    const s = await readInboxFile();
+    if (s.inboxes[supervisorId] === undefined) return;
+    delete s.inboxes[supervisorId];
+    await writeInboxFile(s);
+  });
+}

--- a/packages/server/src/orchestration/tools.ts
+++ b/packages/server/src/orchestration/tools.ts
@@ -1,0 +1,888 @@
+/**
+ * Agent-facing tool surface for supervisor sessions.
+ *
+ * Eight `orchestrate_*` tools, registered onto a session ONLY when
+ * that session has supervisor mode enabled AND the instance-level
+ * `ORCHESTRATION_ENABLED` flag is on AND MINIMAL_UI is off. Wired
+ * through `createAgentSession({ customTools })` in session-registry.
+ *
+ * Topology is hub-and-spoke by tool surface: workers don't get
+ * these tools, so there's no way to express worker→worker comms.
+ * Same-project enforcement: spawn_worker creates in the supervisor's
+ * project; cross-project is intentionally out of scope for v1.
+ *
+ * Every tool that names a workerId verifies ownership against the
+ * store before acting — defense in depth so a confused supervisor
+ * LLM can't reach into another supervisor's worker by id-guessing.
+ */
+import { Type } from "typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import {
+  createSession,
+  disposeSession,
+  findSessionLocation,
+  getSession,
+  resumeSessionById,
+  SessionNotFoundError,
+  deleteColdSession,
+} from "../session-registry.js";
+import { maxWorkersPerSupervisor } from "./config.js";
+import { drainInbox } from "./inbox.js";
+import {
+  getWorkerIds,
+  getWorkerRecord,
+  OrchestrationError,
+  registerWorker,
+  unregisterWorker,
+} from "./store.js";
+
+// ---- result shape helpers ----
+
+/**
+ * Build a tool result. CRITICAL: the `text` field is what the
+ * supervisor LLM actually sees on its next turn. `details` is
+ * structured metadata for downstream consumers (REST, tests) but is
+ * NOT in the agent's context window. So every tool that wants the
+ * orchestrator to make decisions on real data has to encode that
+ * data into the text — putting it only in `details` is the same as
+ * not returning it at all from the LLM's perspective.
+ */
+function ok(payload: Record<string, unknown>, text: string): AgentToolResult<unknown> {
+  return {
+    content: [{ type: "text", text }],
+    details: payload,
+  };
+}
+
+function err(code: string, message: string): AgentToolResult<unknown> {
+  return {
+    content: [{ type: "text", text: `[error: ${code}] ${message}` }],
+    details: { error: code, message },
+  };
+}
+
+// ---- message serialization for the supervisor LLM ----
+
+/**
+ * Per-message hard cap when serializing a worker transcript for the
+ * supervisor. Long bash outputs / write tool results blow up the
+ * supervisor's context fast otherwise. 1.2k chars ≈ 400 tokens is
+ * enough for the model to see the gist of any single step; the
+ * supervisor can always call `orchestrate_read_worker` with a
+ * tighter `limit` to focus on fewer messages in full.
+ */
+const PER_MESSAGE_CAP = 1_200;
+
+/**
+ * Total cap across all serialized messages in one read_worker call.
+ * 24k chars ≈ 8k tokens. Bigger than `PER_MESSAGE_CAP × default
+ * limit (20)`, so the default-limit case fits comfortably; if the
+ * caller bumps limit, we still bound the total to protect the
+ * supervisor's context budget.
+ */
+const TOTAL_TRANSCRIPT_CAP = 24_000;
+
+interface SerializedBlock {
+  text?: string;
+  toolCalls?: string[];
+  toolResults?: string[];
+  imageCount?: number;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
+}
+
+function previewArgs(input: unknown): string {
+  try {
+    const j = JSON.stringify(input);
+    return truncate(j, 200);
+  } catch {
+    return "(unserializable)";
+  }
+}
+
+function extractFromContent(content: unknown): SerializedBlock {
+  const out: SerializedBlock = {};
+  if (typeof content === "string") {
+    out.text = content;
+    return out;
+  }
+  if (!Array.isArray(content)) return out;
+  const textParts: string[] = [];
+  const toolCalls: string[] = [];
+  const toolResults: string[] = [];
+  let imageCount = 0;
+  for (const raw of content) {
+    const b = raw as {
+      type?: string;
+      text?: string;
+      name?: string;
+      input?: unknown;
+      tool_use_id?: string;
+      content?: unknown;
+      is_error?: boolean;
+    };
+    if (b.type === "text" && typeof b.text === "string") {
+      textParts.push(b.text);
+      continue;
+    }
+    if (b.type === "tool_use" && typeof b.name === "string") {
+      toolCalls.push(`${b.name}(${previewArgs(b.input)})`);
+      continue;
+    }
+    if (b.type === "tool_result") {
+      // tool_result.content can itself be a string or an array of
+      // content blocks. Flatten to a short preview either way so the
+      // supervisor sees what the worker's tool actually returned —
+      // that's often the load-bearing signal for "did the worker
+      // succeed."
+      let resultText = "";
+      if (typeof b.content === "string") resultText = b.content;
+      else if (Array.isArray(b.content)) {
+        const inner: string[] = [];
+        for (const c of b.content as { type?: string; text?: string }[]) {
+          if (c.type === "text" && typeof c.text === "string") inner.push(c.text);
+        }
+        resultText = inner.join("\n");
+      }
+      const prefix = b.is_error === true ? "[error] " : "";
+      toolResults.push(prefix + truncate(resultText.trim(), 400));
+      continue;
+    }
+    if (b.type === "image") {
+      imageCount += 1;
+      continue;
+    }
+  }
+  if (textParts.length > 0) out.text = textParts.join("\n");
+  if (toolCalls.length > 0) out.toolCalls = toolCalls;
+  if (toolResults.length > 0) out.toolResults = toolResults;
+  if (imageCount > 0) out.imageCount = imageCount;
+  return out;
+}
+
+/**
+ * Render one worker message as plain text the supervisor LLM can
+ * read. Squashes the SDK's AgentMessage union into:
+ *
+ *     [role]
+ *     <text>
+ *     → tool_use: bash(...)
+ *     ← tool_result: <preview>
+ *     (+ N image(s))
+ *
+ * Caller is responsible for capping total transcript size; this
+ * function only caps the per-message body so individual messages
+ * stay readable when one of them is very long.
+ */
+function formatMessageForOrchestrator(msg: unknown, index: number, total: number): string {
+  const m = msg as { role?: string; type?: string };
+  const role = m.role ?? m.type ?? "unknown";
+  const blocks = extractFromContent((m as { content?: unknown }).content);
+  const lines: string[] = [`[${index + 1}/${total}] ${role}`];
+  if (blocks.text !== undefined && blocks.text.trim().length > 0) {
+    lines.push(truncate(blocks.text.trim(), PER_MESSAGE_CAP));
+  }
+  for (const tc of blocks.toolCalls ?? []) lines.push(`→ tool_use: ${tc}`);
+  for (const tr of blocks.toolResults ?? []) lines.push(`← tool_result: ${tr}`);
+  if ((blocks.imageCount ?? 0) > 0) lines.push(`(+${blocks.imageCount} image(s))`);
+  if (lines.length === 1) lines.push("(no readable content)");
+  return lines.join("\n");
+}
+
+/**
+ * Concatenate per-message renders with a total-size budget. If we'd
+ * blow past `TOTAL_TRANSCRIPT_CAP`, drop messages from the FRONT
+ * (oldest) — the supervisor cares most about what the worker did
+ * recently, and the caller can always re-call with a smaller `limit`
+ * to see fewer messages in full.
+ */
+/**
+ * Pick the most useful one-line detail from an inbox item's
+ * `data` payload, based on its event type. Keeps the inbox summary
+ * compact while still surfacing the load-bearing signal — the
+ * supervisor LLM shouldn't have to guess what happened from just
+ * a type name.
+ */
+function summarizeInboxData(type: string, data: Record<string, unknown>): string {
+  if (type === "worker.ended") {
+    const stop = typeof data.stopReason === "string" ? data.stopReason : "unknown";
+    const err = typeof data.errorMessage === "string" ? data.errorMessage : "";
+    const preview =
+      typeof data.assistantTextPreview === "string" ? truncate(data.assistantTextPreview, 200) : "";
+    const parts: string[] = [`stop=${stop}`];
+    if (err !== "") parts.push(`error="${truncate(err, 120)}"`);
+    if (preview !== "") parts.push(`said: ${preview}`);
+    return parts.join(" ");
+  }
+  if (type === "worker.ask_user") {
+    const header = typeof data.firstQuestionHeader === "string" ? data.firstQuestionHeader : "";
+    const text = typeof data.firstQuestionText === "string" ? data.firstQuestionText : "";
+    const count = typeof data.questionCount === "number" ? data.questionCount : 1;
+    return `${count} question(s)${header !== "" ? `, first: "${header}"` : ""}${text !== "" ? ` (${truncate(text, 120)})` : ""}`;
+  }
+  if (type === "worker.auto_retry_failed") {
+    const attempt = typeof data.attempt === "number" ? data.attempt : "?";
+    const maxA = typeof data.maxAttempts === "number" ? data.maxAttempts : "?";
+    const finalErr = typeof data.finalError === "string" ? data.finalError : "";
+    return `attempts=${attempt}/${maxA}${finalErr !== "" ? ` err="${truncate(finalErr, 120)}"` : ""}`;
+  }
+  if (type === "worker.process_alert") {
+    const reason = typeof data.reason === "string" ? data.reason : "unknown";
+    const name = typeof data.name === "string" ? data.name : "(unnamed)";
+    const exit = typeof data.exitCode === "number" ? data.exitCode : "?";
+    return `${reason} process="${name}" exit=${exit}`;
+  }
+  if (type === "worker.deleted") {
+    const wasLive = data.wasLive === true;
+    return wasLive ? "was live" : "was cold";
+  }
+  // Unknown event type — fall back to a compact JSON preview so the
+  // supervisor at least sees something actionable.
+  try {
+    return truncate(JSON.stringify(data), 200);
+  } catch {
+    return "";
+  }
+}
+
+function renderTranscript(messages: readonly unknown[], total: number): string {
+  const rendered: string[] = [];
+  let used = 0;
+  // Walk newest-to-oldest, prepend in render order at the end.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const block = formatMessageForOrchestrator(messages[i], total - (messages.length - i), total);
+    if (used + block.length + 2 > TOTAL_TRANSCRIPT_CAP) break;
+    rendered.unshift(block);
+    used += block.length + 2;
+  }
+  if (rendered.length < messages.length) {
+    rendered.unshift(
+      `[truncated — older ${messages.length - rendered.length} message(s) omitted to keep the transcript under ${TOTAL_TRANSCRIPT_CAP} chars]`,
+    );
+  }
+  return rendered.join("\n\n");
+}
+
+// ---- ownership guard ----
+
+async function assertOwns(
+  supervisorId: string,
+  workerId: string,
+): Promise<undefined | AgentToolResult<unknown>> {
+  const rec = await getWorkerRecord(workerId);
+  if (rec === undefined) {
+    return err("worker_not_found", `No worker registered with id ${workerId}.`);
+  }
+  if (rec.supervisorId !== supervisorId) {
+    return err(
+      "not_owner",
+      `Worker ${workerId} is linked to a different supervisor; refusing to act on it.`,
+    );
+  }
+  return undefined;
+}
+
+// ---- spawn_worker ----
+
+const spawnSchema = {
+  type: "object",
+  required: ["name", "initialPrompt"],
+  additionalProperties: false,
+  properties: {
+    name: {
+      type: "string",
+      minLength: 1,
+      maxLength: 200,
+      description:
+        "Required short, descriptive label shown in the session picker — " +
+        "this is how the user (and you, on later turns) will recognise the " +
+        "worker among others. Concrete task names work best: " +
+        "'Implement /auth route', 'Add tests for orders module', " +
+        "'Audit RLS policies'. AVOID generic placeholders ('helper', " +
+        "'worker 1', 'task') — those defeat the whole point of having " +
+        "named workers.",
+    },
+    initialPrompt: {
+      type: "string",
+      minLength: 1,
+      description:
+        "The TASK assigned to this worker. The worker is a fresh autonomous " +
+        "agent — it does not see your transcript or memory. Write a self-" +
+        "contained task brief: what to do, where (file paths), constraints, " +
+        "and what 'done' looks like. Instruct, don't collaborate.",
+    },
+    contextSummary: {
+      type: "string",
+      maxLength: 8_000,
+      description:
+        "Optional handoff context summary. When present, prepended " +
+        "to `initialPrompt` so the worker starts with relevant " +
+        "background. Use this for the 'A finishes → B picks up' " +
+        "pipeline pattern. Cap is 8k chars to keep the worker's " +
+        "first-turn token cost predictable.",
+    },
+  },
+} as const;
+
+function createSpawnWorker(supervisorId: string): ToolDefinition {
+  return {
+    name: "orchestrate_spawn_worker",
+    label: "Spawn worker session",
+    description:
+      "Create a new worker session in the same project as the supervisor and " +
+      "assign it a task. Workers are autonomous task-running agents — NOT " +
+      "conversational helpers. Each spawn delegates a discrete unit of " +
+      "work; the worker executes against the task in `initialPrompt`, " +
+      "reports completion via its inbox, then waits for the next task " +
+      "(or shutdown). ALWAYS pass a descriptive `name` so the user (and " +
+      "you, on later turns) can tell workers apart in the picker — " +
+      "generic placeholders make the multi-worker case unusable. " +
+      "Worker events (turn-end, ask-user-question, etc.) feed back into the " +
+      "supervisor's inbox; check with `orchestrate_read_inbox`. " +
+      "Same-project only in v1 — cross-project orchestration is intentionally " +
+      "disabled. Subject to the per-supervisor fan-out cap (default 8).",
+    parameters: Type.Unsafe<Record<string, unknown>>(spawnSchema),
+    async execute(_toolCallId, params) {
+      const p = params as {
+        name: string;
+        initialPrompt: string;
+        contextSummary?: string;
+      };
+      const supLive = getSession(supervisorId);
+      if (supLive === undefined) {
+        return err("supervisor_not_live", "Supervisor session is not currently live.");
+      }
+      // Enforce fan-out cap on LIVE workers — a worker that was killed
+      // earlier (registry-gone) shouldn't count against the cap even
+      // though the store may still list it transiently.
+      const workerIds = await getWorkerIds(supervisorId);
+      const liveWorkers = workerIds.filter((id) => getSession(id) !== undefined);
+      const cap = maxWorkersPerSupervisor();
+      if (liveWorkers.length >= cap) {
+        return err(
+          "fanout_limit_exceeded",
+          `Supervisor already has ${liveWorkers.length} live workers (cap ${cap}). ` +
+            `Kill or detach an existing worker before spawning another.`,
+        );
+      }
+      // Spawn into the supervisor's project — never cross-project.
+      let worker: Awaited<ReturnType<typeof createSession>>;
+      try {
+        worker = await createSession(supLive.projectId, supLive.workspacePath);
+      } catch (e) {
+        return err(
+          "spawn_failed",
+          `createSession threw: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+      // Register the link AFTER successful session creation so a
+      // createSession failure doesn't leave a dangling store entry.
+      try {
+        await registerWorker({
+          supervisorId,
+          workerId: worker.sessionId,
+          spawnedFrom: {
+            sessionId: supervisorId,
+            mode: p.contextSummary !== undefined ? "summary" : "fresh",
+          },
+        });
+      } catch (e) {
+        // Roll back the session create on registration failure —
+        // otherwise we leak a session the user can't see linked
+        // anywhere.
+        await disposeSession(worker.sessionId).catch(() => undefined);
+        await deleteColdSession(worker.sessionId).catch(() => undefined);
+        if (e instanceof OrchestrationError) {
+          return err(e.code, e.message);
+        }
+        return err("register_failed", e instanceof Error ? e.message : String(e));
+      }
+      // Apply the required name. Best-effort — the worker is fully
+      // functional even if naming fails, so we don't roll back the
+      // spawn on this. The user just sees the SDK default in the
+      // picker until they rename it manually.
+      try {
+        worker.session.setSessionName(p.name);
+      } catch (e) {
+        process.stderr.write(
+          JSON.stringify({
+            level: "warn",
+            time: new Date().toISOString(),
+            msg: "orchestration-worker-rename-failed",
+            workerId: worker.sessionId,
+            requestedName: p.name,
+            err: e instanceof Error ? e.message : String(e),
+          }) + "\n",
+        );
+      }
+      // Build the initial prompt: optional context summary + the
+      // caller's prompt. The context summary is prepended as its
+      // own paragraph so the worker LLM can clearly distinguish
+      // background from the task.
+      const initialPrompt =
+        p.contextSummary !== undefined && p.contextSummary.length > 0
+          ? `# Handoff context\n${p.contextSummary}\n\n# Task\n${p.initialPrompt}`
+          : p.initialPrompt;
+      // Fire the initial prompt. Fire-and-forget — the supervisor
+      // will see the turn outcome via its inbox; making the tool
+      // wait here would block the supervisor's loop for the entire
+      // worker turn.
+      worker.session.prompt(initialPrompt).catch((e: unknown) => {
+        process.stderr.write(
+          JSON.stringify({
+            level: "warn",
+            time: new Date().toISOString(),
+            msg: "orchestration-worker-initial-prompt-failed",
+            workerId: worker.sessionId,
+            err: e instanceof Error ? e.message : String(e),
+          }) + "\n",
+        );
+      });
+      return ok(
+        {
+          workerId: worker.sessionId,
+          name: worker.session.sessionName ?? p.name,
+          projectId: worker.projectId,
+        },
+        `Spawned worker "${p.name}" (${worker.sessionId}). Initial prompt delivered. ` +
+          `Monitor via orchestrate_read_inbox or orchestrate_read_worker.`,
+      );
+    },
+  } satisfies ToolDefinition;
+}
+
+// ---- list_workers ----
+
+function createListWorkers(supervisorId: string): ToolDefinition {
+  return {
+    name: "orchestrate_list_workers",
+    label: "List workers",
+    description:
+      "Return every worker registered under this supervisor with its " +
+      "current state (live / idle / streaming / cold), last activity " +
+      "timestamp, and message count. Cheap to call repeatedly.",
+    parameters: Type.Unsafe<Record<string, unknown>>({ type: "object", properties: {} }),
+    async execute() {
+      interface WorkerRow {
+        workerId: string;
+        state: "cold" | "idle" | "streaming";
+        isLive: boolean;
+        isStreaming: boolean;
+        messageCount: number | null;
+        lastActivityAt: string | null;
+        name: string | null;
+      }
+      const ids = await getWorkerIds(supervisorId);
+      const workers: WorkerRow[] = ids.map((workerId) => {
+        const live = getSession(workerId);
+        if (live === undefined) {
+          return {
+            workerId,
+            state: "cold",
+            isLive: false,
+            isStreaming: false,
+            messageCount: null,
+            lastActivityAt: null,
+            name: null,
+          };
+        }
+        return {
+          workerId,
+          state: live.session.isStreaming ? "streaming" : "idle",
+          isLive: true,
+          isStreaming: live.session.isStreaming,
+          messageCount: live.session.messages.length,
+          lastActivityAt: live.lastActivityAt.toISOString(),
+          name: live.session.sessionName ?? null,
+        };
+      });
+      const summary =
+        `${workers.length} worker(s) registered. ` +
+        `${workers.filter((w) => w.state === "streaming").length} streaming, ` +
+        `${workers.filter((w) => w.state === "idle").length} idle, ` +
+        `${workers.filter((w) => w.state === "cold").length} cold.`;
+      const rows = workers.map((w) => {
+        const label = w.name ?? "(unnamed)";
+        const msgs = w.messageCount !== null ? `${w.messageCount} msgs` : "no live state";
+        const last = w.lastActivityAt !== null ? `last activity ${w.lastActivityAt}` : "";
+        return `- ${w.state.padEnd(9)} "${label}" (${w.workerId}) — ${msgs}${last !== "" ? `, ${last}` : ""}`;
+      });
+      const body = rows.length === 0 ? "(no workers spawned yet)" : rows.join("\n");
+      return ok({ workers }, `${summary}\n${body}`);
+    },
+  } satisfies ToolDefinition;
+}
+
+// ---- read_worker ----
+
+const readWorkerSchema = {
+  type: "object",
+  required: ["workerId"],
+  additionalProperties: false,
+  properties: {
+    workerId: { type: "string", minLength: 1 },
+    limit: {
+      type: "integer",
+      minimum: 1,
+      maximum: 100,
+      description:
+        "How many of the most recent messages to return. Default 1 — " +
+        "the worker's single latest message is enough context for most " +
+        "supervisor decisions (typically the assistant's last turn or the " +
+        "last user-side handoff). Bump this only when one-message context " +
+        "isn't enough — e.g. you need to see the worker's reasoning chain " +
+        "across several turns, or you're auditing a long tool-call sequence. " +
+        "Bigger `limit` burns more of YOUR context window per call.",
+    },
+  },
+} as const;
+
+function createReadWorker(supervisorId: string): ToolDefinition {
+  return {
+    name: "orchestrate_read_worker",
+    label: "Read worker transcript",
+    description:
+      "Fetch the most recent messages from a worker's transcript. Returns the " +
+      "last N messages newest-last (chronological order, ready to read). " +
+      "Default `limit` is 1: most supervisor decisions only need the worker's " +
+      "latest message. Only bump `limit` when one message doesn't give you " +
+      "enough context. Auto-resumes cold workers from disk so the tool works " +
+      "regardless of whether the worker is currently live.",
+    parameters: Type.Unsafe<Record<string, unknown>>(readWorkerSchema),
+    async execute(_toolCallId, params) {
+      const p = params as { workerId: string; limit?: number };
+      const guard = await assertOwns(supervisorId, p.workerId);
+      if (guard !== undefined) return guard;
+      let live = getSession(p.workerId);
+      if (live === undefined) {
+        try {
+          live = await resumeSessionById(p.workerId);
+        } catch (e) {
+          if (e instanceof SessionNotFoundError) {
+            return err("worker_session_missing", `Worker session ${p.workerId} not on disk.`);
+          }
+          return err("resume_failed", e instanceof Error ? e.message : String(e));
+        }
+      }
+      const limit = Math.min(Math.max(p.limit ?? 1, 1), 100);
+      const all = live.session.messages;
+      const tail = all.slice(Math.max(0, all.length - limit));
+      const name = live.session.sessionName ?? "(unnamed)";
+      const header =
+        `Worker "${name}" (${p.workerId}) — ` +
+        `${live.session.isStreaming ? "streaming" : "idle"}. ` +
+        `Showing the last ${tail.length} of ${all.length} message(s).`;
+      const transcript =
+        tail.length === 0
+          ? "(no messages yet — worker hasn't started its first turn)"
+          : renderTranscript(tail, all.length);
+      return ok(
+        {
+          workerId: p.workerId,
+          totalMessages: all.length,
+          returned: tail.length,
+          isStreaming: live.session.isStreaming,
+          messages: tail,
+        },
+        `${header}\n\n${transcript}`,
+      );
+    },
+  } satisfies ToolDefinition;
+}
+
+// ---- send_to_worker ----
+
+const sendSchema = {
+  type: "object",
+  required: ["workerId", "message"],
+  additionalProperties: false,
+  properties: {
+    workerId: { type: "string", minLength: 1 },
+    message: {
+      type: "string",
+      minLength: 1,
+      description:
+        "The next task or directive — concrete instruction, not " +
+        "conversational filler (every send spends a worker turn). " +
+        "Typical uses: assign follow-up work, course-correct mid-" +
+        "execution (with mode='steer'), or answer a pending " +
+        "ask_user_question.",
+    },
+    mode: {
+      type: "string",
+      enum: ["prompt", "steer", "followUp"],
+      description:
+        "`prompt` (default): new turn, or queue if busy. " +
+        "`steer`: interrupt the current turn — for course-correction. " +
+        "`followUp`: wait for idle, then send — for queued next tasks.",
+    },
+  },
+} as const;
+
+function createSendToWorker(supervisorId: string): ToolDefinition {
+  return {
+    name: "orchestrate_send_to_worker",
+    label: "Send message to worker",
+    description:
+      "Assign a follow-up task or directive to a running worker. The message " +
+      "is tagged as supervisor-sourced in the worker's transcript so the " +
+      "worker LLM can distinguish it from a human user message. Frame each " +
+      "send as a concrete instruction (next task, course-correction, " +
+      "specific answer to a pending question) — NOT chitchat. Every send " +
+      "spends a worker turn.",
+    parameters: Type.Unsafe<Record<string, unknown>>(sendSchema),
+    async execute(_toolCallId, params) {
+      const p = params as {
+        workerId: string;
+        message: string;
+        mode?: "prompt" | "steer" | "followUp";
+      };
+      const guard = await assertOwns(supervisorId, p.workerId);
+      if (guard !== undefined) return guard;
+      const live = getSession(p.workerId);
+      if (live === undefined) {
+        return err(
+          "worker_not_live",
+          `Worker ${p.workerId} is not currently live. Resume it first (open in the UI or call orchestrate_read_worker).`,
+        );
+      }
+      // Tag the message so the client can render it with a
+      // supervisor badge. The marker is part of the message text
+      // — not a separate metadata channel — because the SDK's
+      // prompt/steer/followUp signature only accepts text. Same
+      // pattern as the [orchestration] wake-up prefix in inbox.ts.
+      const tagged = `[supervisor:${supervisorId}] ${p.message}`;
+      const mode = p.mode ?? "prompt";
+      try {
+        if (mode === "prompt") {
+          live.session.prompt(tagged).catch(() => undefined);
+        } else if (mode === "steer") {
+          live.session.steer(tagged).catch(() => undefined);
+        } else {
+          live.session.followUp(tagged).catch(() => undefined);
+        }
+      } catch (e) {
+        return err("send_failed", e instanceof Error ? e.message : String(e));
+      }
+      return ok(
+        { workerId: p.workerId, mode, accepted: true },
+        `Queued ${mode} message to worker ${p.workerId}.`,
+      );
+    },
+  } satisfies ToolDefinition;
+}
+
+// ---- interrupt_worker ----
+
+const interruptSchema = {
+  type: "object",
+  required: ["workerId"],
+  additionalProperties: false,
+  properties: { workerId: { type: "string", minLength: 1 } },
+} as const;
+
+function createInterruptWorker(supervisorId: string): ToolDefinition {
+  return {
+    name: "orchestrate_interrupt_worker",
+    label: "Interrupt worker",
+    description:
+      "Abort the worker's current turn. Idempotent on idle workers. " +
+      "The worker session itself stays live; use `orchestrate_kill_worker` " +
+      "to fully terminate.",
+    parameters: Type.Unsafe<Record<string, unknown>>(interruptSchema),
+    async execute(_toolCallId, params) {
+      const p = params as { workerId: string };
+      const guard = await assertOwns(supervisorId, p.workerId);
+      if (guard !== undefined) return guard;
+      const live = getSession(p.workerId);
+      if (live === undefined) {
+        return err("worker_not_live", `Worker ${p.workerId} is not currently live.`);
+      }
+      try {
+        await live.session.abort();
+      } catch (e) {
+        return err("abort_failed", e instanceof Error ? e.message : String(e));
+      }
+      return ok(
+        { workerId: p.workerId, aborted: true },
+        `Aborted worker ${p.workerId}'s current turn.`,
+      );
+    },
+  } satisfies ToolDefinition;
+}
+
+// ---- kill_worker ----
+
+const killSchema = {
+  type: "object",
+  required: ["workerId"],
+  additionalProperties: false,
+  properties: {
+    workerId: { type: "string", minLength: 1 },
+    deleteOnDisk: {
+      type: "boolean",
+      description:
+        "When true, also delete the worker's .jsonl from disk (the session " +
+        "is gone from the sidebar). Default false — keeps the transcript " +
+        "for later inspection.",
+    },
+  },
+} as const;
+
+function createKillWorker(supervisorId: string): ToolDefinition {
+  return {
+    name: "orchestrate_kill_worker",
+    label: "Kill worker",
+    description:
+      "Dispose the worker session (terminate any in-flight turn, close " +
+      "SSE clients) and unregister it from this supervisor. By default " +
+      "the .jsonl transcript stays on disk; pass `deleteOnDisk: true` " +
+      "to also remove it.",
+    parameters: Type.Unsafe<Record<string, unknown>>(killSchema),
+    async execute(_toolCallId, params) {
+      const p = params as { workerId: string; deleteOnDisk?: boolean };
+      const guard = await assertOwns(supervisorId, p.workerId);
+      if (guard !== undefined) return guard;
+      const wasLive = await disposeSession(p.workerId);
+      let diskDeleted = false;
+      if (p.deleteOnDisk === true) {
+        const r = await deleteColdSession(p.workerId).catch(() => "not_found" as const);
+        diskDeleted = r === "deleted";
+      }
+      await unregisterWorker(p.workerId);
+      return ok(
+        { workerId: p.workerId, wasLive, diskDeleted },
+        `Killed worker ${p.workerId}${diskDeleted ? " (and deleted from disk)" : ""}.`,
+      );
+    },
+  } satisfies ToolDefinition;
+}
+
+// ---- detach_worker ----
+
+const detachSchema = {
+  type: "object",
+  required: ["workerId"],
+  additionalProperties: false,
+  properties: { workerId: { type: "string", minLength: 1 } },
+} as const;
+
+function createDetachWorker(supervisorId: string): ToolDefinition {
+  return {
+    name: "orchestrate_detach_worker",
+    label: "Detach worker",
+    description:
+      "Drop the supervisor↔worker link. The worker session stays live " +
+      "(transcript untouched) but its events no longer feed this " +
+      "supervisor's inbox. Use when the worker is done and should " +
+      "continue as a standalone session.",
+    parameters: Type.Unsafe<Record<string, unknown>>(detachSchema),
+    async execute(_toolCallId, params) {
+      const p = params as { workerId: string };
+      const guard = await assertOwns(supervisorId, p.workerId);
+      if (guard !== undefined) return guard;
+      await unregisterWorker(p.workerId);
+      return ok(
+        { workerId: p.workerId, detached: true },
+        `Detached worker ${p.workerId}. It remains live as a standalone session.`,
+      );
+    },
+  } satisfies ToolDefinition;
+}
+
+// ---- read_inbox ----
+
+function createReadInbox(supervisorId: string): ToolDefinition {
+  return {
+    name: "orchestrate_read_inbox",
+    label: "Read inbox",
+    description:
+      "Drain pending worker events: turn-ends, ask-user-question requests, " +
+      "auto-retry failures, process alerts, and deletions. Items are " +
+      "returned oldest-first and marked delivered — calling again returns " +
+      "only NEW items unless you also call `orchestrate_list_workers` to " +
+      "re-survey state. Items stay in the audit history (visible in the " +
+      "REST UI) regardless.",
+    parameters: Type.Unsafe<Record<string, unknown>>({ type: "object", properties: {} }),
+    async execute() {
+      const items = await drainInbox(supervisorId);
+      if (items.length === 0) {
+        return ok({ items: [] }, "No new inbox items.");
+      }
+      // Render each item as a readable line. The structured items
+      // also go in `details` for the REST layer, but the supervisor
+      // LLM reads them from this text — `details` doesn't reach the
+      // model's context. Per-item key fields are picked based on
+      // the event type so the supervisor sees the load-bearing
+      // signal without needing a follow-up read_worker call for
+      // every event.
+      const lines = items.map((it) => {
+        const d = it.data;
+        const detail = summarizeInboxData(it.type, d);
+        return `- [${it.occurredAt}] ${it.type} worker=${it.workerId}${detail !== "" ? ` — ${detail}` : ""}`;
+      });
+      return ok(
+        {
+          items: items.map((it) => ({
+            id: it.id,
+            type: it.type,
+            workerId: it.workerId,
+            occurredAt: it.occurredAt,
+            data: it.data,
+          })),
+        },
+        `Drained ${items.length} inbox item(s):\n${lines.join("\n")}`,
+      );
+    },
+  } satisfies ToolDefinition;
+}
+
+// ---- public factory ----
+
+/**
+ * Build the complete orchestration tool set for a supervisor session.
+ * Returns 8 tools. Caller (session-registry) is responsible for
+ * checking `isOrchestrationEnabled()` and the per-session supervisor
+ * flag BEFORE calling — this factory just builds the tools.
+ *
+ * Workers do NOT call this; their customTools array doesn't include
+ * any orchestration tools by design (hub-and-spoke enforcement via
+ * tool surface).
+ */
+export function createOrchestrationTools(supervisorId: string): ToolDefinition[] {
+  return [
+    createSpawnWorker(supervisorId),
+    createListWorkers(supervisorId),
+    createReadWorker(supervisorId),
+    createSendToWorker(supervisorId),
+    createInterruptWorker(supervisorId),
+    createKillWorker(supervisorId),
+    createDetachWorker(supervisorId),
+    createReadInbox(supervisorId),
+  ];
+}
+
+/** Public for the allowlist machinery in session-registry. */
+export const ORCHESTRATION_TOOL_NAMES = [
+  "orchestrate_spawn_worker",
+  "orchestrate_list_workers",
+  "orchestrate_read_worker",
+  "orchestrate_send_to_worker",
+  "orchestrate_interrupt_worker",
+  "orchestrate_kill_worker",
+  "orchestrate_detach_worker",
+  "orchestrate_read_inbox",
+] as const;
+
+/** Helper: best-effort sanity check that `findSessionLocation` can
+ *  reach the worker. Used by tests; not used by the tools themselves
+ *  because every tool that needs the session already calls
+ *  `getSession`/`resumeSessionById` directly. */
+export async function workerLocationExists(workerId: string): Promise<boolean> {
+  const loc = await findSessionLocation(workerId);
+  return loc !== undefined;
+}

--- a/packages/server/src/orchestration/types.ts
+++ b/packages/server/src/orchestration/types.ts
@@ -1,0 +1,121 @@
+/**
+ * Session orchestration — types + constants.
+ *
+ * A "supervisor" session has the `orchestrate_*` tool group enabled
+ * and can spawn / observe / message / interrupt / kill / detach a set
+ * of "worker" sessions. Workers are real first-class sessions (same
+ * .jsonl on disk, same browser visibility) — the link is purely
+ * forge-side metadata in `${FORGE_DATA_DIR}/session-orchestration.json`.
+ *
+ * Topology is strict hub-and-spoke: workers don't get the orchestrate
+ * tools and have no way to enumerate or message other workers.
+ * Enforcement is by tool-surface (the tools simply aren't there),
+ * not by permission check at the registry layer.
+ *
+ * Depth is limited to 1: a worker cannot become a supervisor. Keeps
+ * the worst case bounded against fork-bomb runaway prompts.
+ */
+
+export const ORCHESTRATION_VERSION = 1 as const;
+
+/**
+ * Inbox events the supervisor's LLM sees when it calls
+ * `orchestrate_read_inbox`. All carry the workerId; the `data`
+ * shape is event-specific and intentionally small — the supervisor
+ * can call `orchestrate_read_worker` to fetch full detail.
+ */
+export const INBOX_EVENT_TYPES = [
+  "worker.ended",
+  "worker.ask_user",
+  "worker.auto_retry_failed",
+  "worker.process_alert",
+  "worker.deleted",
+] as const;
+
+export type InboxEventType = (typeof INBOX_EVENT_TYPES)[number];
+
+export function isInboxEventType(v: unknown): v is InboxEventType {
+  return typeof v === "string" && (INBOX_EVENT_TYPES as readonly string[]).includes(v);
+}
+
+export interface InboxItem {
+  /** UUID assigned at enqueue. */
+  id: string;
+  type: InboxEventType;
+  workerId: string;
+  /** ISO timestamp. */
+  occurredAt: string;
+  /** Event-specific small payload. The supervisor calls
+   *  `orchestrate_read_worker` for full transcript context. */
+  data: Record<string, unknown>;
+  /** True once `read_inbox` has surfaced this item to the supervisor's
+   *  LLM. Items stay in the file for one more drain cycle (so the user
+   *  can audit recent activity via the REST UI) then evict via cap. */
+  delivered: boolean;
+}
+
+export interface SupervisorRecord {
+  /** ISO timestamp the supervisor mode was enabled. */
+  enabledAt: string;
+  /** Live worker session IDs spawned (or attached) under this
+   *  supervisor. Authoritative — the per-worker `supervisorId` is a
+   *  back-pointer. Kept in sync via the same store-level lock. */
+  workerIds: string[];
+}
+
+export interface WorkerRecord {
+  supervisorId: string;
+  spawnedAt: string;
+  /** Best-effort: how the worker was created. Helps the UI badge
+   *  "↳ handoff from <id>" without round-tripping the supervisor. */
+  spawnedFrom?: {
+    sessionId: string;
+    mode: "fresh" | "summary";
+  };
+}
+
+/**
+ * Persisted store shape — written to `session-orchestration.json`.
+ * Two maps so a worker→supervisor lookup is O(1) without iterating
+ * every supervisor's worker list. supervisors[id].workerIds is the
+ * source of truth for the fanout cap; workers[id].supervisorId is
+ * the back-pointer used by the event bridge.
+ */
+export interface OrchestrationStore {
+  version: typeof ORCHESTRATION_VERSION;
+  supervisors: Record<string, SupervisorRecord>;
+  workers: Record<string, WorkerRecord>;
+}
+
+export function emptyStore(): OrchestrationStore {
+  return { version: ORCHESTRATION_VERSION, supervisors: {}, workers: {} };
+}
+
+export interface InboxStore {
+  version: typeof ORCHESTRATION_VERSION;
+  /** supervisorId → FIFO-capped item list, oldest first. */
+  inboxes: Record<string, InboxItem[]>;
+}
+
+export function emptyInboxStore(): InboxStore {
+  return { version: ORCHESTRATION_VERSION, inboxes: {} };
+}
+
+/**
+ * Per-supervisor inbox cap. Items beyond this evict from the FIFO
+ * front. 200 is enough headroom for a supervisor that goes offline
+ * for an hour while 20 workers run; the supervisor can still see the
+ * last few hundred events on resume. Bumping this is cheap (small
+ * JSON blob); shrinking risks an inattentive supervisor missing
+ * events that fired before its next wake-up.
+ */
+export const MAX_INBOX_ITEMS = 200;
+
+/** Default per-supervisor concurrent worker cap. Configurable via
+ *  `ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR`. */
+export const DEFAULT_MAX_WORKERS_PER_SUPERVISOR = 8;
+
+/** Depth limit — workers cannot themselves be supervisors. Phase 1
+ *  ships at depth=1 only. Reconsider once real usage clarifies what
+ *  the worst-case prompt loops look like. */
+export const MAX_DEPTH = 1;

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -5,6 +5,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { sessionCount } from "../session-registry.js";
 import { ptyCount } from "../pty-manager.js";
 import { config, passwordAuthEnabled } from "../config.js";
+import { isOrchestrationEnabled } from "../orchestration/config.js";
 
 /**
  * Read the server's own package.json once at module load. Used by the
@@ -96,7 +97,13 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
         response: {
           200: {
             type: "object",
-            required: ["minimal", "workspaceRoot", "version", "passwordAuthEnabled"],
+            required: [
+              "minimal",
+              "workspaceRoot",
+              "version",
+              "passwordAuthEnabled",
+              "orchestrationEnabled",
+            ],
             properties: {
               // True when MINIMAL_UI is set: hides terminal, git pane,
               // last-turn pane, and providers/agent settings sections;
@@ -117,6 +124,11 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
               // deployments report false; the Settings → General
               // password change section hides in that case.
               passwordAuthEnabled: { type: "boolean" },
+              // True iff session orchestration is reachable. Off
+              // when ORCHESTRATION_ENABLED is unset OR MINIMAL_UI
+              // is true (orchestration is hard-disabled under
+              // MINIMAL_UI regardless of the env flag).
+              orchestrationEnabled: { type: "boolean" },
             },
           },
         },
@@ -127,6 +139,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
       workspaceRoot: config.workspacePath,
       version: SERVER_VERSION,
       passwordAuthEnabled: passwordAuthEnabled(),
+      orchestrationEnabled: isOrchestrationEnabled(),
     }),
   );
 };

--- a/packages/server/src/routes/orchestration.ts
+++ b/packages/server/src/routes/orchestration.ts
@@ -1,0 +1,558 @@
+/**
+ * REST surface for session orchestration.
+ *
+ * Routes (all under `/api/v1/`):
+ *   GET    /orchestration/config                          — instance flag + caps
+ *   GET    /orchestration/sessions/:id                    — role + linkage for a session
+ *   POST   /orchestration/sessions/:id/enable             — make session a supervisor
+ *   POST   /orchestration/sessions/:id/disable            — remove supervisor mode
+ *   GET    /orchestration/sessions/:id/workers            — list workers for a supervisor
+ *   GET    /orchestration/sessions/:id/inbox              — full inbox history (newest first)
+ *   POST   /orchestration/sessions/:id/inbox/clear        — wipe inbox
+ *   POST   /orchestration/sessions/:id/workers/:wid/detach — drop supervisor link
+ *   POST   /orchestration/sessions/:id/workers/:wid/kill   — dispose worker (UI control)
+ *
+ * Every route is gated by `isOrchestrationEnabled()` — returns 403
+ * `orchestration_disabled` or `minimal_ui_disabled` based on which
+ * gate is closed. The instance-level env flag is the kill switch;
+ * MINIMAL_UI is a hard secondary gate (orchestration never surfaces
+ * under MINIMAL_UI even with the env flag on, same posture as the
+ * webhooks mutation gate).
+ */
+import type { FastifyPluginAsync, FastifyReply } from "fastify";
+import {
+  disposeSession,
+  findProjectIdForSession,
+  getSession,
+  rebuildAgentSessionForTools,
+  resumeSessionById,
+} from "../session-registry.js";
+import {
+  isOrchestrationEnabled,
+  maxWorkersPerSupervisor,
+  orchestrationDisabledReason,
+} from "../orchestration/config.js";
+import {
+  disableSupervisor,
+  enableSupervisor,
+  getWorkerIds,
+  getWorkerRecord,
+  isSupervisor,
+  isWorker,
+  OrchestrationError,
+  unregisterWorker,
+} from "../orchestration/store.js";
+import { clearInbox, pendingInboxCount, readAllInbox } from "../orchestration/store.js";
+import { MAX_DEPTH } from "../orchestration/types.js";
+import { errorSchema } from "./_schemas.js";
+
+function gate(reply: FastifyReply): FastifyReply | undefined {
+  if (isOrchestrationEnabled()) return undefined;
+  const reason = orchestrationDisabledReason();
+  const message =
+    reason === "minimal_ui_disabled"
+      ? "Session orchestration is disabled under MINIMAL_UI."
+      : "Session orchestration is disabled. Set ORCHESTRATION_ENABLED=true to enable.";
+  return reply.code(403).send({ error: reason, message });
+}
+
+function handleStoreError(reply: FastifyReply, err: unknown): FastifyReply {
+  if (err instanceof OrchestrationError) {
+    // Map specific codes to HTTP — depth_limit and validation
+    // failures are 400s (client mistake); supervisor_not_found
+    // is a 404 only when the SESSION exists but isn't a supervisor,
+    // which is its own thing. We rely on the code field.
+    if (err.code === "depth_limit_exceeded" || err.code === "worker_already_linked") {
+      return reply.code(400).send({ error: err.code, message: err.message });
+    }
+    if (err.code === "supervisor_not_found") {
+      return reply.code(404).send({ error: err.code, message: err.message });
+    }
+    return reply.code(400).send({ error: err.code, message: err.message });
+  }
+  reply.log.error({ err }, "orchestration route error");
+  return reply.code(500).send({ error: "internal_error" });
+}
+
+const sessionLinkSchema = {
+  type: "object",
+  required: ["sessionId", "role"],
+  properties: {
+    sessionId: { type: "string" },
+    role: { type: "string", enum: ["supervisor", "worker", "standalone"] },
+    supervisorId: { type: "string" },
+    workerIds: { type: "array", items: { type: "string" } },
+    pendingInbox: { type: "integer", minimum: 0 },
+    enabledAt: { type: "string" },
+    spawnedAt: { type: "string" },
+    spawnedFrom: {
+      type: "object",
+      required: ["sessionId", "mode"],
+      properties: {
+        sessionId: { type: "string" },
+        mode: { type: "string", enum: ["fresh", "summary"] },
+      },
+    },
+  },
+} as const;
+
+const workerSummarySchema = {
+  type: "object",
+  required: ["workerId", "isLive"],
+  properties: {
+    workerId: { type: "string" },
+    isLive: { type: "boolean" },
+    isStreaming: { type: "boolean" },
+    name: { type: "string" },
+    state: { type: "string", enum: ["streaming", "idle", "cold"] },
+    lastActivityAt: { type: "string" },
+    messageCount: { type: "integer", minimum: 0 },
+    projectId: { type: "string" },
+    spawnedAt: { type: "string" },
+    spawnedFrom: {
+      type: "object",
+      properties: {
+        sessionId: { type: "string" },
+        mode: { type: "string" },
+      },
+    },
+  },
+} as const;
+
+const inboxItemSchema = {
+  type: "object",
+  required: ["id", "type", "workerId", "occurredAt", "data", "delivered"],
+  properties: {
+    id: { type: "string" },
+    type: { type: "string" },
+    workerId: { type: "string" },
+    occurredAt: { type: "string" },
+    data: { type: "object", additionalProperties: true },
+    delivered: { type: "boolean" },
+  },
+} as const;
+
+export const orchestrationRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get(
+    "/orchestration/config",
+    {
+      schema: {
+        description:
+          "Return whether orchestration is enabled on this instance plus the " +
+          "current caps. Always available (no auth surface beyond the standard " +
+          "API auth gate); the UI uses this to decide whether to render the " +
+          "supervisor toggle and Workers panel.",
+        tags: ["orchestration"],
+        response: {
+          200: {
+            type: "object",
+            required: ["enabled", "maxWorkersPerSupervisor", "maxDepth", "disabledReason"],
+            properties: {
+              enabled: { type: "boolean" },
+              maxWorkersPerSupervisor: { type: "integer", minimum: 1 },
+              maxDepth: { type: "integer", minimum: 1 },
+              disabledReason: {
+                type: "string",
+                enum: ["", "minimal_ui_disabled", "orchestration_disabled"],
+              },
+            },
+          },
+        },
+      },
+    },
+    async () => {
+      const enabled = isOrchestrationEnabled();
+      return {
+        enabled,
+        maxWorkersPerSupervisor: maxWorkersPerSupervisor(),
+        maxDepth: MAX_DEPTH,
+        disabledReason: enabled ? "" : orchestrationDisabledReason(),
+      };
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/orchestration/sessions/:id",
+    {
+      schema: {
+        description:
+          "Return the orchestration role of a session: 'supervisor', 'worker', " +
+          "or 'standalone'. For supervisors, includes the worker list + pending " +
+          "inbox count; for workers, includes the supervisor id + handoff lineage.",
+        tags: ["orchestration"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: sessionLinkSchema,
+          403: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const g = gate(reply);
+      if (g !== undefined) return g;
+      const sessionId = req.params.id;
+      if (await isSupervisor(sessionId)) {
+        const workerIds = await getWorkerIds(sessionId);
+        const pending = await pendingInboxCount(sessionId);
+        return {
+          sessionId,
+          role: "supervisor",
+          workerIds,
+          pendingInbox: pending,
+        };
+      }
+      if (await isWorker(sessionId)) {
+        const rec = await getWorkerRecord(sessionId);
+        const out: Record<string, unknown> = {
+          sessionId,
+          role: "worker",
+        };
+        if (rec !== undefined) {
+          out.supervisorId = rec.supervisorId;
+          out.spawnedAt = rec.spawnedAt;
+          if (rec.spawnedFrom !== undefined) out.spawnedFrom = rec.spawnedFrom;
+        }
+        return out;
+      }
+      return { sessionId, role: "standalone" };
+    },
+  );
+
+  fastify.post<{ Params: { id: string } }>(
+    "/orchestration/sessions/:id/enable",
+    {
+      schema: {
+        description:
+          "Mark the session as a supervisor AND rebuild its live agent " +
+          "session in-place so the orchestrate_* tools become available " +
+          "immediately. The SDK only builds its tool list at " +
+          "AgentSession-creation time, so an enable without rebuild would " +
+          "leave a running session toolless until the user manually closed " +
+          "and reopened it. The rebuild keeps the SSE attached — the " +
+          "browser sees no reconnect, the new tools just appear on the " +
+          "next turn.",
+        tags: ["orchestration"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: sessionLinkSchema,
+          400: errorSchema,
+          403: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const g = gate(reply);
+      if (g !== undefined) return g;
+      try {
+        const rec = await enableSupervisor(req.params.id);
+        // Rebuild AFTER the store write so the new AgentSession's
+        // `customTools` resolution sees the supervisor flag and
+        // adds the orchestrate_* tools. Best-effort — if the
+        // session isn't live (browser opened a cold session, never
+        // attached SSE), there's nothing to rebuild and the next
+        // resume will pick up the tools naturally.
+        try {
+          await rebuildAgentSessionForTools(req.params.id);
+        } catch (err) {
+          req.log.warn(
+            { err, sessionId: req.params.id },
+            "orchestration enable: rebuild failed (non-fatal — next resume will pick up tools)",
+          );
+        }
+        return {
+          sessionId: req.params.id,
+          role: "supervisor",
+          workerIds: rec.workerIds,
+          enabledAt: rec.enabledAt,
+          pendingInbox: 0,
+        };
+      } catch (err) {
+        return handleStoreError(reply, err);
+      }
+    },
+  );
+
+  fastify.post<{ Params: { id: string } }>(
+    "/orchestration/sessions/:id/disable",
+    {
+      schema: {
+        description:
+          "Remove supervisor mode. Detaches every linked worker (they survive " +
+          "as standalone sessions), clears the supervisor's inbox, AND " +
+          "rebuilds the supervisor's live agent session in-place so the " +
+          "orchestrate_* tools disappear immediately. Same rebuild rationale " +
+          "as /enable — the SDK's tool list is fixed at agent-session " +
+          "creation time, so the tools would otherwise linger until the " +
+          "session was reloaded.",
+        tags: ["orchestration"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          204: { type: "null" },
+          403: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const g = gate(reply);
+      if (g !== undefined) return g;
+      await disableSupervisor(req.params.id);
+      await clearInbox(req.params.id);
+      try {
+        await rebuildAgentSessionForTools(req.params.id);
+      } catch (err) {
+        req.log.warn(
+          { err, sessionId: req.params.id },
+          "orchestration disable: rebuild failed (non-fatal — next resume drops the tools)",
+        );
+      }
+      return reply.code(204).send();
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/orchestration/sessions/:id/workers",
+    {
+      schema: {
+        description:
+          "Return the worker list for a supervisor with live state (streaming/" +
+          "idle/cold) and metadata. The UI renders this as the supervisor's " +
+          "Workers side panel.",
+        tags: ["orchestration"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["workers"],
+            properties: { workers: { type: "array", items: workerSummarySchema } },
+          },
+          403: errorSchema,
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const g = gate(reply);
+      if (g !== undefined) return g;
+      if (!(await isSupervisor(req.params.id))) {
+        return reply.code(404).send({ error: "not_a_supervisor" });
+      }
+      const ids = await getWorkerIds(req.params.id);
+      const workers = await Promise.all(
+        ids.map(async (workerId) => {
+          const rec = await getWorkerRecord(workerId);
+          const live = getSession(workerId);
+          const base: Record<string, unknown> = { workerId, isLive: live !== undefined };
+          if (rec !== undefined) {
+            base.spawnedAt = rec.spawnedAt;
+            if (rec.spawnedFrom !== undefined) base.spawnedFrom = rec.spawnedFrom;
+          }
+          if (live !== undefined) {
+            base.isStreaming = live.session.isStreaming;
+            base.state = live.session.isStreaming ? "streaming" : "idle";
+            base.name = live.session.sessionName ?? undefined;
+            base.messageCount = live.session.messages.length;
+            base.lastActivityAt = live.lastActivityAt.toISOString();
+            base.projectId = live.projectId;
+          } else {
+            base.state = "cold";
+            const projectId = await findProjectIdForSession(workerId);
+            if (projectId !== undefined) base.projectId = projectId;
+          }
+          return base;
+        }),
+      );
+      return { workers };
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/orchestration/sessions/:id/inbox",
+    {
+      schema: {
+        description:
+          "Return the supervisor's inbox history — every event the bridge " +
+          "captured (delivered + pending), newest first. Capped at 200 items " +
+          "per supervisor via FIFO eviction.",
+        tags: ["orchestration"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["items"],
+            properties: { items: { type: "array", items: inboxItemSchema } },
+          },
+          403: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const g = gate(reply);
+      if (g !== undefined) return g;
+      const items = await readAllInbox(req.params.id);
+      return { items };
+    },
+  );
+
+  fastify.post<{ Params: { id: string } }>(
+    "/orchestration/sessions/:id/inbox/clear",
+    {
+      schema: {
+        description: "Wipe the supervisor's inbox (history + pending).",
+        tags: ["orchestration"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          204: { type: "null" },
+          403: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const g = gate(reply);
+      if (g !== undefined) return g;
+      await clearInbox(req.params.id);
+      return reply.code(204).send();
+    },
+  );
+
+  fastify.post<{ Params: { id: string; wid: string } }>(
+    "/orchestration/sessions/:id/workers/:wid/detach",
+    {
+      schema: {
+        description:
+          "UI control: drop the supervisor→worker link without killing the " +
+          "worker. The worker continues running as a standalone session. " +
+          "Refuses if the worker isn't linked to this supervisor.",
+        tags: ["orchestration"],
+        params: {
+          type: "object",
+          required: ["id", "wid"],
+          properties: { id: { type: "string" }, wid: { type: "string" } },
+        },
+        response: {
+          204: { type: "null" },
+          403: errorSchema,
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const g = gate(reply);
+      if (g !== undefined) return g;
+      const rec = await getWorkerRecord(req.params.wid);
+      if (rec === undefined || rec.supervisorId !== req.params.id) {
+        return reply.code(404).send({ error: "worker_not_linked" });
+      }
+      await unregisterWorker(req.params.wid);
+      return reply.code(204).send();
+    },
+  );
+
+  fastify.post<{ Params: { id: string; wid: string } }>(
+    "/orchestration/sessions/:id/workers/:wid/kill",
+    {
+      schema: {
+        description:
+          "UI control: dispose the worker session AND unregister it from this " +
+          "supervisor. Does NOT delete the .jsonl from disk — use DELETE " +
+          "/sessions/:id for that.",
+        tags: ["orchestration"],
+        params: {
+          type: "object",
+          required: ["id", "wid"],
+          properties: { id: { type: "string" }, wid: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["wasLive"],
+            properties: { wasLive: { type: "boolean" } },
+          },
+          403: errorSchema,
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const g = gate(reply);
+      if (g !== undefined) return g;
+      const rec = await getWorkerRecord(req.params.wid);
+      if (rec === undefined || rec.supervisorId !== req.params.id) {
+        return reply.code(404).send({ error: "worker_not_linked" });
+      }
+      const wasLive = await disposeSession(req.params.wid);
+      await unregisterWorker(req.params.wid);
+      return { wasLive };
+    },
+  );
+
+  // Used by the UI "Resume worker" button when the worker is cold.
+  // No body — just a hint to the registry to load the session from
+  // disk so subsequent UI calls (read transcript, send message) hit
+  // a live session.
+  fastify.post<{ Params: { id: string; wid: string } }>(
+    "/orchestration/sessions/:id/workers/:wid/resume",
+    {
+      schema: {
+        description:
+          "Force-resume a cold worker into the live registry. Idempotent on " +
+          "already-live workers.",
+        tags: ["orchestration"],
+        params: {
+          type: "object",
+          required: ["id", "wid"],
+          properties: { id: { type: "string" }, wid: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["resumed"],
+            properties: { resumed: { type: "boolean" } },
+          },
+          403: errorSchema,
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const g = gate(reply);
+      if (g !== undefined) return g;
+      const rec = await getWorkerRecord(req.params.wid);
+      if (rec === undefined || rec.supervisorId !== req.params.id) {
+        return reply.code(404).send({ error: "worker_not_linked" });
+      }
+      const existing = getSession(req.params.wid);
+      if (existing !== undefined) return { resumed: false };
+      try {
+        await resumeSessionById(req.params.wid);
+      } catch (err) {
+        req.log.warn({ err, workerId: req.params.wid }, "resume worker failed");
+        return reply.code(404).send({ error: "resume_failed" });
+      }
+      return { resumed: true };
+    },
+  );
+};

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -12,6 +12,8 @@ import {
   type UnifiedSession,
 } from "../session-registry.js";
 import { bridgeSessionDeleted } from "../webhooks/event-bridge.js";
+import { bridgeWorkerDeleted } from "../orchestration/event-bridge.js";
+import { unregisterWorker } from "../orchestration/store.js";
 import { errorSchema, liveSummaryBody, liveSummarySchema } from "./_schemas.js";
 import { buildTurnDiff } from "../turn-diff-builder.js";
 import { buildCompactionHistory } from "../compaction-history.js";
@@ -812,6 +814,11 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
           ...(projectIdForWebhook !== undefined ? { projectId: projectIdForWebhook } : {}),
           wasLive,
         });
+        // Fire the worker.deleted inbox event BEFORE unregistering
+        // so the bridge can still resolve the supervisor link.
+        // Best-effort: a failure here doesn't undo the delete.
+        void bridgeWorkerDeleted(req.params.id, { wasLive });
+        void unregisterWorker(req.params.id).catch(() => undefined);
         return reply.code(204).send();
       }
       if (r === "live") {
@@ -832,6 +839,8 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
                 ...(projectIdForWebhook !== undefined ? { projectId: projectIdForWebhook } : {}),
                 wasLive: true,
               });
+              void bridgeWorkerDeleted(req.params.id, { wasLive: true });
+              void unregisterWorker(req.params.id).catch(() => undefined);
               return reply.code(204).send();
             }
           } catch (err) {
@@ -855,6 +864,8 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
           ...(projectIdForWebhook !== undefined ? { projectId: projectIdForWebhook } : {}),
           wasLive: true,
         });
+        void bridgeWorkerDeleted(req.params.id, { wasLive: true });
+        void unregisterWorker(req.params.id).catch(() => undefined);
         return reply.code(204).send();
       }
       return notFound(reply);

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -30,6 +30,11 @@ import {
 import { createProcessTool } from "./processes/tool.js";
 import { processManager } from "./processes/manager.js";
 import { bridgeAgentSessionEvent, bridgeSessionCreated } from "./webhooks/event-bridge.js";
+import { isOrchestrationEnabled } from "./orchestration/config.js";
+import { isSupervisor } from "./orchestration/store.js";
+import { createOrchestrationTools } from "./orchestration/tools.js";
+import { bridgeWorkerAgentEvent } from "./orchestration/event-bridge.js";
+import { notifySupervisorDisposed, notifySupervisorIdle } from "./orchestration/inbox.js";
 
 /**
  * Minimal SSE client contract used by the registry to fan out events.
@@ -420,7 +425,57 @@ function makeSubscribeHandler(live: LiveSession): () => void {
       { sessionId: live.sessionId, projectId: live.projectId, session: live.session },
       event,
     );
+
+    // Orchestration fan-out. Filters internally for agent_end and
+    // failed auto_retry_end; routes worker events to the owning
+    // supervisor's inbox (no-op for non-worker sessions). Separate
+    // call from the webhook bridge so the two systems stay
+    // independent — disabling one doesn't affect the other.
+    void bridgeWorkerAgentEvent({ sessionId: live.sessionId, session: live.session }, event);
+
+    // Supervisor-side wake-up recovery: when a supervisor's own
+    // agent_end fires (i.e. it just became idle), check whether
+    // any inbox items piled up during the just-finished turn and
+    // re-fire the wake-up nudge. Covers the case where the
+    // supervisor LLM finished a turn without calling
+    // orchestrate_read_inbox.
+    if (e.type === "agent_end") {
+      void (async () => {
+        try {
+          if (await isSupervisor(live.sessionId)) {
+            await notifySupervisorIdle(live.sessionId);
+          }
+        } catch {
+          // Best-effort recovery; never surface to the SSE caller.
+        }
+      })();
+    }
   });
+}
+
+/**
+ * Resolve the orchestration tools for a given session. Returns the
+ * empty array when:
+ *   - the instance-level orchestration flag is off (env or
+ *     MINIMAL_UI gate), OR
+ *   - the session isn't a registered supervisor.
+ *
+ * Read fresh per session create/resume so toggling supervisor mode
+ * in the UI and then re-resuming the session picks up the new
+ * tools (same recompute-on-create posture MCP / tool-overrides
+ * already use).
+ */
+async function resolveOrchestrationTools(sessionId: string): Promise<ToolDefinition[]> {
+  if (!isOrchestrationEnabled()) return [];
+  try {
+    if (!(await isSupervisor(sessionId))) return [];
+  } catch {
+    // If the store is unreadable, skip — orchestration is
+    // experimental + opt-in; a missing/corrupt file should not
+    // break session creation.
+    return [];
+  }
+  return createOrchestrationTools(sessionId);
 }
 
 export async function createSession(
@@ -444,7 +499,14 @@ export async function createSession(
   const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
   const todoTool = createTodoTool(sessionManager.getSessionId(), sessionManager);
   const processTool = createProcessTool(sessionManager.getSessionId(), workspacePath);
-  const customTools: ToolDefinition[] = [...mcpTools, askTool, todoTool, processTool];
+  const orchestrationTools = await resolveOrchestrationTools(sessionManager.getSessionId());
+  const customTools: ToolDefinition[] = [
+    ...mcpTools,
+    askTool,
+    todoTool,
+    processTool,
+    ...orchestrationTools,
+  ];
   const settingsManager = await buildSessionSettingsManager(workspacePath, projectId);
   const resourceLoader = await buildForgeResourceLoader(
     workspacePath,
@@ -669,7 +731,14 @@ export async function resumeSession(
     const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
     const todoTool = createTodoTool(sessionManager.getSessionId(), sessionManager);
     const processTool = createProcessTool(sessionManager.getSessionId(), workspacePath);
-    const customTools: ToolDefinition[] = [...mcpTools, askTool, todoTool, processTool];
+    const orchestrationTools = await resolveOrchestrationTools(sessionManager.getSessionId());
+    const customTools: ToolDefinition[] = [
+      ...mcpTools,
+      askTool,
+      todoTool,
+      processTool,
+      ...orchestrationTools,
+    ];
     // Resumed session — refresh the todo cache from the branch so
     // the UI panel sees the persisted state on first SSE connect,
     // not an empty list.
@@ -879,6 +948,11 @@ export async function disposeSession(sessionId: string): Promise<boolean> {
     // path; even without this, a future session with the same id
     // would recover via replay-on-miss. Cleaner to be explicit.
     clearTodoForSession(sessionId);
+    // Clear the orchestration in-memory dedupe state. Cheap
+    // (Set/Map delete) and idempotent on non-supervisors, so call
+    // unconditionally rather than gating on `isSupervisor` (which
+    // would mean an extra disk read inside the dispose hot path).
+    notifySupervisorDisposed(sessionId);
     // Terminate every live process owned by this session (SIGTERM,
     // brief grace, SIGKILL) and remove the per-session log dir.
     // Best-effort + bounded — disposeSession itself can take up to
@@ -1311,7 +1385,14 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
   const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
   const todoTool = createTodoTool(sessionManager.getSessionId(), sessionManager);
   const processTool = createProcessTool(sessionManager.getSessionId(), source.workspacePath);
-  const customTools: ToolDefinition[] = [...mcpTools, askTool, todoTool, processTool];
+  const orchestrationTools = await resolveOrchestrationTools(sessionManager.getSessionId());
+  const customTools: ToolDefinition[] = [
+    ...mcpTools,
+    askTool,
+    todoTool,
+    processTool,
+    ...orchestrationTools,
+  ];
   // Forked session — replay the branch (which now belongs to the
   // fork) so the new session's todo cache reflects the inherited
   // state, not the parent's stale entry.
@@ -1396,11 +1477,15 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
         restoredManager.getSessionId(),
         source.workspacePath,
       );
+      const restoredOrchestrationTools = await resolveOrchestrationTools(
+        restoredManager.getSessionId(),
+      );
       const restoredCustomTools: ToolDefinition[] = [
         ...restoredMcpTools,
         restoredAskTool,
         restoredTodoTool,
         restoredProcessTool,
+        ...restoredOrchestrationTools,
       ];
       // Re-derive the original source's todo cache from the (now
       // un-mutated) source JSONL — the SDK's fork machinery left
@@ -1460,6 +1545,112 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
     }
   }
 
+  return live;
+}
+
+/**
+ * Rebuild the live AgentSession in-place — same SessionManager, fresh
+ * `customTools` list. Used by the orchestration enable/disable route
+ * to make the orchestrate_* tools appear (or disappear) immediately
+ * without disposing the session (and triggering all the SSE-disconnect
+ * + tombstone + cold-session race fallout that comes with dispose).
+ *
+ * Pattern mirrors the source-restore branch of `forkSession`:
+ * unsubscribe the old AgentSession, instantiate a new one against
+ * the same SessionManager, mutate `live.session` in place, re-wire
+ * the registry's own subscribe handler against the new instance.
+ * The LiveSession entry stays in the registry, attached SSE clients
+ * stay connected, the live.clients Set is reused so events from the
+ * new AgentSession fan out to the same browsers without a reconnect.
+ *
+ * Aborts any in-flight turn first (best-effort, bounded at 5s) so a
+ * mid-stream rebuild doesn't leave the old AgentSession's LLM call
+ * orphaned. No-op when the session isn't live.
+ *
+ * Why not dispose + let SSE reconnect:
+ *   1. Pre-prompt sessions have no .jsonl on disk yet — `resumeSession`
+ *      throws `SessionNotFoundError`, the client's SSE error handler
+ *      maps the 404 to "session was deleted elsewhere" and removes
+ *      the session from local state. The session vanishes from the
+ *      sidebar with no warning.
+ *   2. Post-prompt sessions hit the dispose tombstone — the
+ *      `disposeTombstones` map blocks resume for `TOMBSTONE_MS` (1.5s)
+ *      to prevent a polling SSE client from racing a hard-delete.
+ *      The orchestration enable doesn't have a hard-delete intent, but
+ *      it still sets the tombstone, so the SSE reconnect attempts
+ *      get 410 `stream_open_failed` until it expires.
+ */
+export async function rebuildAgentSessionForTools(
+  sessionId: string,
+): Promise<LiveSession | undefined> {
+  const live = registry.get(sessionId);
+  if (live === undefined) return undefined;
+  // Bound the abort race so a hung LLM call can't block the rebuild
+  // (and therefore the operator's UI click) forever. Best-effort —
+  // the SDK doesn't currently throw from abort, but defend against
+  // future versions same as disposeSession does.
+  try {
+    await Promise.race([
+      live.session.abort(),
+      new Promise<void>((resolve) => setTimeout(resolve, 5_000).unref()),
+    ]);
+  } catch (err) {
+    void err;
+  }
+  try {
+    live.unsubscribe();
+  } catch {
+    // ignore
+  }
+  // Reuse the SessionManager so the underlying .jsonl identity
+  // doesn't shift. For pre-prompt sessions this is the in-memory
+  // SessionManager from SessionManager.create — no file on disk
+  // yet, the SDK rehydrates an empty session from it. For sessions
+  // with prior turns, the SDK reads the existing messages from the
+  // file the SessionManager points at.
+  const sessionManager = live.session.sessionManager;
+  const mcpTools = await resolveMcpCustomTools(live.projectId, live.workspacePath);
+  const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
+  const todoTool = createTodoTool(sessionManager.getSessionId(), sessionManager);
+  const processTool = createProcessTool(sessionManager.getSessionId(), live.workspacePath);
+  const orchestrationTools = await resolveOrchestrationTools(sessionManager.getSessionId());
+  const customTools: ToolDefinition[] = [
+    ...mcpTools,
+    askTool,
+    todoTool,
+    processTool,
+    ...orchestrationTools,
+  ];
+  const settingsManager = await buildSessionSettingsManager(live.workspacePath, live.projectId);
+  const resourceLoader = await buildForgeResourceLoader(
+    live.workspacePath,
+    config.piConfigDir,
+    settingsManager,
+    live.projectId,
+  );
+  const { session: newSession } = await createAgentSession({
+    cwd: live.workspacePath,
+    sessionManager,
+    settingsManager,
+    resourceLoader,
+    agentDir: config.piConfigDir,
+    customTools,
+    tools: await buildToolsAllowlist(customTools, live.projectId, live.workspacePath),
+  });
+  // Drop the old AgentSession only AFTER the new one is constructed
+  // — if createAgentSession throws, we still have a working session.
+  try {
+    live.session.dispose();
+  } catch {
+    // ignore — SDK doesn't currently throw, H2-defensive
+  }
+  // Swap in place. Same sessionId, same projectId, same SSE clients
+  // — the browser side notices nothing beyond the new tools showing
+  // up on the next agent turn.
+  live.session = newSession;
+  live.lastActivityAt = new Date();
+  live.lastAgentStartIndex = undefined;
+  live.unsubscribe = makeSubscribeHandler(live);
   return live;
 }
 

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -1,0 +1,679 @@
+/**
+ * Integration test for session orchestration.
+ *
+ * Coverage:
+ *   - Instance-flag gate: routes 403 with `orchestration_disabled`
+ *     when ORCHESTRATION_ENABLED is unset
+ *   - MINIMAL_UI gate: routes 403 with `minimal_ui_disabled` even
+ *     when env flag is set
+ *   - enable / disable supervisor mode round-trip
+ *   - GET /orchestration/sessions/:id reports role correctly
+ *   - Depth limit: cannot enable supervisor on a registered worker
+ *   - Fanout limit enforced when registering workers
+ *   - Workers list / inbox routes return wired data
+ *   - Store layer: register/unregister/getSupervisorIdForWorker
+ *   - Inbox layer: FIFO cap, drain marks delivered, readAll
+ *   - bridgeWorkerEvent enqueues for owned workers, skips orphans
+ *
+ * The orchestration tools that drive real agent sessions
+ * (`orchestrate_spawn_worker` etc.) are exercised indirectly via
+ * direct store calls — testing the full LLM round-trip requires
+ * credentials and is out of scope here. The tool functions are
+ * thin wrappers around the same store / inbox / session-registry
+ * functions covered below.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type Server } from "node:net";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+const serverEntry = resolve(repoRoot, "packages/server/dist/index.js");
+
+interface OrchestrationStoreModule {
+  enableSupervisor: (sessionId: string) => Promise<unknown>;
+  disableSupervisor: (sessionId: string) => Promise<void>;
+  registerWorker: (opts: {
+    supervisorId: string;
+    workerId: string;
+    spawnedFrom?: { sessionId: string; mode: "fresh" | "summary" };
+  }) => Promise<void>;
+  unregisterWorker: (workerId: string) => Promise<void>;
+  isSupervisor: (sessionId: string) => Promise<boolean>;
+  isWorker: (sessionId: string) => Promise<boolean>;
+  getSupervisorIdForWorker: (workerId: string) => Promise<string | undefined>;
+  getWorkerIds: (supervisorId: string) => Promise<string[]>;
+  enqueueInboxItem: (
+    supervisorId: string,
+    item: {
+      type: string;
+      workerId: string;
+      occurredAt: string;
+      data: Record<string, unknown>;
+    },
+  ) => Promise<{ id: string; delivered: boolean }>;
+  readPendingInbox: (
+    supervisorId: string,
+    opts?: { markDelivered?: boolean },
+  ) => Promise<{ id: string; delivered: boolean }[]>;
+  readAllInbox: (supervisorId: string) => Promise<{ id: string; delivered: boolean }[]>;
+  pendingInboxCount: (supervisorId: string) => Promise<number>;
+  clearInbox: (supervisorId: string) => Promise<void>;
+  OrchestrationError: new (code: string, message: string) => Error & { code: string };
+}
+
+interface InboxModule {
+  bridgeWorkerEvent: (
+    workerId: string,
+    type: string,
+    data: Record<string, unknown>,
+  ) => Promise<{ id: string } | undefined>;
+}
+
+interface ToolResult {
+  content: { type: string; text?: string }[];
+  details?: unknown;
+}
+interface ToolsModule {
+  createOrchestrationTools: (supervisorId: string) => {
+    name: string;
+    execute: (id: string, params: Record<string, unknown>) => Promise<ToolResult>;
+  }[];
+}
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function pickFreePort(): Promise<number> {
+  return new Promise((resolveFn, rejectFn) => {
+    const srv: Server = createServer();
+    srv.unref();
+    srv.on("error", rejectFn);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === "string") {
+        rejectFn(new Error("failed to acquire free port"));
+        return;
+      }
+      const { port } = addr;
+      srv.close(() => resolveFn(port));
+    });
+  });
+}
+
+async function waitFor(url: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(url);
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  throw new Error(`timeout waiting for ${url}`);
+}
+
+interface RunningServer {
+  base: string;
+  workspacePath: string;
+  configDir: string;
+  dataDir: string;
+  child?: ChildProcess;
+  stop: () => Promise<void>;
+}
+
+async function startServer(opts: {
+  orchestrationEnabled?: boolean;
+  minimalUi?: boolean;
+  fanoutCap?: number;
+  workspacePath?: string;
+  configDir?: string;
+  dataDir?: string;
+}): Promise<RunningServer> {
+  const workspacePath = opts.workspacePath ?? (await mkdtemp(join(tmpdir(), "pi-forge-orch-ws-")));
+  const configDir = opts.configDir ?? (await mkdtemp(join(tmpdir(), "pi-forge-orch-cfg-")));
+  const dataDir = opts.dataDir ?? (await mkdtemp(join(tmpdir(), "pi-forge-orch-data-")));
+  const ownedDirs = opts.dataDir === undefined;
+  const port = await pickFreePort();
+  const child = spawn(process.execPath, [serverEntry], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      LOG_LEVEL: "warn",
+      NODE_ENV: "test",
+      WORKSPACE_PATH: workspacePath,
+      PI_CONFIG_DIR: configDir,
+      FORGE_DATA_DIR: dataDir,
+      SESSION_DIR: join(workspacePath, ".pi", "sessions"),
+      SERVE_CLIENT: "false",
+      UI_PASSWORD: undefined,
+      JWT_SECRET: undefined,
+      API_KEY: undefined,
+      MINIMAL_UI: opts.minimalUi === true ? "1" : undefined,
+      ORCHESTRATION_ENABLED: opts.orchestrationEnabled === true ? "1" : undefined,
+      ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR:
+        opts.fanoutCap !== undefined ? String(opts.fanoutCap) : undefined,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (b: Buffer) => process.stderr.write(`[orch-srv] ${String(b)}`));
+  const base = `http://127.0.0.1:${port}`;
+  const stop = async (): Promise<void> => {
+    if (child.exitCode === null && child.signalCode === null) {
+      await new Promise<void>((res) => {
+        child.once("exit", () => res());
+        child.kill("SIGTERM");
+        setTimeout(() => child.kill("SIGKILL"), 1500).unref();
+      });
+    }
+    if (ownedDirs) {
+      await rm(workspacePath, { recursive: true, force: true });
+      await rm(configDir, { recursive: true, force: true });
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  };
+  try {
+    await waitFor(`${base}/api/v1/health`);
+  } catch (err) {
+    await stop();
+    throw err;
+  }
+  return { base, workspacePath, configDir, dataDir, child, stop };
+}
+
+async function jsend(
+  base: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(`${base}${path}`, init);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function main(): Promise<void> {
+  // The store + inbox modules read `FORGE_DATA_DIR` from `config.ts`
+  // at module-import time. Plant the env BEFORE the first dynamic
+  // import so the in-test calls share a data dir with the spawned
+  // server. Same pattern as test-webhooks.ts.
+  const sharedWs = await mkdtemp(join(tmpdir(), "pi-forge-orch-ws-"));
+  const sharedCfg = await mkdtemp(join(tmpdir(), "pi-forge-orch-cfg-"));
+  const sharedData = await mkdtemp(join(tmpdir(), "pi-forge-orch-data-"));
+  process.env.WORKSPACE_PATH = sharedWs;
+  process.env.PI_CONFIG_DIR = sharedCfg;
+  process.env.FORGE_DATA_DIR = sharedData;
+
+  console.log("[test-orchestration] store layer");
+  const store = (await import(
+    resolve(repoRoot, "packages/server/dist/orchestration/store.js")
+  )) as unknown as OrchestrationStoreModule;
+  const inbox = (await import(
+    resolve(repoRoot, "packages/server/dist/orchestration/inbox.js")
+  )) as unknown as InboxModule;
+
+  // ===== enable / disable supervisor =====
+  await store.enableSupervisor("sup-1");
+  assert("isSupervisor returns true after enable", await store.isSupervisor("sup-1"));
+  assert("isWorker returns false for supervisor", !(await store.isWorker("sup-1")));
+
+  // Idempotent
+  await store.enableSupervisor("sup-1");
+  assert("enableSupervisor idempotent", await store.isSupervisor("sup-1"));
+
+  // Register a worker
+  await store.registerWorker({ supervisorId: "sup-1", workerId: "w-1" });
+  assert("isWorker true after register", await store.isWorker("w-1"));
+  assert(
+    "getSupervisorIdForWorker resolves",
+    (await store.getSupervisorIdForWorker("w-1")) === "sup-1",
+  );
+  const ids = await store.getWorkerIds("sup-1");
+  assert("getWorkerIds includes w-1", ids.length === 1 && ids[0] === "w-1");
+
+  // ===== depth limit: worker can't be supervisor =====
+  let depthLimitOk = false;
+  try {
+    await store.enableSupervisor("w-1");
+  } catch (err) {
+    depthLimitOk = err instanceof store.OrchestrationError && err.code === "depth_limit_exceeded";
+  }
+  assert("depth limit blocks worker→supervisor", depthLimitOk);
+
+  // ===== fanout: cannot register the same worker twice =====
+  let dupOk = false;
+  try {
+    await store.registerWorker({ supervisorId: "sup-1", workerId: "w-1" });
+  } catch (err) {
+    dupOk = err instanceof store.OrchestrationError && err.code === "worker_already_linked";
+  }
+  assert("duplicate worker registration rejected", dupOk);
+
+  // ===== unregister =====
+  await store.unregisterWorker("w-1");
+  assert("isWorker false after unregister", !(await store.isWorker("w-1")));
+  const idsAfter = await store.getWorkerIds("sup-1");
+  assert("getWorkerIds empty after unregister", idsAfter.length === 0);
+
+  // ===== inbox layer =====
+  console.log("\n[test-orchestration] inbox layer");
+  // Register a worker so the bridge can resolve.
+  await store.registerWorker({ supervisorId: "sup-1", workerId: "w-2" });
+  await inbox.bridgeWorkerEvent("w-2", "worker.ended", { stopReason: "end_turn" });
+  await inbox.bridgeWorkerEvent("w-2", "worker.ask_user", {
+    requestId: "r1",
+    questionCount: 1,
+  });
+  const pending = await store.readPendingInbox("sup-1");
+  assert("inbox enqueued 2 pending", pending.length === 2);
+  // Orphan worker — no enqueue
+  await inbox.bridgeWorkerEvent("not-a-worker", "worker.ended", {});
+  const pendingAfterOrphan = await store.readPendingInbox("sup-1");
+  assert(
+    "orphan worker event ignored",
+    pendingAfterOrphan.length === 2,
+    `got ${pendingAfterOrphan.length}`,
+  );
+
+  // Drain marks delivered
+  const drained = await store.readPendingInbox("sup-1", { markDelivered: true });
+  assert("drain returns 2", drained.length === 2);
+  const pendingAfterDrain = await store.readPendingInbox("sup-1");
+  assert("after drain no pending", pendingAfterDrain.length === 0);
+  const all = await store.readAllInbox("sup-1");
+  assert("history retains drained items", all.length === 2);
+
+  // pendingInboxCount
+  const cnt = await store.pendingInboxCount("sup-1");
+  assert("pendingInboxCount = 0 after drain", cnt === 0);
+  await inbox.bridgeWorkerEvent("w-2", "worker.process_alert", { reason: "exit" });
+  const cnt2 = await store.pendingInboxCount("sup-1");
+  assert("pendingInboxCount = 1 after new event", cnt2 === 1);
+
+  // Clear inbox
+  await store.clearInbox("sup-1");
+  const allAfterClear = await store.readAllInbox("sup-1");
+  assert("clearInbox wipes history", allAfterClear.length === 0);
+
+  // ===== Tool-result text carries the data (not just details) =====
+  // The supervisor LLM reads `content[0].text`; `details` is for
+  // downstream consumers (REST, tests) and DOES NOT reach the
+  // model's context. The previous bug shipped the messages/inbox/
+  // workers payloads in `details` only, so the orchestrator couldn't
+  // see worker state. Regression-test the serializer for all three
+  // read tools.
+  console.log("\n[test-orchestration] tool-result text serialization");
+  const tools = (await import(
+    resolve(repoRoot, "packages/server/dist/orchestration/tools.js")
+  )) as unknown as ToolsModule;
+
+  // Refresh supervisor + worker for these checks.
+  await store.enableSupervisor("ser-sup");
+  await store.registerWorker({ supervisorId: "ser-sup", workerId: "ser-w1" });
+  await store.registerWorker({ supervisorId: "ser-sup", workerId: "ser-w2" });
+  await inbox.bridgeWorkerEvent("ser-w1", "worker.ended", {
+    stopReason: "end_turn",
+    errorMessage: null,
+    assistantTextPreview: "Implemented the /auth route and added unit tests.",
+  });
+  await inbox.bridgeWorkerEvent("ser-w2", "worker.ask_user", {
+    requestId: "rq1",
+    questionCount: 1,
+    firstQuestionHeader: "Auth method",
+    firstQuestionText: "Should I use bcrypt or argon2?",
+  });
+
+  const serTools = tools.createOrchestrationTools("ser-sup");
+  const listTool = serTools.find((t) => t.name === "orchestrate_list_workers");
+  const inboxTool = serTools.find((t) => t.name === "orchestrate_read_inbox");
+  assert("createOrchestrationTools returns list_workers", listTool !== undefined);
+  assert("createOrchestrationTools returns read_inbox", inboxTool !== undefined);
+
+  if (listTool !== undefined) {
+    const res = await listTool.execute("call-1", {});
+    const text = res.content[0]?.text ?? "";
+    assert(
+      "list_workers content text mentions worker ids",
+      text.includes("ser-w1") && text.includes("ser-w2"),
+      `got: ${text.slice(0, 300)}`,
+    );
+    assert(
+      "list_workers content text shows 'cold' state (no live session in test)",
+      text.includes("cold"),
+      `got: ${text.slice(0, 300)}`,
+    );
+  }
+  if (inboxTool !== undefined) {
+    const res = await inboxTool.execute("call-2", {});
+    const text = res.content[0]?.text ?? "";
+    assert(
+      "read_inbox content text includes ended assistantText preview",
+      text.includes("Implemented the /auth route"),
+      `got: ${text.slice(0, 300)}`,
+    );
+    assert(
+      "read_inbox content text includes ask_user question preview",
+      text.includes("bcrypt") || text.includes("Auth method"),
+      `got: ${text.slice(0, 300)}`,
+    );
+    assert(
+      "read_inbox content text tags worker ids",
+      text.includes("ser-w1") && text.includes("ser-w2"),
+      `got: ${text.slice(0, 300)}`,
+    );
+  }
+
+  // Clean up store state for the REST tests
+  await store.disableSupervisor("sup-1");
+  await store.disableSupervisor("ser-sup");
+
+  // ===== REST layer: orchestration_disabled gate =====
+  console.log("\n[test-orchestration] REST gates");
+  const offSrv = await startServer({
+    orchestrationEnabled: false,
+    workspacePath: sharedWs,
+    configDir: sharedCfg,
+    dataDir: sharedData,
+  });
+  try {
+    const cfg = await jsend(offSrv.base, "GET", "/api/v1/orchestration/config");
+    assert(
+      "config returns enabled=false",
+      cfg.status === 200 &&
+        (cfg.body as { enabled: boolean }).enabled === false &&
+        (cfg.body as { disabledReason: string }).disabledReason === "orchestration_disabled",
+    );
+    const en = await jsend(offSrv.base, "POST", "/api/v1/orchestration/sessions/sx/enable");
+    assert(
+      "enable 403 when disabled",
+      en.status === 403 && (en.body as { error: string }).error === "orchestration_disabled",
+    );
+    const ui = await jsend(offSrv.base, "GET", "/api/v1/ui-config");
+    assert(
+      "/ui-config reports orchestrationEnabled=false",
+      ui.status === 200 &&
+        (ui.body as { orchestrationEnabled: boolean }).orchestrationEnabled === false,
+    );
+  } finally {
+    await offSrv.stop();
+  }
+
+  // ===== MINIMAL_UI gate beats env flag =====
+  const minimalSrv = await startServer({
+    orchestrationEnabled: true,
+    minimalUi: true,
+    workspacePath: sharedWs,
+    configDir: sharedCfg,
+    dataDir: sharedData,
+  });
+  try {
+    const cfg = await jsend(minimalSrv.base, "GET", "/api/v1/orchestration/config");
+    assert(
+      "MINIMAL_UI forces disabled even with env flag",
+      cfg.status === 200 &&
+        (cfg.body as { enabled: boolean }).enabled === false &&
+        (cfg.body as { disabledReason: string }).disabledReason === "minimal_ui_disabled",
+    );
+    const en = await jsend(minimalSrv.base, "POST", "/api/v1/orchestration/sessions/sy/enable");
+    assert(
+      "enable 403 under MINIMAL_UI",
+      en.status === 403 && (en.body as { error: string }).error === "minimal_ui_disabled",
+    );
+  } finally {
+    await minimalSrv.stop();
+  }
+
+  // ===== REST happy path =====
+  console.log("\n[test-orchestration] REST happy path");
+  const onSrv = await startServer({
+    orchestrationEnabled: true,
+    fanoutCap: 2,
+    workspacePath: sharedWs,
+    configDir: sharedCfg,
+    dataDir: sharedData,
+  });
+  try {
+    // ui-config reports enabled
+    const ui = await jsend(onSrv.base, "GET", "/api/v1/ui-config");
+    assert(
+      "/ui-config reports orchestrationEnabled=true",
+      ui.status === 200 &&
+        (ui.body as { orchestrationEnabled: boolean }).orchestrationEnabled === true,
+    );
+
+    // Initial role is standalone
+    const link0 = await jsend(onSrv.base, "GET", "/api/v1/orchestration/sessions/rest-sup");
+    assert(
+      "standalone session reported as standalone",
+      link0.status === 200 && (link0.body as { role: string }).role === "standalone",
+    );
+
+    // Enable
+    const en = await jsend(onSrv.base, "POST", "/api/v1/orchestration/sessions/rest-sup/enable");
+    assert(
+      "enable supervisor returns 200",
+      en.status === 200 && (en.body as { role: string }).role === "supervisor",
+    );
+
+    // GET reflects role
+    const link1 = await jsend(onSrv.base, "GET", "/api/v1/orchestration/sessions/rest-sup");
+    assert("link reports supervisor role", (link1.body as { role: string }).role === "supervisor");
+
+    // ===== Regression: enable on a REAL live session must NOT
+    // delete it (pre-prompt session has no .jsonl) and must NOT
+    // trigger the dispose tombstone (post-prompt would get 410 on
+    // next stream attach). Both bugs were caused by the previous
+    // dispose+reconnect strategy; the rebuild-in-place fix should
+    // leave the session intact and live.
+    // -----
+    const realProj = await jsend(onSrv.base, "POST", "/api/v1/projects", {
+      name: "orch-rebuild",
+      path: sharedWs,
+    });
+    assert(
+      "create real project → 201",
+      realProj.status === 201 && typeof (realProj.body as { id: string }).id === "string",
+    );
+    const realProjectId = (realProj.body as { id: string }).id;
+    const realSess = await jsend(onSrv.base, "POST", "/api/v1/sessions", {
+      projectId: realProjectId,
+    });
+    assert(
+      "create real session → 201",
+      realSess.status === 201 &&
+        typeof (realSess.body as { sessionId: string }).sessionId === "string",
+    );
+    const realSid = (realSess.body as { sessionId: string }).sessionId;
+
+    // Pre-prompt: no .jsonl on disk. Confirm session is live.
+    const preEnable = await jsend(onSrv.base, "GET", `/api/v1/sessions/${realSid}`);
+    assert(
+      "fresh session is live before enable",
+      preEnable.status === 200 && (preEnable.body as { isLive: boolean }).isLive === true,
+    );
+
+    // Enable supervisor — the bug being regression-tested: this
+    // used to dispose+tombstone the session, leaving the next
+    // stream attach to 404 (pre-prompt) or 410 (post-prompt).
+    const enRes = await jsend(
+      onSrv.base,
+      "POST",
+      `/api/v1/orchestration/sessions/${realSid}/enable`,
+    );
+    assert(
+      "enable on real session → 200 (no delete)",
+      enRes.status === 200 && (enRes.body as { role: string }).role === "supervisor",
+    );
+
+    // Session must still be live (rebuild kept it in the registry).
+    const postEnable = await jsend(onSrv.base, "GET", `/api/v1/sessions/${realSid}`);
+    assert(
+      "session still live after enable (not disposed)",
+      postEnable.status === 200 && (postEnable.body as { isLive: boolean }).isLive === true,
+    );
+
+    // SSE stream attach must NOT get 410 — there's no tombstone
+    // since we never disposed. Fetch the stream briefly, capture
+    // status, then close.
+    const sseAc = new AbortController();
+    const sseRes = await fetch(`${onSrv.base}/api/v1/sessions/${realSid}/stream`, {
+      signal: sseAc.signal,
+    });
+    assert(
+      "SSE attach after enable → 200 (no 410 tombstone)",
+      sseRes.status === 200,
+      `got ${sseRes.status}`,
+    );
+    sseAc.abort();
+    try {
+      await sseRes.body?.cancel();
+    } catch {
+      // ignore — body cancel after abort can throw
+    }
+
+    // Disable + same check: session must stay live, no 410 on
+    // subsequent attach.
+    const disRes = await jsend(
+      onSrv.base,
+      "POST",
+      `/api/v1/orchestration/sessions/${realSid}/disable`,
+    );
+    assert("disable on real session → 204", disRes.status === 204);
+    const postDisable = await jsend(onSrv.base, "GET", `/api/v1/sessions/${realSid}`);
+    assert(
+      "session still live after disable (not disposed)",
+      postDisable.status === 200 && (postDisable.body as { isLive: boolean }).isLive === true,
+    );
+
+    // Plant some workers + inbox items via the store (since real
+    // spawn_worker requires a live agent session).
+    await store.registerWorker({ supervisorId: "rest-sup", workerId: "rest-w1" });
+    await store.registerWorker({ supervisorId: "rest-sup", workerId: "rest-w2" });
+    await inbox.bridgeWorkerEvent("rest-w1", "worker.ended", { stopReason: "end_turn" });
+    await inbox.bridgeWorkerEvent("rest-w2", "worker.ask_user", { questionCount: 1 });
+
+    // GET /sessions/:id/workers
+    const wList = await jsend(onSrv.base, "GET", "/api/v1/orchestration/sessions/rest-sup/workers");
+    assert(
+      "list workers returns 2",
+      wList.status === 200 &&
+        Array.isArray((wList.body as { workers: unknown[] }).workers) &&
+        (wList.body as { workers: unknown[] }).workers.length === 2,
+    );
+
+    // GET /sessions/:id/inbox
+    const inboxRes = await jsend(
+      onSrv.base,
+      "GET",
+      "/api/v1/orchestration/sessions/rest-sup/inbox",
+    );
+    assert(
+      "inbox returns 2 items",
+      inboxRes.status === 200 && (inboxRes.body as { items: unknown[] }).items.length === 2,
+    );
+
+    // pendingInbox in the link summary
+    const linkSum = await jsend(onSrv.base, "GET", "/api/v1/orchestration/sessions/rest-sup");
+    assert(
+      "pendingInbox reflected in link",
+      (linkSum.body as { pendingInbox: number }).pendingInbox === 2,
+    );
+
+    // Worker side: GET on rest-w1 reports worker role
+    const wLink = await jsend(onSrv.base, "GET", "/api/v1/orchestration/sessions/rest-w1");
+    assert(
+      "worker session reported as worker",
+      wLink.status === 200 &&
+        (wLink.body as { role: string }).role === "worker" &&
+        (wLink.body as { supervisorId: string }).supervisorId === "rest-sup",
+    );
+
+    // Detach worker via REST
+    const det = await jsend(
+      onSrv.base,
+      "POST",
+      "/api/v1/orchestration/sessions/rest-sup/workers/rest-w2/detach",
+    );
+    assert("detach returns 204", det.status === 204);
+    const wLink2 = await jsend(onSrv.base, "GET", "/api/v1/orchestration/sessions/rest-w2");
+    assert(
+      "detached worker now standalone",
+      (wLink2.body as { role: string }).role === "standalone",
+    );
+
+    // detach for non-linked worker → 404
+    const detMissing = await jsend(
+      onSrv.base,
+      "POST",
+      "/api/v1/orchestration/sessions/rest-sup/workers/rest-w2/detach",
+    );
+    assert(
+      "detach for unlinked worker 404",
+      detMissing.status === 404 &&
+        (detMissing.body as { error: string }).error === "worker_not_linked",
+    );
+
+    // Clear inbox
+    const clr = await jsend(
+      onSrv.base,
+      "POST",
+      "/api/v1/orchestration/sessions/rest-sup/inbox/clear",
+    );
+    assert("inbox clear returns 204", clr.status === 204);
+    const inboxAfter = await jsend(
+      onSrv.base,
+      "GET",
+      "/api/v1/orchestration/sessions/rest-sup/inbox",
+    );
+    assert("inbox empty after clear", (inboxAfter.body as { items: unknown[] }).items.length === 0);
+
+    // Disable supervisor
+    const dis = await jsend(onSrv.base, "POST", "/api/v1/orchestration/sessions/rest-sup/disable");
+    assert("disable returns 204", dis.status === 204);
+    const linkAfter = await jsend(onSrv.base, "GET", "/api/v1/orchestration/sessions/rest-sup");
+    assert(
+      "disabled session now standalone",
+      (linkAfter.body as { role: string }).role === "standalone",
+    );
+    // The remaining worker (rest-w1) was detached as part of disable
+    const w1After = await jsend(onSrv.base, "GET", "/api/v1/orchestration/sessions/rest-w1");
+    assert(
+      "linked workers detached on disable",
+      (w1After.body as { role: string }).role === "standalone",
+    );
+  } finally {
+    await onSrv.stop();
+  }
+
+  await rm(sharedWs, { recursive: true, force: true });
+  await rm(sharedCfg, { recursive: true, force: true });
+  await rm(sharedData, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.log(`\n[test-orchestration] ${failures} failure(s).`);
+    process.exit(1);
+  }
+  console.log(`\n[test-orchestration] all checks passed.`);
+}
+
+main().catch((err: unknown) => {
+  console.error("[test-orchestration] unhandled:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds session orchestration — one session can act as a **supervisor** that spawns, observes, messages, interrupts, and kills other sessions in the same project. Off by default; gated by `ORCHESTRATION_ENABLED=true` at the instance level and per-session opt-in via the chat-view `Orch` toggle. **Hard-disabled under MINIMAL_UI** regardless of the env flag.

## Topology

- **Hub-and-spoke at depth=1**, enforced by tool surface: workers don't get the `orchestrate_*` tools, so there's no API to express worker-to-worker comms. Workers can't become supervisors (no fork-bombs).
- **Same-project only** in v1. Cross-project orchestration is intentionally out of scope.
- **Per-supervisor fanout cap** (default 8, `ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR`).

## Tool surface (supervisor-only)

| Tool | Purpose |
|---|---|
| `orchestrate_spawn_worker` | Spawn a worker with a task. `name` required; optional `contextSummary` for handoff. |
| `orchestrate_list_workers` | Current state per worker (streaming/idle/cold + counts). |
| `orchestrate_read_worker` | Fetch worker messages. Default `limit=1` (latest only). |
| `orchestrate_send_to_worker` | Inject next task / course-correction / answer to ask_user. |
| `orchestrate_interrupt_worker` | Abort the worker's current turn. |
| `orchestrate_kill_worker` | Dispose the worker; optional disk delete. |
| `orchestrate_detach_worker` | Drop the link; worker continues standalone. |
| `orchestrate_read_inbox` | Drain pending worker events. |

Tool results serialize payloads into the **content text** as readable transcripts/tables/event summaries — `details` is invisible to the LLM, so encoding only there was a footgun in early drafts.

## Wakeup mechanism

Per-supervisor inbox queue at `${FORGE_DATA_DIR}/orchestrator-inbox.json` (FIFO-capped 200/sup) collects worker events: turn-end, ask_user_question, auto_retry failures, process alerts, deletion. When the supervisor is live and idle, a small `[orchestration] N pending events…` prompt is injected to start a turn. Mid-turn pushes skip (dedupe flag) and a recovery push fires on the supervisor's own `agent_end`.

## Live tool toggle (no SSE reconnect)

Enable/disable rebuild the live `AgentSession` in-place — same `SessionManager`, fresh `customTools`, SSE clients stay attached. Fixes two bugs from an earlier dispose+reconnect strategy: pre-prompt sessions getting deleted via the cold-resume 404 race, and post-prompt sessions hitting the dispose tombstone's 410.

## Safety

- `ORCHESTRATION_ENABLED=false` is the default. MINIMAL_UI is a hard secondary gate.
- Every tool that names a `workerId` verifies ownership against the store — supervisors can't reach into another supervisor's workers by id-guessing.
- Audit log is stderr JSON-line (`orchestration-inbox-enqueued`, `orchestration-wake-delivered`, etc.) — no separate UI by design.
- Tool descriptions explicitly frame prompts as tasks, not chat ("autonomous task-running agents — NOT conversational helpers"). Trimmed to ~900 tokens for the whole tool group after a moderate pass.

## UI

`Orch` toggle in the chat-view toolbar (only renders when instance flag is on) opens the per-session Orchestration panel. Standalone sessions → "Enable supervisor mode" button. Supervisors → workers list with detach/kill/resume + inbox-history drawer. Workers → back-link to supervisor. Panel polls every 4s.

## Files

- New: `packages/server/src/orchestration/{types,config,store,inbox,tools,event-bridge,init}.ts`, `routes/orchestration.ts`, `packages/client/src/components/OrchestrationPanel.tsx`, `tests/test-orchestration.ts`
- Modified: `session-registry.ts` (`rebuildAgentSessionForTools`, orchestration tools in customTools, event bridge wiring), `routes/sessions.ts` (worker.deleted inbox fan-out on DELETE), `routes/health.ts` (`orchestrationEnabled` in `/ui-config`), `index.ts` (boot wiring), client API + ui-config store, `ChatView.tsx` (toolbar toggle)

20 files, +4204 / -5.

## Test plan

49 assertions in `tests/test-orchestration.ts`:
- [x] Store: enable/disable/register/unregister round-trip, depth limit, duplicate worker rejection
- [x] Inbox: enqueue/drain/pending count, FIFO cap, clear, orphan-worker events ignored
- [x] REST gates: 403 with `orchestration_disabled` when env flag off; 403 `minimal_ui_disabled` when MINIMAL_UI=1 even with env flag on
- [x] REST happy path: enable→200, role reflected, workers list, inbox list, detach, disable cascades to detach workers
- [x] **Regression**: enabling/disabling on a real live session keeps it live (no 404 delete, no 410 tombstone on SSE reattach) — covers both bugs we hit during dev
- [x] **Serializer**: tool-result `content[0].text` (not just `details`) contains worker IDs, assistant text previews, and ask_user question text — what the supervisor LLM actually sees

Plus smoke items worth poking manually:
- [x] Toggle supervisor mode on a fresh session and on one mid-conversation; verify `orchestrate_*` tools appear/disappear on the next turn with no reconnect
- [x] Spawn a worker, watch its events feed back into the supervisor's inbox; verify wake-up prompt arrives when supervisor is idle
- [ ] Verify `MINIMAL_UI=1` deployment hides the Orch button entirely and 403s the orchestration routes