### PR TITLE
fix(chat): clear streaming bubble on mid-turn assistant message_end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,21 @@ section. See the "Versions" section of the README for the support window policy.
   subagents that meant up to several minutes of staleness, and
   for orchestration workers no refresh at all (the toolName check
   only matched `subagent`).
+- **Streaming bubble at the bottom of the chat no longer
+  accumulates text across tool-call boundaries within a turn.**
+  The `streamingTextBySession` buffer used to reset only at
+  `agent_start` and `agent_end` — so when an assistant message
+  ended mid-turn (a tool call about to start), the assistant
+  message moved into the transcript via the post-`message_end`
+  refetch, but the streaming bubble kept its accumulated text.
+  The next assistant message's `text_delta` events then APPENDED
+  onto the previous message's text, so for the rest of the turn
+  the bottom bubble showed
+  `<prior message text> + <currently streaming text>` until
+  `agent_end` finally cleared it. Now `message_end` for an
+  assistant message also drops the streaming buffer (and any
+  in-flight RAF / pendingDeltas so a mid-flight delta can't
+  flush into the now-cleared buffer).
 
 ## [1.3.0] — 2026-05-25
 

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -911,13 +911,18 @@ function applyEvent(
     // overflow that pi's auto-compaction couldn't recover from).
     // Surface the embedded errorMessage as a banner.
     //
-    // This branch USED to live in its own `if (event.type ===
-    // "message_end")` block lower in this function — which was dead
-    // code because the handler above matched first and returned. The
-    // user-visible symptom was a blank assistant bubble + no banner,
-    // even though the server logged the full error to stderr.
+    // Also drop the streaming buffer (and any in-flight RAF /
+    // pendingDeltas) when an assistant message_end fires MID-TURN:
+    // the refetch above has just promoted those bytes into a real
+    // message, so leaving them in the streaming bubble shows the
+    // text twice. Worse, the next assistant message's text_delta
+    // events APPEND to the existing buffer, so the bottom bubble
+    // would show "<prior message text> + <currently streaming text>"
+    // until agent_end finally clears it.
     if (event.type === "message_end") {
-      const msg = (event as { message?: { stopReason?: unknown; errorMessage?: unknown } }).message;
+      const msg = (
+        event as { message?: { stopReason?: unknown; errorMessage?: unknown; role?: unknown } }
+      ).message;
       if (msg?.stopReason === "error") {
         const m = typeof msg.errorMessage === "string" ? msg.errorMessage : "";
         if (m.length > 0) {
@@ -925,6 +930,15 @@ function applyEvent(
             bannerBySession: { ...s.bannerBySession, [sessionId]: `Agent error: ${m}` },
           }));
         }
+      }
+      if (msg?.role === "assistant") {
+        const raf = pendingRaf.get(sessionId);
+        if (raf !== undefined) cancelAnimationFrame(raf);
+        pendingRaf.delete(sessionId);
+        pendingDeltas.delete(sessionId);
+        set((s) => ({
+          streamingTextBySession: { ...s.streamingTextBySession, [sessionId]: "" },
+        }));
       }
     }
     return;


### PR DESCRIPTION
## Summary

`streamingTextBySession` was only reset at `agent_start` and `agent_end`. Inside a single turn, every `text_delta` event appended to whatever was already in the buffer — so when an assistant message ended mid-turn (a tool call about to start):

1. Refetch after `message_end` moved the assistant text into the transcript ✅
2. But the streaming bubble at the bottom kept its accumulated content ❌
3. The next assistant message's `text_delta` events then **appended** onto the previous message's text in the buffer
4. The bottom bubble showed `<prior message text> + <currently streaming text>` for the rest of the turn
5. `agent_end` finally cleared it — at which point the refetch replaced the bubble with the canonical messages array

## Fix

`message_end` with `role: "assistant"` now also drops:
- `streamingTextBySession[sessionId]` → `""`
- The pending RAF (so a delta still mid-flight doesn't flush into the now-cleared buffer)
- The `pendingDeltas[sessionId]` accumulator

Tool result `message_end` (role `toolResult`) is intentionally not cleared — that branch doesn't touch the streaming bubble. Just assistant-role.

## Test plan

- [x] `npm run check` clean (typecheck + lint + format)
- [x] Full test suite still 39/39
- [x] **Manual smoke** (against dev server): multi-step turn that includes assistant text → tool call → tool result → more assistant text → tool call → … — confirmed the bottom bubble resets between each assistant chunk, while the transcript keeps growing with the real persisted messages.

**Browser cache caveat**: pi-forge's PWA service worker caches the JS bundle aggressively. If testing locally, hard-refresh (Cmd-Shift-R) or unregister the SW from DevTools → Application before retesting. The version bump *should* invalidate, but in practice doesn't always on dev builds.

## Conflict heads-up

This touches the same `message_end || tool_result` branch in `applyEvent` that #163 modifies (provider-error banner). Whichever lands first, the other needs a small rebase to keep both `if (event.type === "message_end")` sub-blocks. Trivial — both branches go inside the combined handler, independent of each other.

Queued under `[Unreleased]` for v1.3.1 alongside #163 and #164.