### PR TITLE
chore(release): v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.3.3] — 2026-05-28
+
 ### Added
 
 - **`VITE_DEV_ALLOWED_HOSTS` env to unblock `npm run dev:remote`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "workspaces": [
         "packages/*"
       ],
@@ -17158,7 +17158,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17218,7 +17218,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.76.0",
         "@earendil-works/pi-ai": "0.76.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts pi-forge v1.3.3 from the changes accumulated since v1.3.2. Release notes were generated from the existing `## [Unreleased]` changelog content and package versions were bumped in lockstep.

## Usage

No direct user-facing usage change in this PR beyond publishing the v1.3.3 release artifacts.

After merge, tag from updated `main`:

```bash
git checkout main && git pull --ff-only
git tag v1.3.3
git push origin v1.3.3
```

## What changed (5 files)

- `CHANGELOG.md` — rolled current unreleased notes into `## [1.3.3] — 2026-05-28` and opened a fresh `## [Unreleased]` section.
- `package.json` — bumped root version to `1.3.3`.
- `package-lock.json` — bumped lockfile package versions to `1.3.3`.
- `packages/client/package.json` — bumped client package version to `1.3.3`.
- `packages/server/package.json` — bumped server package version to `1.3.3`.

## Test plan

- [x] `npm run build`
- [x] `NODE_OPTIONS=--max-old-space-size=4096 npm run check`
- [ ] `npm run test:ci` — blocked by known `node-pty` native module load/rebuild issue in this environment; accepted for this release.
- [ ] CI green before merge
