### PR TITLE
chore(release): v1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.3.5] — 2026-05-28
+
+### Added
+
+- **Agent guidance now standardizes worker worktrees and lighter formatting checks.**
+  Main agent instructions tell workers to create git worktrees under `.worktrees/`,
+  document the `npm run format:check` Prettier check, and remove release-bump
+  guidance that asked version-only PRs to run the full build/check/test loop.
+
+### Fixed
+
+- **Tool call batches render consistently outside assistant bubbles.** Chat now
+  splits tool calls out into timeline-level cards, batches adjacent calls across
+  assistant message boundaries in groups of up to 10, keeps `edit` and `write`
+  visible as standalone cards, and improves the batch-card header layout on
+  mobile.
+- **Clone target validation rejects symlink escapes.** `/projects/clone` now
+  resolves the workspace and clone parent before constructing the target path,
+  preventing a symlink inside the workspace from redirecting clone output outside
+  `WORKSPACE_PATH`.
+
 ## [1.3.4] — 2026-05-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "workspaces": [
         "packages/*"
       ],
@@ -17158,7 +17158,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17218,7 +17218,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.76.0",
         "@earendil-works/pi-ai": "0.76.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Summary
- Bump pi-forge packages from 1.3.4 to 1.3.5.
- Roll CHANGELOG.md from Unreleased to v1.3.5 with notes for the merged worker/tool batching, clone validation, and agent guidance changes.

Usage
- Release bump PR only; no runtime behavior beyond already-merged changes.

What changed
- Updated root, client, and server package versions.
- Updated package-lock version metadata.
- Added CHANGELOG.md v1.3.5 entry.

Test plan
- npx prettier --check CHANGELOG.md package.json package-lock.json packages/client/package.json packages/server/package.json