### PR TITLE
chore(release): v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.3.4] — 2026-05-28
+
+### Added
+
+- **Deleted sessions are archived before removal.** Session deletion now
+  writes the removed JSONL into pi-forge's archive path before disposing
+  the active registry entry, preserving recoverable local history instead
+  of immediately discarding the session file.
+- **Low-noise tool calls collapse into batch cards in chat.** Consecutive
+  read/search/list/process/todo-style tool calls now render as compact
+  expandable groups, while high-signal writes and edits stay visible as
+  standalone cards.
+
+### Fixed
+
+- **File viewer and turn diff rendering are more reliable.** File browser
+  paths, search-panel selection, and turn diff reconstruction handle more
+  edge cases, with expanded integration coverage for diff and file flows.
+- **Container images include Python 3.14 and pip support.** The Dockerfile
+  now builds the newer Python runtime and documents the container setup so
+  Python-based agent tooling works out of the box.
+- **Agent tool guidance avoids noisy process polling.** Todo/process tool
+  prompt strings now steer agents away from repeated status polling and
+  toward event-driven process notifications.
+- **Vite dev proxy respects the configured API port.** Local client dev
+  proxying now targets the dev API port rather than assuming the default.
+
+### Documentation
+
+- **Documented node-pty rebuild setup.** CONTRIBUTING.md now covers the
+  rebuild steps needed when native terminal dependencies change.
+
 ## [1.3.3] — 2026-05-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "workspaces": [
         "packages/*"
       ],
@@ -17158,7 +17158,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17218,7 +17218,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.76.0",
         "@earendil-works/pi-ai": "0.76.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cut the v1.3.4 release by rolling the changelog entries for changes since v1.3.3 and bumping the root, client, server, and lockfile versions in lockstep.

## Usage

No direct runtime usage change in this PR. After merge, tag from updated `main`:

```bash
git checkout main && git pull --ff-only
git tag v1.3.4
git push origin v1.3.4
```

## What changed (5 files, +39/-7)

- `CHANGELOG.md` — added the v1.3.4 dated release section covering deleted-session archiving, compact tool batches, file/diff fixes, container Python/pip support, process guidance, Vite dev proxy, and node-pty rebuild docs.
- `package.json` — bumped root version to `1.3.4`.
- `packages/client/package.json` — bumped client package version to `1.3.4`.
- `packages/server/package.json` — bumped server package version to `1.3.4`.
- `package-lock.json` — refreshed workspace package versions for `1.3.4`.

## Test plan

- [x] `npm run build`
- [x] `NODE_OPTIONS=--max-old-space-size=4096 npm run check`
- [x] `npm run test:ci`
- [ ] CI green before merge
