### PR TITLE
fix: add Python 3.14 and pip to container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,8 @@
 # Multi-stage Dockerfile for pi-forge.
 #
 #   builder  → install deps, compile server TS, build Vite client
-#   runtime  → minimal node:22-bookworm-slim with the compiled output
-#              and hoisted node_modules; runs as a non-root user.
+#   runtime  → node:22-bookworm-slim with Python 3.14 + pip, compiled
+#              output, and hoisted node_modules; runs as a non-root user.
 #
 # Why bookworm-slim and not alpine: the Node native-module ecosystem
 # (node-pty, bcrypt, sharp, better-sqlite3, …) ships prebuilt binaries
@@ -15,8 +15,44 @@
 # native-module footguns, and a friendlier interactive shell for the
 # integrated terminal (bash + readline + a real coreutils).
 
+# ---------- shared Node + Python base ----------
+FROM python:3.14-slim-bookworm AS python-base
+
+FROM node:22-bookworm-slim AS node-python-base
+
+# Keep the final image lineage on the official Node image — pi-forge is a
+# Node app, so preserving Node/npm/corepack exactly as shipped is more
+# important than preserving the Python image as the final base. Copy the
+# official Python 3.14 runtime into /usr/local (Docker COPY merges into
+# the existing Node-owned tree without deleting Node/npm/corepack) and
+# install the Debian runtime libraries CPython extension modules commonly
+# link against.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      libbz2-1.0 \
+      libexpat1 \
+      libffi8 \
+      libgdbm-compat4 \
+      liblzma5 \
+      libncursesw6 \
+      libreadline8 \
+      libsqlite3-0 \
+      libssl3 \
+      libuuid1 \
+      zlib1g \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=python-base /usr/local/ /usr/local/
+RUN ln -sf /usr/local/bin/python3 /usr/local/bin/python \
+ && ln -sf /usr/local/bin/python3 /usr/local/bin/py \
+ && ldconfig \
+ && node --version \
+ && npm --version \
+ && python3 --version \
+ && pip3 --version
+
 # ---------- builder ----------
-FROM node:22-bookworm-slim AS builder
+FROM node-python-base AS builder
 
 # Native deps for node-pty (Phase 11 will use it; the dep is already in
 # server/package.json, so install needs the toolchain regardless). On
@@ -25,7 +61,7 @@ FROM node:22-bookworm-slim AS builder
 # works on platforms without a prebuild, and so any other native module
 # pulled in transitively still installs cleanly.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends python3 make g++ ca-certificates \
+ && apt-get install -y --no-install-recommends make g++ \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -45,7 +81,7 @@ COPY . .
 RUN npm run build
 
 # ---------- runtime ----------
-FROM node:22-bookworm-slim AS runtime
+FROM node-python-base AS runtime
 
 # `tini` for proper PID-1 signal handling (Ctrl-C → SIGTERM → graceful
 # shutdown of pi-forge's onClose hook). Without it, dropped SIGTERMs
@@ -60,11 +96,10 @@ FROM node:22-bookworm-slim AS runtime
 ARG PUID=1000
 ARG PGID=1000
 
-# `node:22-bookworm-slim` ships a pre-baked `node` user/group at
-# UID/GID 1000 — the same default we want for `pi`. Drop it before
-# creating `pi`, otherwise `groupadd -g 1000` fails with "GID '1000'
-# already exists." `|| true` keeps the build green on any future base
-# image that drops the node user.
+# Some upstream base images have shipped a pre-baked `node` user/group
+# at UID/GID 1000 — the same default we want for `pi`. Drop it before
+# creating `pi` if present; `|| true` keeps the build green on bases
+# without that user.
 #
 # Runtime tools the agent + interactive terminal need:
 #   - tini: PID-1 signal handling (see above)
@@ -88,17 +123,19 @@ ARG PGID=1000
 #     hygiene. curl for fetching, ca-certificates so HTTPS works, less
 #     so `git log` and similar pagers don't bomb, procps so `ps`/`top`
 #     are present for users debugging long-running tool processes.
-#   - python3, make, g++: native-module rebuild toolchain for people
-#     using the container as a development environment. `npm install`
-#     can rebuild node-pty when the mounted checkout's lockfile / Node
-#     ABI differs from the baked image; without Python node-gyp fails
-#     before it can compile the binding.
+#   - python3/pip3: Python 3.14 package tooling from the official
+#     Python image. `python` and `py` are aliases for `python3`.
+#   - make, g++: native-module rebuild toolchain for people using the
+#     container as a development environment. `npm install` can rebuild
+#     node-pty when the mounted checkout's lockfile / Node ABI differs
+#     from the baked image; without Python node-gyp fails before it can
+#     compile the binding.
 #   - gnupg: needed only to verify the GitHub CLI apt-source signing
 #     key during install — kept in the same RUN so the keyring is
 #     present when `apt-get install gh` runs.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      tini git ripgrep bash curl ca-certificates less procps python3 make g++ gnupg \
+      tini git ripgrep bash curl ca-certificates less procps make g++ gnupg \
  && install -dm 0755 /etc/apt/keyrings \
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -130,8 +167,8 @@ COPY --from=builder --chown=pi:pi /app/packages/client/dist ./packages/client/di
 # Workspace + pi config + pi-forge data dirs are mounted at runtime;
 # create them so non-root `pi` can read them on first start even if the
 # host bind is currently empty.
-RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge \
- && chown -R pi:pi /workspace /home/pi/.pi /home/pi/.pi-forge
+RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local \
+ && chown -R pi:pi /workspace /home/pi/.pi /home/pi/.pi-forge /home/pi/.local
 
 USER pi
 
@@ -139,19 +176,22 @@ USER pi
 # (pty-manager.ts uses `process.env.SHELL || '/bin/sh'`). TERM hint
 # helps line-editing programs pick a sane terminfo entry inside xterm.
 #
-# PATH prepends /app/node_modules/.bin so the `pi` CLI shipped by
-# @mariozechner/pi-coding-agent (already a server dep) is on PATH for
-# the running server and any process it spawns. The pi-subagents
-# plugin shells out via `child_process.spawn("pi", ...)` with no
-# fallback resolution on Linux — without this, the subagent tool
-# fails with `spawn pi ENOENT` inside the container.
+# PATH prepends /home/pi/.local/bin for scripts installed by
+# `python3 -m pip install --user ...`, then /app/node_modules/.bin so
+# the `pi` CLI shipped by @mariozechner/pi-coding-agent (already a
+# server dep) is on PATH for the running server and any process it
+# spawns. The pi-subagents plugin shells out via
+# `child_process.spawn("pi", ...)` with no fallback resolution on Linux
+# — without this, the subagent tool fails with `spawn pi ENOENT` inside
+# the container.
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
     PORT=3000 \
-    PATH=/app/node_modules/.bin:$PATH \
+    PATH=/home/pi/.local/bin:/app/node_modules/.bin:$PATH \
     WORKSPACE_PATH=/workspace \
     PI_CONFIG_DIR=/home/pi/.pi/agent \
     FORGE_DATA_DIR=/home/pi/.pi-forge \
+    PYTHONUSERBASE=/home/pi/.local \
     SHELL=/bin/bash \
     TERM=xterm-256color
 

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -19,23 +19,26 @@ runtime (Node + native bindings), and makes deploys reproducible.
 
 | Stage | Base | Purpose |
 |---|---|---|
-| `builder` | `node:22-bookworm-slim` | Installs all deps including devDeps, compiles native bindings (`node-pty`), runs `npm run build` for both packages |
-| `runtime` | `node:22-bookworm-slim` | Production deps + built artifacts only. Adds `git`, `ripgrep`, `bash`, `curl`, `less`, `procps`, and the Python/C++ toolchain needed for native-module rebuilds during in-container development. Runs as non-root `pi`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
+| `python-base` | `python:3.14-slim-bookworm` | Source for the Python 3.14 + pip runtime copied into the shared Node base |
+| `node-python-base` | `node:22-bookworm-slim` | Shared Debian slim base with Node.js 22 plus Python 3.14 + pip |
+| `builder` | `node-python-base` | Installs all deps including devDeps, compiles native bindings (`node-pty`), runs `npm run build` for both packages |
+| `runtime` | `node-python-base` | Production deps + built artifacts only. Adds `git`, `ripgrep`, `bash`, `curl`, `less`, `procps`, and the C++ toolchain needed for native-module rebuilds during in-container development. Runs as non-root `pi`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
 
-Final image is ~330 MB. Debian-based (not Alpine) because the Node
-native-module ecosystem ships glibc prebuilds; on musl, those packages
-fall back to source builds.
+Final image size varies by architecture and cache state. Debian-based
+(not Alpine) because the Node native-module ecosystem ships glibc
+prebuilds; on musl, those packages fall back to source builds.
 
 Installed at runtime:
 
 - **Node.js 22**
+- **Python 3.14 + pip** — callable as `python3`, `python`, or `py`
 - **`tini`** — init for signal forwarding + zombie reaping
 - **`git`** — required by the agent's `bash` tool and the GitPanel routes
 - **`ripgrep`** — pi's `grep` tool delegates to `rg` when present;
   silently degrades to a Node walker without it
-- **`python3`, `make`, `g++`** — keeps `npm install` / `npm rebuild`
-  working inside the running container when native modules such as
-  `node-pty` need to compile against the container's Node ABI
+- **`make`, `g++`** — keeps `npm install` / `npm rebuild` working
+  inside the running container when native modules such as `node-pty`
+  need to compile against the container's Node ABI
 
 ### User and permissions
 
@@ -64,6 +67,39 @@ Session JSONLs default to `${WORKSPACE_PATH}/.pi/sessions/` so they
 live on the workspace bind mount — backing up the workspace backs up
 conversation history. Override with `SESSION_DIR` to relocate.
 
+### Persistent Python packages outside this project
+
+The image includes Python 3.14 and pip. Python is callable as `python3`,
+`python`, or `py`. The shipped compose file does not persist Python
+package installs by default. If you want package installs
+to survive image rebuilds/container replacement without storing them in
+the pi-forge checkout or workspace, mount an external host directory or
+named volume at `/home/pi/.local` from your own Docker Compose override
+or deployment wrapper:
+
+```yaml
+services:
+  pi-forge:
+    volumes:
+      - ~/.pi-forge-python:/home/pi/.local
+```
+
+Then install with:
+
+```bash
+python3 -m pip install --user <package>
+```
+
+The image sets `PYTHONUSERBASE=/home/pi/.local` and prepends
+`/home/pi/.local/bin` to `PATH`, so console scripts installed by pip are
+available automatically. On Linux, pre-create the host directory with the
+same owner as `PUID` / `PGID` if Docker would otherwise create it as
+root.
+
+For per-project isolation, create virtual environments inside
+`/workspace/<project>` instead; those persist because `/workspace` is a
+bind mount.
+
 ## Environment variables
 
 The full env-var reference lives in
@@ -78,6 +114,7 @@ in `docker/.env`:
 | `WORKSPACE_PATH` | `/workspace` |
 | `PI_CONFIG_DIR` | `/home/pi/.pi/agent` |
 | `FORGE_DATA_DIR` | `/home/pi/.pi-forge` |
+| `PYTHONUSERBASE` | `/home/pi/.local` |
 
 Set `UI_PASSWORD` and / or `API_KEY` in `.env` for any non-loopback
 deploy — without them, auth is disabled.
@@ -206,7 +243,8 @@ The native `node-pty` binding doesn't match the runtime Node version.
 Rebuild the image first: `docker compose up -d --build` (note `--build`).
 If you're using the running container as a development shell and running
 `npm install` against a bind-mounted checkout, the runtime image includes
-`python3`, `make`, and `g++` so node-gyp can rebuild `node-pty` in place.
+Python 3.14, `pip`, `make`, and `g++` so node-gyp can rebuild `node-pty`
+in place.
 
 ### Health check failing on first start
 

--- a/tests/test-docker.ts
+++ b/tests/test-docker.ts
@@ -6,7 +6,8 @@
  * - Brings the stack up on a unique container name + port to avoid clashing
  *   with whatever the developer might already have running.
  * - Polls `GET /api/v1/health` until 200, then asserts:
- *     - runtime image can rebuild `node-pty` from source (dev-container npm install path)
+ *     - runtime image has Python 3.14 + pip and can rebuild `node-pty` from source
+ *       (dev-container npm install path)
  *     - `/manifest.webmanifest` returns 200 with `display: "standalone"`
  *     - `/sw.js` returns 200 (service worker present)
  *     - `/icons/icon.svg` returns 200
@@ -160,22 +161,28 @@ services:
     // ---- Dev-container native rebuild support ----
     // The production image is often used as a development shell against a
     // bind-mounted checkout. Fresh `npm install` / `npm rebuild` can force
-    // node-pty through node-gyp, so the runtime layer must include Python
-    // and the C++ build toolchain instead of only the builder stage having it.
+    // node-pty through node-gyp, so the runtime layer must include Python,
+    // pip, and the C++ build toolchain instead of only the builder stage
+    // having them.
+    const rebuildCommand = [
+      "python3 --version | grep -E '^Python 3\\.14\\.'",
+      "python --version | grep -E '^Python 3\\.14\\.'",
+      "py --version | grep -E '^Python 3\\.14\\.'",
+      "python3 -m pip --version",
+      'test "$PYTHONUSERBASE" = /home/pi/.local',
+      'test "$(python3 -m site --user-base)" = /home/pi/.local',
+      "test -w /home/pi/.local",
+      "make --version",
+      "g++ --version",
+      "npm rebuild node-pty --build-from-source",
+    ].join(" && ");
     const rebuild = compose(
-      [
-        "exec",
-        "-T",
-        "pi-forge",
-        "sh",
-        "-lc",
-        "python3 --version && make --version && g++ --version && npm rebuild node-pty --build-from-source",
-      ],
+      ["exec", "-T", "pi-forge", "sh", "-lc", rebuildCommand],
       { composeFile, projectName },
       true,
     );
     assert(
-      "runtime image can rebuild node-pty from source",
+      "runtime image has Python 3.14/pip and can rebuild node-pty from source",
       rebuild.status === 0,
       `exit=${rebuild.status}; stdout=${rebuild.stdout.slice(-1000)}; stderr=${rebuild.stderr.slice(-1000)}`,
     );


### PR DESCRIPTION
## Summary

The runtime container previously only installed Debian's `python3` package, which does not include pip in this slim image and does not provide the requested Python 3.14 runtime. This PR keeps the final image lineage on `node:22-bookworm-slim` for the Node app, then copies the official Python 3.14 + pip runtime from `python:3.14-slim-bookworm` into `/usr/local`.

It also makes Python callable as `python3`, `python`, and `py`, and documents how operators can persist Python user installs outside the pi-forge checkout/workspace with their own external volume mount.

## Usage

Python is available in the container as:

```bash
python3 --version
python --version
py --version
python3 -m pip --version
```

To persist Python packages outside this project, add your own compose override or deployment wrapper that mounts an external path at `/home/pi/.local`:

```yaml
services:
  pi-forge:
    volumes:
      - ~/.pi-forge-python:/home/pi/.local
```

Then install packages with:

```bash
python3 -m pip install --user <package>
```

The shipped `docker/docker-compose.yml` is unchanged and does not add project-owned persistence for Python packages.

## What changed (3 files, +131/-46)

- `docker/Dockerfile` — adds a `python:3.14-slim-bookworm` source stage, keeps `node:22-bookworm-slim` as the shared/final base, copies Python 3.14 + pip into `/usr/local`, adds `py`/`python` aliases, and keeps `/home/pi/.local/bin` on `PATH`.
- `docs/containers.md` — documents Python 3.14 + pip availability, the `python3`/`python`/`py` commands, and an external-volume pattern for persistent user installs outside the project.
- `tests/test-docker.ts` — extends the Docker smoke test to assert Python 3.14 through all three command aliases, pip availability, `PYTHONUSERBASE`, and node-pty rebuild support.

## Test plan

- [x] `npm run build`
- [x] `npx eslint tests/test-docker.ts && npm run format:check`
- [x] `npx tsx tests/test-docker.ts` (skipped: Docker daemon unavailable in this environment)
- [ ] CI / reviewer Docker environment runs `tests/test-docker.ts` against a reachable Docker daemon
