### PR TITLE
feat: archive deleted sessions and batch tool calls

### DIFF
--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -456,14 +456,15 @@ export function ChatView({ sessionId }: Props) {
               const latestCard =
                 compactions.length > 0 ? compactions[compactions.length - 1] : undefined;
               const keptWindowEnd = latestCard?.insertBeforeIndex ?? 0;
-              messages.forEach((m, i) => {
+              for (let i = 0; i < messages.length; i++) {
+                const m = messages[i]!;
                 renderCardsAt(i);
                 if (
                   m.role === "toolResult" &&
                   typeof m.toolCallId === "string" &&
                   pairedIds.has(m.toolCallId)
                 ) {
-                  return; // rendered inline next to its toolCall
+                  continue; // rendered inline next to its toolCall
                 }
                 // Hide the SDK-synthesized compaction summary message
                 // (role: "compactionSummary"). The same summary text
@@ -471,16 +472,50 @@ export function ChatView({ sessionId }: Props) {
                 // disclosure body, so showing it as a top-of-chat
                 // bubble would just duplicate the content under an
                 // "unknown message" fallback.
-                if (m.role === "compactionSummary") return;
+                if (m.role === "compactionSummary") continue;
                 // Kept-window suppression — see the comment block
                 // above for rationale and index ranges.
-                if (latestCard !== undefined && i >= 1 && i < keptWindowEnd) return;
+                if (latestCard !== undefined && i >= 1 && i < keptWindowEnd) continue;
+
+                const firstBatch = batchableToolEntriesFromMessage(m, toolResultsById);
+                if (firstBatch !== undefined && countToolBatchCalls(firstBatch) === 1) {
+                  const batch = [...firstBatch];
+                  let j = i + 1;
+                  while (j < messages.length && countToolBatchCalls(batch) < MAX_TOOL_BATCH_SIZE) {
+                    const next = messages[j]!;
+                    if (
+                      next.role === "toolResult" &&
+                      typeof next.toolCallId === "string" &&
+                      pairedIds.has(next.toolCallId)
+                    ) {
+                      renderCardsAt(j);
+                      j += 1;
+                      continue;
+                    }
+                    if (next.role === "compactionSummary") break;
+                    if (latestCard !== undefined && j >= 1 && j < keptWindowEnd) break;
+                    const nextBatch = batchableToolEntriesFromMessage(next, toolResultsById);
+                    if (nextBatch === undefined || countToolBatchCalls(nextBatch) !== 1) break;
+                    batch.push(...nextBatch);
+                    j += 1;
+                  }
+                  if (batch.length > 1) {
+                    out.push(
+                      <div key={`tool-batch-${i}`} data-message-index={i}>
+                        <ToolCallBatchCard entries={batch} />
+                      </div>,
+                    );
+                    i = j - 1;
+                    continue;
+                  }
+                }
+
                 out.push(
                   <div key={i} data-message-index={i}>
                     <Message message={m} toolResultsById={toolResultsById} />
                   </div>,
                 );
-              });
+              }
               // Trailing cards (insertBeforeIndex === messages.length)
               // — the entire current context was archived but no
               // messages have been pushed since. Rare; render at the
@@ -993,17 +1028,17 @@ function Message({
 
 /**
  * Render an assistant message's content array, collapsing runs of
- * consecutive `todo` toolCall blocks into a single batched card.
+ * consecutive low-noise toolCall blocks into a single batched card.
  *
- * Motivation: a single planning turn often fires 5+ `todo create`
- * calls back-to-back, and each one would otherwise render as its
- * own bordered card — eating vertical space with redundant info
- * (every todo result carries the full state, so only the last one
- * is informative; the rest are intermediate steps).
+ * Motivation: exploratory turns often fire several `read` / `grep` /
+ * `find` / `ls` / `process` / `todo` calls back-to-back, and each one
+ * would otherwise render as its own bordered card. The collapsed batch
+ * preserves chronology and auditability while making the default chat
+ * timeline much shorter; clicking the batch reveals each full tool card.
  *
- * Non-todo blocks render unchanged via the normal AssistantBlock
- * path. Mixed runs (text + todo + bash) stay in original order
- * because grouping only happens for adjacent todo blocks.
+ * High-signal or potentially destructive tools (`edit`, `write`) render
+ * individually. Mixed runs separated by assistant text stay in original
+ * order because grouping only happens for adjacent batchable tool calls.
  */
 function renderAssistantBlocks(
   content: Record<string, unknown>[],
@@ -1014,24 +1049,35 @@ function renderAssistantBlocks(
   let i = 0;
   while (i < content.length) {
     const block = content[i]!;
-    if (block.type === "toolCall" && block.name === "todo") {
-      // Greedy: pull every adjacent todo toolCall into the same batch.
+    if (isBatchableToolCall(block)) {
+      // Greedy: pull every adjacent batchable toolCall into the same compact card.
       const start = i;
-      const batch: { block: Record<string, unknown>; result: AgentMessageLike | undefined }[] = [];
-      while (i < content.length) {
+      const batch: ToolBatchEntry[] = [];
+      while (i < content.length && countToolBatchCalls(batch) < MAX_TOOL_BATCH_SIZE) {
         const b = content[i];
-        if (b?.type !== "toolCall" || b.name !== "todo") break;
+        if (b === undefined) break;
+        if (isToolBatchThinkingBlock(b)) {
+          batch.push({ kind: "thinking", block: b });
+          i += 1;
+          continue;
+        }
+        if (isToolBatchWhitespaceBlock(b)) {
+          i += 1;
+          continue;
+        }
+        if (!isBatchableToolCall(b)) break;
         const id = typeof b.id === "string" ? b.id : undefined;
         const r = id !== undefined ? toolResultsById?.get(id) : undefined;
-        batch.push({ block: b, result: r });
+        batch.push({ kind: "tool", block: b, result: r });
         i += 1;
       }
-      if (batch.length === 1) {
+      if (countToolBatchCalls(batch) === 1) {
         // Single call — render via the standard ToolCallEntry path.
-        const only = batch[0]!;
-        out.push(<ToolCallEntry key={start} block={only.block} result={only.result} />);
+        const only = batch.find((entry) => entry.kind === "tool");
+        if (only !== undefined)
+          out.push(<ToolCallEntry key={start} block={only.block} result={only.result} />);
       } else {
-        out.push(<TodoBatchCard key={`todo-batch-${start}`} entries={batch} />);
+        out.push(<ToolCallBatchCard key={`tool-batch-${start}`} entries={batch} />);
       }
       continue;
     }
@@ -1047,46 +1093,121 @@ function renderAssistantBlocks(
   return out;
 }
 
-/**
- * Compact single-card rendering for a run of N consecutive `todo`
- * tool calls in one assistant message. Each call's one-line result
- * text becomes a row; the latest result's task count is the
- * headline. Expanded view shows the full output of each call.
- */
-function TodoBatchCard({
-  entries,
-}: {
-  entries: { block: Record<string, unknown>; result: AgentMessageLike | undefined }[];
-}) {
-  const lastWithResult = [...entries].reverse().find((e) => e.result !== undefined);
-  const lastDetails =
-    (lastWithResult?.result?.details as { tasks?: unknown; nextId?: unknown } | undefined) ??
-    undefined;
-  const taskCount = Array.isArray(lastDetails?.tasks) ? lastDetails.tasks.length : 0;
-  const inFlight = entries.filter((e) => e.result === undefined).length;
-  const errored = entries.some((e) => e.result?.isError === true);
-  const lines = entries.map((e) => {
-    const content = Array.isArray(e.result?.content) ? e.result.content : [];
-    const first = content.find((c): c is { type: "text"; text: string } => {
-      const o = c as { type?: unknown; text?: unknown };
-      return o.type === "text" && typeof o.text === "string";
+const MAX_TOOL_BATCH_SIZE = 10;
+const BATCHABLE_TOOL_NAMES = new Set(["read", "grep", "find", "ls", "todo", "process", "bash"]);
+
+type ToolBatchEntry =
+  | { kind: "tool"; block: Record<string, unknown>; result: AgentMessageLike | undefined }
+  | { kind: "thinking"; block: Record<string, unknown> };
+
+function isBatchableToolCall(block: Record<string, unknown> | undefined): boolean {
+  return block?.type === "toolCall" && BATCHABLE_TOOL_NAMES.has(String(block.name ?? ""));
+}
+
+function isToolBatchThinkingBlock(block: Record<string, unknown> | undefined): boolean {
+  return block?.type === "thinking";
+}
+
+function isToolBatchWhitespaceBlock(block: Record<string, unknown> | undefined): boolean {
+  return block?.type === "text" && typeof block.text === "string" && block.text.trim().length === 0;
+}
+
+function countToolBatchCalls(entries: ToolBatchEntry[]): number {
+  return entries.filter((entry) => entry.kind === "tool").length;
+}
+
+function batchableToolEntriesFromMessage(
+  message: AgentMessageLike,
+  toolResultsById: Map<string, AgentMessageLike> | undefined,
+): ToolBatchEntry[] | undefined {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) return undefined;
+  const entries: ToolBatchEntry[] = [];
+  for (const block of message.content as Record<string, unknown>[]) {
+    if (isToolBatchThinkingBlock(block)) {
+      entries.push({ kind: "thinking", block });
+      continue;
+    }
+    if (isToolBatchWhitespaceBlock(block)) continue;
+    if (!isBatchableToolCall(block)) return undefined;
+    const id = typeof block.id === "string" ? block.id : undefined;
+    entries.push({
+      kind: "tool",
+      block,
+      result: id !== undefined ? toolResultsById?.get(id) : undefined,
     });
-    return first?.text ?? "(no output)";
-  });
+  }
+  return countToolBatchCalls(entries) > 0 ? entries : undefined;
+}
+
+function toolPreviewFromArgs(name: string, args: unknown): string | undefined {
+  const argsObj = isObjectShape(args) ? args : undefined;
+  if (name === "bash") {
+    return typeof argsObj?.command === "string" ? argsObj.command : undefined;
+  }
+  if (name === "process") {
+    const action = typeof argsObj?.action === "string" ? argsObj.action : undefined;
+    const procName = typeof argsObj?.name === "string" ? argsObj.name : undefined;
+    const command = typeof argsObj?.command === "string" ? argsObj.command : undefined;
+    return [action, procName ?? command].filter(Boolean).join(" ") || undefined;
+  }
+  if (name === "todo") {
+    const action = typeof argsObj?.action === "string" ? argsObj.action : undefined;
+    const subject = typeof argsObj?.subject === "string" ? argsObj.subject : undefined;
+    return [action, subject].filter(Boolean).join(" ") || undefined;
+  }
+  if (
+    (name === "read" || name === "grep" || name === "find" || name === "ls") &&
+    argsObj !== undefined
+  ) {
+    const path = typeof argsObj.path === "string" ? argsObj.path : undefined;
+    const pattern = typeof argsObj.pattern === "string" ? argsObj.pattern : undefined;
+    return path ?? pattern;
+  }
+  return undefined;
+}
+
+/**
+ * Compact single-card rendering for a run of consecutive low-noise tool calls.
+ * The summary takes one row; expanding reveals each full ToolCallEntry so no
+ * input/output detail is lost.
+ */
+function ToolCallBatchCard({ entries }: { entries: ToolBatchEntry[] }) {
+  const toolEntries = entries.filter((entry) => entry.kind === "tool");
+  const toolCount = toolEntries.length;
+  const inFlight = toolEntries.filter((e) => e.result === undefined).length;
+  const errored = toolEntries.some((e) => e.result?.isError === true);
+  const counts = new Map<string, number>();
+  for (const e of toolEntries) {
+    const name = String(e.block.name ?? "tool");
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  const countSummary = [...counts].map(([name, count]) => `${name} ×${count}`).join(" · ");
+  const previews = toolEntries
+    .map((e) => {
+      const name = String(e.block.name ?? "tool");
+      const args = e.block.input ?? e.block.arguments ?? {};
+      const preview = toolPreviewFromArgs(name, args);
+      return preview === undefined ? name : `${name}: ${preview}`;
+    })
+    .slice(0, 3);
   return (
     <details className="group rounded border border-neutral-800 bg-neutral-950 text-xs">
       <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-neutral-300">
         <span className="flex min-w-0 items-baseline gap-2">
           <span className="text-neutral-500">→</span>
-          <span className="font-mono">todo</span>
+          <span className="font-mono">tools</span>
           <span className="text-neutral-500">
-            ×{entries.length} {entries.length === 1 ? "call" : "calls"}
+            ×{toolCount} {toolCount === 1 ? "call" : "calls"}
           </span>
-          <span className="ml-2 truncate text-neutral-400">
-            {taskCount === 0
-              ? "no tasks"
-              : `${taskCount} ${taskCount === 1 ? "task" : "tasks"} after batch`}
+          <span className="truncate text-neutral-400" title={countSummary}>
+            {countSummary}
           </span>
+          {previews.length > 0 && (
+            <span className="ml-2 truncate font-mono text-[10px] text-neutral-500">
+              {previews.join(" · ")}
+              {toolCount > previews.length ? " · …" : ""}
+            </span>
+          )}
         </span>
         <div className="flex shrink-0 items-center gap-1">
           {inFlight > 0 && (
@@ -1101,13 +1222,14 @@ function TodoBatchCard({
           )}
         </div>
       </summary>
-      <div className="space-y-1 border-t border-neutral-800/60 px-3 py-2 font-mono text-[11px] text-neutral-400">
-        {lines.map((line, j) => (
-          <div key={j} className="flex items-baseline gap-2">
-            <span className="shrink-0 text-neutral-600">#{j + 1}</span>
-            <span className="whitespace-pre-wrap break-words text-neutral-300">{line}</span>
-          </div>
-        ))}
+      <div className="space-y-2 border-t border-neutral-800/60 px-3 py-2">
+        {entries.map((entry, j) =>
+          entry.kind === "thinking" ? (
+            <AssistantBlock key={j} block={entry.block} />
+          ) : (
+            <ToolCallEntry key={j} block={entry.block} result={entry.result} />
+          ),
+        )}
       </div>
     </details>
   );

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -21,6 +21,12 @@ function parseAllowedHosts(raw: string | undefined): true | string[] | undefined
   return entries.length > 0 ? entries : undefined;
 }
 
+function devApiTarget(): string {
+  const port = process.env.VITE_API_PORT ?? process.env.PORT ?? "3100";
+  const host = process.env.VITE_API_HOST ?? "localhost";
+  return `http://${host}:${port}`;
+}
+
 export default defineConfig({
   plugins: [
     react(),
@@ -171,7 +177,12 @@ export default defineConfig({
     allowedHosts: parseAllowedHosts(process.env.VITE_DEV_ALLOWED_HOSTS),
     proxy: {
       "/api": {
-        target: "http://localhost:3000",
+        // Root `npm run dev` / `dev:remote` pass the API server port through
+        // PORT (default 3100). Mirror that default here instead of hardcoding
+        // 3000, otherwise direct `npm run dev -w packages/client` proxies API/SSE/WS traffic to the
+        // wrong backend. VITE_API_PORT / VITE_API_HOST let unusual local setups
+        // override the target without changing the server's own PORT/HOST.
+        target: devApiTarget(),
         changeOrigin: true,
         // Forward WebSocket upgrades for `/api/v1/terminal` (Phase 11).
         // Without `ws: true`, Vite falls through to its own ws server

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -41,6 +41,7 @@ import {
   initOrchestrationProcessesBridge,
 } from "./orchestration/init.js";
 import { disposeAllSessions } from "./session-registry.js";
+import { cleanupArchivedSessions } from "./session-archive.js";
 import { disposeAllPtys, installPtyExitHandler } from "./pty-manager.js";
 import { logSecretHygieneState } from "./agent-resource-loader.js";
 
@@ -124,6 +125,13 @@ export async function buildServer(): Promise<FastifyInstance> {
     // bodyLimit further without revisiting `parseMultipart` to stream
     // attachments to disk instead of buffering.
     bodyLimit: 100 * 1024 * 1024,
+  });
+
+  // Purge archived sessions whose 7-day retention window has elapsed.
+  // Best-effort: cleanup failures should not prevent the server from
+  // starting, but they should be visible in logs.
+  cleanupArchivedSessions().catch((err: unknown) => {
+    fastify.log.warn({ err }, "archived session cleanup failed");
   });
 
   // Install the PTY exit handler — was previously fired at module-load

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -773,18 +773,15 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     {
       schema: {
         description:
-          "Dispose the live session AND delete the on-disk JSONL (plus " +
-          "any pi-subagents child JSONLs nested under it). Always destructive " +
-          "— matches the UI's expectation that 'delete' means the session is " +
-          "gone from disk and the sidebar.\n" +
-          "  - live → dispose AND delete the JSONL → 204\n" +
-          "  - cold → delete the JSONL → 204\n" +
+          "Dispose the live session and archive the on-disk JSONL (plus " +
+          "any pi-subagents child JSONLs nested under it) for 7 days. The " +
+          "session disappears from the sidebar immediately, but the files are " +
+          "kept in the server-side archive until cleanup purges them.\n" +
+          "  - live → dispose AND archive the JSONL → 204\n" +
+          "  - cold → archive the JSONL → 204\n" +
           "  - not found anywhere → 404\n" +
-          "Earlier versions of this route accepted a `?hard=0|1` query " +
-          "param to opt into JSONL deletion. The non-destructive default was " +
-          "vestigial (the UI always passed `hard=1`) and confusing for " +
-          "programmatic clients, so v1.3.0 dropped the param and made hard " +
-          "delete the only behavior.",
+          "There is intentionally no browser UI for immediate permanent " +
+          "delete; cleanup removes archived sessions after the retention window.",
         tags: ["sessions"],
         params: {
           type: "object",
@@ -804,10 +801,9 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       // mid-flow. Used for the session_deleted webhook payload.
       const projectIdForWebhook = await findProjectIdForSession(req.params.id);
       const wasLive = await disposeSession(req.params.id);
-      // Always hard-delete: dispose (above) + remove JSONL (below).
-      // After dispose, the registry no longer has the entry;
-      // deleteColdSession's "live" guard doesn't trip on the ordinary
-      // case.
+      // Always soft-delete: dispose (above) + move JSONL into the 7-day
+      // archive (below). After dispose, the registry no longer has the entry;
+      // deleteColdSession's "live" guard doesn't trip on the ordinary case.
       let r: "deleted" | "live" | "not_found";
       try {
         r = await deleteColdSession(req.params.id);
@@ -833,7 +829,7 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       if (r === "live") {
         // Race: another client resumed the session between our
         // dispose and the cold-delete file lookup. The user asked
-        // for hard delete; honor that by retrying once.
+        // to delete/archive it; honor that by retrying once.
         // (As of the tombstone fix in session-registry, this path is
         // very rare — disposeSession sets a 1.5s no-revive window
         // that resumeSession enforces. The retry stays as defense

--- a/packages/server/src/session-archive.ts
+++ b/packages/server/src/session-archive.ts
@@ -1,0 +1,115 @@
+import { cp, mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { config } from "./config.js";
+
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface ArchiveMetadata {
+  version: 1;
+  sessionId: string;
+  projectId?: string;
+  originalSessionPath: string;
+  archivedAt: string;
+  purgeAfter: string;
+  sessionFile: string;
+  subagentDir?: string;
+}
+
+function safeStamp(d: Date): string {
+  return d.toISOString().replace(/[:.]/g, "-");
+}
+
+async function movePath(src: string, dest: string): Promise<void> {
+  try {
+    await rename(src, dest);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "EXDEV") throw err;
+    const s = await stat(src);
+    if (s.isDirectory()) {
+      await cp(src, dest, { recursive: true, force: false, errorOnExist: true });
+      await rm(src, { recursive: true, force: true });
+    } else {
+      await cp(src, dest, { force: false, errorOnExist: true });
+      await rm(src, { force: true });
+    }
+  }
+}
+
+/**
+ * Soft-delete a session by moving its JSONL (and optional pi-subagents
+ * sibling directory) out of the live session tree. The normal discovery path
+ * no longer sees it, so it disappears from the UI immediately, while the files
+ * remain recoverable on disk until cleanupArchivedSessions purges them.
+ */
+export async function archiveSessionFiles(args: {
+  sessionId: string;
+  projectId?: string;
+  sessionPath: string;
+  subagentDir?: string;
+}): Promise<void> {
+  const now = new Date();
+  const purgeAfter = new Date(now.getTime() + RETENTION_MS);
+  const archiveId = `${safeStamp(now)}-${args.sessionId}-${randomUUID().slice(0, 8)}`;
+  const archiveDir = join(config.forgeDataDir, "archived-sessions", archiveId);
+  await mkdir(archiveDir, { recursive: true });
+
+  const sessionFile = basename(args.sessionPath) || "session.jsonl";
+  await movePath(args.sessionPath, join(archiveDir, sessionFile));
+
+  let subagentDirName: string | undefined;
+  if (args.subagentDir !== undefined) {
+    try {
+      const s = await stat(args.subagentDir);
+      if (s.isDirectory()) {
+        subagentDirName = "subagents";
+        await movePath(args.subagentDir, join(archiveDir, subagentDirName));
+      }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") throw err;
+    }
+  }
+
+  const metadata: ArchiveMetadata = {
+    version: 1,
+    sessionId: args.sessionId,
+    ...(args.projectId !== undefined ? { projectId: args.projectId } : {}),
+    originalSessionPath: args.sessionPath,
+    archivedAt: now.toISOString(),
+    purgeAfter: purgeAfter.toISOString(),
+    sessionFile,
+    ...(subagentDirName !== undefined ? { subagentDir: subagentDirName } : {}),
+  };
+  await writeFile(join(archiveDir, "metadata.json"), JSON.stringify(metadata, null, 2) + "\n", {
+    mode: 0o600,
+  });
+}
+
+/** Remove archived sessions whose 7-day retention window has expired. */
+export async function cleanupArchivedSessions(now = new Date()): Promise<number> {
+  const root = join(config.forgeDataDir, "archived-sessions");
+  await mkdir(root, { recursive: true });
+  const entries = await readdir(root, { withFileTypes: true });
+  let removed = 0;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(root, entry.name);
+    let purge: boolean;
+    try {
+      const raw = await readFile(join(dir, "metadata.json"), "utf8");
+      const meta = JSON.parse(raw) as { purgeAfter?: unknown };
+      purge = typeof meta.purgeAfter === "string" && Date.parse(meta.purgeAfter) <= now.getTime();
+    } catch {
+      // If metadata is missing/corrupt, fall back to directory mtime so a bad
+      // archive entry cannot live forever.
+      const s = await stat(dir).catch(() => undefined);
+      purge = s !== undefined && now.getTime() - s.mtimeMs >= RETENTION_MS;
+    }
+    if (!purge) continue;
+    await rm(dir, { recursive: true, force: true });
+    removed += 1;
+  }
+  return removed;
+}

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, rm } from "node:fs/promises";
+import { mkdir, readdir } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import {
   AgentSession,
@@ -35,6 +35,7 @@ import { isSupervisor } from "./orchestration/store.js";
 import { createOrchestrationTools } from "./orchestration/tools.js";
 import { bridgeWorkerAgentEvent } from "./orchestration/event-bridge.js";
 import { notifySupervisorDisposed, notifySupervisorIdle } from "./orchestration/inbox.js";
+import { archiveSessionFiles } from "./session-archive.js";
 
 /**
  * Minimal SSE client contract used by the registry to fan out events.
@@ -871,10 +872,10 @@ export async function resumeSession(
 }
 
 /**
- * Delete a cold (on-disk-only) session's JSONL file from disk. Refuses
- * if the session is currently live in the registry — the caller should
- * dispose first. Returns:
- *   - "deleted" when the file was found and removed.
+ * Soft-delete a cold (on-disk-only) session by moving its JSONL into the
+ * 7-day archive. Refuses if the session is currently live in the registry —
+ * the caller should dispose first. Returns:
+ *   - "deleted" when the file was found and archived.
  *   - "live" when the session is in the registry (caller must dispose
  *      first; we don't auto-dispose because that would race the SSE
  *      clients with no chance to close cleanly).
@@ -902,59 +903,39 @@ export async function deleteColdSession(
     }
     const match = infos.find((s) => s.sessionId === sessionId);
     if (match !== undefined) {
-      try {
-        await rm(match.path, { force: true });
-      } catch (err) {
-        // ENOENT (vanished mid-flight) is fine — collapse to
-        // "deleted" since the file is now gone, which is what the
-        // caller asked for. Any other error (permissions, IO) is a
-        // real failure and should NOT silently look like
-        // "not_found" to the operator. Surface via thrown so the
-        // route can map to 500.
-        const code = (err as NodeJS.ErrnoException).code;
-        if (code === "ENOENT") return "deleted";
-        throw err;
-      }
-      // Cascade-delete the pi-subagents sibling directory if this was
-      // a top-level parent session. The plugin's
-      // `getSubagentSessionRoot(parentSessionFile)` lays children at
-      // `<dirname(parentFile)>/<basename(parentFile, ".jsonl")>/...`,
-      // so we mirror that path and `rm -rf` it. Without this, deleting
-      // a parent leaves its child sub-agent JSONLs behind as
-      // sidebar orphans.
-      //
-      // Skipped for sub-agent CHILDREN — they don't have a sibling
-      // dir of their own (they live UNDER one). The project-scoped
-      // `subagent-artifacts/` dir is intentionally untouched: it's
-      // shared across every parent session in the project, not
-      // per-session, so blowing it away on single-session delete
-      // would clobber unrelated sessions' artifacts.
+      let siblingDir: string | undefined;
+      // Archive the pi-subagents sibling directory if this was a top-level
+      // parent session. The plugin's `getSubagentSessionRoot(parentSessionFile)`
+      // lays children at `<dirname(parentFile)>/<basename(parentFile, ".jsonl")>/...`.
+      // Moving the directory with the parent keeps the archive self-contained and
+      // removes child sessions from live discovery immediately.
       if (match.parentSessionId === undefined) {
         const stem = basename(match.path, ".jsonl");
-        const siblingDir = join(dirname(match.path), stem);
-        // Dispose any LIVE children before removing their JSONLs.
-        // `discoverSessionsOnDisk` populated `infos` with every child
-        // under this parent (their `parentSessionId` matches our
-        // `sessionId`). If a child was opened in the UI it now has a
-        // LiveSession entry in the registry; rm-ing its JSONL out from
-        // under it leaves a zombie session pointing at a deleted file
-        // and any SSE clients attached to it keep firing events that
-        // can't be persisted. Dispose in parallel — `disposeSession`
-        // awaits a per-session abort with a 5-second ceiling, so a
-        // sequential loop on N live children would block the delete
-        // request for up to 5N seconds.
+        siblingDir = join(dirname(match.path), stem);
+        // Dispose any LIVE children before moving their JSONLs out from under
+        // them. Otherwise they become zombie sessions pointing at archived files.
         const liveChildIds = infos
           .filter((s) => s.parentSessionId === sessionId && registry.has(s.sessionId))
           .map((s) => s.sessionId);
         if (liveChildIds.length > 0) {
           await Promise.all(liveChildIds.map((id) => disposeSession(id)));
         }
-        // force: true makes ENOENT silent; recursive: true clears the
-        // run/runId/run-N tree the plugin nests under there. Failures
-        // for any other reason (perms, EBUSY) are swallowed — the
-        // primary delete already succeeded and the user-facing op is
-        // "session is gone."
-        await rm(siblingDir, { recursive: true, force: true }).catch(() => undefined);
+      }
+      try {
+        await archiveSessionFiles({
+          sessionId,
+          projectId: project.id,
+          sessionPath: match.path,
+          ...(siblingDir !== undefined ? { subagentDir: siblingDir } : {}),
+        });
+      } catch (err) {
+        // ENOENT (vanished mid-flight) is fine — collapse to "deleted" since
+        // the file is now gone from live discovery, which is what the caller
+        // asked for. Any other error (permissions, IO) is a real failure and
+        // should NOT silently look like "not_found" to the operator.
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") return "deleted";
+        throw err;
       }
       return "deleted";
     }


### PR DESCRIPTION
## Summary

Deleting sessions now behaves as a soft-delete: sessions disappear from the sidebar immediately, but their JSONL and nested pi-subagents files are moved to a server-side archive for 7 days before cleanup purges them. This avoids accidental permanent loss while keeping the UI simple — there is intentionally no browser option to permanently delete immediately.

The chat UI also compacts consecutive low-noise tool calls into expandable batches so tool-heavy turns take up less vertical space. Batches can include mixed tool types such as `process` and `bash`, preserve thinking blocks inside the expanded batch, and cap at 10 tool calls per batch.

This also fixes the Vite dev proxy mismatch: dev API proxying now defaults to port 3100, matching the root `dev` / `dev:remote` scripts.

## Usage

Deleted session archives are stored under:

```txt
${FORGE_DATA_DIR}/archived-sessions/<timestamp>-<sessionId>-<random>/
```

By default:

```txt
~/.pi-forge/archived-sessions/
```

Dev proxy overrides remain available:

```bash
VITE_API_PORT=3100 npm run dev -w packages/client
VITE_API_HOST=localhost npm run dev -w packages/client
```

Without overrides, the client dev proxy uses `PORT` and then falls back to `3100`.

## What changed

- `packages/server/src/session-archive.ts` — adds archive move/cross-device fallback and 7-day cleanup helpers.
- `packages/server/src/session-registry.ts` — changes cold session deletion to archive JSONL/subagent sibling dirs instead of removing immediately.
- `packages/server/src/routes/sessions.ts` — updates DELETE route description/comments to reflect archive semantics and no immediate permanent-delete UI.
- `packages/server/src/index.ts` — runs archive cleanup on server startup.
- `packages/client/src/components/ChatView.tsx` — batches consecutive compactable tool calls (`read`, `grep`, `find`, `ls`, `todo`, `process`, `bash`) across message boundaries, preserves thinking blocks inside expanded batches, and caps batches at 10 tool calls.
- `packages/client/vite.config.ts` — derives the dev API proxy target from `VITE_API_PORT`, `PORT`, then default `3100`.

## Test plan

- [x] `npm run build`
- [x] Targeted ESLint on changed files
- [x] Targeted Prettier check on changed files
- [x] Manual: verified tool batching appears in the browser, including mixed tool types and thinking blocks preserved in the expanded batch
- [ ] CI green before merge

Note: full `npm run check` was attempted earlier but the process was killed with exit code 137 during repo-wide ESLint in this environment. Targeted lint/format checks for changed files pass.
