### PR TITLE
fix: kill terminal process on tab close

### DIFF
--- a/packages/server/src/routes/terminal.ts
+++ b/packages/server/src/routes/terminal.ts
@@ -5,7 +5,7 @@ import type { WebSocket } from "ws";
 import { extractBearer, verifyApiKey, verifyToken } from "../auth.js";
 import { authEnabled } from "../config.js";
 import { getProject } from "../project-manager.js";
-import { attachSink, findPtyByTabId, spawnPty } from "../pty-manager.js";
+import { attachSink, findPtyByTabId, killPty, spawnPty } from "../pty-manager.js";
 
 /**
  * WebSocket close codes used here. Per RFC 6455 §7.4, codes in
@@ -22,6 +22,10 @@ const CLOSE_INTERNAL_ERROR = 4500;
  *
  *   { type: "input",  data: string }            keystrokes
  *   { type: "resize", cols: number, rows: number } pty resize
+ *
+ * An intentional terminal-tab close is signalled by closing the
+ * WebSocket with reason `tab_closed`; ordinary socket drops detach
+ * for reattach instead.
  *
  * Server → client is raw bytes (the PTY's stdout). xterm consumes
  * those directly. We don't wrap them in JSON to avoid latency on
@@ -345,16 +349,25 @@ export const terminalRoutes: FastifyPluginAsync = async (fastify) => {
       });
 
       let disposed = false;
-      const cleanup = (reason: string): void => {
+      const cleanup = (reason: string, killOnClose = false): void => {
         if (disposed) return;
         disposed = true;
         clearInterval(keepAliveTimer);
         detach();
         exitDisposable.dispose();
-        // NB: no killPty here. The PTY is intentionally kept alive
-        // so a page-refresh / network blip can reattach. The idle
-        // reaper inside attachSink will GC it after IDLE_REAP_MS
-        // if no reconnect arrives.
+        if (killOnClose) {
+          // Explicit tab close is different from a transient WS drop:
+          // the user asked to close this terminal, so terminate the
+          // backing PTY (and any foreground process attached to it)
+          // immediately instead of keeping it alive for reattach.
+          killPty(managed.ptyId);
+          log.info({ ptyId: managed.ptyId, tabId: managed.tabId, reason }, "terminal closed");
+          return;
+        }
+        // NB: no killPty on ordinary WS close. The PTY is intentionally
+        // kept alive so a page-refresh / network blip can reattach. The
+        // idle reaper inside attachSink will GC it after IDLE_REAP_MS if
+        // no reconnect arrives.
         log.info({ ptyId: managed.ptyId, tabId: managed.tabId, reason }, "terminal detached");
       };
 
@@ -389,7 +402,9 @@ export const terminalRoutes: FastifyPluginAsync = async (fastify) => {
         }
       });
 
-      socket.on("close", () => cleanup("ws_close"));
+      socket.on("close", (_code: number, reason: Buffer) => {
+        cleanup("ws_close", reason.toString("utf8") === "tab_closed");
+      });
       socket.on("error", (err) => {
         log.warn({ err, ptyId: managed.ptyId }, "terminal websocket error");
         cleanup("ws_error");

--- a/tests/test-terminal.ts
+++ b/tests/test-terminal.ts
@@ -101,13 +101,14 @@ interface OpenedSocket {
  */
 function openTerminal(
   base: string,
-  query: { projectId: string; token?: string },
+  query: { projectId: string; token?: string; tabId?: string },
   onClose?: () => void,
 ): Promise<OpenedSocket> {
   return new Promise((resolveFn, rejectFn) => {
     const qs = new URLSearchParams();
     qs.set("projectId", query.projectId);
     if (query.token !== undefined) qs.set("token", query.token);
+    if (query.tabId !== undefined) qs.set("tabId", query.tabId);
     const url = `${base.replace(/^http/, "ws")}/api/v1/terminal?${qs.toString()}`;
     const ws = new WebSocket(url);
     const state: OpenedSocket = { ws, output: "", closed: false };
@@ -171,6 +172,19 @@ async function waitForShellReady(state: OpenedSocket, timeoutMs = 5_000): Promis
   while (Date.now() < deadline) {
     if (state.output.length > 0) return true;
     await new Promise((r) => setTimeout(r, 25));
+  }
+  return false;
+}
+
+async function waitForProcessGone(pid: number, timeoutMs = 3_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 50));
   }
   return false;
 }
@@ -384,6 +398,40 @@ async function main(): Promise<void> {
       assert("term2 sees its own marker", got2);
       assert("term1 does NOT see term2's marker", !term.output.includes(m2));
       assert("term2 does NOT see term1's marker", !term2.output.includes(m1));
+    }
+
+    // ---- Explicit tab close kills the backing PTY/process immediately ----
+    {
+      const tabId = "close-kills-" + randomBytes(4).toString("hex");
+      const term3 = await openTerminal(base, { projectId: project.id, token: apiKey, tabId });
+      assert("activePtys === 3 before explicit tab close", (await waitForPtyCount(base, 3)) === 3);
+      const ready3 = await waitForShellReady(term3);
+      assert("term3 shell flushed initial output", ready3, `output: ${term3.output.slice(-200)}`);
+
+      send(term3.ws, { type: "input", data: "sh -c 'echo CLOSE_PID=$$; sleep 30'\n" });
+      const sawPid = await waitForOutput(term3, "CLOSE_PID=", 5_000);
+      const pidMatch = /CLOSE_PID=(\d+)/.exec(term3.output);
+      const childPid = pidMatch !== null ? Number(pidMatch[1]) : undefined;
+      assert(
+        "foreground process started before close",
+        sawPid && childPid !== undefined,
+        `output: ${term3.output.slice(-400)}`,
+      );
+
+      const closed = new Promise<void>((res) => term3.ws.on("close", () => res()));
+      term3.ws.close(1000, "tab_closed");
+      await closed;
+      assert(
+        "activePtys drops after explicit tab close",
+        (await waitForPtyCount(base, 2, 1_000)) === 2,
+      );
+      if (childPid !== undefined) {
+        assert(
+          "foreground process exits after explicit tab close",
+          await waitForProcessGone(childPid),
+          `pid=${childPid}`,
+        );
+      }
     }
 
     // ---- Close cleanup ----


### PR DESCRIPTION
## Summary

Closing an integrated terminal tab used to only close the WebSocket. The server treated that the same as a transient disconnect, detached the PTY, and kept the shell/foreground process alive for the reattach grace window.

This PR makes explicit tab closes terminate the backing PTY immediately while preserving detach-and-reattach behavior for ordinary WebSocket drops, page reloads, and network blips.

## Usage

No new user-facing controls or configuration. Use the existing terminal tab close button; if a command is running in that tab, the backing PTY/process is terminated. Reload/reconnect behavior still uses the existing `tabId` reattach path.

## What changed (2 files, +71)

- `packages/server/src/routes/terminal.ts` — imports `killPty` and treats WebSocket close reason `tab_closed` as an explicit terminal close, killing the PTY immediately instead of arming idle reattach cleanup.
- `tests/test-terminal.ts` — adds coverage that opens a terminal with a stable tab id, starts a foreground `sleep`, closes with `tab_closed`, and asserts both PTY count and child process lifetime end promptly.

## Test plan

- [x] `npm run build`
- [x] `scripts/run-tests.sh --only terminal,pty-reattach`
- [x] `npx prettier --check packages/server/src/routes/terminal.ts tests/test-terminal.ts`
- [ ] CI green before merge
