### PR TITLE
feat(dev): VITE_DEV_ALLOWED_HOSTS to unblock dev:remote behind a proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Added
+
+- **`VITE_DEV_ALLOWED_HOSTS` env to unblock `npm run dev:remote`
+  behind a reverse proxy.** Vite's `server.allowedHosts` default
+  (localhost + LAN IPs, anti-DNS-rebinding) blocks requests whose
+  `Host:` header is a public/internal hostname like
+  `dev.example.com` with `Blocked request. This host (...) is not
+  allowed.` The new env accepts a comma-separated list
+  (`VITE_DEV_ALLOWED_HOSTS=a.example.com,b.example.com`) or the
+  literal `"all"` to disable the check entirely (dev convenience,
+  accepts the DNS-rebinding risk — only use on trusted networks).
+  Unset = Vite's default behaviour. Production / built bundle is
+  unaffected; this is dev-server only. CONTRIBUTING.md gets a new
+  "Running dev:remote behind a proxy" section walking through the
+  options.
+
 ## [1.3.2] — 2026-05-27
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,29 @@ no base-URL config. Environment variables are in
 [`docs/configuration.md`](./docs/configuration.md); the Docker-compose path
 is in [`docs/containers.md`](./docs/containers.md).
 
+### Running dev:remote behind a proxy
+
+`npm run dev:remote` exposes Vite on `0.0.0.0` so other devices on
+your LAN can hit it directly by IP. Vite's anti-DNS-rebinding
+allowlist permits `localhost` + LAN-IP requests by default, but
+*blocks* requests whose `Host:` header is a hostname (e.g. a
+reverse-proxied `dev.example.com`) with `Blocked request. This host
+(...) is not allowed.`
+
+Pass extra allowed hosts via `VITE_DEV_ALLOWED_HOSTS`:
+
+```bash
+# Specific hostnames (comma-separated, whitespace-tolerant):
+VITE_DEV_ALLOWED_HOSTS=dev.example.com,staging.example.com npm run dev:remote
+
+# Or disable the check entirely (dev convenience; accepts the
+# DNS-rebinding risk — only use on trusted networks):
+VITE_DEV_ALLOWED_HOSTS=all npm run dev:remote
+```
+
+Unset, the default Vite behaviour stays in effect. Production builds
+are unaffected — this is dev-server only.
+
 ### Native module gotcha (node-pty)
 
 The integrated terminal needs `node-pty`'s prebuilt binary to be

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -3,6 +3,24 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
 
+/**
+ * Parse the `VITE_DEV_ALLOWED_HOSTS` env into the shape Vite's
+ * `server.allowedHosts` expects. Returns `undefined` when unset (Vite
+ * falls back to its default allowlist), `true` for `"all"` (disable
+ * the check entirely), or a string[] for a comma-separated list. See
+ * the comment on the `server.allowedHosts` field below for the
+ * security trade-offs of each shape.
+ */
+function parseAllowedHosts(raw: string | undefined): true | string[] | undefined {
+  if (raw === undefined) return undefined;
+  if (raw.trim().toLowerCase() === "all") return true;
+  const entries = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return entries.length > 0 ? entries : undefined;
+}
+
 export default defineConfig({
   plugins: [
     react(),
@@ -133,6 +151,24 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: true,
+    // `VITE_DEV_ALLOWED_HOSTS` opens the dev server up to reverse-proxy
+    // hostnames that Vite's default `allowedHosts` (localhost + LAN
+    // IPs, the anti-DNS-rebinding allowlist) would otherwise block.
+    // Needed when `npm run dev:remote` is fronted by a proxy serving a
+    // public/internal hostname like `forgetest.example.com` — without
+    // it Vite responds with `Blocked request. This host (...) is not
+    // allowed.` and refuses to load the SPA.
+    //
+    // Three accepted shapes:
+    //   - unset       → use Vite's default allowlist (safest)
+    //   - "all"       → disable the check entirely (dev convenience;
+    //                   ACCEPTS the DNS-rebinding risk — only use on
+    //                   trusted networks)
+    //   - "a.b,c.d"   → comma-separated explicit allowlist; whitespace
+    //                   around entries is trimmed, empties dropped
+    //
+    // Production / built bundle is unaffected — this is dev-server only.
+    allowedHosts: parseAllowedHosts(process.env.VITE_DEV_ALLOWED_HOSTS),
     proxy: {
       "/api": {
         target: "http://localhost:3000",


### PR DESCRIPTION
## Summary

`npm run dev:remote` exposes Vite on `0.0.0.0` so LAN-IP access works, but Vite's `server.allowedHosts` default (anti-DNS-rebinding) blocks requests whose `Host:` header is a hostname rather than an IP. Anyone who fronts dev:remote with a reverse proxy (e.g. `forgetest.example.com → http://10.x.x.x:5173`) hits:

```
Blocked request. This host ("forgetest.example.com") is not allowed.
To allow this host, add "forgetest.example.com" to `server.allowedHosts` in vite.config.js.
```

This PR adds a `VITE_DEV_ALLOWED_HOSTS` env var so operators can add their proxy hostnames without editing committed config or maintaining a per-deployment fork.

## Usage

```bash
# Specific hostnames (comma-separated, whitespace-tolerant):
VITE_DEV_ALLOWED_HOSTS=forgetest.example.com,staging.example.com npm run dev:remote

# Or disable the check entirely (dev convenience; accepts the
# DNS-rebinding risk — only use on trusted networks):
VITE_DEV_ALLOWED_HOSTS=all npm run dev:remote
```

Unset = Vite's default behaviour. Production / built bundle unaffected — this is dev-server only.

## What changed (3 files, +75)

- `packages/client/vite.config.ts` — new `parseAllowedHosts(raw)` helper that returns `undefined` / `true` / `string[]` matching Vite's `server.allowedHosts` shape; wired into the `server` block with the security trade-offs documented inline so future readers don't strip it as "looks unused"
- `CONTRIBUTING.md` — new "Running dev:remote behind a proxy" section before the existing node-pty gotcha section, walks through the three accepted env shapes
- `CHANGELOG.md` — `### Added` entry under `## [Unreleased]`

## Test plan

- [x] `npm run check` (typecheck + lint + format) clean
- [ ] Manual: `VITE_DEV_ALLOWED_HOSTS=forgetest.dmarks.me npm run dev:remote`, hit `https://forgetest.dmarks.me/` through the reverse proxy → no more "Blocked request" error
- [ ] Manual: unset env, `npm run dev:remote`, hit `http://<lan-ip>:5173/` → still works (default allowlist intact)
- [ ] Manual: `VITE_DEV_ALLOWED_HOSTS=all npm run dev:remote`, hit any hostname → loads
- [ ] CI green before merge