### PR TITLE
feat(chat): dismiss (x) button on session banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ section. See the "Versions" section of the README for the support window policy.
 
 ### Added
 
+- **Dismiss (×) button on the chat session banner.** The amber strip
+  that pins above the message list (carries reconnect notices,
+  compaction in-progress messages, auto-retry status, stream errors)
+  now has an inline close button that clears it for the current
+  session. New `clearBanner(sessionId)` action on the session store
+  just sets `bannerBySession[sessionId]` to undefined — the next
+  agent event (auto-retry, compaction, stream error) is free to set
+  a new value. Intentional "acknowledge, not fix" semantics: if the
+  underlying condition is still active, the banner reappears on the
+  next event. The smaller composer-footer error spans (model error,
+  thinking-level error, attachment error, global API error) are
+  intentionally left without close buttons — they auto-clear on the
+  next successful operation.
 - **Per-session thinking-level picker, inline next to the chat-input
   model picker.** Shown only for models whose
   `supportedThinkingLevels` array (computed server-side via the SDK's

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -12,6 +12,7 @@ import {
   GitBranch,
   Rows2,
   Users,
+  X,
 } from "lucide-react";
 import {
   EMPTY_COMPACTIONS,
@@ -95,6 +96,7 @@ export function ChatView({ sessionId }: Props) {
   const isStreaming = useSessionStore((s) => s.streamingBySession[sessionId] ?? false);
   const activeTool = useSessionStore((s) => s.activeToolBySession[sessionId]);
   const banner = useSessionStore((s) => s.bannerBySession[sessionId]);
+  const clearBanner = useSessionStore((s) => s.clearBanner);
   const queued = useSessionStore((s) => s.queuedBySession[sessionId]);
   const openStream = useSessionStore((s) => s.openStream);
   const closeStream = useSessionStore((s) => s.closeStream);
@@ -347,8 +349,17 @@ export function ChatView({ sessionId }: Props) {
             which meant a long-running streaming session pushed the
             "Reconnecting…" / compaction banners off-screen. */}
         {banner !== undefined && (
-          <div className="border-b border-amber-700/40 bg-amber-900/20 px-6 py-2 text-xs text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800">
-            {banner}
+          <div className="flex items-start gap-2 border-b border-amber-700/40 bg-amber-900/20 px-6 py-2 text-xs text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800">
+            <div className="flex-1">{banner}</div>
+            <button
+              type="button"
+              onClick={() => clearBanner(sessionId)}
+              className="-mr-1 shrink-0 rounded p-0.5 text-amber-300 hover:bg-amber-900/40 hover:text-amber-100 light:text-amber-700 light:hover:bg-amber-100 light:hover:text-amber-900"
+              title="Dismiss"
+              aria-label="Dismiss banner"
+            >
+              <X size={14} />
+            </button>
           </div>
         )}
         <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto px-6 py-4">

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -328,6 +328,15 @@ interface SessionState {
   sendSteer: (sessionId: string, text: string, mode?: "steer" | "followUp") => Promise<void>;
   abortSession: (sessionId: string) => Promise<void>;
   disposeSession: (sessionId: string) => Promise<void>;
+  /**
+   * User-initiated dismiss of the per-session amber banner. Just sets
+   * `bannerBySession[sessionId]` to undefined — the next agent event
+   * (auto-retry, compaction, stream error) is free to set a new value,
+   * which is the intended behaviour: dismissing acknowledges THIS
+   * banner, not the underlying state. If the cause is still active
+   * the banner reappears on the next event.
+   */
+  clearBanner: (sessionId: string) => void;
 }
 
 export const useSessionStore = create<SessionState>((set, get) => ({
@@ -701,6 +710,11 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     } catch (err) {
       set({ error: err instanceof ApiError ? err.code : (err as Error).message });
     }
+  },
+  clearBanner: (sessionId) => {
+    set((s) => ({
+      bannerBySession: { ...s.bannerBySession, [sessionId]: undefined },
+    }));
   },
 }));
 


### PR DESCRIPTION
## Summary

Adds an inline close button to the amber session banner that pins above the chat message list. Previously the only way to clear it was waiting for the next agent event (or hard-refreshing); now there's a one-click dismiss for "I saw it, move on."

The banner carries reconnect notices, compaction in-progress messages, auto-retry status, and stream errors — all states where the user often wants to silence the strip after acknowledging it without losing the underlying behaviour.

## Behaviour

**"Acknowledge, not fix" semantics.** `clearBanner(sessionId)` sets `bannerBySession[sessionId]` to undefined; the next agent event (auto-retry, compaction, stream error) is free to set a new value. If the underlying condition is still active, the banner reappears on the next event — dismissing acknowledges *this* banner, not the root cause.

## Scope

Per-pre-merge scoping discussion, this PR only touches the global session banner. The smaller composer-footer error spans were intentionally left as-is:

| Surface | Dismiss? | Reason |
|---|---|---|
| Session banner (amber, above messages) | ✅ now has × | This PR |
| Model error span (red, composer footer) | ❌ | Auto-clears on next successful `setModel` |
| Thinking-level error span (red, composer footer) | ❌ | Auto-clears on next successful `setThinkingLevel` |
| Attachment error span (amber, composer footer) | ❌ | Auto-clears on next file pick |
| Global API error span (red, composer footer) | ❌ | Auto-clears on next successful op |
| Provider error in assistant bubble | ❌ | Tied to message data — would re-render on refresh |
| Panel-level errors (FileBrowser, Processes, etc.) | ❌ | Reflect live panel state — dismissing would lie about it |

## What changed (3 files, +40/-2)

- `packages/client/src/store/session-store.ts` — new `clearBanner(sessionId)` action on `SessionState`, sets `bannerBySession[sessionId]` to undefined
- `packages/client/src/components/ChatView.tsx` — banner element switched from a plain `<div>` text strip to a `flex` row with text + `<button>` containing a `lucide-react X` (14px, amber tones matching the banner background, hover bg, dark+light mode variants). Mirrors the existing dismiss pattern from `ProcessesPanel`'s watch-alert banner.
- `CHANGELOG.md` — `### Added` entry under `## [Unreleased]` documenting the scope and the "acknowledge, not fix" semantics

## Test plan

- [x] `npm run check` (typecheck + lint + format) clean
- [x] Manual smoke (`npm run dev:remote`):
  - Triggered an auto-retry → banner appeared → clicked × → banner dismissed without affecting the underlying retry
  - Confirmed no other banner sites accidentally got an X (composer-footer spans, message bubble inline errors, panel-state banners all unchanged)
- [ ] CI green before merge