### PR TITLE
Harden clone path validation

### DIFF
--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync, FastifyReply } from "fastify";
-import { join, resolve } from "node:path";
+import { realpath } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { config } from "../config.js";
 import {
   assertTargetClonable,
@@ -48,6 +49,11 @@ const CLONE_HEARTBEAT_INTERVAL_MS = 20_000;
  */
 const CLONE_PADDING_BYTES = 2048;
 const CLONE_PADDING_LINE = `: pad-flush ${"_".repeat(CLONE_PADDING_BYTES - 14)}\n\n`;
+
+function isPathInsideOrEqual(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel.length === 0 || (!rel.startsWith("..") && !isAbsolute(rel));
+}
 
 const projectSchema = {
   type: "object",
@@ -510,18 +516,16 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
         return reply.code(400).send({ error: "invalid_directory_name" });
       }
       // Resolve target path and confirm it's inside WORKSPACE_PATH.
-      // Reuses the project-manager error so the route surface stays
-      // consistent.
+      // Realpath the parent before joining so a symlink inside the
+      // workspace cannot redirect the clone target outside it.
       const parentResolved = resolve(parentPath);
-      const targetPath = join(parentResolved, folderName);
-      const workspaceResolved = resolve(config.workspacePath);
-      if (
-        !parentResolved.startsWith(workspaceResolved + "/") &&
-        parentResolved !== workspaceResolved
-      ) {
+      const workspaceResolved = await realpath(config.workspacePath);
+      const parentReal = await realpath(parentResolved).catch(() => parentResolved);
+      const targetPath = join(parentReal, folderName);
+      if (!isPathInsideOrEqual(parentReal, workspaceResolved)) {
         return reply.code(403).send({ error: "path_not_allowed" });
       }
-      if (!targetPath.startsWith(workspaceResolved + "/") && targetPath !== workspaceResolved) {
+      if (!isPathInsideOrEqual(targetPath, workspaceResolved)) {
         return reply.code(403).send({ error: "path_not_allowed" });
       }
       try {

--- a/tests/test-clone.ts
+++ b/tests/test-clone.ts
@@ -18,7 +18,7 @@
  * leaking into the cloned `origin` URL.
  */
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -353,6 +353,30 @@ async function main(): Promise<void> {
         projectName: "Cloned Repo 2",
       });
       assert("re-clone into non-empty folder → 409", second.status === 409);
+
+      // A parent directory that is a symlink inside WORKSPACE_PATH but
+      // resolves outside it must be rejected before spawning `git clone`.
+      const outsideParent = await mkdtemp(join(tmpdir(), "pi-forge-clone-outside-"));
+      const symlinkParent = join(srv.workspacePath, "outside-link");
+      try {
+        await symlink(outsideParent, symlinkParent, "dir");
+        const escaped = await streamClone(srv.base, {
+          url: sourceUrl,
+          parentPath: symlinkParent,
+          folderName: "escaped-repo",
+          projectName: "Escaped Repo",
+        });
+        assert("clone parent symlink outside workspace → 403", escaped.status === 403);
+        let escapedStat: Awaited<ReturnType<typeof stat>> | undefined;
+        try {
+          escapedStat = await stat(join(outsideParent, "escaped-repo"));
+        } catch {
+          escapedStat = undefined;
+        }
+        assert("symlink escape target was not created", escapedStat === undefined);
+      } finally {
+        await rm(outsideParent, { recursive: true, force: true });
+      }
     } finally {
       await rm(sourceParent, { recursive: true, force: true });
     }


### PR DESCRIPTION
Summary
- Fix symlink escape risk in /projects/clone parent path validation.
- Add regression coverage for clone parent symlink escaping outside the workspace.
- Security/secrets review found no committed real secrets.

Usage
- /projects/clone now rejects parents that resolve outside WORKSPACE_PATH.

What changed
- Realpath workspace and clone parent before constructing the target path.
- Added inside-or-equal path helper.
- Added clone symlink escape test.

Test plan
- npx prettier --check packages/server/src/routes/projects.ts tests/test-clone.ts
- npx tsx tests/test-clone.ts