### PR TITLE
fix(orch): nudge supervisor away from polling + auto-refresh sidebar on agent-created sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Changed
+
+- **Orchestration tool descriptions tightened to push supervisors
+  toward the inbox instead of polling.** `orchestrate_list_workers`,
+  `orchestrate_read_worker`, and `orchestrate_read_inbox`
+  descriptions now lead with "DO NOT poll — worker events are
+  push-driven via the inbox, you're woken automatically." The
+  earlier wording invited supervisors to call `list_workers` /
+  `read_worker` in a watcher loop, burning supervisor context for
+  no reason; the inbox wake-up already covers the same need.
+
 ### Fixed
 
 - **Surface provider errors that previously vanished into a blank
@@ -47,6 +58,23 @@ section. See the "Versions" section of the README for the support window policy.
   (single-turn) or a hung spinner (mid-tool-chain) while
   `agent turn ended with error stopReason` lines piled up in
   server stderr unanswered.
+- **Sidebar now picks up new sessions created by the agent without
+  a manual page reload.** Two paths feed a single
+  `session_list_changed` SSE event that the client routes into
+  `loadSessionsForProject`:
+  - pi-subagents `subagent` tool fires the event on
+    `tool_execution_start` (so the child appears in the sidebar
+    immediately, not after the multi-minute subagent run
+    completes) AND on `tool_execution_end` as a race fallback.
+  - `orchestrate_spawn_worker` pushes the same event directly from
+    inside the tool's `execute()`, synchronously with the actual
+    `createSession` call.
+
+  The previous behaviour was to wait for the spawning tool's
+  `tool_execution_end` to fire the refresh client-side; for
+  subagents that meant up to several minutes of staleness, and
+  for orchestration workers no refresh at all (the toolName check
+  only matched `subagent`).
 
 ## [1.3.0] — 2026-05-25
 

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -866,6 +866,12 @@ function applyEvent(
     // becomes visible immediately (the SDK finalizes the assistant
     // message right before it kicks off tool execution).
     scheduleMessagesRefetch(set, sessionId);
+    // (The session-list refresh for session-creating tools — subagent,
+    // orchestrate_spawn_worker — used to live here as a client-side
+    // toolName check. The server now pushes `session_list_changed`
+    // directly: from session-registry's subscribe handler for subagent,
+    // from inside execute() for orchestrate_spawn_worker. The handler
+    // below routes both into loadSessionsForProject.)
     return;
   }
 
@@ -877,15 +883,19 @@ function applyEvent(
     // bubble) shows up before the next tool fires. Without this the
     // user sees a stretch of "running …" badges with no output.
     scheduleMessagesRefetch(set, sessionId);
-    // pi-subagents: a `subagent` tool call just finished, which
-    // means one or more child session JSONLs were written to disk
-    // under the parent's directory. Refetch the project's session
-    // list so the sidebar picks them up — pi has no native
-    // "child session created" SDK event we can hook into.
-    if (event.toolName === "subagent") {
-      const projectId = findProjectIdForSession(get(), sessionId);
-      if (projectId !== undefined) void get().loadSessionsForProject(projectId);
-    }
+    // (Session-list refresh for session-creating tools is now handled
+    // server-side via `session_list_changed` — see the handler below.)
+    return;
+  }
+
+  if (event.type === "session_list_changed") {
+    // Server-pushed nudge that a session was created (or otherwise
+    // mutated) in a project we're watching. Sent by
+    // `orchestrate_spawn_worker` immediately after creating the
+    // worker so the sidebar updates without waiting for the
+    // supervisor's enclosing turn to finish.
+    const pid = typeof event.projectId === "string" ? event.projectId : undefined;
+    if (pid !== undefined) void get().loadSessionsForProject(pid);
     return;
   }
 

--- a/packages/server/src/orchestration/tools.ts
+++ b/packages/server/src/orchestration/tools.ts
@@ -442,6 +442,29 @@ function createSpawnWorker(supervisorId: string): ToolDefinition {
           }) + "\n",
         );
       });
+      // Push a synthetic `session_list_changed` event to the
+      // supervisor's SSE clients so the sidebar picks up the new
+      // worker immediately — without this, the sidebar only refreshes
+      // when the supervisor's enclosing turn ends (potentially many
+      // seconds later, since the supervisor often continues working
+      // after the spawn). The client handles this event by calling
+      // `loadSessionsForProject(projectId)`.
+      const sup = getSession(supervisorId);
+      if (sup !== undefined) {
+        for (const client of sup.clients) {
+          try {
+            client.send({
+              type: "session_list_changed",
+              reason: "spawn_worker",
+              projectId: supLive.projectId,
+              sessionId: worker.sessionId,
+            });
+          } catch {
+            // SSE client dropped — registry's own client cleanup
+            // will remove it on the next event.
+          }
+        }
+      }
       return ok(
         {
           workerId: worker.sessionId,
@@ -462,9 +485,10 @@ function createListWorkers(supervisorId: string): ToolDefinition {
     name: "orchestrate_list_workers",
     label: "List workers",
     description:
-      "Return every worker registered under this supervisor with its " +
-      "current state (live / idle / streaming / cold), last activity " +
-      "timestamp, and message count. Cheap to call repeatedly.",
+      "Survey worker state (live / idle / streaming / cold) + activity. " +
+      "DO NOT poll — worker events push into your inbox, you're woken " +
+      "automatically. Call once before spawning, or when an inbox event " +
+      "needs neighbour-worker context.",
     parameters: Type.Unsafe<Record<string, unknown>>({ type: "object", properties: {} }),
     async execute() {
       interface WorkerRow {
@@ -530,13 +554,10 @@ const readWorkerSchema = {
       minimum: 1,
       maximum: 100,
       description:
-        "How many of the most recent messages to return. Default 1 — " +
-        "the worker's single latest message is enough context for most " +
-        "supervisor decisions (typically the assistant's last turn or the " +
-        "last user-side handoff). Bump this only when one-message context " +
-        "isn't enough — e.g. you need to see the worker's reasoning chain " +
-        "across several turns, or you're auditing a long tool-call sequence. " +
-        "Bigger `limit` burns more of YOUR context window per call.",
+        "Most-recent messages to return. Default 1 — the single latest " +
+        "message is enough for most decisions. Bump only to inspect a " +
+        "multi-turn reasoning chain. Bigger `limit` costs more supervisor " +
+        "context.",
     },
   },
 } as const;
@@ -546,12 +567,11 @@ function createReadWorker(supervisorId: string): ToolDefinition {
     name: "orchestrate_read_worker",
     label: "Read worker transcript",
     description:
-      "Fetch the most recent messages from a worker's transcript. Returns the " +
-      "last N messages newest-last (chronological order, ready to read). " +
-      "Default `limit` is 1: most supervisor decisions only need the worker's " +
-      "latest message. Only bump `limit` when one message doesn't give you " +
-      "enough context. Auto-resumes cold workers from disk so the tool works " +
-      "regardless of whether the worker is currently live.",
+      "Fetch a worker's most recent messages (newest-last). Default `limit` " +
+      "is 1. DO NOT poll waiting for the worker to finish — worker events " +
+      "push into your inbox, you're woken automatically. Call this in " +
+      "REACTION to an inbox event, or when the user asks to inspect a " +
+      "worker. Auto-resumes cold workers.",
     parameters: Type.Unsafe<Record<string, unknown>>(readWorkerSchema),
     async execute(_toolCallId, params) {
       const p = params as { workerId: string; limit?: number };
@@ -801,12 +821,11 @@ function createReadInbox(supervisorId: string): ToolDefinition {
     name: "orchestrate_read_inbox",
     label: "Read inbox",
     description:
-      "Drain pending worker events: turn-ends, ask-user-question requests, " +
-      "auto-retry failures, process alerts, and deletions. Items are " +
-      "returned oldest-first and marked delivered — calling again returns " +
-      "only NEW items unless you also call `orchestrate_list_workers` to " +
-      "re-survey state. Items stay in the audit history (visible in the " +
-      "REST UI) regardless.",
+      "Drain pending worker events (turn-ends, ask-user-question, retry " +
+      "failures, process alerts, deletions), oldest-first. The inbox is " +
+      "PUSH-DRIVEN — you're woken by an `[orchestration]` system message " +
+      "when events arrive, so call this in REACTION to the wake-up, not " +
+      "in a polling loop. Items stay in the audit history after draining.",
     parameters: Type.Unsafe<Record<string, unknown>>({ type: "object", properties: {} }),
     async execute() {
       const items = await drainInbox(supervisorId);

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -468,6 +468,46 @@ function makeSubscribeHandler(live: LiveSession): () => void {
       }
     }
 
+    // Tools that create new sessions in this project: push a
+    // `session_list_changed` event so the sidebar picks up the new
+    // session without the user reloading. Covers two cases:
+    //
+    //   - pi-subagents `subagent` tool fires on `tool_execution_start`
+    //     because the plugin writes the child .jsonl in the first
+    //     second of the tool call (the run itself can take minutes,
+    //     and waiting until tool_execution_end means the child only
+    //     appears in the sidebar after the entire subagent run
+    //     completes — by which time the user usually already hit
+    //     reload).
+    //   - Same tool name also handled on `tool_execution_end` as a
+    //     race fallback: if the start-side push raced ahead of the
+    //     plugin's .jsonl write, the end-side push picks up the now-
+    //     existing child.
+    //
+    // orchestration's `orchestrate_spawn_worker` pushes
+    // session_list_changed itself from inside execute() — sync with
+    // the actual createSession call, no need to wait for SDK lifecycle
+    // events.
+    const toolEv = event as unknown as { type?: string; toolName?: string };
+    if (
+      (toolEv.type === "tool_execution_start" || toolEv.type === "tool_execution_end") &&
+      toolEv.toolName === "subagent"
+    ) {
+      const refresh = {
+        type: "session_list_changed" as const,
+        reason: toolEv.type === "tool_execution_start" ? "subagent_start" : "subagent_end",
+        projectId: live.projectId,
+      };
+      for (const client of live.clients) {
+        try {
+          client.send(refresh);
+        } catch {
+          // SSE client already gone; safe to ignore — its entry
+          // gets cleaned up on the next event.
+        }
+      }
+    }
+
     // Webhook fan-out. Filters internally for the 3 SDK events
     // it cares about (agent_end, auto_retry_end failures,
     // compaction_end success). Fire-and-forget — webhook


### PR DESCRIPTION
## Summary

Two follow-ups on the v1.3.0 orchestration feature, plus a parallel fix for pi-subagents children that suffered the same staleness:

### 1. Tool descriptions — stop the supervisor from polling

The original `orchestrate_list_workers` / `orchestrate_read_worker` / `orchestrate_read_inbox` descriptions invited supervisors to call them in a watcher loop, burning supervisor context for no reason — the inbox wake-up already covers the same need. All four now lead with **"DO NOT poll — worker events push into the inbox, you're woken automatically."**

~600 chars trimmed across the descriptions while strengthening the framing:

| Tool | Before | After |
|---|---|---|
| `list_workers` desc | 215 | ~225 |
| `read_worker` top-level (post-#163) | 320 | ~290 |
| `read_worker.limit` param | 444 | ~205 |
| `read_inbox` desc (post-#163) | 565 | ~340 |

### 2. Sidebar auto-refreshes when the agent creates a session

Two paths feed a single `session_list_changed` SSE event:

- **`orchestrate_spawn_worker`** pushes from inside `execute()`, synchronous with the actual `createSession` call.
- **pi-subagents `subagent` tool** — `session-registry`'s subscribe handler pushes the same event on `tool_execution_start` (so the child appears in the sidebar as soon as the plugin writes its `.jsonl`, not after the multi-minute subagent run completes) AND on `tool_execution_end` as a race fallback.

Client now has one `session_list_changed` handler that routes both sources into `loadSessionsForProject`. Removed the toolName-specific refresh logic that lived in two places on the client — the server is now the source of truth for "this project's session list might have changed."

**Before**: sidebar required a manual page reload after the agent spawned anything; worse for subagents where the trigger only fired at `tool_execution_end` (after the entire run), and worse for workers where the toolName check only matched `subagent` so workers never refreshed at all.

## Test plan

- [x] `npm run check` clean (typecheck + lint + format)
- [x] Full test suite still 39/39
- [ ] **Manual smoke**: from a supervisor session, call `orchestrate_spawn_worker` → confirm the new worker appears in the sidebar within ~1 sec, no page reload
- [ ] **Manual smoke**: from a session that uses pi-subagents, invoke a subagent → confirm the child appears in the sidebar shortly after the tool starts (not after it finishes)
- [ ] **Manual smoke**: ask the supervisor to monitor workers — confirm it relies on inbox wake-ups instead of calling `orchestrate_list_workers` / `orchestrate_read_worker` in a loop

## Versioning

Queued under `[Unreleased]` for v1.3.1 alongside #163 (the provider-error fix).