### PR TITLE
fix: refresh sessions after worker spawn

### DIFF
--- a/packages/server/src/sse-bridge.ts
+++ b/packages/server/src/sse-bridge.ts
@@ -100,6 +100,21 @@ const COMPACTION_START_PADDING_BYTES = 2048;
 const COMPACTION_START_PADDING_LINE = `: pad-flush ${"_".repeat(COMPACTION_START_PADDING_BYTES - 14)}\n\n`;
 
 /**
+ * One-shot padding flush for tiny forge-native session-list nudges.
+ *
+ * `session_list_changed` is intentionally a small event (usually just
+ * projectId + reason), which makes it vulnerable to L7 proxy buffering in
+ * the exact path where users need it most: long-running supervisor turns
+ * that spawn a worker, then continue working while the sidebar should update.
+ * Follow the data frame with a padded SSE comment so nginx/HAProxy/Vite proxy
+ * release it immediately instead of batching it with a later heartbeat.
+ */
+const SESSION_LIST_CHANGED_PADDING_BYTES = 2048;
+const SESSION_LIST_CHANGED_PADDING_LINE = `: session-list-changed ${"_".repeat(
+  SESSION_LIST_CHANGED_PADDING_BYTES - 24,
+)}\n\n`;
+
+/**
  * One-shot snapshot event sent immediately on SSE connect so the browser can
  * hydrate full session state without a separate HTTP round-trip.
  */
@@ -154,6 +169,10 @@ const ALLOWED_EVENT_TYPES = new Set<string>([
   "process_update",
   "process_output",
   "process_watch",
+  // Forge-native session-list invalidation used when tools create sessions
+  // out-of-band relative to the user's current sidebar list: pi-subagents'
+  // `subagent` and orchestration's `orchestrate_spawn_worker`.
+  "session_list_changed",
 ]);
 
 export function isAllowedEvent(event: { type: string }): boolean {
@@ -447,6 +466,9 @@ export function createSSEClient(reply: FastifyReply, live: LiveSession): SSEClie
       // Cheap — fires at most once per compaction, ~2KB on the wire.
       if (event.type === "compaction_start") {
         writeRaw(COMPACTION_START_PADDING_LINE);
+      }
+      if (event.type === "session_list_changed") {
+        writeRaw(SESSION_LIST_CHANGED_PADDING_LINE);
       }
     };
 

--- a/tests/test-sse.ts
+++ b/tests/test-sse.ts
@@ -106,6 +106,10 @@ async function main(): Promise<void> {
   assert("isAllowedEvent('agent_start') === true", bridge.isAllowedEvent({ type: "agent_start" }));
   assert("isAllowedEvent('snapshot') === true", bridge.isAllowedEvent({ type: "snapshot" }));
   assert(
+    "isAllowedEvent('session_list_changed') === true",
+    bridge.isAllowedEvent({ type: "session_list_changed" }),
+  );
+  assert(
     "isAllowedEvent('session_info_changed') === false (filtered)",
     !bridge.isAllowedEvent({ type: "session_info_changed" }),
   );
@@ -237,7 +241,34 @@ async function main(): Promise<void> {
     }
     assert("client count drops to 1 after first abort", live.clients.size === 1);
 
-    // 8. Unknown sessionId → 404.
+    // 8. Forge-native session-list invalidation events must pass the
+    // bridge filter. worker_spawn relies on this synthetic event to
+    // refresh the sidebar immediately (including through proxy paths).
+    const remainingClient = [...live.clients][0];
+    remainingClient?.send({
+      type: "session_list_changed",
+      reason: "test_spawn_worker",
+      projectId,
+      sessionId: "worker-test",
+    });
+    const listChanged = await Promise.race([
+      (async (): Promise<{ type: string }> => {
+        while (true) {
+          const evt = await readUntilEvent();
+          if (evt.type === "session_list_changed") return evt;
+        }
+      })(),
+      new Promise<{ type: string }>((resolve) =>
+        setTimeout(() => resolve({ type: "__timeout__" }), 1000),
+      ),
+    ]);
+    assert(
+      "session_list_changed is delivered over SSE",
+      listChanged.type === "session_list_changed",
+      `type=${listChanged.type}`,
+    );
+
+    // 9. Unknown sessionId → 404.
     const res404 = await fetch(
       `${listenAddr}/api/v1/sessions/00000000-0000-0000-0000-000000000000/stream`,
       { headers: { Accept: "text/event-stream" } },
@@ -254,7 +285,7 @@ async function main(): Promise<void> {
       // expected
     }
 
-    // 9. Optional: live prompt with PI_TEST_LIVE_PROMPT=1.
+    // 10. Optional: live prompt with PI_TEST_LIVE_PROMPT=1.
     if (process.env.PI_TEST_LIVE_PROMPT === "1") {
       console.log("\n[test-sse] PI_TEST_LIVE_PROMPT=1 — running live prompt");
       const promptSession = await registry.createSession(projectId, workspacePath);


### PR DESCRIPTION
## Summary

Session pane refreshes could miss worker sessions created by `orchestrate_spawn_worker`, especially through buffering proxy paths. The server was already emitting a synthetic `session_list_changed` nudge, but the SSE bridge did not allow that forge-native event through its filter. Even once allowed, the small frame can be buffered by L7 proxies during long supervisor turns.

This PR allows `session_list_changed` through the SSE bridge and follows it with a padded comment flush so browser clients receive the refresh nudge promptly and reload the project session list.

## Usage

No direct operator action required. When a supervisor uses `orchestrate_spawn_worker`, connected session streams now deliver `session_list_changed`, and the existing client handler calls `loadSessionsForProject(projectId)`.

## What changed (2 files, +55)

- `packages/server/src/sse-bridge.ts` — adds `session_list_changed` to the SSE allowlist and writes a 2KB padded flush comment after those events to defeat proxy buffering.
- `tests/test-sse.ts` — verifies `session_list_changed` is allowed by the bridge and delivered over an active SSE stream.

## Test plan

- [x] `npm run build`
- [x] `npm run format:check`
- [x] `scripts/run-tests.sh --only sse`
- [x] Manual/user CPP check: worker spawn refresh appears to work over proxy
- [ ] CI green before merge
