### PR TITLE
fix(models): reload auth + models.json before setModel on live sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`set_model_failed` when picking a model from a provider that
+  was enabled AFTER the session was created.** The live
+  `AgentSession`'s `ModelRegistry` is built once at session-create
+  time from a snapshot of `auth.json` + `models.json` and never
+  re-reads either file on its own. The server's `POST
+  /api/v1/sessions/:id/model` route validated the requested model
+  against a *fresh* `liveModelRegistry()` (which passed), but the
+  SDK's `setModel()` then re-validated via
+  `_modelRegistry.hasConfiguredAuth(...)` against its own *frozen*
+  `AuthStorage.data` snapshot — which couldn't see the just-added
+  auth entry — and threw `"No API key for ..."`, surfacing as the
+  `set_model_failed` banner. Now the route reloads both layers in
+  place before the SDK call: `modelRegistry.authStorage.reload()`
+  (re-reads `auth.json` into the in-memory `data` map that
+  `hasAuth` queries) followed by `modelRegistry.refresh()`
+  (re-reads `models.json` + resets API/OAuth provider
+  registrations). `refresh()` alone is insufficient — it
+  intentionally does not touch `AuthStorage`. Both calls mutate
+  in place, so every subsequent SDK use inside this session (turn
+  execution, per-request auth lookup, model picker enumeration)
+  also picks up the new keys — no app restart, no session
+  recreate.
+
 ## [1.3.1] — 2026-05-26
 
 ### Changed

--- a/packages/server/src/routes/control.ts
+++ b/packages/server/src/routes/control.ts
@@ -502,6 +502,30 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
           // undefined so we don't try to restore a phantom snapshot.
         }
         try {
+          // The live AgentSession was created with a ModelRegistry
+          // snapshot of auth.json + models.json at session-create time;
+          // the SDK never re-reads either file on its own. If the user
+          // added a provider/key AFTER this session was created, the
+          // SDK's `setModel` -> `_modelRegistry.hasConfiguredAuth(...)`
+          // check would fail against the stale snapshot even though
+          // our route-level `liveModelRegistry()` validation just
+          // passed (it reads fresh each call).
+          //
+          // TWO reloads are needed, in this order: ModelRegistry's
+          // `refresh()` re-reads models.json + resets API/OAuth
+          // provider registrations, but does NOT touch AuthStorage —
+          // the AuthStorage.data map (what `hasAuth(provider)` queries)
+          // stays frozen at session-create time. Without the explicit
+          // `authStorage.reload()`, refresh() alone closes only half
+          // the staleness gap and `set_model_failed` still fires for
+          // any provider whose key was added post-create.
+          //
+          // Both calls mutate in place, so every subsequent SDK use
+          // inside this session (turn execution, per-request auth
+          // lookup, model picker enumeration) also picks up the new
+          // keys without restarting the session.
+          live.session.modelRegistry.authStorage.reload();
+          live.session.modelRegistry.refresh();
           // Wrap in withTimeout so a hung SDK setModel can't hold the
           // settings lock indefinitely. Without this, a single hung
           // setModel blocks every subsequent PUT /config/settings,


### PR DESCRIPTION
## Summary

Fixes a `set_model_failed` banner that fires when you enable a new API provider in Settings and try to pick one of its models from the chat picker on an **already-active** session. Previously the only workaround was to restart the app or recreate the session.

## Root cause

The live `AgentSession` is created with a `ModelRegistry` snapshot of `auth.json` + `models.json` at session-create time. The SDK never re-reads either file on its own. After `writeApiKey` lands the new credential on disk:

1. Route handler validates against `liveModelRegistry()` (which reads fresh each call) — **passes**
2. SDK's `setModel()` re-validates via `_modelRegistry.hasConfiguredAuth(model)`, which queries the *frozen* `AuthStorage.data` snapshot — **fails**
3. SDK throws `"No API key for {provider}/{modelId}"` (`agent-session.js:1082`)
4. Server wraps as `{ error: "set_model_failed", message: ... }` (`routes/control.ts:530`)

## Fix

Reload both layers in place before the SDK call, in this order (`routes/control.ts`, inside the `withSettingsLock` block):

```ts
live.session.modelRegistry.authStorage.reload();  // re-reads auth.json into AuthStorage.data
live.session.modelRegistry.refresh();              // re-reads models.json + resets API/OAuth providers
```

`refresh()` alone is insufficient — by design it does not touch `AuthStorage` (the in-memory `data` map that `hasAuth()` queries). Both calls mutate in place, so every subsequent SDK use inside the same session (turn execution, per-request auth lookup, model picker enumeration) also picks up the new keys.

Both `ModelRegistry.authStorage` and `AuthStorage.reload()` are part of the SDK's public typed surface (`.d.ts`-declared, no private-field access).

## Diff

- `packages/server/src/routes/control.ts` — the two reload calls + a comment explaining the staleness so a future reader doesn't strip them as redundant
- `CHANGELOG.md` — `### Fixed` entry under `## [Unreleased]`

## Test plan

- [x] `npm run check` clean
- [x] Manually verified: active session → add provider in Settings → pick a model from it in chat picker → persists without `set_model_failed`
- [ ] No-op verify for the unchanged path: pick a model from an already-configured provider on a fresh session still works
- [ ] Inverse check: remove a provider's key, then try to pick one of its models — should now correctly fail (previously the stale registry might still have accepted it)