### PR TITLE
fix: support node-pty rebuilds in container dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,12 +88,17 @@ ARG PGID=1000
 #     hygiene. curl for fetching, ca-certificates so HTTPS works, less
 #     so `git log` and similar pagers don't bomb, procps so `ps`/`top`
 #     are present for users debugging long-running tool processes.
+#   - python3, make, g++: native-module rebuild toolchain for people
+#     using the container as a development environment. `npm install`
+#     can rebuild node-pty when the mounted checkout's lockfile / Node
+#     ABI differs from the baked image; without Python node-gyp fails
+#     before it can compile the binding.
 #   - gnupg: needed only to verify the GitHub CLI apt-source signing
 #     key during install — kept in the same RUN so the keyring is
 #     present when `apt-get install gh` runs.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      tini git ripgrep bash curl ca-certificates less procps gnupg \
+      tini git ripgrep bash curl ca-certificates less procps python3 make g++ gnupg \
  && install -dm 0755 /etc/apt/keyrings \
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -20,7 +20,7 @@ runtime (Node + native bindings), and makes deploys reproducible.
 | Stage | Base | Purpose |
 |---|---|---|
 | `builder` | `node:22-bookworm-slim` | Installs all deps including devDeps, compiles native bindings (`node-pty`), runs `npm run build` for both packages |
-| `runtime` | `node:22-bookworm-slim` | Production deps + built artifacts only. Adds `git`, `ripgrep`, `bash`, `curl`, `less`, `procps`. Runs as non-root `pi`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
+| `runtime` | `node:22-bookworm-slim` | Production deps + built artifacts only. Adds `git`, `ripgrep`, `bash`, `curl`, `less`, `procps`, and the Python/C++ toolchain needed for native-module rebuilds during in-container development. Runs as non-root `pi`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
 
 Final image is ~330 MB. Debian-based (not Alpine) because the Node
 native-module ecosystem ships glibc prebuilds; on musl, those packages
@@ -33,6 +33,9 @@ Installed at runtime:
 - **`git`** — required by the agent's `bash` tool and the GitPanel routes
 - **`ripgrep`** — pi's `grep` tool delegates to `rg` when present;
   silently degrades to a Node walker without it
+- **`python3`, `make`, `g++`** — keeps `npm install` / `npm rebuild`
+  working inside the running container when native modules such as
+  `node-pty` need to compile against the container's Node ABI
 
 ### User and permissions
 
@@ -200,9 +203,10 @@ either:
 ### Terminal fails to spawn (`posix_spawnp failed`)
 
 The native `node-pty` binding doesn't match the runtime Node version.
-This is a host-only issue (the Docker image rebuilds the binding during
-its build stage). If you somehow hit it inside the container, your
-local image is stale — `docker compose up -d --build` (note `--build`).
+Rebuild the image first: `docker compose up -d --build` (note `--build`).
+If you're using the running container as a development shell and running
+`npm install` against a bind-mounted checkout, the runtime image includes
+`python3`, `make`, and `g++` so node-gyp can rebuild `node-pty` in place.
 
 ### Health check failing on first start
 

--- a/tests/test-docker.ts
+++ b/tests/test-docker.ts
@@ -6,6 +6,7 @@
  * - Brings the stack up on a unique container name + port to avoid clashing
  *   with whatever the developer might already have running.
  * - Polls `GET /api/v1/health` until 200, then asserts:
+ *     - runtime image can rebuild `node-pty` from source (dev-container npm install path)
  *     - `/manifest.webmanifest` returns 200 with `display: "standalone"`
  *     - `/sw.js` returns 200 (service worker present)
  *     - `/icons/icon.svg` returns 200
@@ -155,6 +156,29 @@ services:
     assert("GET /api/v1/health returns 200", health.status === 200);
     const healthBody = (await health.json()) as Record<string, unknown>;
     assert("health body.status === 'ok'", healthBody.status === "ok");
+
+    // ---- Dev-container native rebuild support ----
+    // The production image is often used as a development shell against a
+    // bind-mounted checkout. Fresh `npm install` / `npm rebuild` can force
+    // node-pty through node-gyp, so the runtime layer must include Python
+    // and the C++ build toolchain instead of only the builder stage having it.
+    const rebuild = compose(
+      [
+        "exec",
+        "-T",
+        "pi-forge",
+        "sh",
+        "-lc",
+        "python3 --version && make --version && g++ --version && npm rebuild node-pty --build-from-source",
+      ],
+      { composeFile, projectName },
+      true,
+    );
+    assert(
+      "runtime image can rebuild node-pty from source",
+      rebuild.status === 0,
+      `exit=${rebuild.status}; stdout=${rebuild.stdout.slice(-1000)}; stderr=${rebuild.stderr.slice(-1000)}`,
+    );
 
     // ---- PWA assets ----
     const manifestRes = await fetch(`${base}/manifest.webmanifest`);


### PR DESCRIPTION
## Summary
- install python3, make, and g++ in the runtime container image so in-container dev npm installs can rebuild node-pty
- document the runtime native-module rebuild support
- extend the Docker integration test to verify node-pty can rebuild from source inside the runtime container

## Tests
- prettier --write docs/containers.md tests/test-docker.ts
- git diff --check