### PR TITLE
chore(settings): drop dead steeringMode + followUpMode form fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Removed
+
+- **Settings → Agent: dropped the "Steering mode" and "Follow-up
+  mode" form fields.** Both wrote to `settings.json` keys
+  (`steeringMode`, `followUpMode`) that no code path ever read —
+  steering behaviour is and has been driven entirely per-request
+  via the `streamingBehavior` field on `POST
+  /api/v1/sessions/:id/prompt` and the `mode` field on `POST
+  /api/v1/sessions/:id/steer`, plus the `mode` parameter on
+  `orchestrate_send_to_worker`. The corresponding members on the
+  `SettingsJson` interface and the JSON-schema validators on
+  `PUT /api/v1/config/settings` are also gone. The route schema
+  keeps `additionalProperties: true` and the type keeps its
+  `[k: string]: unknown` index signature, so existing
+  `settings.json` files containing these keys keep validating
+  and persisting through GET/PUT — they're just untyped extras
+  now until you clear them.
+
 ### Fixed
 
 - **`set_model_failed` when picking a model from a provider that

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,9 +148,7 @@ Defaults applied to new sessions:
 {
   "defaultProvider": "anthropic",
   "defaultModel": "claude-sonnet-4-5-20250929",
-  "defaultThinkingLevel": "medium",
-  "steeringMode": "all",
-  "followUpMode": "all"
+  "defaultThinkingLevel": "medium"
 }
 ```
 
@@ -159,8 +157,6 @@ Defaults applied to new sessions:
 | `defaultProvider` | provider key | Picked by new sessions when no per-session model is set |
 | `defaultModel` | model id from the chosen provider | Same |
 | `defaultThinkingLevel` | `minimal` / `low` / `medium` / `high` / `xhigh` | Reasoning-capable models only |
-| `steeringMode` | `all` / `one-at-a-time` | How the SDK delivers queued steering messages — flush-all vs wait-between |
-| `followUpMode` | `all` / `one-at-a-time` | Same, for follow-up (post-idle) delivery |
 
 Other SDK keys are accepted by `PUT /api/v1/config/settings` and persist
 verbatim. Pi-forge's typed form covers the common ones; an "Edit as

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -56,8 +56,7 @@ interface Props {
  *     JSON editor — typed schema editing is deferred (DEFERRED.md Pol5).
  *
  *   - Agent — `settings.json` knobs: defaultProvider, defaultModel,
- *     defaultThinkingLevel, steeringMode, followUpMode. Sending `null`
- *     clears a key.
+ *     defaultThinkingLevel. Sending `null` clears a key.
  *
  *   - Skills — per-project skill list from `GET /config/skills` with
  *     toggle. Requires an active project; surfaces a hint otherwise.
@@ -639,24 +638,6 @@ function AgentTab({ onError }: { onError: (msg: string | undefined) => void }) {
           value={get("defaultThinkingLevel")}
           options={["", "off", "low", "medium", "high"]}
           onSave={(v) => update({ defaultThinkingLevel: v.length === 0 ? null : v })}
-          disabled={busy}
-        />
-      </Field>
-
-      <Field label="Steering mode" hint="how interruptions during streaming are queued">
-        <SelectSetting
-          value={get("steeringMode")}
-          options={["", "steer", "followUp"]}
-          onSave={(v) => update({ steeringMode: v.length === 0 ? null : v })}
-          disabled={busy}
-        />
-      </Field>
-
-      <Field label="Follow-up mode" hint="how queued messages are delivered after agent_end">
-        <SelectSetting
-          value={get("followUpMode")}
-          options={["", "steer", "followUp"]}
-          onSave={(v) => update({ followUpMode: v.length === 0 ? null : v })}
           disabled={busy}
         />
       </Field>

--- a/packages/server/src/config-manager.ts
+++ b/packages/server/src/config-manager.ts
@@ -66,8 +66,6 @@ export interface SettingsJson {
   defaultProvider?: string;
   defaultModel?: string;
   defaultThinkingLevel?: string;
-  steeringMode?: "all" | "one-at-a-time";
-  followUpMode?: "all" | "one-at-a-time";
   skills?: string[];
   /** Pi's prompt-pattern overrides — same `!name`/`+name`/`-name` grammar as `skills`. */
   prompts?: string[];

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -69,8 +69,6 @@ const settingsSchema = {
     defaultProvider: { type: ["string", "null"] },
     defaultModel: { type: ["string", "null"] },
     defaultThinkingLevel: { type: ["string", "null"] },
-    steeringMode: { type: ["string", "null"] },
-    followUpMode: { type: ["string", "null"] },
     skills: { type: ["array", "null"], items: { type: "string" } },
     enableSkillCommands: { type: ["boolean", "null"] },
   },

--- a/tests/test-config.ts
+++ b/tests/test-config.ts
@@ -233,7 +233,6 @@ async function main(): Promise<void> {
       const update = await jsend(base, "PUT", "/api/v1/config/settings", {
         defaultProvider: "anthropic",
         defaultModel: "claude-opus-4-5",
-        steeringMode: "all",
       });
       assert("PUT /config/settings → 200", update.status === 200);
       const merged = update.body as { defaultProvider: string; defaultModel: string };


### PR DESCRIPTION
## Summary

Removes the **Steering mode** and **Follow-up mode** dropdowns from Settings → Agent. Both wrote to `settings.json` keys (`steeringMode`, `followUpMode`) that **no code path ever read** — they were leftover scaffolding from an earlier design.

Steering behaviour has been (and still is) driven entirely **per-request**:

| Surface | Param |
|---|---|
| `POST /api/v1/sessions/:id/prompt` | `streamingBehavior: "steer" | "followUp"` (multipart or JSON) |
| `POST /api/v1/sessions/:id/steer` | `mode: "steer" | "followUp"` (JSON body) |
| `orchestrate_send_to_worker` tool | `mode: "prompt" | "steer" | "followUp"` |

So a global default would have been ignored even if anything read it. Cleaning up the UI to match reality.

## What changed (6 files, +20/-30)

- `packages/client/src/components/SettingsPanel.tsx` — removed both `<Field>` blocks + the doc-comment mention of these keys
- `packages/server/src/config-manager.ts` — removed the two members from the `SettingsJson` interface
- `packages/server/src/routes/config.ts` — removed both entries from the `settingsSchema` JSON-schema
- `docs/configuration.md` — removed both keys from the example `settings.json` block + two corresponding table rows
- `tests/test-config.ts` — removed `steeringMode: "all"` from the PUT body in the settings-merge test (test still verifies the merge behaviour with the remaining keys)
- `CHANGELOG.md` — `### Removed` entry under `## [Unreleased]`

## Backward-compat

**No migration required.** Existing `settings.json` files that contain `steeringMode` / `followUpMode` keys keep working because:

- `SettingsJson` keeps its `[k: string]: unknown` index signature → extra keys still permitted at the type level
- `settingsSchema` keeps `additionalProperties: true` → extra keys still validate on `PUT /config/settings`
- `GET /config/settings` already returns the raw file content, so the keys still round-trip

They're just **untyped extras** until users clear them manually (or via a future migration).

## Test plan

- [x] `npm run check` (typecheck + lint + format) clean
- [x] Manual smoke: `npm run dev:remote`, opened Settings → Agent, the two dropdowns are gone; defaultProvider / defaultModel / defaultThinkingLevel still render and save correctly
- [ ] CI green before merge