### PR TITLE
fix(chat): thinking-level picker no longer disappears on default-model sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,23 @@ section. See the "Versions" section of the README for the support window policy.
   "Running dev:remote behind a proxy" section walking through the
   options.
 
+### Fixed
+
+- **Inline thinking-level picker no longer disappears when the
+  session is running on the default model.** The picker resolved its
+  "active model" by checking `modelChoice` (per-session override)
+  with a fallback to `settings.json`'s `defaultProvider` /
+  `defaultModel`. That fallback is empty when no global default is
+  configured AND can point at a model the registry no longer knows
+  about — in both cases the SDK is happily running on its own
+  compile-time fallback model, but the client lookup returned
+  `undefined` and the picker hid. Server's `liveSummary` now also
+  emits `modelProvider` + `modelId` from `session.model.provider/id`
+  (alongside the existing `thinkingLevel`); client uses those as the
+  no-override fallback instead of `settings.json`, so the picker
+  reflects the actual live model the SDK has loaded — reasoning or
+  not — regardless of settings-file state.
+
 ## [1.3.2] — 2026-05-27
 
 ### Added

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -941,6 +941,18 @@ export function ChatInput({ sessionId }: Props) {
   // the call failed; the picker hides itself in that case.
   const [thinkingLevel, setThinkingLevel] = useState<string | undefined>(undefined);
   const [thinkingError, setThinkingError] = useState<string | undefined>(undefined);
+  // The live AgentSession's actual active model, as reported by the
+  // server (`session.model.provider` / `session.model.id`). Used as the
+  // activeModel fallback when the user hasn't set a per-session
+  // override. The settings.json `defaultModel` we fetched above is NOT
+  // a substitute: it's empty when no global default is configured and
+  // can point at a model the registry doesn't know about, both of which
+  // would hide the thinking-level picker even though the SDK
+  // definitely has SOME reasoning-capable model loaded. Undefined while
+  // the initial GET /sessions/:id is in flight or if the call failed.
+  const [activeSessionModel, setActiveSessionModel] = useState<
+    { provider: string; modelId: string } | undefined
+  >(undefined);
 
   useEffect(() => {
     void api
@@ -980,10 +992,11 @@ export function ChatInput({ sessionId }: Props) {
     setModelError(undefined);
     setThinkingError(undefined);
     setThinkingLevel(undefined);
-    // Pull the SDK-persisted thinking level for this session. Same
-    // captured-id pattern as the setModel call below — a slow GET for
-    // session A that resolves after the user switched to B mustn't
-    // overwrite B's thinkingLevel state with A's value.
+    setActiveSessionModel(undefined);
+    // Pull the SDK-persisted thinking level + active model for this
+    // session. Same captured-id pattern as the setModel call below — a
+    // slow GET for session A that resolves after the user switched to
+    // B mustn't overwrite B's state with A's values.
     {
       const callSessionId = sessionId;
       void api
@@ -991,6 +1004,12 @@ export function ChatInput({ sessionId }: Props) {
         .then((summary) => {
           if (callSessionId !== sessionId) return;
           setThinkingLevel(summary.thinkingLevel);
+          if (summary.modelProvider !== undefined && summary.modelId !== undefined) {
+            setActiveSessionModel({
+              provider: summary.modelProvider,
+              modelId: summary.modelId,
+            });
+          }
         })
         .catch(() => {
           // Disk-only or transient — leave thinkingLevel undefined so
@@ -1067,13 +1086,23 @@ export function ChatInput({ sessionId }: Props) {
       // the active level against the new model's capabilities (e.g.
       // picking a non-reasoning model after running on "high" forces
       // the level to "off"). Refetch the summary so the picker
-      // reflects whatever the SDK landed on.
+      // reflects whatever the SDK landed on. Also refresh
+      // activeSessionModel so the lookup-key for the thinking picker
+      // matches the SDK's new state (the optimistic modelChoice we
+      // just set covers this too, but the server-canonical value
+      // keeps both in sync after any clamp / fallback the SDK applies).
       const callSessionId = sessionId;
       void api
         .getSession(callSessionId)
         .then((summary) => {
           if (callSessionId !== sessionId) return;
           setThinkingLevel(summary.thinkingLevel);
+          if (summary.modelProvider !== undefined && summary.modelId !== undefined) {
+            setActiveSessionModel({
+              provider: summary.modelProvider,
+              modelId: summary.modelId,
+            });
+          }
         })
         .catch(() => {
           // Non-fatal: a stale picker is recoverable on next session
@@ -1085,14 +1114,27 @@ export function ChatInput({ sessionId }: Props) {
     }
   };
 
-  // Resolve which model is currently active (per-session override if
-  // set, otherwise the settings.json default) and pull its entry from
-  // the providers listing so we can gate the thinking-level picker on
-  // `reasoning`. Returns undefined while providers/defaultModel are
-  // still loading OR when the active model can't be found in the
-  // listing (e.g. settings.json points at a model that's since been
-  // removed from models.json) — in either case the picker stays
-  // hidden.
+  // Resolve which model the SDK is actually running for this session
+  // and pull its entry from the providers listing so we can gate the
+  // thinking-level picker on `reasoning`. Returns undefined while
+  // providers/activeSessionModel are still loading OR when the active
+  // model can't be found in the listing (e.g. settings.json points at
+  // a removed model and the SDK fell back to a default the registry
+  // doesn't know about) — in either case the picker stays hidden.
+  //
+  // Two sources, in priority order:
+  //   1. modelChoice — per-session override the user just picked.
+  //      Optimistic: takes effect before the setModel round-trip
+  //      completes so the picker doesn't flicker mid-call.
+  //   2. activeSessionModel — server-canonical
+  //      session.model.provider/id, refreshed on session switch and
+  //      after every setModel success.
+  //
+  // settings.json's defaultModel is NOT consulted here — it can be
+  // empty (no global default set) or stale (points at a removed model)
+  // while the SDK is happily running on its own compile-time fallback.
+  // Falling back to it produced the bug where the picker disappeared
+  // for default-model sessions even on reasoning-capable models.
   const activeModel = useMemo(() => {
     if (providers === undefined) return undefined;
     let provider: string;
@@ -1102,19 +1144,15 @@ export function ChatInput({ sessionId }: Props) {
       if (p === undefined) return undefined;
       provider = p;
       modelId = rest.join(":");
-    } else if (
-      defaultModel !== undefined &&
-      defaultModel.provider.length > 0 &&
-      defaultModel.modelId.length > 0
-    ) {
-      provider = defaultModel.provider;
-      modelId = defaultModel.modelId;
+    } else if (activeSessionModel !== undefined) {
+      provider = activeSessionModel.provider;
+      modelId = activeSessionModel.modelId;
     } else {
       return undefined;
     }
     const entry = providers.providers.find((p) => p.provider === provider);
     return entry?.models.find((m) => m.id === modelId);
-  }, [providers, modelChoice, defaultModel]);
+  }, [providers, modelChoice, activeSessionModel]);
 
   const onThinkingLevelChange = async (level: string): Promise<void> => {
     // Optimistic — the SDK clamps so the response may differ; we

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -302,6 +302,8 @@ function vSessionSummary(value: unknown, status: number): SessionSummary {
   };
   if (typeof value.name === "string") out.name = value.name;
   if (typeof value.thinkingLevel === "string") out.thinkingLevel = value.thinkingLevel;
+  if (typeof value.modelProvider === "string") out.modelProvider = value.modelProvider;
+  if (typeof value.modelId === "string") out.modelId = value.modelId;
   return out;
 }
 

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -329,6 +329,18 @@ export interface SessionSummary {
    * want the discriminated union should narrow at use site.
    */
   thinkingLevel?: string;
+  /**
+   * Active model identity (`session.model.provider` / `session.model.id`)
+   * on the live AgentSession. Used by the chat-input thinking-level
+   * picker to resolve "what model is this session actually using" when
+   * the user has no per-session override — without it, the client
+   * would fall back to settings.json's defaultProvider/defaultModel,
+   * which can be empty when the SDK is running on its own compile-time
+   * default and would hide the thinking picker. Only set for live
+   * sessions.
+   */
+  modelProvider?: string;
+  modelId?: string;
 }
 
 export type SkillOverrideState = "enabled" | "disabled";

--- a/packages/server/src/routes/_schemas.ts
+++ b/packages/server/src/routes/_schemas.ts
@@ -54,6 +54,16 @@ export const liveSummarySchema = {
     // the current value requires the replay logic, which is what
     // session-manager does on resume).
     thinkingLevel: { type: "string" },
+    // Live AgentSession's active model identity (`session.model.provider`
+    // and `session.model.id`). The client uses this to resolve the
+    // "what model is this session actually using" question for UI
+    // surfaces like the inline thinking-level picker — without it, the
+    // client could only guess from per-session localStorage override OR
+    // settings.json default, both of which can be empty/stale when the
+    // SDK is running on its compile-time fallback model. Omitted for
+    // disk-only entries (no live session, no active model).
+    modelProvider: { type: "string" },
+    modelId: { type: "string" },
   },
 } as const;
 
@@ -76,6 +86,12 @@ export function liveSummaryBody(args: {
   isStreaming: boolean;
   isLive?: boolean;
   thinkingLevel?: string;
+  // `string | undefined` (not just `?: string`) so callers can pass
+  // `session.model?.provider` directly without an upstream guard —
+  // exactOptionalPropertyTypes rejects an explicit `undefined` against a
+  // bare optional field. Body skips the emit when undefined either way.
+  modelProvider?: string | undefined;
+  modelId?: string | undefined;
 }): Record<string, unknown> {
   const out: Record<string, unknown> = {
     sessionId: args.sessionId,
@@ -89,5 +105,7 @@ export function liveSummaryBody(args: {
   };
   if (args.name !== undefined) out.name = args.name;
   if (args.thinkingLevel !== undefined) out.thinkingLevel = args.thinkingLevel;
+  if (args.modelProvider !== undefined) out.modelProvider = args.modelProvider;
+  if (args.modelId !== undefined) out.modelId = args.modelId;
   return out;
 }

--- a/packages/server/src/routes/control.ts
+++ b/packages/server/src/routes/control.ts
@@ -237,6 +237,8 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
             lastActivityAt: forked.lastActivityAt,
             name: forked.session.sessionName,
             thinkingLevel: forked.session.thinkingLevel,
+            modelProvider: forked.session.model?.provider,
+            modelId: forked.session.model?.id,
             messageCount: forked.session.messages.length,
             isStreaming: forked.session.isStreaming,
           }),

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -206,6 +206,8 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
           messageCount: live.session.messages.length,
           isStreaming: live.session.isStreaming,
           thinkingLevel: live.session.thinkingLevel,
+          modelProvider: live.session.model?.provider,
+          modelId: live.session.model?.id,
         }),
       );
     },
@@ -243,6 +245,8 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
           messageCount: live.session.messages.length,
           isStreaming: live.session.isStreaming,
           thinkingLevel: live.session.thinkingLevel,
+          modelProvider: live.session.model?.provider,
+          modelId: live.session.model?.id,
         });
       }
       const loc = await findSessionLocation(req.params.id);
@@ -758,6 +762,8 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
         messageCount: live.session.messages.length,
         isStreaming: live.session.isStreaming,
         thinkingLevel: live.session.thinkingLevel,
+        modelProvider: live.session.model?.provider,
+        modelId: live.session.model?.id,
       });
     },
   );


### PR DESCRIPTION
## Summary

The inline thinking-level picker hid for sessions running on the SDK's compile-time default model — i.e. anyone who hadn't set `defaultProvider`/`defaultModel` in `settings.json`, OR had set them to a model that's since been removed from the registry. Despite the SDK happily running on a reasoning-capable model, the picker thought it didn't know what the active model was and hid itself.

## Root cause

`ChatInput.tsx`'s `activeModel` lookup checked `modelChoice` (per-session override) with a fallback to `defaultModel` (from `settings.json#defaultProvider/defaultModel`). That fallback:
- Is empty when no global default is configured (very common — the SDK has its own compile-time fallback so this works silently elsewhere)
- Can point at a removed model (the registry's `find()` returns undefined, the SDK had already swapped to a working model)

In both cases the client lookup returned `undefined` → the picker render condition (`activeModel?.supportedThinkingLevels.length > 1`) failed → no picker.

## Fix

`liveSummary` (used by `GET /sessions/:id`, `POST /sessions`, `POST /fork`, PATCH rename) now also emits `modelProvider` + `modelId` from `live.session.model.provider/id` — alongside the existing `thinkingLevel`. The client adds an `activeSessionModel` state populated from those, and the `activeModel` lookup falls back to it instead of `settings.json`. So the picker reflects what the SDK is actually running, not what `settings.json` happens to say.

Priority order in the lookup is preserved: per-session `modelChoice` (optimistic, takes effect before the setModel round-trip) → server-canonical `activeSessionModel`. `settings.json`'s defaultModel is no longer consulted for picker visibility (it's still used by `ModelPicker` itself for the "Use agent default" label, which is correct).

## What changed (7 files, +116/-21)

### Server

- `packages/server/src/routes/_schemas.ts` — `liveSummary` shape extended with optional `modelProvider` + `modelId`; `liveSummaryBody` signature widened with `string | undefined` (needed under `exactOptionalPropertyTypes` since the SDK's `session.model` getter returns `Model<any> | undefined`)
- `packages/server/src/routes/sessions.ts` + `routes/control.ts` — all 5 live `liveSummaryBody(...)` call sites (POST /sessions, GET /sessions/:id, PATCH rename, POST /fork) pass `live.session.model?.provider` / `?.id`

### Client

- `packages/client/src/lib/api-client/types.ts` — `SessionSummary` gains optional `modelProvider` / `modelId`
- `packages/client/src/lib/api-client/index.ts` — `vSessionSummary` parses them
- `packages/client/src/components/ChatInput.tsx` — new `activeSessionModel` state, populated alongside `thinkingLevel` on session-id change AND after each `setModel` success (so SDK auto-clamps from a new model selection still reconcile correctly). `activeModel` useMemo's fallback chain becomes `modelChoice → activeSessionModel`, replacing the old `modelChoice → defaultModel` chain.

### CHANGELOG

- `### Fixed` entry under `## [Unreleased]`

## Test plan

- [x] `npm run check` clean
- [x] Manual: cleared `defaultProvider`/`defaultModel` from `settings.json` → picker still appears on a reasoning model
- [x] Manual: set them to a removed model → picker still appears (uses SDK's actual loaded model)
- [x] Manual: swap to a non-reasoning model via picker → picker hides
- [ ] CI green before merge