### PR TITLE
fix(processes): kill managed process trees

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces --if-present",
-    "dev": "concurrently \"npm run dev -w packages/server\" \"npm run dev -w packages/client\"",
-    "dev:remote": "HOST=0.0.0.0 concurrently \"npm run dev -w packages/server\" \"npm run dev -w packages/client -- --host\"",
+    "dev": "concurrently \"PORT=${PORT:-3100} npm run dev -w packages/server\" \"PORT=${PORT:-3100} npm run dev -w packages/client\"",
+    "dev:remote": "concurrently \"HOST=${HOST:-0.0.0.0} PORT=${PORT:-3100} npm run dev -w packages/server\" \"PORT=${PORT:-3100} npm run dev -w packages/client -- --host\"",
     "typecheck": "npm run check --workspaces --if-present && tsc -p tests/tsconfig.json",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/packages/server/src/processes/manager.ts
+++ b/packages/server/src/processes/manager.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { rm } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { join } from "node:path";
@@ -106,11 +106,13 @@ class ProcessManagerRegistry {
       cwd,
       env: scrubbedEnv(),
       stdio: ["pipe", "pipe", "pipe"],
-      // detached=false on purpose — when pi-forge exits, the OS
-      // sends SIGTERM to the process group via the parent's death,
-      // matching the plugin's behavior. detached=true would orphan
-      // processes; we want them tied to our lifetime.
-      detached: false,
+      // Put each managed command in its own process group. The
+      // tracked child is only the `/bin/sh -c` wrapper; npm scripts,
+      // concurrently, Vite, test watchers, etc. commonly spawn
+      // grandchildren that do not reliably receive signals sent to
+      // the shell alone. A dedicated process group lets kill() and
+      // disposeSession() signal the whole tree with `kill(-pid)`.
+      detached: true,
     });
 
     const info: ProcessInfo = {
@@ -288,14 +290,17 @@ class ProcessManagerRegistry {
       m.killSent = "SIGTERM";
       m.info.status = "terminating";
       this.notify({ type: "processes_changed", sessionId });
-      m.child.kill("SIGTERM");
+      const targets = await collectProcessTreeTargets(m.child.pid);
+      signalProcessTree(m.child, "SIGTERM", targets);
       m.killTimer = setTimeout(() => {
         if (!LIVE_STATUSES.has(m.info.status)) return;
         m.info.status = "terminate_timeout";
         m.killSent = "SIGKILL";
         this.notify({ type: "processes_changed", sessionId });
         try {
-          m.child.kill("SIGKILL");
+          void collectProcessTreeTargets(m.child.pid).then((currentTargets) => {
+            signalProcessTree(m.child, "SIGKILL", mergeKillTargets(targets, currentTargets));
+          });
         } catch {
           // ignore
         }
@@ -364,10 +369,13 @@ class ProcessManagerRegistry {
     const s = this.bySession.get(sessionId);
     if (s === undefined) return;
     const live = [...s.processes.values()].filter((m) => LIVE_STATUSES.has(m.info.status));
+    const targetsByPid = new Map<number, KillTargets>();
     for (const m of live) {
       try {
         m.killSent = "SIGTERM";
-        m.child.kill("SIGTERM");
+        const targets = await collectProcessTreeTargets(m.child.pid);
+        if (m.child.pid !== undefined) targetsByPid.set(m.child.pid, targets);
+        signalProcessTree(m.child, "SIGTERM", targets);
       } catch {
         // ignore
       }
@@ -377,7 +385,16 @@ class ProcessManagerRegistry {
       for (const m of live) {
         if (LIVE_STATUSES.has(m.info.status)) {
           try {
-            m.child.kill("SIGKILL");
+            const originalTargets =
+              m.child.pid === undefined
+                ? emptyKillTargets()
+                : (targetsByPid.get(m.child.pid) ?? emptyKillTargets());
+            const currentTargets = await collectProcessTreeTargets(m.child.pid);
+            signalProcessTree(
+              m.child,
+              "SIGKILL",
+              mergeKillTargets(originalTargets, currentTargets),
+            );
           } catch {
             // ignore
           }
@@ -408,6 +425,153 @@ class ProcessManagerRegistry {
   private getManaged(sessionId: string, id: string): ManagedProcess | undefined {
     return this.bySession.get(sessionId)?.processes.get(id);
   }
+}
+
+interface ProcessRow {
+  pid: number;
+  ppid: number;
+  pgid: number;
+  sid: number;
+}
+
+interface KillTargets {
+  pids: number[];
+  pgids: number[];
+}
+
+function signalProcessTree(
+  child: ChildProcessWithoutNullStreams,
+  signal: NodeJS.Signals,
+  targets: KillTargets = emptyKillTargets(),
+): void {
+  const pid = child.pid;
+  const pgids = new Set(targets.pgids);
+  if (pid !== undefined) pgids.add(pid);
+
+  // Signal process groups first, including any descendant-created
+  // groups found by the ps snapshot. Then signal individual PIDs as
+  // a fallback for processes that escaped/reparented between the
+  // snapshot and the group signal.
+  for (const pgid of pgids) {
+    try {
+      process.kill(-pgid, signal);
+    } catch {
+      // ignore
+    }
+  }
+
+  if (pid !== undefined) {
+    try {
+      child.kill(signal);
+    } catch {
+      // ignore
+    }
+  }
+
+  for (const targetPid of new Set(targets.pids)) {
+    if (targetPid === pid) continue;
+    try {
+      process.kill(targetPid, signal);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+async function collectProcessTreeTargets(pid: number | undefined): Promise<KillTargets> {
+  if (pid === undefined) return emptyKillTargets();
+  const rows = await listProcesses();
+  const root = rows.find((row) => row.pid === pid);
+  const childrenByParent = new Map<number, ProcessRow[]>();
+  for (const row of rows) {
+    const siblings = childrenByParent.get(row.ppid) ?? [];
+    siblings.push(row);
+    childrenByParent.set(row.ppid, siblings);
+  }
+
+  const targetRows: ProcessRow[] = [];
+  const seen = new Set<number>();
+  const stack = [...(childrenByParent.get(pid) ?? [])];
+  while (stack.length > 0) {
+    const child = stack.pop();
+    if (child === undefined || seen.has(child.pid)) continue;
+    seen.add(child.pid);
+    targetRows.push(child);
+    stack.push(...(childrenByParent.get(child.pid) ?? []));
+  }
+
+  // detached:true creates a fresh session for the managed shell.
+  // Most npm/concurrently/vite descendants stay in that session even
+  // if an intermediate shell exits and they are reparented to PID 1.
+  // Include the whole session while the root row is still visible.
+  if (root !== undefined) {
+    for (const row of rows) {
+      if (row.pid !== pid && row.sid === root.sid && !seen.has(row.pid)) {
+        seen.add(row.pid);
+        targetRows.push(row);
+      }
+    }
+  }
+
+  return {
+    pids: targetRows.map((row) => row.pid),
+    pgids: [...new Set(targetRows.map((row) => row.pgid))],
+  };
+}
+
+function emptyKillTargets(): KillTargets {
+  return { pids: [], pgids: [] };
+}
+
+function mergeKillTargets(...targets: KillTargets[]): KillTargets {
+  return {
+    pids: [...new Set(targets.flatMap((target) => target.pids))],
+    pgids: [...new Set(targets.flatMap((target) => target.pgids))],
+  };
+}
+
+async function listProcesses(): Promise<ProcessRow[]> {
+  for (const args of [
+    ["-eo", "pid=,ppid=,pgid=,sid="],
+    ["-Ao", "pid=,ppid=,pgid=,sid="],
+  ]) {
+    const stdout = await execFileText("ps", args);
+    if (stdout === "") continue;
+    const rows: ProcessRow[] = [];
+    for (const line of stdout.split("\n")) {
+      const parts = line.trim().split(/\s+/).map(Number);
+      const pid = parts[0];
+      const ppid = parts[1];
+      const pgid = parts[2];
+      const sid = parts[3];
+      if (
+        pid !== undefined &&
+        ppid !== undefined &&
+        pgid !== undefined &&
+        sid !== undefined &&
+        Number.isInteger(pid) &&
+        Number.isInteger(ppid) &&
+        Number.isInteger(pgid) &&
+        Number.isInteger(sid)
+      ) {
+        rows.push({ pid, ppid, pgid, sid });
+      }
+    }
+    return rows;
+  }
+  return [];
+}
+
+function execFileText(file: string, args: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    execFile(file, args, { encoding: "utf8" }, (error, stdout) => {
+      if (error !== null) {
+        resolve("");
+        return;
+      }
+      resolve(stdout);
+    });
+  });
 }
 
 function cloneInfo(info: ProcessInfo): ProcessInfo {

--- a/packages/server/src/processes/prompt-strings.ts
+++ b/packages/server/src/processes/prompt-strings.ts
@@ -20,7 +20,7 @@ export const PROMPT_SNIPPET = "Manage background processes without blocking the 
 export const PROMPT_GUIDELINES: string[] = [
   "Use the process tool for long-running commands such as dev servers, test watchers, build watchers, and log tails instead of bash.",
   "Avoid shell background patterns such as &, nohup, disown, or setsid when the process tool fits.",
-  "After starting a process, continue other work instead of waiting for it.",
+  "After starting a process, continue other work instead of waiting for it. Do not repeatedly call list/output just to see whether it has finished.",
   "Use the pi-forge process tool's notify flags (alertOnSuccess / alertOnFailure / alertOnKill) and logWatches when you need to react to events without polling.",
 ];
 
@@ -40,6 +40,6 @@ export const TOOL_DESCRIPTION = `Manage background processes. Actions:
 - clear: Remove all finished processes from the list
 - write: Write to process stdin (requires 'id' and 'input', optional 'end' to close stdin)
 
-Important: You DON'T need to poll or wait for processes. Notifications arrive automatically based on your preferences. Start processes and continue with other work — you'll be informed if something requires attention.
+Important: You DON'T need to poll or wait for processes. Do not repeatedly call list/output after start just to check whether the process has completed. Notifications arrive automatically based on your preferences; start processes and continue with other work — you'll be informed if something requires attention.
 
 Note: User always sees process updates in the UI. The notify flags control whether YOU (the agent) get a turn to react (e.g. check results, fix code, restart).`;

--- a/tests/test-processes.ts
+++ b/tests/test-processes.ts
@@ -16,7 +16,7 @@
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -181,6 +181,36 @@ async function bootSubprocess(
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPidExit(pid: number, timeoutMs = 8_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) return true;
+    await sleep(100);
+  }
+  return !isPidAlive(pid);
+}
+
+async function waitForFile(path: string, timeoutMs = 4_000): Promise<string | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      return await readFile(path, "utf8");
+    } catch {
+      await sleep(50);
+    }
+  }
+  return undefined;
 }
 
 async function main(): Promise<void> {
@@ -458,6 +488,33 @@ async function main(): Promise<void> {
       );
     }
 
+    // -------- kill reaches shell-spawned child processes --------
+    {
+      const pidFile = join(projectPath, "nested-child.pid");
+      const r = await call({
+        action: "start",
+        name: "nested-child",
+        // This intentionally does NOT use `exec`. The managed shell
+        // starts a child sleep and waits for it, matching npm/dev
+        // server wrappers where the long-lived work is below the
+        // tracked shell process. Killing the managed process must
+        // kill the child too.
+        command: "sleep 30 & echo $! > nested-child.pid; wait",
+      });
+      const info = r.details.process as { id: string; status: string } | undefined;
+      const nestedId = info?.id ?? "";
+      assert("start nested child → running", info?.status === "running");
+
+      const pidText = await waitForFile(pidFile);
+      const childPid = Number(pidText?.trim());
+      assert("  nested child pid captured", Number.isInteger(childPid) && childPid > 0);
+      assert("  nested child initially alive", isPidAlive(childPid));
+
+      await call({ action: "kill", id: nestedId });
+      const exited = await waitForPidExit(childPid);
+      assert("  process kill terminates nested child", exited, `pid=${childPid}`);
+    }
+
     // -------- agent alerts on process completion --------
     // alertOnSuccess, alertOnFailure, alertOnKill fire `process_alert`
     // events on the manager; the SSE bridge translates those into
@@ -596,12 +653,20 @@ async function main(): Promise<void> {
       // Start a long-lived process, then dispose the session.
       // After dispose, the in-process manager should have no
       // entries for this session.
+      const disposePidFile = join(projectPath, "dispose-child.pid");
       const startR = await call({
         action: "start",
         name: "to-be-killed",
-        command: "sleep 30",
+        command: "sleep 30 & echo $! > dispose-child.pid; wait",
       });
       assert("pre-dispose start → success", startR.details.success === true);
+      const disposePidText = await waitForFile(disposePidFile);
+      const disposeChildPid = Number(disposePidText?.trim());
+      assert(
+        "pre-dispose: child pid captured",
+        Number.isInteger(disposeChildPid) && disposeChildPid > 0,
+      );
+      assert("pre-dispose: child alive", isPidAlive(disposeChildPid));
       const liveCount = managerMod.processManager.list(sessionId).length;
       assert("pre-dispose: at least one tracked", liveCount >= 1);
 
@@ -610,6 +675,7 @@ async function main(): Promise<void> {
       // SIGTERMs + grace + SIGKILLs + clears state.
       const after = managerMod.processManager.list(sessionId);
       assert("post-dispose: manager state cleared", after.length === 0, `len=${after.length}`);
+      assert("post-dispose: child terminated", await waitForPidExit(disposeChildPid));
     }
     sseHandle.abort();
   } finally {


### PR DESCRIPTION
## Summary
- run managed process-tool commands in their own process group
- signal the full process group for explicit kill and session-dispose cleanup
- add regression coverage for shell-spawned child processes

## Validation
- npm run build
- npm run typecheck
- npm run format:check

Note: targeted process test could not run in this environment because node-pty lacks a linux-x64 native build in node_modules.