### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-05-25
+
 ### Security
 
 - **Bumped `uuid` to ≥11.1.1** via an `overrides` entry to fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "workspaces": [
         "packages/*"
       ],
@@ -17140,7 +17140,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17202,7 +17202,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.75.5",
         "@earendil-works/pi-ai": "0.75.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts pi-forge **v1.3.0**. Rolls up the unreleased work since v1.2.5:

- **feat: session orchestration** (#156) — opt-in supervisor mode with `orchestrate_*` tool group, hub-and-spoke worker topology, inbox-driven wake-up.
- **feat: webhooks** (#155) — HTTPS POST deliveries on agent/session events with HMAC signing, retry, delivery history. Also bundled: clone-as-project's "Allow self-signed TLS" checkbox.
- **chore(deps): batch dependabot updates + qs/uuid security fixes** (#157, #159) — pi SDK trio 0.74.0 → 0.75.5, qs / uuid vulnerabilities patched via overrides, dev-tooling bumps, katex 0.16 → 0.17.
- **docs: cover orchestration, webhooks, quick-actions + surface STDIO MCP / processes / todo / ask** (#160, #161) — three new feature docs, four existing docs added to the site sidebar, README features list updated, Docker config picks up `ORCHESTRATION_ENABLED`.

Full notes live under `## [1.3.0]` in `CHANGELOG.md`.

## What this PR changes

Generated by `scripts/bump-version.sh 1.3.0` — no hand edits:

- `package.json`, `packages/server/package.json`, `packages/client/package.json` → version `1.2.5` → `1.3.0`
- `package-lock.json` → workspace versions synced
- `CHANGELOG.md` → `## [Unreleased]` renamed to `## [1.3.0] — 2026-05-25`, fresh empty `## [Unreleased]` heading inserted above for the next cycle

## Test plan

- [x] `npm run check` (typecheck + lint + format) clean on v1.3.0
- [x] `npm run build` succeeds (server + client)
- [x] `scripts/run-tests.sh --ci` — all 39 tests pass
- [x] All three workspace versions match the root
- [x] `## [Unreleased]` non-empty check (bump script guard) passed before the rename

## After merge

Per `scripts/bump-version.sh`:

```bash
git checkout main && git pull --ff-only
git tag v1.3.0
git push origin v1.3.0
```

The release workflow builds the multi-arch image and creates the GitHub Release automatically. npm publish is via the configured trusted publisher.