### PR TITLE
fix(errors): surface provider errors instead of silently swallowing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,39 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Surface provider errors that previously vanished into a blank
+  assistant turn (or a frozen spinner mid-tool-chain).** Three
+  defects piled up: (1) the client store had two `message_end`
+  handlers; the first refetched messages and returned, leaving the
+  second (which set the error banner) unreachable. A 402 / 401 /
+  5xx from the provider was logged to stderr but never surfaced in
+  the UI. (2) The server's `agent_end` enrichment only forwarded
+  `session.errorMessage`; some failure paths populate
+  `message.errorMessage` on the last assistant message but never
+  promote it to the session, so even after the SSE round-trip the
+  client got an empty `agent_end`. (3) The chat renderer ignored
+  per-message `errorMessage` entirely — so even when a banner did
+  set, the failed turn itself stayed a blank bubble. All three
+  closed:
+  - Merged the two `message_end` branches so the error banner
+    actually sets on `stopReason="error"`.
+  - Added a fallback in `session-registry.ts` that scans the most-
+    recent assistant message for an `errorMessage` when
+    `session.errorMessage` is empty.
+  - Assistant message bubbles now render an inline amber
+    "Provider error:" strip when the message carries
+    `stopReason="error"` + `errorMessage`. Stays visible after the
+    next prompt clears the global banner.
+
+  Repro that surfaced the bugs: an openrouter key with a per-key
+  monthly cap returned `HTTP 402 This request requires more
+  credits` mid-turn; the user saw a blank assistant bubble
+  (single-turn) or a hung spinner (mid-tool-chain) while
+  `agent turn ended with error stopReason` lines piled up in
+  server stderr unanswered.
+
 ## [1.3.0] — 2026-05-25
 
 ### Security

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -902,6 +902,18 @@ function Message({
     // text block — toolCall and thinking blocks aren't markdown and
     // the toggle would do nothing useful for them.
     const hasTextBlock = content.some((b) => (b as Record<string, unknown>).type === "text");
+    // Provider-side failures (openai-completions catch path, openrouter
+    // 4xx, etc.) finalise the assistant message with `stopReason="error"`
+    // and an `errorMessage`. The session-level banner gets cleared by the
+    // next agent_start, so without an inline indicator the failed turn
+    // would show as a blank bubble with no signal what went wrong. Render
+    // an amber inline strip below the content carrying the SDK's message.
+    const stopReason = (message as { stopReason?: unknown }).stopReason;
+    const errorMessage = (message as { errorMessage?: unknown }).errorMessage;
+    const inlineError =
+      stopReason === "error" && typeof errorMessage === "string" && errorMessage.length > 0
+        ? errorMessage
+        : undefined;
     return (
       <div
         className="message-bubble group rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3"
@@ -925,6 +937,15 @@ function Message({
         <div className="space-y-2 text-sm text-neutral-100">
           {renderAssistantBlocks(content as Record<string, unknown>[], toolResultsById, showRaw)}
         </div>
+        {inlineError !== undefined && (
+          <div
+            className="mt-2 rounded border border-amber-700/40 bg-amber-900/20 px-3 py-2 text-xs text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800"
+            role="alert"
+          >
+            <span className="font-medium">Provider error: </span>
+            {inlineError}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -894,6 +894,29 @@ function applyEvent(
     // that finalize an assistant message containing a toolCall before
     // any execution event fires).
     scheduleMessagesRefetch(set, sessionId);
+    // openai-completions and a few other provider adapters surface
+    // upstream errors as `message_end` with stopReason="error" rather
+    // than throwing — so it's the only signal we get for several
+    // failure modes (provider 401/402/5xx mid-tool-chain, context-
+    // overflow that pi's auto-compaction couldn't recover from).
+    // Surface the embedded errorMessage as a banner.
+    //
+    // This branch USED to live in its own `if (event.type ===
+    // "message_end")` block lower in this function — which was dead
+    // code because the handler above matched first and returned. The
+    // user-visible symptom was a blank assistant bubble + no banner,
+    // even though the server logged the full error to stderr.
+    if (event.type === "message_end") {
+      const msg = (event as { message?: { stopReason?: unknown; errorMessage?: unknown } }).message;
+      if (msg?.stopReason === "error") {
+        const m = typeof msg.errorMessage === "string" ? msg.errorMessage : "";
+        if (m.length > 0) {
+          set((s) => ({
+            bannerBySession: { ...s.bannerBySession, [sessionId]: `Agent error: ${m}` },
+          }));
+        }
+      }
+    }
     return;
   }
 
@@ -1091,24 +1114,10 @@ function applyEvent(
     }));
     return;
   }
-  if (event.type === "message_end") {
-    // openai-completions and a few other provider adapters surface
-    // upstream errors as message_end with stopReason="error" rather
-    // than throwing — so it's the only signal we get for some
-    // failure modes (notably context-window overflow that pi's
-    // auto-compaction couldn't recover from). Surface the embedded
-    // errorMessage as a banner; otherwise let the event flow through.
-    const msg = (event as { message?: { stopReason?: unknown; errorMessage?: unknown } }).message;
-    if (msg?.stopReason === "error") {
-      const m = typeof msg.errorMessage === "string" ? msg.errorMessage : "";
-      if (m.length > 0) {
-        set((s) => ({
-          bannerBySession: { ...s.bannerBySession, [sessionId]: `Agent error: ${m}` },
-        }));
-      }
-    }
-    return;
-  }
+  // (The former second `message_end` handler that lived here was
+  // unreachable — the earlier `message_end || tool_result` branch
+  // matched first and returned. Its error-surfacing logic has been
+  // folded into that earlier branch.)
 
   // For message_*/tool_*/turn_* events the chat surface in Phase 8 displays
   // the latest authoritative state by re-fetching on agent_end (above).

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -286,6 +286,34 @@ function logAgentEvent(level: "info" | "warn", payload: Record<string, unknown>)
   );
 }
 
+/**
+ * Walk the session's messages newest-to-oldest and return the first
+ * assistant message that ended with `stopReason="error"` (capturing
+ * its `errorMessage`). Used by the `agent_end` enrichment as a
+ * fallback when `session.errorMessage` is empty but a provider
+ * failure landed on a message earlier in the turn.
+ *
+ * Provider-error messages have `stopReason === "error"` per the
+ * SDK's openai-completions catch path; we scope the scan to those
+ * to avoid surfacing a stale errorMessage from a previous turn.
+ */
+function findLastAssistantErrorMessage(messages: readonly unknown[]): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i] as {
+      role?: string;
+      stopReason?: string;
+      errorMessage?: string;
+    };
+    if (m?.role !== "assistant") continue;
+    if (m.stopReason !== "error") continue;
+    if (typeof m.errorMessage === "string" && m.errorMessage.length > 0) return m.errorMessage;
+    // Found an errored assistant but no message text — stop here
+    // rather than picking up an older one from a previous turn.
+    return undefined;
+  }
+  return undefined;
+}
+
 function makeSubscribeHandler(live: LiveSession): () => void {
   const verbose = process.env.DEBUG_AGENT_EVENTS === "1";
   return live.session.subscribe((event: AgentSessionEvent) => {
@@ -382,13 +410,37 @@ function makeSubscribeHandler(live: LiveSession): () => void {
     // no error banner, and the user sees an empty assistant message.
     let outboundEvent: AgentSessionEvent = event;
     if (e.type === "agent_end") {
-      const errMsg = (live.session as unknown as { errorMessage?: string }).errorMessage;
-      if (errMsg !== undefined && errMsg !== "") {
+      // Primary: session-level `errorMessage` — the SDK's
+      // documented authoritative field. Most failure modes set
+      // this (auth failures, validation, etc.).
+      let errMsg = (live.session as unknown as { errorMessage?: string }).errorMessage;
+      // Fallback: a provider-side failure (openai-completions catch
+      // path, openrouter 4xx, etc.) finalises the assistant message
+      // with `stopReason="error"` and `errorMessage` on the MESSAGE
+      // but does NOT always promote it to `session.errorMessage`.
+      // Without this fallback, agent_end goes out empty, the client
+      // shows neither a banner nor any per-message indicator, and
+      // the user just sees a blank assistant turn (or a frozen
+      // spinner mid-tool-chain). Scan the post-turn messages for the
+      // most-recent assistant with an error and surface that.
+      if (errMsg === undefined || errMsg === "") {
+        const fromMessage = findLastAssistantErrorMessage(live.session.messages);
+        if (fromMessage !== undefined && fromMessage !== "") {
+          errMsg = fromMessage;
+          logAgentEvent("warn", {
+            msg: "agent_end without session.errorMessage — surfacing message-level error",
+            sessionId: live.sessionId,
+            errorMessage: errMsg,
+          });
+        }
+      } else {
         logAgentEvent("warn", {
           msg: "agent_end with session.errorMessage",
           sessionId: live.sessionId,
           errorMessage: errMsg,
         });
+      }
+      if (errMsg !== undefined && errMsg !== "") {
         // Forward a merged event that includes the error detail. Cast
         // through unknown — the SDK's union doesn't declare an
         // errorMessage field on agent_end (it expects callers to read


### PR DESCRIPTION
## Summary

Three independent defects piled up so a provider failure (401 / 402 / 5xx mid-tool-chain) vanished into either a blank assistant bubble or a frozen spinner, with the only signal being a stderr log line nobody saw:

```json
{
  "level": "warn",
  "msg": "agent turn ended with error stopReason",
  "errorMessage": "402 This request requires more credits…",
  "provider": "openrouter"
}
```

All three closed.

## What was wrong

### 1. Client store: dead-code `message_end` handler

`applyEvent` in `packages/client/src/store/session-store.ts` had two `message_end` branches. The first (refetch fallback at the top of the function) returned before the second (which set the error banner on `stopReason="error"`) could run. The banner-setting code had been there for a long time but never fired.

### 2. Server: `agent_end` enrichment only checked `session.errorMessage`

`session-registry.ts`'s fanout enriched `agent_end` with `live.session.errorMessage` only. Some failure paths in pi-coding-agent populate `message.errorMessage` on the last assistant message but never promote it to the session-level field — so even after fixing #1, the client got an empty `agent_end` for that subset of failures.

### 3. Chat renderer ignored per-message `errorMessage`

`ChatView.tsx` never read `message.errorMessage` or `message.stopReason` on assistant bubbles. Even when a global banner did set, the next `agent_start` cleared it, and the failed turn itself stayed a blank bubble with no indication of what went wrong.

## What this PR changes

- **`session-store.ts`**: merged the two `message_end` branches into one combined handler that does the refetch AND surfaces the error banner. Removed the dead second handler.
- **`session-registry.ts`**: `agent_end` enrichment now falls back to a new `findLastAssistantErrorMessage` helper when `session.errorMessage` is empty. Stderr log includes `"agent_end without session.errorMessage — surfacing message-level error"` for diagnosability when the fallback path fires.
- **`ChatView.tsx`**: assistant message bubbles render an inline amber **Provider error:** strip when the message carries `stopReason="error"` + non-empty `errorMessage`. Inline (not a banner) so it stays with the failed turn after the next prompt's `agent_start` clears `bannerBySession`.

## Test plan

- [x] `npm run check` clean (typecheck + lint + format)
- [x] Full test suite still 39/39
- [ ] **Manual smoke**: cap an openrouter key, send a prompt that exceeds the cap → confirm an amber "Provider error: 402…" appears inline under the empty assistant bubble (single turn)
- [ ] **Manual smoke**: send a prompt that calls a tool, then triggers the same 402 on the continuation → confirm the spinner clears AND the error renders inline (mid-tool-chain case)
- [ ] **Manual smoke**: confirm the banner case still works — banner appears on `message_end`, persists until the next prompt

## Notes on the "frozen spinner" symptom

If `agent_end` does fire on the failure (as the SDK's "agent_end always fires" comment claims), this PR fixes both symptoms. If you still see a genuinely stuck spinner after this lands, the new stderr line (`"agent_end without session.errorMessage — surfacing message-level error"`) will help pinpoint whether `agent_end` is reaching the bridge at all. If it isn't, that's a separate cause and worth a follow-up issue.

## Versioning

Queued under `[Unreleased]` for v1.3.1 since v1.3.0 just shipped.