### PR TITLE
fix: nest orchestrator child sessions recursively

### DIFF
--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -134,7 +134,7 @@ export function SessionList({ projectId }: Props) {
   };
 
   /**
-   * Per-parent expansion state for the pi-subagents sub-agent dropdown.
+   * Per-parent expansion state for nested child/worker session dropdowns.
    * Tracks user TOGGLES — undefined entries inherit the default
    * (auto-expanded when the parent has children). Storing toggles
    * rather than absolute state means a freshly-discovered parent
@@ -161,30 +161,36 @@ export function SessionList({ projectId }: Props) {
    */
   const { topLevel, childrenByParent } = useMemo(() => {
     const childrenByParent = new Map<string, UnifiedSession[]>();
-    const topLevelIds = new Set(
-      sessions.filter((s) => s.parentSessionId === undefined).map((s) => s.sessionId),
-    );
+    const allIds = new Set(sessions.map((s) => s.sessionId));
     for (const s of sessions) {
       if (s.parentSessionId === undefined) continue;
-      if (!topLevelIds.has(s.parentSessionId)) continue; // orphan — keep at top level
+      if (!allIds.has(s.parentSessionId)) continue; // orphan — keep at top level
+      if (s.parentSessionId === s.sessionId) continue; // invalid self-cycle — keep visible
       const arr = childrenByParent.get(s.parentSessionId);
       if (arr === undefined) childrenByParent.set(s.parentSessionId, [s]);
       else arr.push(s);
     }
-    const topLevel = sessions.filter(
-      (s) => s.parentSessionId === undefined || !topLevelIds.has(s.parentSessionId),
+    let topLevel = sessions.filter(
+      (s) =>
+        s.parentSessionId === undefined ||
+        !allIds.has(s.parentSessionId) ||
+        s.parentSessionId === s.sessionId,
     );
+    // If malformed metadata creates a closed parent cycle, every row
+    // would otherwise disappear. Fall back to a flat list rather than
+    // hiding sessions from the sidebar.
+    if (topLevel.length === 0 && sessions.length > 0) topLevel = sessions;
     // One-shot diagnostic so a still-broken grouping report can be
     // triaged from the browser console: shows what parentSessionIds
     // came in on the wire and which buckets they landed in. Strip
-    // when the sub-agent UX stabilises.
+    // when nested-session UX stabilises.
     if (sessions.some((s) => s.parentSessionId !== undefined)) {
-      console.info("[subagent] SessionList grouping", {
+      console.info("[sessions] SessionList grouping", {
         projectId,
         sessionCount: sessions.length,
         topLevelCount: topLevel.length,
         childCount: Array.from(childrenByParent.values()).reduce((n, a) => n + a.length, 0),
-        topLevelIds: Array.from(topLevelIds),
+        allIds: Array.from(allIds),
         parentIdsOnChildren: sessions
           .filter((s) => s.parentSessionId !== undefined)
           .map((s) => s.parentSessionId),
@@ -250,6 +256,49 @@ export function SessionList({ projectId }: Props) {
     }
   };
 
+  const renderSessionRows = (
+    s: UnifiedSession,
+    depth: number,
+    ancestors: ReadonlySet<string>,
+  ): ReactNode[] => {
+    const children = childrenByParent.get(s.sessionId) ?? [];
+    // Default-collapsed: most parents have zero children, and a
+    // sweeping "show every run's child/worker sessions" expansion adds
+    // noise to the sidebar. User toggle persists.
+    const userToggle = expandedParents.get(s.sessionId);
+    const isExpanded = userToggle === true;
+    const rows: ReactNode[] = [
+      <SessionRow
+        key={s.sessionId}
+        session={s}
+        isActive={s.sessionId === activeSessionId}
+        isSelected={selectedIds.has(s.sessionId)}
+        isRenaming={renamingId === s.sessionId}
+        renameDraft={renameDraft}
+        childCount={children.length}
+        isExpanded={isExpanded}
+        depth={depth}
+        onSelect={selectSession}
+        onToggleSelect={toggleSelected}
+        onStartRename={startRename}
+        onChangeRename={setRenameDraft}
+        onRenameKeyDown={onRenameKeyDown}
+        onCommitRename={(id) => void commitRename(id)}
+        onToggleExpanded={toggleExpanded}
+        isArmedForDelete={armedDeleteId === s.sessionId}
+        onDeleteClick={onDeleteClick}
+      />,
+    ];
+    if (!isExpanded) return rows;
+    const nextAncestors = new Set(ancestors);
+    nextAncestors.add(s.sessionId);
+    for (const c of children) {
+      if (nextAncestors.has(c.sessionId)) continue;
+      rows.push(...renderSessionRows(c, depth + 1, nextAncestors));
+    }
+    return rows;
+  };
+
   return (
     // `mt-1` separates the first session row from the project row
     // above; without it, the active-row highlight backgrounds (both
@@ -287,63 +336,7 @@ export function SessionList({ projectId }: Props) {
         appear directly under their parent in DOM order, not as a
         separate group at the bottom of the list.
       */}
-      {topLevel.flatMap((s) => {
-        const children = childrenByParent.get(s.sessionId) ?? [];
-        // Default-collapsed: most parents have zero children, and a
-        // sweeping "show every run's sub-agents" expansion adds noise
-        // to the sidebar. User toggle persists.
-        const userToggle = expandedParents.get(s.sessionId);
-        const isExpanded = userToggle === true;
-        const rows: ReactNode[] = [
-          <SessionRow
-            key={s.sessionId}
-            session={s}
-            isActive={s.sessionId === activeSessionId}
-            isSelected={selectedIds.has(s.sessionId)}
-            isRenaming={renamingId === s.sessionId}
-            renameDraft={renameDraft}
-            childCount={children.length}
-            isExpanded={isExpanded}
-            isChild={false}
-            onSelect={selectSession}
-            onToggleSelect={toggleSelected}
-            onStartRename={startRename}
-            onChangeRename={setRenameDraft}
-            onRenameKeyDown={onRenameKeyDown}
-            onCommitRename={(id) => void commitRename(id)}
-            onToggleExpanded={toggleExpanded}
-            isArmedForDelete={armedDeleteId === s.sessionId}
-            onDeleteClick={onDeleteClick}
-          />,
-        ];
-        if (isExpanded) {
-          for (const c of children) {
-            rows.push(
-              <SessionRow
-                key={c.sessionId}
-                session={c}
-                isActive={c.sessionId === activeSessionId}
-                isSelected={selectedIds.has(c.sessionId)}
-                isRenaming={renamingId === c.sessionId}
-                renameDraft={renameDraft}
-                childCount={0}
-                isExpanded={false}
-                isChild={true}
-                onSelect={selectSession}
-                onToggleSelect={toggleSelected}
-                onStartRename={startRename}
-                onChangeRename={setRenameDraft}
-                onRenameKeyDown={onRenameKeyDown}
-                onCommitRename={(id) => void commitRename(id)}
-                onToggleExpanded={toggleExpanded}
-                isArmedForDelete={armedDeleteId === c.sessionId}
-                onDeleteClick={onDeleteClick}
-              />,
-            );
-          }
-        }
-        return rows;
-      })}
+      {topLevel.flatMap((s) => renderSessionRows(s, 0, new Set()))}
       <ConfirmDialog
         open={deleteDialog !== undefined}
         onClose={() => setDeleteDialog(undefined)}
@@ -365,11 +358,11 @@ interface SessionRowProps {
   isSelected: boolean;
   isRenaming: boolean;
   renameDraft: string;
-  /** Number of pi-subagents children for this session — drives chevron visibility. */
+  /** Number of nested child/worker sessions — drives chevron visibility. */
   childCount: number;
   isExpanded: boolean;
-  /** When true, render with extra left indent + nested-row treatment. */
-  isChild: boolean;
+  /** Nesting depth: 0 for top-level sessions, 1+ for children/workers. */
+  depth: number;
   onSelect: (sessionId: string) => void;
   onToggleSelect: (sessionId: string) => void;
   onStartRename: (sessionId: string, current: string) => void;
@@ -391,7 +384,7 @@ function SessionRow(props: SessionRowProps) {
     renameDraft,
     childCount,
     isExpanded,
-    isChild,
+    depth,
     onSelect,
     onToggleSelect,
     onStartRename,
@@ -415,7 +408,8 @@ function SessionRow(props: SessionRowProps) {
       // when unselected) so toggling selection doesn't shift content
       // by 2 px. Blue, not emerald, to disambiguate from any future
       // success / drop affordances on these rows.
-      className={`group flex items-center gap-1 rounded border-l-2 ${isChild ? "ml-4" : ""} px-2 py-0.5 text-xs ${
+      style={depth > 0 ? { marginLeft: `${Math.min(depth, 3) * 8}px` } : undefined}
+      className={`group flex items-center gap-1 rounded border-l-2 px-2 py-0.5 text-xs ${
         isSelected
           ? "border-blue-400 bg-blue-500/15 text-neutral-100 hover:bg-blue-500/25"
           : isActive
@@ -430,8 +424,8 @@ function SessionRow(props: SessionRowProps) {
         <button
           onClick={() => onToggleExpanded(s.sessionId, isExpanded)}
           className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-neutral-500 hover:text-neutral-200"
-          title={`${childCount} sub-agent session${childCount === 1 ? "" : "s"}`}
-          aria-label={isExpanded ? "Collapse sub-agents" : "Expand sub-agents"}
+          title={`${childCount} child/worker session${childCount === 1 ? "" : "s"}`}
+          aria-label={isExpanded ? "Collapse child sessions" : "Expand child sessions"}
         >
           {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         </button>
@@ -463,8 +457,11 @@ function SessionRow(props: SessionRowProps) {
           title={`${s.sessionId} — double-click to rename, Cmd/Ctrl+click to select for bulk delete`}
         >
           {s.isLive && <span className="mr-1 text-emerald-500 light:text-emerald-700">●</span>}
-          {isChild && (
-            <span className="mr-1 text-purple-400 light:text-purple-700" title="sub-agent">
+          {depth > 0 && (
+            <span
+              className="mr-1 text-purple-400 light:text-purple-700"
+              title="child/worker session"
+            >
               ↳
             </span>
           )}

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -291,9 +291,10 @@ export interface UnifiedSession {
   messageCount: number;
   firstMessage: string;
   /**
-   * Set when this session was spawned by the pi-subagents extension —
-   * the parent session's id. The sidebar groups children under their
-   * parent in a chevron dropdown.
+   * Set when this session should be nested under another session —
+   * pi-subagents children use their parent session id; orchestration
+   * workers use their supervisor/orchestrator session id. The sidebar
+   * groups children under their parent in a chevron dropdown.
    */
   parentSessionId?: string;
   /** pi-subagents run id when this is a child session. */

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -41,8 +41,8 @@ const unifiedSchema = {
     messageCount: { type: "integer", minimum: 0 },
     firstMessage: { type: "string" },
     /**
-     * Set on pi-subagents child sessions — the id of the session that
-     * spawned this sub-agent. Drives the sidebar's parent-row chevron
+     * Set when this row is nested under another session (pi-subagents child
+     * or orchestration worker). Drives the sidebar's parent-row chevron
      * grouping.
      */
     parentSessionId: { type: "string" },

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -31,7 +31,7 @@ import { createProcessTool } from "./processes/tool.js";
 import { processManager } from "./processes/manager.js";
 import { bridgeAgentSessionEvent, bridgeSessionCreated } from "./webhooks/event-bridge.js";
 import { isOrchestrationEnabled } from "./orchestration/config.js";
-import { isSupervisor } from "./orchestration/store.js";
+import { isSupervisor, readStore } from "./orchestration/store.js";
 import { createOrchestrationTools } from "./orchestration/tools.js";
 import { bridgeWorkerAgentEvent } from "./orchestration/event-bridge.js";
 import { notifySupervisorDisposed, notifySupervisorIdle } from "./orchestration/inbox.js";
@@ -122,7 +122,7 @@ export interface UnifiedSession {
   createdAt: Date;
   messageCount: number;
   firstMessage: string;
-  /** Parent session id when this is a pi-subagents child session. */
+  /** Parent session id when this is a nested child session (pi-subagents or orchestration). */
   parentSessionId?: string;
   /** pi-subagents run id when this is a child session. */
   runId?: string;
@@ -1329,6 +1329,34 @@ export async function listSessionsForProject(
     if (d.runId !== undefined) u.runId = d.runId;
     liveById.set(d.sessionId, u);
   }
+
+  // Orchestration workers are ordinary top-level pi sessions on disk, with
+  // their supervisor link stored in FORGE_DATA_DIR rather than in the JSONL
+  // path. Overlay that topology onto the unified list so the sidebar can
+  // render worker sessions beneath their supervisor the same way it nests
+  // pi-subagents child sessions. Existing disk-derived parentSessionId wins
+  // because those are true child JSONLs whose resume/delete semantics depend
+  // on the subdirectory layout.
+  try {
+    const orchestrationStore = await readStore();
+    for (const [workerId, rec] of Object.entries(orchestrationStore.workers)) {
+      const worker = liveById.get(workerId);
+      if (worker === undefined) continue;
+      if (worker.parentSessionId !== undefined) continue;
+      worker.parentSessionId = rec.supervisorId;
+    }
+  } catch (err) {
+    process.stderr.write(
+      JSON.stringify({
+        level: "warn",
+        time: new Date().toISOString(),
+        msg: "listSessionsForProject: failed to overlay orchestration worker links",
+        projectId,
+        err: err instanceof Error ? err.message : String(err),
+      }) + "\n",
+    );
+  }
+
   return Array.from(liveById.values()).sort(
     (a, b) => b.lastActivityAt.getTime() - a.lastActivityAt.getTime(),
   );

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -549,7 +549,7 @@ async function main(): Promise<void> {
       `/api/v1/sessions?projectId=${encodeURIComponent(realProjectId)}`,
     );
     const nestedWorker = (
-      nestedList.body as { sessions?: Array<{ sessionId: string; parentSessionId?: string }> }
+      nestedList.body as { sessions?: { sessionId: string; parentSessionId?: string }[] }
     ).sessions?.find((s) => s.sessionId === realWorkerId);
     assert(
       "session list nests orchestration worker under supervisor",
@@ -595,7 +595,7 @@ async function main(): Promise<void> {
       `/api/v1/sessions?projectId=${encodeURIComponent(realProjectId)}`,
     );
     const unnestedWorker = (
-      unnestedList.body as { sessions?: Array<{ sessionId: string; parentSessionId?: string }> }
+      unnestedList.body as { sessions?: { sessionId: string; parentSessionId?: string }[] }
     ).sessions?.find((s) => s.sessionId === realWorkerId);
     assert(
       "session list unnests worker after supervisor disable",

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -529,6 +529,34 @@ async function main(): Promise<void> {
       postEnable.status === 200 && (postEnable.body as { isLive: boolean }).isLive === true,
     );
 
+    // A worker is stored as an ordinary session, with the supervisor link in
+    // session-orchestration.json. The unified /sessions list overlays that
+    // link as parentSessionId so the sidebar can nest the worker under its
+    // orchestrator.
+    const realWorker = await jsend(onSrv.base, "POST", "/api/v1/sessions", {
+      projectId: realProjectId,
+    });
+    assert(
+      "create real worker session → 201",
+      realWorker.status === 201 &&
+        typeof (realWorker.body as { sessionId: string }).sessionId === "string",
+    );
+    const realWorkerId = (realWorker.body as { sessionId: string }).sessionId;
+    await store.registerWorker({ supervisorId: realSid, workerId: realWorkerId });
+    const nestedList = await jsend(
+      onSrv.base,
+      "GET",
+      `/api/v1/sessions?projectId=${encodeURIComponent(realProjectId)}`,
+    );
+    const nestedWorker = (
+      nestedList.body as { sessions?: Array<{ sessionId: string; parentSessionId?: string }> }
+    ).sessions?.find((s) => s.sessionId === realWorkerId);
+    assert(
+      "session list nests orchestration worker under supervisor",
+      nestedList.status === 200 && nestedWorker?.parentSessionId === realSid,
+      `parentSessionId=${nestedWorker?.parentSessionId}`,
+    );
+
     // SSE stream attach must NOT get 410 — there's no tombstone
     // since we never disposed. Fetch the stream briefly, capture
     // status, then close.
@@ -560,6 +588,19 @@ async function main(): Promise<void> {
     assert(
       "session still live after disable (not disposed)",
       postDisable.status === 200 && (postDisable.body as { isLive: boolean }).isLive === true,
+    );
+    const unnestedList = await jsend(
+      onSrv.base,
+      "GET",
+      `/api/v1/sessions?projectId=${encodeURIComponent(realProjectId)}`,
+    );
+    const unnestedWorker = (
+      unnestedList.body as { sessions?: Array<{ sessionId: string; parentSessionId?: string }> }
+    ).sessions?.find((s) => s.sessionId === realWorkerId);
+    assert(
+      "session list unnests worker after supervisor disable",
+      unnestedList.status === 200 && unnestedWorker?.parentSessionId === undefined,
+      `parentSessionId=${unnestedWorker?.parentSessionId}`,
     );
 
     // Plant some workers + inbox items via the store (since real

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -88,12 +88,21 @@ interface TestDiscovered {
   parentSessionId?: string;
   runId?: string;
 }
+interface TestUnifiedSession {
+  sessionId: string;
+  parentSessionId?: string;
+  runId?: string;
+}
 interface TestRegistry {
   createSession: (projectId: string, workspacePath: string) => Promise<TestLive>;
   disposeSession: (id: string) => Promise<boolean>;
   disposeAllSessions: () => Promise<void>;
   resumeSession: (id: string, projectId: string, workspacePath: string) => Promise<TestLive>;
   discoverSessionsOnDisk: (projectId: string, workspacePath: string) => Promise<TestDiscovered[]>;
+  listSessionsForProject: (
+    projectId: string,
+    workspacePath: string,
+  ) => Promise<TestUnifiedSession[]>;
   findSessionLocation: (
     id: string,
   ) => Promise<{ projectId: string; workspacePath: string } | undefined>;
@@ -102,6 +111,30 @@ interface TestRegistry {
 }
 interface TestProjectManager {
   createProject: (name: string, path: string) => Promise<{ id: string; path: string }>;
+}
+interface TestOrchestrationStore {
+  enableSupervisor: (sessionId: string) => Promise<unknown>;
+  registerWorker: (opts: { supervisorId: string; workerId: string }) => Promise<void>;
+}
+
+function appendFixtureMessage(live: TestLive, text: string): void {
+  live.session.sessionManager.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text, id: "stub-1" }],
+    api: "messages",
+    provider: "anthropic",
+    model: "test-fixture",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  });
 }
 
 async function main(): Promise<void> {
@@ -115,6 +148,9 @@ async function main(): Promise<void> {
   const pm = (await import(
     resolve(repoRoot, "packages/server/dist/project-manager.js")
   )) as unknown as TestProjectManager;
+  const orchestrationStore = (await import(
+    resolve(repoRoot, "packages/server/dist/orchestration/store.js")
+  )) as unknown as TestOrchestrationStore;
 
   // Register the project so findSessionLocation can locate children.
   const project = await pm.createProject("test-subagent-project", workspacePath);
@@ -130,23 +166,7 @@ async function main(): Promise<void> {
     // the live-test pattern in tests/test-session.ts). Inject a
     // minimal assistant message so the parent's JSONL header lands on
     // disk and `discoverSessionsOnDisk` can see it.
-    parent.session.sessionManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "test fixture", id: "stub-1" }],
-      api: "messages",
-      provider: "anthropic",
-      model: "test-fixture",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: Date.now(),
-    });
+    appendFixtureMessage(parent, "test fixture");
 
     // 2. Fake a pi-subagents child JSONL nested under the parent's id.
     //    Layout: <sessionDir>/<projectId>/<parentId>/<runId>/<childId>.jsonl
@@ -185,6 +205,42 @@ async function main(): Promise<void> {
     assert(
       "parent session has no parentSessionId / runId tagging",
       parentEntry?.parentSessionId === undefined && parentEntry?.runId === undefined,
+    );
+
+    // 3b. Mixed hierarchy regression: orchestration workers are top-level
+    // sessions whose supervisor link is overlaid from session-orchestration.json,
+    // while pi-subagents children are discovered from disk below their parent.
+    // When a worker uses a subagent, both links must coexist so the sidebar can
+    // render: orchestrator -> worker -> subagent.
+    const orchestrator = await registry.createSession(project.id, project.path);
+    appendFixtureMessage(orchestrator, "orchestrator fixture");
+    const worker = await registry.createSession(project.id, project.path);
+    appendFixtureMessage(worker, "worker fixture");
+    await orchestrationStore.enableSupervisor(orchestrator.sessionId);
+    await orchestrationStore.registerWorker({
+      supervisorId: orchestrator.sessionId,
+      workerId: worker.sessionId,
+    });
+    const workerSubagentId = randomUUID();
+    const workerSubagentRunId = "run-" + randomUUID().slice(0, 8);
+    await writeChildSessionFile(
+      join(projectSessionDir, worker.sessionId, workerSubagentRunId, `${workerSubagentId}.jsonl`),
+      workerSubagentId,
+      project.path,
+    );
+    const mixedList = await registry.listSessionsForProject(project.id, project.path);
+    const workerRow = mixedList.find((s) => s.sessionId === worker.sessionId);
+    const workerSubagentRow = mixedList.find((s) => s.sessionId === workerSubagentId);
+    assert(
+      "orchestration worker is nested under orchestrator in unified list",
+      workerRow?.parentSessionId === orchestrator.sessionId,
+      `parentSessionId=${workerRow?.parentSessionId}`,
+    );
+    assert(
+      "worker subagent remains nested under the worker in unified list",
+      workerSubagentRow?.parentSessionId === worker.sessionId &&
+        workerSubagentRow?.runId === workerSubagentRunId,
+      `parentSessionId=${workerSubagentRow?.parentSessionId} runId=${workerSubagentRow?.runId}`,
     );
 
     // 4. findSessionLocation resolves the child to its project.


### PR DESCRIPTION
## Summary

Orchestration worker sessions were surfaced as top-level sessions, and the sessions pane only grouped one nesting level. That meant an orchestrator's worker could be nested, but a pi-subagents child created by that worker did not render beneath the worker.

This PR overlays orchestration worker links onto the unified session list and renders the sidebar as a recursive hierarchy, so mixed relationships display as `orchestrator -> worker -> subagent`. It also reduces nested row indentation so deep hierarchies stay compact.

## Usage

No new operator-facing commands. In the browser sessions pane, expanding an orchestrator now shows worker sessions, and expanding a worker shows any pi-subagents child sessions it created.

## What changed (6 files)

- `packages/server/src/session-registry.ts` — overlays orchestration worker supervisor links onto `UnifiedSession.parentSessionId` while preserving disk-derived pi-subagents parent links.
- `packages/server/src/routes/sessions.ts` — updates the `parentSessionId` schema comment to describe both pi-subagents and orchestration workers.
- `packages/client/src/components/SessionList.tsx` — changes grouping/rendering from one-level buckets to recursive session rows, with compact normalized indentation and cycle/orphan safeguards.
- `packages/client/src/lib/api-client/types.ts` — documents `parentSessionId` as the generic nested-session linkage for pi-subagents and orchestration workers.
- `tests/test-orchestration.ts` — verifies orchestration workers are nested under supervisors and un-nested after disable.
- `tests/test-subagent-discovery.ts` — adds regression coverage for `orchestrator -> worker -> subagent` hierarchy.

## Test plan

- [x] `npx prettier --check packages/client/src/components/SessionList.tsx tests/test-subagent-discovery.ts tests/test-orchestration.ts packages/server/src/session-registry.ts packages/server/src/routes/sessions.ts packages/client/src/lib/api-client/types.ts`
- [x] `npm run build`
- [x] `scripts/run-tests.sh --only subagent-discovery,orchestration`
- [x] Manual/user verification of nested orchestrator behavior