### PR TITLE
chore(release): v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.3.2] — 2026-05-27
+
 ### Added
 
 - **Dismiss (×) button on the chat session banner.** The amber strip

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "workspaces": [
         "packages/*"
       ],
@@ -17044,7 +17044,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17106,7 +17106,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.75.5",
         "@earendil-works/pi-ai": "0.75.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts pi-forge **v1.3.2**. Rolls up the unreleased work since v1.3.1:

- **feat: per-session thinking-level picker, inline next to the chat-input model picker** (#175) — visible only for models with `supportedThinkingLevels.length > 1`; per-model dynamic option list (GPT-5-class models that expose `xhigh` get it, models that opt out of a standard level hide it). Settings → Agent `defaultThinkingLevel` still drives the new-session default; the inline picker overrides for one session. Server enriches `GET /config/providers` with the SDK's `getSupportedThinkingLevels(model)` and adds `POST /sessions/:id/thinking-level` under the same withSettingsLock snapshot-restore pattern as `setModel`.
- **feat: dismiss (×) button on the chat session banner** (#176) — the amber strip pinned above the chat message list (reconnect, compaction, auto-retry, stream errors) now has an inline close button. "Acknowledge, not fix" semantics — if the underlying condition is still active the banner reappears on the next event. Scoped intentionally to the session banner; smaller composer-footer error spans left as-is.

Full notes under `## [1.3.2]` in `CHANGELOG.md`.

## What this PR changes

Generated by `scripts/bump-version.sh 1.3.2` — no hand edits:

- `package.json`, `packages/server/package.json`, `packages/client/package.json` → version `1.3.1` → `1.3.2`
- `package-lock.json` → workspace versions synced
- `CHANGELOG.md` → `## [Unreleased]` renamed to `## [1.3.2] — 2026-05-27`, fresh empty `## [Unreleased]` heading inserted above for the next cycle

## Test plan

- [x] `npm run check` (typecheck + lint + format) clean on v1.3.2
- [x] All three workspace versions match the root
- [x] `## [Unreleased]` retained as an empty placeholder for the next cycle
- [ ] CI build / image build green before merge

## After merge

```bash
git checkout main && git pull --ff-only
git tag v1.3.2
git push origin v1.3.2
```

The release workflow builds the multi-arch image and creates the GitHub Release automatically. npm publish runs via the configured trusted publisher.