### PR TITLE
chore: pin container Python to 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Changed
+
+- **Container images now use Python 3.12.** The Docker runtime, container docs,
+  and Docker smoke test now pin Python 3.12 for agent tooling and native-module
+  rebuild support.
+
 ## [1.3.5] — 2026-05-28
 
 ### Added

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Multi-stage Dockerfile for pi-forge.
 #
 #   builder  → install deps, compile server TS, build Vite client
-#   runtime  → node:22-bookworm-slim with Python 3.14 + pip, compiled
+#   runtime  → node:22-bookworm-slim with Python 3.12 + pip, compiled
 #              output, and hoisted node_modules; runs as a non-root user.
 #
 # Why bookworm-slim and not alpine: the Node native-module ecosystem
@@ -16,14 +16,14 @@
 # integrated terminal (bash + readline + a real coreutils).
 
 # ---------- shared Node + Python base ----------
-FROM python:3.14-slim-bookworm AS python-base
+FROM python:3.12-slim-bookworm AS python-base
 
 FROM node:22-bookworm-slim AS node-python-base
 
 # Keep the final image lineage on the official Node image — pi-forge is a
 # Node app, so preserving Node/npm/corepack exactly as shipped is more
 # important than preserving the Python image as the final base. Copy the
-# official Python 3.14 runtime into /usr/local (Docker COPY merges into
+# official Python 3.12 runtime into /usr/local (Docker COPY merges into
 # the existing Node-owned tree without deleting Node/npm/corepack) and
 # install the Debian runtime libraries CPython extension modules commonly
 # link against.
@@ -123,7 +123,7 @@ ARG PGID=1000
 #     hygiene. curl for fetching, ca-certificates so HTTPS works, less
 #     so `git log` and similar pagers don't bomb, procps so `ps`/`top`
 #     are present for users debugging long-running tool processes.
-#   - python3/pip3: Python 3.14 package tooling from the official
+#   - python3/pip3: Python 3.12 package tooling from the official
 #     Python image. `python` and `py` are aliases for `python3`.
 #   - make, g++: native-module rebuild toolchain for people using the
 #     container as a development environment. `npm install` can rebuild

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -19,8 +19,8 @@ runtime (Node + native bindings), and makes deploys reproducible.
 
 | Stage | Base | Purpose |
 |---|---|---|
-| `python-base` | `python:3.14-slim-bookworm` | Source for the Python 3.14 + pip runtime copied into the shared Node base |
-| `node-python-base` | `node:22-bookworm-slim` | Shared Debian slim base with Node.js 22 plus Python 3.14 + pip |
+| `python-base` | `python:3.12-slim-bookworm` | Source for the Python 3.12 + pip runtime copied into the shared Node base |
+| `node-python-base` | `node:22-bookworm-slim` | Shared Debian slim base with Node.js 22 plus Python 3.12 + pip |
 | `builder` | `node-python-base` | Installs all deps including devDeps, compiles native bindings (`node-pty`), runs `npm run build` for both packages |
 | `runtime` | `node-python-base` | Production deps + built artifacts only. Adds `git`, `ripgrep`, `bash`, `curl`, `less`, `procps`, and the C++ toolchain needed for native-module rebuilds during in-container development. Runs as non-root `pi`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
 
@@ -31,7 +31,7 @@ prebuilds; on musl, those packages fall back to source builds.
 Installed at runtime:
 
 - **Node.js 22**
-- **Python 3.14 + pip** — callable as `python3`, `python`, or `py`
+- **Python 3.12 + pip** — callable as `python3`, `python`, or `py`
 - **`tini`** — init for signal forwarding + zombie reaping
 - **`git`** — required by the agent's `bash` tool and the GitPanel routes
 - **`ripgrep`** — pi's `grep` tool delegates to `rg` when present;
@@ -69,7 +69,7 @@ conversation history. Override with `SESSION_DIR` to relocate.
 
 ### Persistent Python packages outside this project
 
-The image includes Python 3.14 and pip. Python is callable as `python3`,
+The image includes Python 3.12 and pip. Python is callable as `python3`,
 `python`, or `py`. The shipped compose file does not persist Python
 package installs by default. If you want package installs
 to survive image rebuilds/container replacement without storing them in
@@ -243,7 +243,7 @@ The native `node-pty` binding doesn't match the runtime Node version.
 Rebuild the image first: `docker compose up -d --build` (note `--build`).
 If you're using the running container as a development shell and running
 `npm install` against a bind-mounted checkout, the runtime image includes
-Python 3.14, `pip`, `make`, and `g++` so node-gyp can rebuild `node-pty`
+Python 3.12, `pip`, `make`, and `g++` so node-gyp can rebuild `node-pty`
 in place.
 
 ### Health check failing on first start

--- a/tests/test-docker.ts
+++ b/tests/test-docker.ts
@@ -6,7 +6,7 @@
  * - Brings the stack up on a unique container name + port to avoid clashing
  *   with whatever the developer might already have running.
  * - Polls `GET /api/v1/health` until 200, then asserts:
- *     - runtime image has Python 3.14 + pip and can rebuild `node-pty` from source
+ *     - runtime image has Python 3.12 + pip and can rebuild `node-pty` from source
  *       (dev-container npm install path)
  *     - `/manifest.webmanifest` returns 200 with `display: "standalone"`
  *     - `/sw.js` returns 200 (service worker present)
@@ -165,9 +165,9 @@ services:
     // pip, and the C++ build toolchain instead of only the builder stage
     // having them.
     const rebuildCommand = [
-      "python3 --version | grep -E '^Python 3\\.14\\.'",
-      "python --version | grep -E '^Python 3\\.14\\.'",
-      "py --version | grep -E '^Python 3\\.14\\.'",
+      "python3 --version | grep -E '^Python 3\\.12\\.'",
+      "python --version | grep -E '^Python 3\\.12\\.'",
+      "py --version | grep -E '^Python 3\\.12\\.'",
       "python3 -m pip --version",
       'test "$PYTHONUSERBASE" = /home/pi/.local',
       'test "$(python3 -m site --user-base)" = /home/pi/.local',
@@ -182,7 +182,7 @@ services:
       true,
     );
     assert(
-      "runtime image has Python 3.14/pip and can rebuild node-pty from source",
+      "runtime image has Python 3.12/pip and can rebuild node-pty from source",
       rebuild.status === 0,
       `exit=${rebuild.status}; stdout=${rebuild.stdout.slice(-1000)}; stderr=${rebuild.stderr.slice(-1000)}`,
     );


### PR DESCRIPTION
## Summary

The pi-forge container was still pinned to the Python 3.14 image/runtime in Docker configuration, docs, and the Docker smoke test. This PR updates the container to Python 3.12 so agent tooling and native-module rebuild support use the requested Python runtime.

## Usage

No operator workflow changes are required. Rebuild the container to pick up Python 3.12:

```bash
cd docker
docker compose up -d --build
python3 --version # inside the container should report Python 3.12.x
```

## What changed (4 files)

- `docker/Dockerfile` — changes the Python source stage to `python:3.12-slim-bookworm` and updates inline runtime comments.
- `docs/containers.md` — documents Python 3.12 across the image overview, runtime tool list, persistent Python package guidance, and troubleshooting.
- `tests/test-docker.ts` — updates the Docker smoke test to assert `python3`, `python`, and `py` all report Python 3.12.
- `CHANGELOG.md` — adds an Unreleased `### Changed` entry for the container Python runtime pin.

## Test plan

- [x] `npm run format:check`
- [x] `scripts/run-tests.sh --only docker` — passed, but Docker smoke was skipped because Docker is unavailable in this environment.
- [ ] Before release: run `scripts/run-tests.sh --only docker` on a Docker-enabled host and confirm the image builds and reports Python 3.12 at runtime.
- [ ] CI green before merge
