### PR TITLE
fix: improve file viewer and turn diffs

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -197,6 +197,15 @@ export function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openProcessesTabSeq]);
 
+  // Opening a file from the file viewer/search should make the editor
+  // visible even if the user previously toggled the editor pane off.
+  const openEditorPaneSeq = useUiStore((s) => s.openEditorPaneSeq);
+  useEffect(() => {
+    if (openEditorPaneSeq === 0) return;
+    setEditorOpenPersisted(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openEditorPaneSeq]);
+
   // Pane widths (px). Persisted on every drag-end via the ref; we keep
   // the live value in state so drags re-render the layout, and mirror
   // it through the ref so the divider can read the start width without

--- a/packages/client/src/components/FileBrowserPanel.tsx
+++ b/packages/client/src/components/FileBrowserPanel.tsx
@@ -97,6 +97,7 @@ export function FileBrowserPanel() {
     | undefined
   >(undefined);
   const requestChatInsert = useUiStore((s) => s.requestChatInsert);
+  const openEditorPane = useUiStore((s) => s.openEditorPane);
   // Selected paths for the multiselect / bulk-delete affordance.
   // Cmd/Ctrl+click on a row toggles selection; plain click clears and
   // opens/expands as before. Hoisted above the early-return below so
@@ -127,6 +128,7 @@ export function FileBrowserPanel() {
         const path = await createFile(project.id, parentAbsPath, name);
         // Open the new file immediately so the user can start editing.
         await openFile(project.id, path);
+        openEditorPane();
       } else {
         await createFolder(project.id, parentAbsPath, name);
       }
@@ -222,6 +224,7 @@ export function FileBrowserPanel() {
       return;
     }
     await openFile(project.id, joinPath(project.path, node.path));
+    openEditorPane();
   };
 
   // Right-click context menu for file rows. State (`contextMenu`) is

--- a/packages/client/src/components/SearchPanel.tsx
+++ b/packages/client/src/components/SearchPanel.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, FileSearch, Loader2, Search } from "lucide-r
 import { api, ApiError, type SearchMatch, type SearchResponse } from "../lib/api-client";
 import { useFileStore } from "../store/file-store";
 import { useActiveProject } from "../store/project-store";
+import { useUiStore } from "../store/ui-store";
 
 const DEBOUNCE_MS = 250;
 const MIN_QUERY_LEN = 2;
@@ -17,6 +18,7 @@ const RESULT_LIMIT = 200;
 export function SearchPanel() {
   const project = useActiveProject();
   const openFile = useFileStore((s) => s.openFile);
+  const openEditorPane = useUiStore((s) => s.openEditorPane);
 
   const [query, setQuery] = useState("");
   const [regex, setRegex] = useState(false);
@@ -177,12 +179,13 @@ export function SearchPanel() {
               key={path}
               path={path}
               matches={matches}
-              onPick={(m) =>
+              onPick={(m) => {
                 void openFile(project.id, joinProjectPath(project.path, path), {
                   line: m.line,
                   column: m.column,
-                })
-              }
+                });
+                openEditorPane();
+              }}
             />
           ))}
         </ul>

--- a/packages/client/src/store/ui-store.ts
+++ b/packages/client/src/store/ui-store.ts
@@ -109,6 +109,11 @@ interface UiState {
    */
   openProcessesTabSeq: number;
   openProcessesTab: () => void;
+
+  /** Bumped when another component opens a file and needs the editor
+   *  pane made visible, even if the user previously toggled it off. */
+  openEditorPaneSeq: number;
+  openEditorPane: () => void;
 }
 
 export const useUiStore = create<UiState>((set, get) => ({
@@ -153,4 +158,6 @@ export const useUiStore = create<UiState>((set, get) => ({
   },
   openProcessesTabSeq: 0,
   openProcessesTab: () => set((s) => ({ openProcessesTabSeq: s.openProcessesTabSeq + 1 })),
+  openEditorPaneSeq: 0,
+  openEditorPane: () => set((s) => ({ openEditorPaneSeq: s.openEditorPaneSeq + 1 })),
 }));

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -21,6 +21,12 @@ function parseAllowedHosts(raw: string | undefined): true | string[] | undefined
   return entries.length > 0 ? entries : undefined;
 }
 
+function devApiTarget(): string {
+  const port = process.env.VITE_API_PORT ?? process.env.PORT ?? "3100";
+  const host = process.env.VITE_API_HOST ?? "localhost";
+  return `http://${host}:${port}`;
+}
+
 export default defineConfig({
   plugins: [
     react(),
@@ -171,7 +177,12 @@ export default defineConfig({
     allowedHosts: parseAllowedHosts(process.env.VITE_DEV_ALLOWED_HOSTS),
     proxy: {
       "/api": {
-        target: "http://localhost:3000",
+        // Root `npm run dev` / `dev:remote` pass the API server port through
+        // PORT (default 3100). Mirror that default here instead of hardcoding
+        // 3000, otherwise direct `npm run dev -w packages/client` proxies API/SSE/WS traffic to the
+        // wrong backend. VITE_API_PORT / VITE_API_HOST let unusual local setups
+        // override the target without changing the server's own PORT/HOST.
+        target: devApiTarget(),
         changeOrigin: true,
         // Forward WebSocket upgrades for `/api/v1/terminal` (Phase 11).
         // Without `ws: true`, Vite falls through to its own ws server

--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -323,12 +323,30 @@ async function walk(
         path: childRel,
         type: "file",
       });
+    } else if (ent.isSymbolicLink()) {
+      const linked = await safeLinkedStat(childAbs, root).catch(() => undefined);
+      if (linked?.isDirectory()) {
+        if (TREE_SKIP_DIRS.has(ent.name)) continue;
+        const sub = await walk(childAbs, root, childRel, depth + 1, maxDepth);
+        node.children?.push(sub);
+      } else if (linked?.isFile()) {
+        node.children?.push({
+          name: ent.name,
+          path: childRel,
+          type: "file",
+        });
+      }
     }
-    // Symlinks, sockets, fifos: skip silently. We don't follow symlinks —
-    // that's how a malicious project would escape its own root via a
-    // symlink to /etc.
+    // Sockets, fifos, devices, and symlinks that resolve outside the
+    // project root are skipped silently. Safe in-root symlinks are
+    // listed as their target kind so the editor can open linked files.
   }
   return node;
+}
+
+async function safeLinkedStat(path: string, root: string) {
+  await verifyPathSafe(path, root);
+  return stat(path);
 }
 
 /* ----------------------------- read ----------------------------- */

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -382,9 +382,9 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
           "Aggregate every write/edit tool result from the session's most " +
           "recent turn into one reviewable changeset. Returns " +
           "`{ entries: [{ file, tool, diff, additions, deletions, isPureAddition }] }`. " +
-          "Prefers `git diff HEAD -- <path>` for cumulative diffs; falls back " +
-          "to a pure-addition diff when the file is untracked or the project " +
-          "has no `.git`. 404 if the session isn't currently live.",
+          "Prefers the tool result's turn-scoped diff; falls back to " +
+          "`git diff HEAD -- <path>` and then a pure-addition diff when " +
+          "needed. 404 if the session isn't currently live.",
         tags: ["sessions"],
         params: {
           type: "object",

--- a/packages/server/src/turn-diff-builder.ts
+++ b/packages/server/src/turn-diff-builder.ts
@@ -1,4 +1,5 @@
-import { stat, readFile } from "node:fs/promises";
+import { mkdtemp, rm, stat, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { runGitRaw } from "./git-runner.js";
@@ -55,16 +56,23 @@ export interface TurnDiffEntry {
   isPureAddition: boolean;
 }
 
+interface EditOperation {
+  oldText: string;
+  newText: string;
+}
+
 interface ToolCallInfo {
   toolCallId: string;
   toolName: "write" | "edit";
   path: string;
+  edits?: EditOperation[];
 }
 
 interface ToolCallResultPair {
   call: ToolCallInfo;
   result: {
     diff?: string;
+    patch?: string;
     isError: boolean;
   };
 }
@@ -123,10 +131,22 @@ export function collectTurnTouches(
       const name = b.name;
       if (name !== "write" && name !== "edit") continue;
       const id = typeof b.id === "string" ? b.id : undefined;
-      const args = (b.arguments ?? b.input) as { path?: unknown } | undefined;
+      const args = (b.arguments ?? b.input) as { path?: unknown; edits?: unknown } | undefined;
       const path = typeof args?.path === "string" ? args.path : undefined;
       if (id === undefined || path === undefined) continue;
-      callsById.set(id, { toolCallId: id, toolName: name, path });
+      const info: ToolCallInfo = { toolCallId: id, toolName: name, path };
+      if (name === "edit" && Array.isArray(args?.edits)) {
+        const edits = args.edits
+          .map((e) => {
+            const edit = e as { oldText?: unknown; newText?: unknown };
+            return typeof edit.oldText === "string" && typeof edit.newText === "string"
+              ? { oldText: edit.oldText, newText: edit.newText }
+              : undefined;
+          })
+          .filter((e): e is EditOperation => e !== undefined);
+        if (edits.length > 0) info.edits = edits;
+      }
+      callsById.set(id, info);
     }
   }
 
@@ -146,10 +166,12 @@ export function collectTurnTouches(
     if (typeof m.toolCallId !== "string") continue;
     const call = callsById.get(m.toolCallId);
     if (call === undefined) continue;
-    const details = m.details as { diff?: unknown } | undefined;
+    const details = m.details as { diff?: unknown; patch?: unknown } | undefined;
     const diffStr = typeof details?.diff === "string" ? details.diff : undefined;
+    const patchStr = typeof details?.patch === "string" ? details.patch : undefined;
     const result: ToolCallResultPair["result"] = { isError: m.isError === true };
     if (diffStr !== undefined) result.diff = diffStr;
+    if (patchStr !== undefined) result.patch = patchStr;
     out.push({ call, result });
   }
   return out;
@@ -200,29 +222,36 @@ export async function buildTurnDiff(
     let diff: string | undefined;
     let isPureAddition = false;
 
-    if (isGitRepo) {
+    // Prefer the edit tool's own per-operation patch when available.
+    // It is scoped to this turn, while `git diff HEAD` also includes
+    // any pre-existing dirty worktree changes and can make the
+    // last-turn panel look like entire files changed. Multiple
+    // edit/write calls for the same file are kept in chronological
+    // order as separate chunks in one accordion entry. If an older SDK
+    // only has `details.diff`, trim its display-oriented context.
+    diff = combineToolDiffs(pairs);
+
+    if ((diff === undefined || diff.length === 0) && isGitRepo) {
       diff = gitDiffs.get(absPath);
     }
 
     if (diff === undefined || diff.length === 0) {
-      // No git diff available (untracked, no repo, file went missing).
-      // Try pure-addition from current disk contents.
+      // If an edit result did not persist details.patch/details.diff
+      // (or the file is untracked so git has no baseline), reconstruct
+      // a scoped patch from the edit arguments. This prevents edited
+      // pre-existing untracked files from rendering as whole-file
+      // additions.
+      diff = await tryEditArgumentPatch(projectPath, absPath, pairs);
+    }
+
+    if (diff === undefined || diff.length === 0) {
+      // No operation diff, argument patch, or git diff available
+      // (brand-new write, no repo, file went missing). Try
+      // pure-addition from current disk contents.
       const pure = await tryPureAddition(projectPath, absPath);
       if (pure !== undefined) {
         diff = pure;
         isPureAddition = true;
-      }
-    }
-
-    if (diff === undefined || diff.length === 0) {
-      // Last-resort fallback: the LATEST edit's per-edit diff. Better
-      // than dropping the file entirely.
-      for (let i = pairs.length - 1; i >= 0; i--) {
-        const candidate = pairs[i]?.result.diff;
-        if (candidate !== undefined && candidate.length > 0) {
-          diff = candidate;
-          break;
-        }
       }
     }
 
@@ -253,8 +282,145 @@ function preferredTool(pairs: ToolCallResultPair[]): "write" | "edit" {
   return pairs.some((p) => p.call.toolName === "write") ? "write" : "edit";
 }
 
+function combineToolDiffs(pairs: ToolCallResultPair[]): string | undefined {
+  const patchChunks = pairs
+    .map((p) => p.result.patch)
+    .filter((d): d is string => d !== undefined && d.length > 0);
+  if (patchChunks.length > 0) {
+    return patchChunks
+      .map((d) => d.trimEnd())
+      .join("\n")
+      .concat("\n");
+  }
+
+  const displayChunks = pairs
+    .map((p) => p.result.diff)
+    .filter((d): d is string => d !== undefined && d.length > 0);
+  if (displayChunks.length === 0) return undefined;
+  return displayChunks
+    .map((d) => trimPiDiffContext(d).trimEnd())
+    .join("\n")
+    .concat("\n");
+}
+
+const TURN_DIFF_CONTEXT_LINES = 3;
+
+function trimPiDiffContext(diff: string): string {
+  const rawLines = diff.split("\n");
+  const hadTrailingNewline = rawLines.length > 0 && rawLines[rawLines.length - 1] === "";
+  const lines = hadTrailingNewline ? rawLines.slice(0, -1) : rawLines;
+  if (lines.length === 0) return diff;
+
+  const lineRe = /^([+\- ]) *(\d+)(?: (.*))?$/;
+  const skipRe = /^ +\.\.\.$/;
+  const parsed = lines.map((line) => {
+    if (skipRe.test(line)) return { line, changed: false, skip: true };
+    const m = lineRe.exec(line);
+    if (m === null) return undefined;
+    const marker = m[1];
+    return { line, changed: marker === "+" || marker === "-", skip: false };
+  });
+
+  if (parsed.some((p) => p === undefined)) return diff;
+  const changedIndexes = parsed.map((p, i) => (p?.changed === true ? i : -1)).filter((i) => i >= 0);
+  if (changedIndexes.length === 0) return diff;
+
+  const keep = new Set<number>();
+  for (const idx of changedIndexes) {
+    const start = Math.max(0, idx - TURN_DIFF_CONTEXT_LINES);
+    const end = Math.min(parsed.length - 1, idx + TURN_DIFF_CONTEXT_LINES);
+    for (let i = start; i <= end; i++) keep.add(i);
+  }
+
+  const out: string[] = [];
+  let skipped = false;
+  for (let i = 0; i < lines.length; i++) {
+    const p = parsed[i];
+    if (p?.skip === true) {
+      if (out.length > 0 && out[out.length - 1] !== "   ...") out.push("   ...");
+      skipped = false;
+      continue;
+    }
+    if (!keep.has(i)) {
+      skipped = true;
+      continue;
+    }
+    if (skipped && out.length > 0 && out[out.length - 1] !== "   ...") out.push("   ...");
+    out.push(lines[i] ?? "");
+    skipped = false;
+  }
+  return out.join("\n") + (hadTrailingNewline ? "\n" : "");
+}
+
 function absolutize(path: string, projectPath: string): string {
   return isAbsolute(path) ? resolve(path) : resolve(join(projectPath, path));
+}
+
+function relabelNoIndexDiff(diff: string, oldFile: string, newFile: string, rel: string): string {
+  return diff
+    .split("\n")
+    .map((line) => {
+      if (line === `diff --git a/${oldFile} b/${newFile}`) return `diff --git a/${rel} b/${rel}`;
+      if (line.startsWith(`--- ${oldFile}`)) return `--- a/${rel}`;
+      if (line.startsWith(`+++ ${newFile}`)) return `+++ b/${rel}`;
+      return line;
+    })
+    .join("\n");
+}
+
+async function tryEditArgumentPatch(
+  projectPath: string,
+  absPath: string,
+  pairs: ToolCallResultPair[],
+): Promise<string | undefined> {
+  const editPairs = pairs.filter((p) => p.call.toolName === "edit" && p.call.edits !== undefined);
+  if (editPairs.length === 0) return undefined;
+
+  let after: string;
+  try {
+    after = await readFile(absPath, "utf8");
+  } catch {
+    return undefined;
+  }
+
+  let before = after;
+  for (let i = editPairs.length - 1; i >= 0; i--) {
+    const edits = editPairs[i]?.call.edits ?? [];
+    for (let j = edits.length - 1; j >= 0; j--) {
+      const edit = edits[j];
+      if (edit === undefined) continue;
+      const idx = before.lastIndexOf(edit.newText);
+      if (idx === -1) return undefined;
+      before = before.slice(0, idx) + edit.oldText + before.slice(idx + edit.newText.length);
+    }
+  }
+
+  if (before === after) return undefined;
+  const rel = relative(projectPath, absPath);
+  if (rel.startsWith("..")) return undefined;
+
+  const dir = await mkdtemp(join(tmpdir(), "pi-turn-diff-"));
+  try {
+    const oldFile = join(dir, "old");
+    const newFile = join(dir, "new");
+    await writeFile(oldFile, before, "utf8");
+    await writeFile(newFile, after, "utf8");
+    const r = await runGitRaw(
+      projectPath,
+      ["diff", "--no-color", "--no-ext-diff", "--no-index", oldFile, newFile],
+      { maxBuffer: 16 * 1024 * 1024 },
+    ).catch((err: unknown) => {
+      const e = err as { stdout?: unknown };
+      if (typeof e.stdout === "string" && e.stdout.length > 0) return { stdout: e.stdout };
+      if (Buffer.isBuffer(e.stdout) && e.stdout.length > 0) return { stdout: e.stdout.toString() };
+      throw err;
+    });
+    return relabelNoIndexDiff(r.stdout, oldFile, newFile, rel);
+  } catch {
+    return undefined;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 }
 
 /**

--- a/tests/test-diff.ts
+++ b/tests/test-diff.ts
@@ -104,6 +104,7 @@ function makeToolResult(args: {
   toolCallId: string;
   toolName: "write" | "edit";
   diff?: string;
+  patch?: string;
   isError?: boolean;
 }): unknown {
   return {
@@ -111,7 +112,10 @@ function makeToolResult(args: {
     toolCallId: args.toolCallId,
     toolName: args.toolName,
     content: [{ type: "text", text: "ok" }],
-    details: args.diff !== undefined ? { diff: args.diff } : undefined,
+    details:
+      args.diff !== undefined || args.patch !== undefined
+        ? { diff: args.diff, patch: args.patch }
+        : undefined,
     isError: args.isError === true,
     timestamp: Date.now(),
   };
@@ -162,11 +166,20 @@ async function unitTests(): Promise<void> {
     await fsWrite(trackedFile, "line1\nline2\nline3\n", "utf8");
     await execFileAsync("git", ["add", "."], { cwd: trackedDir });
     await execFileAsync("git", ["commit", "-q", "-m", "init"], { cwd: trackedDir });
-    // Now mutate the file (simulating an agent edit).
-    await fsWrite(trackedFile, "line1\nLINE2-CHANGED\nline3\n+ extra\n", "utf8");
+    // Simulate pre-existing user work before the agent turn, then
+    // mutate again for the turn itself. The last-turn diff should use
+    // the tool's scoped details.diff and NOT show the pre-existing
+    // dirty line from `git diff HEAD`.
+    await fsWrite(trackedFile, "line1\npreexisting dirty line\nline2\nline3\n", "utf8");
+    await fsWrite(
+      trackedFile,
+      "line1\npreexisting dirty line\nLINE2-CHANGED\nline3\n+ extra\n",
+      "utf8",
+    );
 
     const callId = randomUUID();
-    const perEditDiff = `--- a/tracked.ts\n+++ b/tracked.ts\n@@ -1,3 +1,4 @@\n line1\n-line2\n+LINE2-CHANGED\n line3\n+ extra\n`;
+    const perEditDiff = `  1 line1\n  2 preexisting dirty line\n- 3 line2\n+ 3 LINE2-CHANGED\n  4 line3\n+ 5 + extra\n`;
+    const perEditPatch = `--- a/tracked.ts\n+++ b/tracked.ts\n@@ -1,3 +1,4 @@\n line1\n-line2\n+LINE2-CHANGED\n line3\n+ extra\n`;
     const messages = [
       makeUserMessage("modify tracked.ts"),
       makeAssistantWithCalls([
@@ -180,7 +193,12 @@ async function unitTests(): Promise<void> {
           },
         },
       ]),
-      makeToolResult({ toolCallId: callId, toolName: "edit", diff: perEditDiff }),
+      makeToolResult({
+        toolCallId: callId,
+        toolName: "edit",
+        diff: perEditDiff,
+        patch: perEditPatch,
+      }),
     ];
     const entries = await buildTurnDiff({ messages: messages as never[] }, trackedDir);
     assert("tracked edit produces 1 entry", entries.length === 1);
@@ -189,8 +207,18 @@ async function unitTests(): Promise<void> {
       assert("entry.tool === 'edit'", e.tool === "edit");
       assert("entry.isPureAddition === false (git diff path)", e.isPureAddition === false);
       assert(
-        "git diff includes the changed line",
+        "turn diff includes the changed line",
         e.diff.includes("LINE2-CHANGED"),
+        `diff: ${e.diff}`,
+      );
+      assert(
+        "turn diff uses details.patch over display diff",
+        !e.diff.includes("  2 preexisting dirty line"),
+        `diff: ${e.diff}`,
+      );
+      assert(
+        "turn diff excludes pre-existing dirty work",
+        !e.diff.includes("preexisting dirty line"),
         `diff: ${e.diff}`,
       );
       assert("additions >= 2", e.additions >= 2, `additions=${e.additions}`);
@@ -199,7 +227,68 @@ async function unitTests(): Promise<void> {
     await rm(trackedDir, { recursive: true, force: true });
   }
 
-  // --- Case C: multi-edit same file in one turn — collapses to one entry. ---
+  // --- Case C: verbose pi-format tool diffs are trimmed around edits. ---
+  {
+    const filePath = join(projectPath, "verbose.ts");
+    await fsWrite(
+      filePath,
+      Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join("\n"),
+      "utf8",
+    );
+    const callId = randomUUID();
+    const verbosePiDiff = Array.from({ length: 20 }, (_, i) => {
+      const lineNo = i + 1;
+      if (lineNo === 10) return `- ${lineNo} line ${lineNo}`;
+      if (lineNo === 11) return `+ ${lineNo} changed line`;
+      return `  ${lineNo} line ${lineNo}`;
+    }).join("\n");
+    const messages = [
+      makeUserMessage("edit verbose.ts"),
+      makeAssistantWithCalls([
+        { type: "toolCall", id: callId, name: "edit", arguments: { path: filePath } },
+      ]),
+      makeToolResult({ toolCallId: callId, toolName: "edit", diff: verbosePiDiff }),
+    ];
+    const entries = await buildTurnDiff({ messages: messages as never[] }, projectPath);
+    const diff = entries[0]?.diff ?? "";
+    assert("verbose pi diff produces 1 entry", entries.length === 1);
+    assert("verbose pi diff keeps changed line", diff.includes("changed line"), diff);
+    assert("verbose pi diff trims distant leading context", !diff.includes("  1 line 1"), diff);
+    assert("verbose pi diff trims distant trailing context", !diff.includes("  20 line 20"), diff);
+  }
+
+  // --- Case D: untracked existing edit without details does NOT render as whole-file add. ---
+  {
+    const filePath = join(projectPath, "untracked-existing.ts");
+    await fsWrite(filePath, "one\ntwo changed\nthree\n", "utf8");
+    const callId = randomUUID();
+    const messages = [
+      makeUserMessage("edit an untracked existing file"),
+      makeAssistantWithCalls([
+        {
+          type: "toolCall",
+          id: callId,
+          name: "edit",
+          arguments: {
+            path: filePath,
+            edits: [{ oldText: "two", newText: "two changed" }],
+          },
+        },
+      ]),
+      makeToolResult({ toolCallId: callId, toolName: "edit" }),
+    ];
+    const entries = await buildTurnDiff({ messages: messages as never[] }, projectPath);
+    const e = entries[0];
+    assert("untracked existing edit produces 1 entry", entries.length === 1);
+    if (e !== undefined) {
+      assert("untracked existing edit is not pure addition", e.isPureAddition === false);
+      assert("untracked existing edit shows deletion", e.diff.includes("-two"), e.diff);
+      assert("untracked existing edit shows insertion", e.diff.includes("+two changed"), e.diff);
+      assert("untracked existing edit does not add every line", e.additions === 1, e.diff);
+    }
+  }
+
+  // --- Case E: multi-edit same file in one turn — collapses to one entry. ---
   {
     const filePath = join(projectPath, "multi.ts");
     await fsWrite(filePath, "a\nb\nc\n", "utf8");
@@ -226,7 +315,7 @@ async function unitTests(): Promise<void> {
     assert("multi-edit same file collapses to 1 entry", entries.length === 1);
   }
 
-  // --- Case D: only consider the LATEST turn (after most recent user message). ---
+  // --- Case F: only consider the LATEST turn (after most recent user message). ---
   {
     const filePath = join(projectPath, "older.ts");
     await fsWrite(filePath, "old\n", "utf8");

--- a/tests/test-files.ts
+++ b/tests/test-files.ts
@@ -22,7 +22,7 @@
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { mkdir, mkdtemp, rm, writeFile as fsWrite } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile as fsWrite } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -131,6 +131,7 @@ async function main(): Promise<void> {
   await mkdir(join(projectPath, "dist"), { recursive: true });
   await fsWrite(join(projectPath, "src", "index.ts"), "export const x = 1;\n", "utf8");
   await fsWrite(join(projectPath, "src", "deep", "nested.txt"), "deep content\n", "utf8");
+  await symlink(join("src", "index.ts"), join(projectPath, "linked-index.ts"));
   await fsWrite(join(projectPath, "node_modules", "fake-pkg", "index.js"), "module.exports={};\n");
   await fsWrite(join(projectPath, ".git", "HEAD"), "ref: refs/heads/main\n");
   // A binary fixture (NUL-byte triggers binary detection).
@@ -204,6 +205,7 @@ async function main(): Promise<void> {
         "tree includes nested src/deep/nested.txt",
         paths.includes("file:src/deep/nested.txt"),
       );
+      assert("tree includes in-root linked files", paths.includes("file:linked-index.ts"));
       assert(
         "tree EXCLUDES node_modules",
         !paths.some((p) => p.startsWith("directory:node_modules")),


### PR DESCRIPTION
## Summary

Fixes three UI/dev-server issues in the file viewer and last-turn review flow:

- Last-turn diffs could render a pre-existing untracked file as an entirely new file when the agent only edited a few lines. The turn-diff builder now prefers edit-tool patches and reconstructs a scoped patch from edit arguments before falling back to whole-file additions.
- The file viewer skipped safe in-project symlinked files/directories. The tree now lists symlinks that resolve inside the project root while continuing to skip symlinks that escape the project.
- Opening a file from Files/Search now re-enables the editor pane if it was toggled off.
- Dev Vite proxy now targets the same API port used by root `npm run dev` / `dev:remote` instead of hardcoding `localhost:3000`.

## Usage

```bash
cd .worktrees/fix-viewer-diffs-linked-files
npm run dev:remote
```

Optional dev proxy overrides:

```bash
VITE_API_HOST=localhost VITE_API_PORT=3100 npm run dev -w packages/client -- --host
```

Production builds are unaffected by the Vite dev proxy change.

## What changed (10 files)

- `packages/server/src/turn-diff-builder.ts` — prefers `details.patch`, trims verbose display diffs, and reconstructs edit-scoped patches for pre-existing untracked files before pure-addition fallback.
- `tests/test-diff.ts` — adds regressions for pre-existing dirty work, verbose pi-format diffs, and untracked existing edits.
- `packages/server/src/file-manager.ts` — includes safe in-root symlinked files/directories in the file tree.
- `tests/test-files.ts` — covers file-tree listing of in-root linked files.
- `packages/client/src/store/ui-store.ts`, `App.tsx`, `FileBrowserPanel.tsx`, `SearchPanel.tsx` — adds a cross-component signal to auto-open the editor pane when files are opened from browser/search.
- `packages/server/src/routes/sessions.ts` — updates turn-diff route description to match patch-first behavior.
- `packages/client/vite.config.ts` — derives the dev API proxy target from `VITE_API_PORT`, `PORT`, and `VITE_API_HOST`.

## Test plan

- [x] `npm run build`
- [x] `scripts/run-tests.sh --only diff,files`
- [x] `npm run build --workspace packages/server`
- [x] `npx tsx tests/test-diff.ts`
- [x] Manual: dev server points client API traffic at the intended port and last-turn diffs show scoped edits instead of whole-file additions
- [ ] CI green before merge

Note: `npm run check` previously reached eslint and then failed with Node heap OOM in this environment, not with a TypeScript/test failure.
