### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-05-26
+
 ### Changed
 
 - **Orchestration tool descriptions tightened to push supervisors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "workspaces": [
         "packages/*"
       ],
@@ -17044,7 +17044,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17106,7 +17106,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.75.5",
         "@earendil-works/pi-ai": "0.75.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Patch release rolling up four PRs landed since v1.3.0:

- **#163** — surface provider errors that previously vanished into blank assistant turns / hung spinners (three-defect fix: dead `message_end` branch, server `agent_end` enrichment fallback, per-message `errorMessage` rendering).
- **#164** — orchestration polish: tightened `orchestrate_{list,read}_workers` / `read_inbox` tool descriptions to push supervisors toward the inbox instead of polling, plus a unified `session_list_changed` SSE event so the sidebar auto-refreshes when subagents or orchestration workers spawn new sessions.
- **#165** — streaming bubble at the bottom of chat no longer accumulates text across tool-call boundaries within a turn (now clears on assistant `message_end`, not just `agent_end`).
- **#167** — Dependabot cadence weekly → daily (CI hygiene only, no runtime surface).

Plus #166 (typescript-eslint 8.59.4 → 8.60.0 dev-dep bump), which is metapackage-only and is folded silently into the dev-tooling chassis.

## What this PR changes

Same five-file pattern as `scripts/bump-version.sh 1.3.1` would produce:

- `package.json`, `packages/server/package.json`, `packages/client/package.json` → version `1.3.0` → `1.3.1`
- `package-lock.json` → workspace versions synced
- `CHANGELOG.md` → `## [1.3.1] — 2026-05-26` heading inserted under the empty `## [Unreleased]` placeholder; the already-accumulated Changed/Fixed sections become the v1.3.1 entry

## Test plan

- [x] `npm run check` (typecheck + lint + format) clean on v1.3.1
- [x] All three workspace versions match the root
- [x] `## [Unreleased]` retained as an empty placeholder for the next cycle
- [ ] CI build / image build green before merge

## After merge

```bash
git checkout main && git pull --ff-only
git tag v1.3.1
git push origin v1.3.1
```

The release workflow builds the multi-arch image and creates the GitHub Release automatically. npm publish runs via the configured trusted publisher.