### PR TITLE
Add drag-and-drop project reordering

### DIFF
--- a/packages/client/src/components/ProjectSidebar.tsx
+++ b/packages/client/src/components/ProjectSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Plus, X, ChevronDown, ChevronRight } from "lucide-react";
+import { Plus, X, ChevronDown, ChevronRight, GripVertical } from "lucide-react";
 import { useProjectStore } from "../store/project-store";
 import { useSessionStore } from "../store/session-store";
 import { ProjectPicker } from "./ProjectPicker";
@@ -21,6 +21,7 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
   const toggleCollapsed = useProjectStore((s) => s.toggleCollapsed);
   const remove = useProjectStore((s) => s.remove);
   const rename = useProjectStore((s) => s.rename);
+  const reorder = useProjectStore((s) => s.reorder);
   const sessionsByProject = useSessionStore((s) => s.byProject);
   const createSession = useSessionStore((s) => s.createSession);
   const disposeSession = useSessionStore((s) => s.disposeSession);
@@ -42,6 +43,8 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
   const [showPicker, setShowPicker] = useState(false);
   const [renamingId, setRenamingId] = useState<string | undefined>();
   const [renameValue, setRenameValue] = useState("");
+  const [draggingProjectId, setDraggingProjectId] = useState<string | undefined>();
+  const [dragOverProjectId, setDragOverProjectId] = useState<string | undefined>();
 
   /**
    * Delete-project modal state. `liveCount` and `onDiskCount` are
@@ -110,6 +113,29 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
     }
   };
 
+  const resetDragState = (): void => {
+    setDraggingProjectId(undefined);
+    setDragOverProjectId(undefined);
+  };
+
+  const handleDrop = async (targetId: string): Promise<void> => {
+    const sourceId = draggingProjectId;
+    resetDragState();
+    if (sourceId === undefined || sourceId === targetId) return;
+    const sourceIndex = projects.findIndex((p) => p.id === sourceId);
+    const targetIndex = projects.findIndex((p) => p.id === targetId);
+    if (sourceIndex === -1 || targetIndex === -1) return;
+    const ids = projects.map((p) => p.id);
+    const [moved] = ids.splice(sourceIndex, 1);
+    if (moved === undefined) return;
+    ids.splice(targetIndex, 0, moved);
+    try {
+      await reorder(ids);
+    } catch {
+      // store.error surfaces; optimistic ordering rolls back in the store.
+    }
+  };
+
   return (
     <aside
       className={`flex h-full w-64 flex-col border-r border-neutral-800 bg-neutral-950 ${className}`}
@@ -143,14 +169,51 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
           const isActive = p.id === activeProjectId;
           const isCollapsed = collapsed[p.id] ?? false;
           return (
-            <div key={p.id} className="mt-1 px-1">
+            <div
+              key={p.id}
+              className={`mt-1 px-1 ${draggingProjectId === p.id ? "opacity-60" : ""}`}
+              draggable={renamingId !== p.id}
+              onDragStart={(e) => {
+                if (renamingId === p.id) {
+                  e.preventDefault();
+                  return;
+                }
+                e.dataTransfer.effectAllowed = "move";
+                e.dataTransfer.setData("text/plain", p.id);
+                setDraggingProjectId(p.id);
+              }}
+              onDragEnter={(e) => {
+                e.preventDefault();
+                if (draggingProjectId !== undefined && draggingProjectId !== p.id) {
+                  setDragOverProjectId(p.id);
+                }
+              }}
+              onDragOver={(e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "move";
+              }}
+              onDragEnd={resetDragState}
+              onDrop={(e) => {
+                e.preventDefault();
+                void handleDrop(p.id);
+              }}
+            >
               <div
-                className={`group flex items-center gap-1 rounded-md px-2 py-1 text-sm ${
-                  isActive
-                    ? "bg-neutral-800 text-neutral-100"
-                    : "text-neutral-300 hover:bg-neutral-900"
+                className={`group flex items-center gap-1 rounded-md px-2 py-1 text-sm ring-inset transition-colors ${
+                  dragOverProjectId === p.id
+                    ? "ring-1 ring-cyan-500/70"
+                    : isActive
+                      ? "bg-neutral-800 text-neutral-100"
+                      : "text-neutral-300 hover:bg-neutral-900"
                 }`}
               >
+                <span
+                  className="flex cursor-grab items-center text-neutral-600 group-hover:text-neutral-400"
+                  title="Drag to reorder projects"
+                  aria-hidden="true"
+                >
+                  <GripVertical size={14} />
+                </span>
                 <button
                   onClick={() => toggleCollapsed(p.id)}
                   className="flex items-center text-neutral-500 hover:text-neutral-300"

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1488,6 +1488,8 @@ export const api = {
       method: "PATCH",
       body: { name },
     }),
+  reorderProjects: (ids: string[]) =>
+    request("/api/v1/projects/order", vProjectList, { method: "PUT", body: { ids } }),
   deleteProject: (id: string) =>
     request(
       `/api/v1/projects/${encodeURIComponent(id)}`,

--- a/packages/client/src/store/project-store.ts
+++ b/packages/client/src/store/project-store.ts
@@ -32,6 +32,7 @@ interface ProjectState {
   load: () => Promise<void>;
   create: (name: string, path: string) => Promise<Project>;
   rename: (id: string, name: string) => Promise<void>;
+  reorder: (ids: string[]) => Promise<void>;
   remove: (id: string) => Promise<void>;
   setActive: (id: string | undefined) => void;
   toggleCollapsed: (id: string) => void;
@@ -80,6 +81,23 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       set((s) => ({ projects: s.projects.map((p) => (p.id === id ? updated : p)) }));
     } catch (err) {
       set({ error: err instanceof ApiError ? err.code : (err as Error).message });
+      throw err;
+    }
+  },
+  reorder: async (ids) => {
+    const previous = get().projects;
+    const byId = new Map(previous.map((p) => [p.id, p] as const));
+    const next = ids.map((id) => byId.get(id)).filter((p): p is Project => p !== undefined);
+    if (next.length !== previous.length) return;
+    set({ projects: next, error: undefined });
+    try {
+      const { projects } = await api.reorderProjects(ids);
+      set({ projects });
+    } catch (err) {
+      set({
+        projects: previous,
+        error: err instanceof ApiError ? err.code : (err as Error).message,
+      });
       throw err;
     }
   },

--- a/packages/server/src/project-manager.ts
+++ b/packages/server/src/project-manager.ts
@@ -75,6 +75,13 @@ export class DuplicatePathError extends Error {
   }
 }
 
+export class InvalidProjectOrderError extends Error {
+  constructor(message = "invalid project order") {
+    super(message);
+    this.name = "InvalidProjectOrderError";
+  }
+}
+
 const PROJECTS_FILE = (): string => join(config.forgeDataDir, "projects.json");
 
 /** True iff `target` is the same path as `root` or strictly inside it. */
@@ -231,6 +238,31 @@ export async function renameProject(id: string, name: string): Promise<Project> 
     projects[idx] = updated;
     await writeProjects(projects);
     return updated;
+  });
+}
+
+export async function reorderProjects(ids: string[]): Promise<Project[]> {
+  return withProjectsLock(async () => {
+    const projects = await readProjects();
+    if (ids.length !== projects.length) {
+      throw new InvalidProjectOrderError("project order must include every project exactly once");
+    }
+    const byId = new Map(projects.map((p) => [p.id, p] as const));
+    const seen = new Set<string>();
+    const next: Project[] = [];
+    for (const id of ids) {
+      if (seen.has(id)) {
+        throw new InvalidProjectOrderError("project order contains duplicate ids");
+      }
+      seen.add(id);
+      const project = byId.get(id);
+      if (project === undefined) {
+        throw new InvalidProjectOrderError("project order contains unknown ids");
+      }
+      next.push(project);
+    }
+    await writeProjects(next);
+    return next;
   });
 }
 

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -17,11 +17,13 @@ import {
   getProject,
   InvalidDirectoryNameError,
   InvalidNameError,
+  InvalidProjectOrderError,
   NotADirectoryError,
   PathOutsideWorkspaceError,
   ProjectNotFoundError,
   readProjects,
   renameProject,
+  reorderProjects,
 } from "../project-manager.js";
 import {
   getProjectSystemPromptAddendum,
@@ -76,6 +78,9 @@ function handleError(reply: FastifyReply, err: unknown): FastifyReply {
   }
   if (err instanceof DuplicatePathError) {
     return reply.code(409).send({ error: "duplicate_path" });
+  }
+  if (err instanceof InvalidProjectOrderError) {
+    return reply.code(400).send({ error: "invalid_project_order" });
   }
   if ((err as NodeJS.ErrnoException).code === "EEXIST") {
     return reply.code(409).send({ error: "already_exists" });
@@ -135,6 +140,41 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
       try {
         const project = await createProject(req.body.name, req.body.path);
         return reply.code(201).send(project);
+      } catch (err) {
+        return handleError(reply, err);
+      }
+    },
+  );
+
+  fastify.put<{ Body: { ids: string[] } }>(
+    "/projects/order",
+    {
+      schema: {
+        description: "Persist the display order of projects in the projects pane.",
+        tags: ["projects"],
+        body: {
+          type: "object",
+          required: ["ids"],
+          additionalProperties: false,
+          properties: {
+            ids: { type: "array", items: { type: "string" }, minItems: 0 },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["projects"],
+            properties: {
+              projects: { type: "array", items: projectSchema },
+            },
+          },
+          400: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      try {
+        return { projects: await reorderProjects(req.body.ids) };
       } catch (err) {
         return handleError(reply, err);
       }

--- a/tests/test-projects.ts
+++ b/tests/test-projects.ts
@@ -134,7 +134,7 @@ async function jget(url: string): Promise<{ status: number; body: unknown }> {
 }
 
 async function jsend(
-  method: "POST" | "PATCH" | "DELETE",
+  method: "POST" | "PUT" | "PATCH" | "DELETE",
   url: string,
   body?: unknown,
 ): Promise<{ status: number; body: unknown }> {
@@ -159,9 +159,13 @@ async function main(): Promise<void> {
     // (which should be filtered out by the browser).
     const repoFolder = join(workspacePath, "my-repo");
     const otherFolder = join(workspacePath, "other");
+    const reorderOneFolder = join(workspacePath, "reorder-one");
+    const reorderTwoFolder = join(workspacePath, "reorder-two");
     const hiddenFolder = join(workspacePath, ".hidden");
     await mkdir(repoFolder, { recursive: true });
     await mkdir(otherFolder, { recursive: true });
+    await mkdir(reorderOneFolder, { recursive: true });
+    await mkdir(reorderTwoFolder, { recursive: true });
     await mkdir(hiddenFolder, { recursive: true });
     await mkdir(join(repoFolder, ".git"));
     await writeFile(join(repoFolder, ".git", "HEAD"), "ref: refs/heads/main\n");
@@ -255,8 +259,9 @@ async function main(): Promise<void> {
       assert("  browse at root returns parentPath=null", r.parentPath === null);
       const names = r.entries.map((e) => e.name).sort();
       assert(
-        "  entries are [my-repo, other] (hidden filtered out)",
-        JSON.stringify(names) === JSON.stringify(["my-repo", "other"]),
+        "  entries include visible folders and filter hidden dirs",
+        JSON.stringify(names) ===
+          JSON.stringify(["my-repo", "other", "reorder-one", "reorder-two"]),
         JSON.stringify(names),
       );
       const repo = r.entries.find((e) => e.name === "my-repo");
@@ -290,6 +295,45 @@ async function main(): Promise<void> {
         "  error code is duplicate_path",
         (body as { error: string }).error === "duplicate_path",
       );
+    }
+
+    // 7d. Persist explicit project order.
+    {
+      const { body: b } = await jsend("POST", `${base}/api/v1/projects`, {
+        name: "reorder-one",
+        path: reorderOneFolder,
+      });
+      const one = b as Project;
+      const { body: c } = await jsend("POST", `${base}/api/v1/projects`, {
+        name: "reorder-two",
+        path: reorderTwoFolder,
+      });
+      const two = c as Project;
+      const wanted = [two.id, created.id, one.id];
+      const { status, body } = await jsend("PUT", `${base}/api/v1/projects/order`, {
+        ids: wanted,
+      });
+      const projects = (body as { projects: Project[] }).projects;
+      assert("PUT /projects/order → 200", status === 200, `status=${status}`);
+      assert(
+        "  list order follows requested ids",
+        JSON.stringify(projects.map((p) => p.id)) === JSON.stringify(wanted),
+        JSON.stringify(projects.map((p) => p.id)),
+      );
+      const { body: listed } = await jget(`${base}/api/v1/projects`);
+      assert(
+        "  reordered list persists to GET /projects",
+        JSON.stringify((listed as { projects: Project[] }).projects.map((p) => p.id)) ===
+          JSON.stringify(wanted),
+      );
+      const invalid = await jsend("PUT", `${base}/api/v1/projects/order`, { ids: [created.id] });
+      assert("PUT /projects/order missing ids → 400", invalid.status === 400);
+      assert(
+        "  invalid order returns invalid_project_order",
+        (invalid.body as { error: string }).error === "invalid_project_order",
+      );
+      await jsend("DELETE", `${base}/api/v1/projects/${one.id}`);
+      await jsend("DELETE", `${base}/api/v1/projects/${two.id}`);
     }
 
     // 8. browse outside workspace → 403


### PR DESCRIPTION
## Summary\n- add a persistent project order endpoint\n- support optimistic project reordering in the client store\n- add drag-and-drop reordering controls to the projects pane\n- cover project order persistence in the project integration test\n\n## Validation\n- npm run build\n- npm run check --workspaces --if-present\n- npx eslint packages/client/src/components/ProjectSidebar.tsx packages/client/src/lib/api-client/index.ts packages/client/src/store/project-store.ts packages/server/src/project-manager.ts packages/server/src/routes/projects.ts tests/test-projects.ts\n\nNote: npx tsx tests/test-projects.ts could not start locally because node-pty native module is missing in node_modules.