### PR TITLE
feat(chat): inline per-session thinking-level picker next to model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,43 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Added
+
+- **Per-session thinking-level picker, inline next to the chat-input
+  model picker.** Shown only for models whose
+  `supportedThinkingLevels` array (computed server-side via the SDK's
+  `getSupportedThinkingLevels(model)` helper) has more than just
+  `["off"]` — non-reasoning models hide the control entirely so users
+  don't see a knob that the SDK would silently clamp to `"off"`. The
+  option list is per-model dynamic: GPT-5-class models that expose
+  `xhigh` get it; models that explicitly opt out of a standard level
+  (`null` entry in their `thinkingLevelMap`) hide it. Each
+  `ProviderModelEntry` on the `GET /config/providers` wire now
+  carries `supportedThinkingLevels: ModelThinkingLevel[]` so the
+  client doesn't have to hardcode the list. The Settings → Agent
+  `defaultThinkingLevel` stays as the new-session default; the
+  inline picker overrides it for one session.
+
+  Persistence is pi-SDK-owned: `session.setThinkingLevel` appends
+  a `thinkingLevel` entry to the session JSONL, and pi's
+  session-manager reconstructs the value on resume — no pi-forge
+  localStorage mirror needed (unlike the model picker, which
+  keeps one because `setModel` has settings.json side effects we
+  have to snapshot-restore around). New server endpoint `POST
+  /api/v1/sessions/:id/thinking-level` is a thin pass-through that
+  reuses the same `withSettingsLock` snapshot-restore pattern as
+  `setModel` to keep the same per-session-change-pollutes-global
+  trap from biting `defaultThinkingLevel`. Live session summary
+  (`GET /sessions/:id`, `POST /sessions`, `POST /fork`, PATCH
+  rename) now also emits `thinkingLevel` so the picker reflects
+  the current value on session switch.
+
+  The SDK auto-clamps the active level when the model changes
+  (e.g. switching from a reasoning model on `"high"` to a non-
+  reasoning model forces `"off"`). The client refetches the
+  summary after `setModel` lands so the picker reflects whatever
+  the SDK landed on instead of stale state.
+
 ### Removed
 
 - **Settings → Agent: dropped the "Steering mode" and "Follow-up

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -934,6 +934,13 @@ export function ChatInput({ sessionId }: Props) {
     () => localStorage.getItem(MODEL_KEY_PREFIX + sessionId) ?? "",
   );
   const [modelError, setModelError] = useState<string | undefined>(undefined);
+  // Per-session thinking-level mirror, sourced from the server (SDK
+  // persists this as first-class session state in the JSONL, so we
+  // don't keep a localStorage copy like we do for the model picker).
+  // Undefined while the initial GET /sessions/:id is in flight or if
+  // the call failed; the picker hides itself in that case.
+  const [thinkingLevel, setThinkingLevel] = useState<string | undefined>(undefined);
+  const [thinkingError, setThinkingError] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     void api
@@ -965,10 +972,31 @@ export function ChatInput({ sessionId }: Props) {
   // would keep showing the previously-active session's model and the new
   // session would silently inherit its default. Skips the setModel call
   // when storage is empty (= "use whatever the session already has").
+  // Also fetches the live session summary to pull the active thinking
+  // level so the picker reflects on session switch.
   useEffect(() => {
     const stored = localStorage.getItem(MODEL_KEY_PREFIX + sessionId) ?? "";
     setModelChoice(stored);
     setModelError(undefined);
+    setThinkingError(undefined);
+    setThinkingLevel(undefined);
+    // Pull the SDK-persisted thinking level for this session. Same
+    // captured-id pattern as the setModel call below — a slow GET for
+    // session A that resolves after the user switched to B mustn't
+    // overwrite B's thinkingLevel state with A's value.
+    {
+      const callSessionId = sessionId;
+      void api
+        .getSession(callSessionId)
+        .then((summary) => {
+          if (callSessionId !== sessionId) return;
+          setThinkingLevel(summary.thinkingLevel);
+        })
+        .catch(() => {
+          // Disk-only or transient — leave thinkingLevel undefined so
+          // the picker stays hidden until next switch / change.
+        });
+    }
     if (stored === "") return;
     const [provider, ...rest] = stored.split(":");
     const modelId = rest.join(":");
@@ -1035,9 +1063,70 @@ export function ChatInput({ sessionId }: Props) {
       await api.setModel(sessionId, provider, modelId);
       localStorage.setItem(storageKey, value);
       setModelError(undefined);
+      // The SDK's setModel calls setThinkingLevel internally to clamp
+      // the active level against the new model's capabilities (e.g.
+      // picking a non-reasoning model after running on "high" forces
+      // the level to "off"). Refetch the summary so the picker
+      // reflects whatever the SDK landed on.
+      const callSessionId = sessionId;
+      void api
+        .getSession(callSessionId)
+        .then((summary) => {
+          if (callSessionId !== sessionId) return;
+          setThinkingLevel(summary.thinkingLevel);
+        })
+        .catch(() => {
+          // Non-fatal: a stale picker is recoverable on next session
+          // switch, and the underlying setModel already succeeded.
+        });
     } catch (err) {
       const code = err instanceof ApiError ? err.code : (err as Error).message;
       setModelError(`set model failed: ${code}`);
+    }
+  };
+
+  // Resolve which model is currently active (per-session override if
+  // set, otherwise the settings.json default) and pull its entry from
+  // the providers listing so we can gate the thinking-level picker on
+  // `reasoning`. Returns undefined while providers/defaultModel are
+  // still loading OR when the active model can't be found in the
+  // listing (e.g. settings.json points at a model that's since been
+  // removed from models.json) — in either case the picker stays
+  // hidden.
+  const activeModel = useMemo(() => {
+    if (providers === undefined) return undefined;
+    let provider: string;
+    let modelId: string;
+    if (modelChoice.length > 0) {
+      const [p, ...rest] = modelChoice.split(":");
+      if (p === undefined) return undefined;
+      provider = p;
+      modelId = rest.join(":");
+    } else if (
+      defaultModel !== undefined &&
+      defaultModel.provider.length > 0 &&
+      defaultModel.modelId.length > 0
+    ) {
+      provider = defaultModel.provider;
+      modelId = defaultModel.modelId;
+    } else {
+      return undefined;
+    }
+    const entry = providers.providers.find((p) => p.provider === provider);
+    return entry?.models.find((m) => m.id === modelId);
+  }, [providers, modelChoice, defaultModel]);
+
+  const onThinkingLevelChange = async (level: string): Promise<void> => {
+    // Optimistic — the SDK clamps so the response may differ; we
+    // reconcile from the response body below.
+    setThinkingLevel(level);
+    try {
+      const res = await api.setThinkingLevel(sessionId, level);
+      setThinkingLevel(res.level);
+      setThinkingError(undefined);
+    } catch (err) {
+      const code = err instanceof ApiError ? err.code : (err as Error).message;
+      setThinkingError(`set thinking level failed: ${code}`);
     }
   };
 
@@ -1517,6 +1606,15 @@ export function ChatInput({ sessionId }: Props) {
             value={modelChoice}
             onChange={(v) => void onModelChange(v)}
           />
+          {activeModel !== undefined &&
+            activeModel.supportedThinkingLevels.length > 1 &&
+            thinkingLevel !== undefined && (
+              <ThinkingLevelPicker
+                value={thinkingLevel}
+                options={activeModel.supportedThinkingLevels}
+                onChange={(v) => void onThinkingLevelChange(v)}
+              />
+            )}
           {fileRefs.length > 0 && (
             <div className="flex flex-wrap items-center gap-1">
               {fileRefs.map((path, i) => (
@@ -1540,12 +1638,16 @@ export function ChatInput({ sessionId }: Props) {
             </div>
           )}
           {(modelError !== undefined ||
+            thinkingError !== undefined ||
             textareaHeight !== undefined ||
             todoCounts.total > 0 ||
             runningProcesses > 0) && (
             <div className="ml-auto flex items-center gap-2">
               {modelError !== undefined && (
                 <span className="text-[11px] text-red-400">{modelError}</span>
+              )}
+              {thinkingError !== undefined && (
+                <span className="text-[11px] text-red-400">{thinkingError}</span>
               )}
               {/* Reset is paired with the drag handle; hide on
                   mobile since the handle is hidden there too and the
@@ -2188,6 +2290,73 @@ function ModelPicker({
           <div className="border-t border-neutral-800 px-3 py-1.5 text-[10px] text-neutral-600">
             {filtered.length} of {options.length} models — ↑↓ to move, Enter to pick, Esc to close
           </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Per-session thinking-level picker rendered next to ModelPicker.
+ * Only mounted when the active model has more than just `["off"]` in
+ * its `supportedThinkingLevels` — gating happens at the parent (see
+ * the conditional render in ChatInput), not inside this component,
+ * so the picker doesn't render an "n/a" state for non-reasoning
+ * models. Option list is the per-model array the server computed via
+ * the SDK's `getSupportedThinkingLevels(model)` helper, so models
+ * that expose `xhigh` get it and models that explicitly opt out of a
+ * standard level (via a `null` entry in `thinkingLevelMap`) hide it.
+ */
+function ThinkingLevelPicker({
+  value,
+  options,
+  onChange,
+}: {
+  value: string;
+  options: readonly string[];
+  onChange: (next: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent): void => {
+      if (wrapperRef.current === null) return;
+      if (!wrapperRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    window.addEventListener("mousedown", onDocClick);
+    return () => window.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-left text-[11px] text-neutral-200"
+        title="Override the thinking level for this session"
+      >
+        <span className="text-neutral-500">thinking:</span>
+        <span className="truncate">{value}</span>
+        <span className="ml-1 text-neutral-500">▾</span>
+      </button>
+      {open && (
+        <div className="absolute bottom-full left-0 z-10 mb-1 w-[140px] rounded border border-neutral-700 bg-neutral-950 shadow-xl">
+          {options.map((level) => (
+            <button
+              key={level}
+              onClick={() => {
+                onChange(level);
+                setOpen(false);
+              }}
+              className={`flex w-full items-center justify-between px-3 py-1.5 text-left text-xs ${
+                level === value ? "bg-neutral-800 text-neutral-100" : "text-neutral-300"
+              }`}
+            >
+              <span>{level}</span>
+              {level === value && <span className="text-emerald-400">●</span>}
+            </button>
+          ))}
         </div>
       )}
     </div>

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -301,6 +301,7 @@ function vSessionSummary(value: unknown, status: number): SessionSummary {
     isStreaming: value.isStreaming,
   };
   if (typeof value.name === "string") out.name = value.name;
+  if (typeof value.thinkingLevel === "string") out.thinkingLevel = value.thinkingLevel;
   return out;
 }
 
@@ -1770,6 +1771,21 @@ export const api = {
         return { provider: v.provider, modelId: v.modelId };
       },
       { method: "POST", body: { provider, modelId } },
+    ),
+  // Per-session thinking-level override. Server clamps to the active
+  // model's supported levels and returns the effective value — callers
+  // should use the response, not the request, to update local UI state
+  // so a "high" pick on a model that caps at "low" reflects accurately.
+  setThinkingLevel: (id: string, level: string) =>
+    request(
+      `/api/v1/sessions/${encodeURIComponent(id)}/thinking-level`,
+      (v, s) => {
+        if (!isObject(v) || typeof v.level !== "string") {
+          fail(s, "expected { level }");
+        }
+        return { level: v.level };
+      },
+      { method: "POST", body: { level } },
     ),
 
   // ---------------- config ----------------

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -309,6 +309,8 @@ export interface UnifiedSession {
   path?: string;
 }
 
+export type ModelThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
 export interface SessionSummary {
   sessionId: string;
   projectId: string;
@@ -319,6 +321,14 @@ export interface SessionSummary {
   name?: string;
   messageCount: number;
   isStreaming: boolean;
+  /**
+   * Active thinking level on the live AgentSession. Only set for live
+   * sessions — disk-only entries omit it because the SDK only surfaces
+   * the active value on a loaded session. Loose `string` typing matches
+   * the wire shape (server validates against the enum); callers that
+   * want the discriminated union should narrow at use site.
+   */
+  thinkingLevel?: string;
 }
 
 export type SkillOverrideState = "enabled" | "disabled";
@@ -482,6 +492,15 @@ export interface ProviderModelEntry {
   reasoning: boolean;
   input: ("text" | "image")[];
   hasAuth: boolean;
+  /**
+   * Per-model list of thinking levels the SDK reports as supported
+   * (via `getSupportedThinkingLevels(model)` on the server). Always at
+   * least `["off"]`; non-reasoning models return only that. Picker
+   * reads this directly — no hardcoded list — so models with `xhigh`
+   * surface it and models that explicitly opt out of `low` (or any
+   * other level) hide it.
+   */
+  supportedThinkingLevels: ModelThinkingLevel[];
 }
 
 export interface ProvidersListing {

--- a/packages/server/src/config-manager.ts
+++ b/packages/server/src/config-manager.ts
@@ -11,7 +11,12 @@ import {
   type Skill,
   loadSkills,
 } from "@earendil-works/pi-coding-agent";
-import type { Api, Model } from "@earendil-works/pi-ai";
+import {
+  getSupportedThinkingLevels,
+  type Api,
+  type Model,
+  type ModelThinkingLevel,
+} from "@earendil-works/pi-ai";
 import { config } from "./config.js";
 import { makeLock } from "./concurrency.js";
 import { discoverExtensionResources } from "./extensions-discovery.js";
@@ -96,6 +101,18 @@ export interface ProvidersListing {
       reasoning: boolean;
       input: ("text" | "image")[];
       hasAuth: boolean;
+      /**
+       * Levels this specific model supports, computed via the SDK's
+       * `getSupportedThinkingLevels(model)` helper. Always at least
+       * `["off"]`; non-reasoning models return only that. Reasoning
+       * models include any of `minimal` / `low` / `medium` / `high`
+       * not explicitly mapped to `null` in `thinkingLevelMap`, plus
+       * `xhigh` ONLY if the model has an explicit mapping for it (most
+       * don't — GPT-5-class models that exposes a "max" tier do). The
+       * inline chat-input thinking-level picker reads this directly
+       * instead of hardcoding a per-model list.
+       */
+      supportedThinkingLevels: ModelThinkingLevel[];
     }[];
   }[];
 }
@@ -392,6 +409,7 @@ export async function liveProvidersListing(): Promise<ProvidersListing> {
       reasoning: m.reasoning,
       input: m.input,
       hasAuth: registry.hasConfiguredAuth(m),
+      supportedThinkingLevels: getSupportedThinkingLevels(m),
     });
   }
   return { providers: Array.from(grouped.values()) };

--- a/packages/server/src/routes/_schemas.ts
+++ b/packages/server/src/routes/_schemas.ts
@@ -47,6 +47,13 @@ export const liveSummarySchema = {
     name: { type: "string" },
     messageCount: { type: "integer", minimum: 0 },
     isStreaming: { type: "boolean" },
+    // Pi's ModelThinkingLevel union: "off" | "minimal" | "low" | "medium" |
+    // "high" | "xhigh". Only present for live sessions — disk-only entries
+    // omit it because the SDK only surfaces the active state on a loaded
+    // AgentSession (the JSONL contains the transitions but reconstructing
+    // the current value requires the replay logic, which is what
+    // session-manager does on resume).
+    thinkingLevel: { type: "string" },
   },
 } as const;
 
@@ -68,6 +75,7 @@ export function liveSummaryBody(args: {
   messageCount: number;
   isStreaming: boolean;
   isLive?: boolean;
+  thinkingLevel?: string;
 }): Record<string, unknown> {
   const out: Record<string, unknown> = {
     sessionId: args.sessionId,
@@ -80,5 +88,6 @@ export function liveSummaryBody(args: {
     isStreaming: args.isStreaming,
   };
   if (args.name !== undefined) out.name = args.name;
+  if (args.thinkingLevel !== undefined) out.thinkingLevel = args.thinkingLevel;
   return out;
 }

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -116,6 +116,7 @@ const providersListingSchema = {
                 "reasoning",
                 "input",
                 "hasAuth",
+                "supportedThinkingLevels",
               ],
               properties: {
                 id: { type: "string" },
@@ -125,6 +126,7 @@ const providersListingSchema = {
                 reasoning: { type: "boolean" },
                 input: { type: "array", items: { type: "string" } },
                 hasAuth: { type: "boolean" },
+                supportedThinkingLevels: { type: "array", items: { type: "string" } },
               },
             },
           },

--- a/packages/server/src/routes/control.ts
+++ b/packages/server/src/routes/control.ts
@@ -236,6 +236,7 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
             createdAt: forked.createdAt,
             lastActivityAt: forked.lastActivityAt,
             name: forked.session.sessionName,
+            thinkingLevel: forked.session.thinkingLevel,
             messageCount: forked.session.messages.length,
             isStreaming: forked.session.isStreaming,
           }),
@@ -576,6 +577,119 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
       });
       if (!result.ok) return reply.code(result.status).send(result.body);
       return { provider: req.body.provider, modelId: req.body.modelId };
+    },
+  );
+
+  // Per-session thinking-level override. The SDK persists thinkingLevel as
+  // first-class session state — it appends a thinkingLevel entry to the
+  // JSONL and reconstructs the value on replay/resume — so this route is
+  // a thin pass-through, no pi-forge-side storage.
+  //
+  // BUT setThinkingLevel has the same settings.json side effect as
+  // setModel: it calls settingsManager.setDefaultThinkingLevel(...), which
+  // would mutate the GLOBAL default on every per-session change. Same
+  // snapshot-and-restore-under-lock pattern as setModel below — without
+  // it, two users on the same instance switching thinking levels would
+  // overwrite each other's "default for new sessions" repeatedly.
+  fastify.post<{ Params: { id: string }; Body: { level: string } }>(
+    "/sessions/:id/thinking-level",
+    {
+      schema: {
+        description:
+          "Set the active thinking level for the session. Body: `{ level }` " +
+          "where level is one of pi's ModelThinkingLevel union " +
+          '("off" | "minimal" | "low" | "medium" | "high" | "xhigh"). The ' +
+          "SDK clamps to the current model's supported levels — picking a " +
+          "level the model doesn't support is not an error, it just gets " +
+          'downgraded. Returns `error: "set_thinking_level_failed"` on ' +
+          "underlying SDK throw.",
+        tags: ["sessions"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          required: ["level"],
+          additionalProperties: false,
+          properties: {
+            level: {
+              type: "string",
+              enum: ["off", "minimal", "low", "medium", "high", "xhigh"],
+            },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["level"],
+            properties: { level: { type: "string" } },
+          },
+          400: errorSchema,
+          404: errorSchema,
+          504: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const live = getSession(req.params.id);
+      if (live === undefined) return notFound(reply);
+      type SetThinkingResult =
+        | { ok: true; level: string }
+        | { ok: false; status: number; body: { error: string; message?: string } };
+      const result = await withSettingsLock<SetThinkingResult>(async () => {
+        let priorSettings: Awaited<ReturnType<typeof readSettings>> | undefined;
+        try {
+          priorSettings = await readSettings();
+        } catch {
+          // settings.json missing / unreadable — leave priorSettings
+          // undefined so we don't try to restore a phantom snapshot.
+        }
+        try {
+          await withTimeout(
+            Promise.resolve(
+              live.session.setThinkingLevel(
+                req.body.level as Parameters<typeof live.session.setThinkingLevel>[0],
+              ),
+            ),
+            30_000,
+            "setThinkingLevel",
+          );
+        } catch (err) {
+          if (err instanceof TimeoutError) {
+            req.log.warn({ err, sessionId: req.params.id }, "setThinkingLevel timed out");
+            return {
+              ok: false,
+              status: 504,
+              body: { error: "set_thinking_level_timeout", message: err.message },
+            };
+          }
+          return {
+            ok: false,
+            status: 400,
+            body: {
+              error: "set_thinking_level_failed",
+              message: err instanceof Error ? err.message : String(err),
+            },
+          };
+        }
+        if (priorSettings !== undefined) {
+          try {
+            await writeSettings(priorSettings);
+          } catch (err) {
+            req.log.warn(
+              { err },
+              "failed to restore prior settings after per-session setThinkingLevel",
+            );
+          }
+        }
+        // SDK clamps; surface the effective value so the client can
+        // reflect any downgrade in the picker without a follow-up GET.
+        return { ok: true, level: live.session.thinkingLevel };
+      });
+      if (!result.ok) return reply.code(result.status).send(result.body);
+      return { level: result.level };
     },
   );
 };

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -205,6 +205,7 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
           name: live.session.sessionName,
           messageCount: live.session.messages.length,
           isStreaming: live.session.isStreaming,
+          thinkingLevel: live.session.thinkingLevel,
         }),
       );
     },
@@ -241,6 +242,7 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
           name: live.session.sessionName,
           messageCount: live.session.messages.length,
           isStreaming: live.session.isStreaming,
+          thinkingLevel: live.session.thinkingLevel,
         });
       }
       const loc = await findSessionLocation(req.params.id);
@@ -755,6 +757,7 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
         name: live.session.sessionName,
         messageCount: live.session.messages.length,
         isStreaming: live.session.isStreaming,
+        thinkingLevel: live.session.thinkingLevel,
       });
     },
   );


### PR DESCRIPTION
## Summary

Adds a thinking-level dropdown that sits next to the model picker in the chat input, so users can adjust reasoning depth without leaving the chat view. Only visible for models that support thinking; the option list is per-model dynamic.

| Before | After |
|---|---|
| Thinking level only configurable as a global default in Settings → Agent | Same global default + an inline per-session override next to the model picker |
| Picker shown unconditionally in Settings — useless for non-reasoning models | Inline picker hidden entirely when the active model is non-reasoning |
| Hardcoded `off`/`low`/`medium`/`high` (no `xhigh`, no per-model filtering) | Per-model list from the SDK: GPT-5-class models expose `xhigh`, models that opt out of a standard level hide it |

The Settings → Agent `defaultThinkingLevel` still drives the value for new sessions; the inline picker overrides it for one session.

## How it works

**Persistence is pi-SDK-owned, end-to-end.** `session.setThinkingLevel(level)` appends a `thinkingLevel` entry to the session JSONL, and pi's session-manager reconstructs the value on resume. pi-forge keeps no parallel storage — unlike the model picker, which mirrors to localStorage because `setModel` has settings.json side effects that have to be snapshot-restored around. The thinking-level path has the same `settings.json` side-effect trap (`settingsManager.setDefaultThinkingLevel`), so the new route reuses the existing `withSettingsLock` snapshot-restore pattern from `setModel` — without it, per-session changes would silently rewrite the GLOBAL default.

The SDK auto-clamps the active level when the model changes (e.g. switching from a reasoning model on `"high"` to a non-reasoning model forces `"off"`). Client refetches the session summary after `setModel` lands so the picker reflects whatever the SDK landed on.

## What changed (9 files, +388/-1)

### Server

- **`packages/server/src/routes/_schemas.ts`** — `liveSummary` shape extended with optional `thinkingLevel: string`. Only set for live sessions (disk-only entries omit it because the SDK only surfaces the active value on a loaded session).
- **`packages/server/src/routes/sessions.ts`** — all four live `liveSummaryBody(...)` call sites pass `live.session.thinkingLevel`.
- **`packages/server/src/routes/control.ts`** — `forkSession` site also passes it. **New route** `POST /api/v1/sessions/:id/thinking-level` body `{ level }` → `live.session.setThinkingLevel(level)` under the same withSettingsLock + timeout + restore pattern as `setModel`. Response: `{ level }` reflecting the SDK's clamped value.
- **`packages/server/src/config-manager.ts`** — `ProvidersListing` extended with `supportedThinkingLevels: ModelThinkingLevel[]` on each entry. `liveProvidersListing()` populates it via the SDK's `getSupportedThinkingLevels(model)` helper (imported from `@earendil-works/pi-ai`).
- **`packages/server/src/routes/config.ts`** — `providersListingSchema` declares the new field as `required` so the wire shape stays self-describing.

### Client

- **`packages/client/src/lib/api-client/types.ts`** — `ModelThinkingLevel` union added; `SessionSummary` gains optional `thinkingLevel`; `ProviderModelEntry` gains required `supportedThinkingLevels: ModelThinkingLevel[]`.
- **`packages/client/src/lib/api-client/index.ts`** — `setThinkingLevel(id, level)` method + `vSessionSummary` reads the new field. Providers validator is already a cast, so the new field passes through.
- **`packages/client/src/components/ChatInput.tsx`** — `thinkingLevel` state mirror, fetch on `sessionId` change, refetch after `setModel`, `onThinkingLevelChange` handler, `activeModel` useMemo (looks up the per-session override or default from the providers listing). New `ThinkingLevelPicker` component takes options as a prop so the per-model array drives the dropdown. Picker rendered only when `activeModel.supportedThinkingLevels.length > 1`.

## Test plan

- [x] `npm run check` (typecheck + lint + format) clean on both packages
- [x] Manual smoke (`npm run dev:remote`):
  - Reasoning model with `xhigh` → picker shows `off`/`minimal`/`low`/`medium`/`high`/`xhigh`
  - Reasoning model without `xhigh` → picker hides `xhigh`
  - Non-reasoning model → picker hidden entirely
  - Pick a level → persists across page reload
  - Switch models → picker show/hide flips per `reasoning`, level reflects SDK auto-clamp
- [ ] Disk-only session detail (resumed cold) — `thinkingLevel` should be reconstructed by the SDK's replay logic when the session loads; verify the picker reflects it after the live session boots
- [ ] CI green before merge