### PR TITLE
fix(terminal): binary WS frames + ping keepalive for proxied deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,34 @@ section. See the "Versions" section of the README for the support window policy.
   no-override fallback instead of `settings.json`, so the picker
   reflects the actual live model the SDK has loaded — reasoning or
   not — regardless of settings-file state.
+- **Random garbage characters in the integrated terminal when
+  accessed through a reverse proxy.** Symptom was bare ANSI
+  parameter bodies leaking into the xterm view — e.g.
+  `11;rgb:0a0a/0a0a/0a0a` (the body of an OSC 11 background-color
+  response xterm.js queries on init) or `1R;222R;...` (the body of
+  CSI cursor-position reports). Root cause: the terminal WS route
+  sent PTY output as WebSocket *text* frames, which some proxies
+  (charset normalisation, WAF control-char filters, anything doing
+  UTF-8 re-encoding) mangle by eating the `0x1B` ESC prefix from
+  the middle of multi-byte sequences. Switched the server to send
+  binary frames (`Buffer` rather than `string`); the client already
+  set `binaryType="arraybuffer"` and had the `term.write(new
+  Uint8Array(...))` branch wired up, so no client change needed.
+  `pty-manager.ts:attachSink` signature changed from
+  `(chunk: string) => void` to `(chunk: Buffer) => void`; the
+  single string→Buffer hop happens once at the node-pty boundary,
+  the rolling replay buffer was already `Buffer[]` so the replay
+  path is unchanged.
+- **Terminal occasionally drops into the "reconnecting" state
+  behind a reverse proxy.** Reverse proxies idle-time-out quiet
+  WebSocket connections (nginx defaults `proxy_read_timeout` to
+  60s, Cloudflare to 100s, etc.). Terminal WS had no keepalive —
+  SSE has `HEARTBEAT_CADENCE_MS` in `sse-bridge.ts` for exactly
+  this reason, the terminal route hadn't acquired an equivalent.
+  Added a 30s server-side `socket.ping()` interval in
+  `routes/terminal.ts`, cleared on close. RFC-standard ping/pong
+  is invisible to xterm; chosen interval comfortably under the
+  common proxy defaults.
 
 ## [1.3.2] — 2026-05-27
 

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -165,10 +165,16 @@ export function spawnPty(opts: SpawnOptions): ManagedPty {
  * `replayBytes` lets the caller request only the tail of the
  * buffer (e.g. xterm already has prior scrollback locally and only
  * wants the last ~16 KB). Pass `Infinity` (default) to replay all.
+ *
+ * `onData` receives raw bytes as `Buffer` — callers should forward
+ * them through whatever transport they own without re-encoding. The
+ * terminal WS route sends them as binary frames so reverse proxies
+ * can't mangle ANSI escape sequences (see the comment on the
+ * `socket.send(chunk)` call in `routes/terminal.ts`).
  */
 export function attachSink(
   ptyId: string,
-  onData: (chunk: string) => void,
+  onData: (chunk: Buffer) => void,
   replayBytes: number = OUTPUT_BUFFER_BYTES,
   closeActiveSocket?: () => void,
 ): (() => void) | undefined {
@@ -217,10 +223,17 @@ export function attachSink(
         remaining = 0;
       }
     }
-    for (const chunk of tail) onData(chunk.toString("utf8"));
+    for (const chunk of tail) onData(chunk);
   }
+  // node-pty's onData callback delivers strings (UTF-8 decoded
+  // already, with `\u{FFFD}` substitution on invalid bytes). Convert
+  // back to a Buffer once here so downstream sinks get the raw byte
+  // stream that proxies / xterm.js parse natively. The replay loop
+  // above already operates on Buffer (the rolling buffer stores
+  // Buffers directly), so this is the only re-encoding hop in the
+  // pipeline.
   const live = entry.managed.process.onData((chunk: string) => {
-    onData(chunk);
+    onData(Buffer.from(chunk, "utf8"));
   });
   entry.dataDisposable = live;
   return () => {

--- a/packages/server/src/routes/terminal.ts
+++ b/packages/server/src/routes/terminal.ts
@@ -293,6 +293,14 @@ export const terminalRoutes: FastifyPluginAsync = async (fastify) => {
         managed.ptyId,
         (chunk) => {
           if (socket.readyState === socket.OPEN) {
+            // Binary frame (Buffer). Text frames were vulnerable to
+            // reverse-proxy charset normalisation / WAF control-char
+            // stripping, which would eat the ESC byte (0x1B) from the
+            // middle of an ANSI escape sequence and leak the bare
+            // parameter body to the user's xterm (e.g. `11;rgb:...` or
+            // `<n>;<m>R` showing up as visible garbage when xterm.js
+            // queried OSC 11 / cursor position). Binary frames pass
+            // the bytes through unchanged.
             socket.send(chunk);
           }
         },
@@ -304,6 +312,26 @@ export const terminalRoutes: FastifyPluginAsync = async (fastify) => {
         socket.close(CLOSE_INTERNAL_ERROR, "attach_failed");
         return;
       }
+
+      // WebSocket keepalive. Reverse proxies (nginx defaults
+      // `proxy_read_timeout` to 60s, Cloudflare to 100s, many others
+      // similar) silently drop idle connections — a terminal that
+      // wasn't generating output would fall over with no diagnostic,
+      // forcing the client into its reconnect loop. SSE has its own
+      // heartbeat (see sse-bridge.ts:HEARTBEAT_CADENCE_MS); the
+      // terminal WS had nothing equivalent until now. 30s comfortably
+      // under the common proxy default; RFC-standard ping/pong is
+      // not exposed to xterm, so the user sees nothing.
+      const keepAliveTimer = setInterval(() => {
+        if (socket.readyState === socket.OPEN) {
+          try {
+            socket.ping();
+          } catch {
+            // Socket about to close — ignore, the close handler
+            // clears the timer below.
+          }
+        }
+      }, 30_000);
 
       // The shell really exiting (user typed `exit`, kill -9, etc.)
       // is a terminal-state event distinct from a transient WS
@@ -320,6 +348,7 @@ export const terminalRoutes: FastifyPluginAsync = async (fastify) => {
       const cleanup = (reason: string): void => {
         if (disposed) return;
         disposed = true;
+        clearInterval(keepAliveTimer);
         detach();
         exitDisposable.dispose();
         // NB: no killPty here. The PTY is intentionally kept alive

--- a/tests/test-pty-reattach.ts
+++ b/tests/test-pty-reattach.ts
@@ -54,7 +54,7 @@ interface PtyManagerModule {
   findPtyByTabId: (tabId: string, projectId: string) => ManagedPty | undefined;
   attachSink: (
     ptyId: string,
-    onData: (chunk: string) => void,
+    onData: (chunk: Buffer) => void,
     replayBytes?: number,
     closeActiveSocket?: () => void,
   ) => (() => void) | undefined;
@@ -86,8 +86,12 @@ async function main(): Promise<void> {
     assert("spawn assigns the projectId", managed.projectId === projectId);
     assert("ptyCount is 1 after first spawn", pty.ptyCount() === 1);
 
-    // 2. attach sink #1 — feed a known prompt + capture echoed output
-    const received1: string[] = [];
+    // 2. attach sink #1 — feed a known prompt + capture echoed output.
+    // Buffers are accumulated (sink now emits binary frames so
+    // proxies can't mangle escape sequences); `Array.prototype.join`
+    // calls Buffer#toString which default-decodes UTF-8, so the
+    // `.includes("hello-1")` ASCII check below still works.
+    const received1: Buffer[] = [];
     const detach1 = pty.attachSink(managed.ptyId, (chunk) => received1.push(chunk));
     assert("attachSink returns a detach function", typeof detach1 === "function");
     if (detach1 === undefined) throw new Error("attachSink failed");
@@ -123,7 +127,7 @@ async function main(): Promise<void> {
     );
 
     // 5. attach sink #2 → replays buffered "while-detached" output
-    const received2: string[] = [];
+    const received2: Buffer[] = [];
     const detach2 = pty.attachSink(managed.ptyId, (chunk) => received2.push(chunk));
     assert("attachSink returns a detach function for sink #2", typeof detach2 === "function");
     await sleep(100);


### PR DESCRIPTION
## Summary

Two independent terminal bugs that only manifested behind a reverse proxy, both server-side only. No client changes — the client was already correctly set up for both paths and just needed the server to cooperate.

## Bug 1 — Random garbage in the active terminal

Symptom: bare ANSI parameter bodies leaking into the xterm view, e.g.
```
11;rgb:0a0a/0a0a/0a0a;1R;222R;56R;222R;36R11;rgb:0a0a/0a0a/0a0a;1R
```
Those are the bodies of OSC 11 (background-color response, xterm.js queries this itself on init for theme detection) and CSI cursor-position reports. The full sequences are `\x1b]11;rgb:RRRR/GGGG/BBBB\x07` and `\x1b[row;colR` — visible payload only when the `\x1b` ESC prefix has been eaten.

**Root cause**: server sent PTY output as WebSocket *text* frames. Some reverse proxies (charset normalisation, WAFs filtering control chars, anything doing UTF-8 re-encoding) mangle text frames by stripping the `0x1B` byte from the middle of multi-byte sequences. The body survives, the prefix doesn't.

**Fix**: switch to binary frames. `attachSink`'s `onData` callback type changes from `string` to `Buffer`; the single string→Buffer hop happens once at the `node-pty` boundary in `pty-manager.ts`. The rolling replay buffer was already `Buffer[]` so the replay path is unchanged. Client already set `binaryType="arraybuffer"` and had the `term.write(new Uint8Array(...))` branch wired up (`TerminalPanel.tsx:502-505`) — no client changes needed.

## Bug 2 — Terminal goes into "reconnecting" intermittently

Reverse proxies idle-time-out quiet WebSocket connections — nginx defaults `proxy_read_timeout` to 60s, Cloudflare to 100s. SSE has `HEARTBEAT_CADENCE_MS` in `sse-bridge.ts:57` for exactly this reason; the terminal WS route had nothing equivalent. A user who left a shell idle for a minute would get bounced to the reconnect loop.

**Fix**: 30s server-side `socket.ping()` interval in `routes/terminal.ts`, cleared in `cleanup()`. RFC-standard ping/pong is invisible to xterm; chosen interval comfortably under the common proxy defaults.

## Why the two bugs share a PR

Both are proxy-amplified, both purely server-side, both in `routes/terminal.ts` (or its `pty-manager.ts` dependency), and both verifiable through the same proxy-deployment smoke test. Splitting them would have meant the second commit rebasing over the first across the same file with nearly-identical setup — easier to reason about together. (Independent commits in branch history would also have been fine; happy to split if the reviewer prefers.)

## What changed (4 files, +84/-7)

| File | Change |
|---|---|
| `packages/server/src/routes/terminal.ts` | 30s `socket.ping()` interval cleared on cleanup; comment on `socket.send(chunk)` explaining the proxy-mangle scenario binary frames now fix |
| `packages/server/src/pty-manager.ts` | `attachSink` callback type `(chunk: string)` → `(chunk: Buffer)`; replay loop drops `.toString("utf8")`; single string→Buffer hop at the node-pty boundary |
| `tests/test-pty-reattach.ts` | Test types updated to `Buffer[]` (Array#join still UTF-8-decodes for the ASCII `.includes()` checks) |
| `CHANGELOG.md` | Two `### Fixed` entries under `## [Unreleased]` |

## Test plan

- [x] `npm run check` clean
- [x] `npx tsx tests/test-pty-reattach.ts` — all 17 assertions pass, including replay-on-reattach and `closeActiveSocket` invariants
- [ ] Manual smoke through a reverse proxy: open terminal → expect no OSC 11 / cursor-position garbage; sit idle for 2 minutes → expect no reconnect spinner
- [ ] CI green before merge

## Operator notes

If you're running pi-forge behind a proxy and you'd already worked around Bug 2 by cranking `proxy_read_timeout`, you don't need to revert that — the keepalive just makes the high timeout unnecessary. If you're running on a network where you'd rather catch a truly-dead connection sooner, you can leave the timeout low (≥35s); the ping ensures the proxy sees activity inside that window.