### PR TITLE
chore(ci): run dependabot daily instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 # Dependabot config for pi-forge.
 #
-# Three ecosystems, weekly cadence each. The npm entry covers root
+# Three ecosystems, daily cadence each. The npm entry covers root
 # plus every workspace under packages/* — Dependabot's npm support
 # auto-discovers workspace-managed packages, so a single root entry
 # is sufficient (no per-workspace duplication needed).
@@ -22,7 +22,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -55,7 +55,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
       - "github-actions"
@@ -67,7 +67,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
       - "docker"


### PR DESCRIPTION
## Summary

- Flip all three `interval: \"weekly\"` entries in `.github/dependabot.yml` to `\"daily\"` (npm, github-actions, docker).
- Updates the header comment to match (\"weekly cadence each\" → \"daily cadence each\").

Motivation: weekly cadence batches up security-relevant bumps with regular ones and adds up to a week of latency on each. Daily surfaces them sooner; the 10-PR open cap already throttles flood risk.

## Notes

- No ignore-rules or other policy bits touched. The `@xterm/xterm` major-version suppression and the Node Docker-base major suppression both remain in place.
- Pi SDK trio remains opt-in-PR-but-no-auto-merge as before — only the cadence shifts.

## Test plan

- [ ] Confirm Dependabot config validates on push (GitHub surfaces parse errors directly on the file in the PR's \"Files changed\" view if any).
- [ ] After merge, watch the Insights → Dependency graph → Dependabot tab for the next scheduled run timestamp to flip to a 24h cadence.