### PR TITLE
fix(mcp): restart stdio tools before sessions

### DIFF
--- a/packages/server/src/mcp/manager.ts
+++ b/packages/server/src/mcp/manager.ts
@@ -97,6 +97,8 @@ const loadedProjects = new Set<string>();
  * have to do file I/O.
  */
 let globallyEnabled = true;
+let globalLoaded = false;
+let globalLoadPromise: Promise<void> | undefined;
 
 export function isGloballyEnabled(): boolean {
   return globallyEnabled;
@@ -105,9 +107,25 @@ export function isGloballyEnabled(): boolean {
 /* ----------------------------- public API ----------------------------- */
 
 export async function loadGlobal(): Promise<void> {
+  if (globalLoadPromise !== undefined) return globalLoadPromise;
+  globalLoadPromise = loadGlobalNow();
+  try {
+    await globalLoadPromise;
+  } finally {
+    globalLoadPromise = undefined;
+  }
+}
+
+export async function ensureGlobalLoaded(): Promise<void> {
+  if (globalLoaded) return;
+  await loadGlobal();
+}
+
+async function loadGlobalNow(): Promise<void> {
   const cfg = await readMcpJson();
   globallyEnabled = cfg.disabled !== true;
   await syncScope("global", cfg.servers);
+  globalLoaded = true;
 }
 
 export async function loadProject(projectId: string, projectPath: string): Promise<void> {
@@ -129,7 +147,12 @@ export async function ensureProjectLoaded(projectId: string, projectPath: string
  */
 export async function reloadGlobal(): Promise<void> {
   loadedProjects.clear(); // project files may reference globals too
-  await loadGlobal();
+  globalLoadPromise = loadGlobalNow();
+  try {
+    await globalLoadPromise;
+  } finally {
+    globalLoadPromise = undefined;
+  }
 }
 
 /**
@@ -323,6 +346,8 @@ export async function disposeAll(): Promise<void> {
   pool.clear();
   loadedProjects.clear();
   cachedProjectPaths.clear();
+  globalLoaded = false;
+  globalLoadPromise = undefined;
 }
 
 /* ----------------------------- internals ----------------------------- */
@@ -338,6 +363,7 @@ async function syncScope(scope: Scope, configs: Record<string, McpServerConfig>)
       pool.delete(key);
     }
   }
+  const toConnect: PoolEntry[] = [];
   // Add / update each declared server.
   for (const [name, cfg] of Object.entries(configs)) {
     const key = entryKey(scope, name);
@@ -346,8 +372,12 @@ async function syncScope(scope: Scope, configs: Record<string, McpServerConfig>)
       const sameEnabled = (existing.config.enabled !== false) === (cfg.enabled !== false);
       const sameConnectionFields = sameConnectionConfig(existing.config, cfg);
       existing.config = cfg;
-      if (sameEnabled && sameConnectionFields) {
-        // Nothing meaningful changed; skip the disconnect/reconnect dance.
+      if (sameEnabled && sameConnectionFields && existing.state === "connected") {
+        // Nothing meaningful changed and the server is already usable;
+        // skip the disconnect/reconnect dance. If the previous attempt
+        // failed or the entry is idle (for example after a teardown-style
+        // reset), retry so persisted stdio servers can come back without a
+        // manual Probe click.
         continue;
       }
       await disconnectEntry(existing);
@@ -355,7 +385,7 @@ async function syncScope(scope: Scope, configs: Record<string, McpServerConfig>)
         existing.state = "disabled";
         continue;
       }
-      void connectEntry(existing);
+      toConnect.push(existing);
       continue;
     }
     const entry: PoolEntry = {
@@ -368,8 +398,11 @@ async function syncScope(scope: Scope, configs: Record<string, McpServerConfig>)
     };
     pool.set(key, entry);
     if (cfg.enabled !== false) {
-      void connectEntry(entry);
+      toConnect.push(entry);
     }
+  }
+  for (const entry of toConnect) {
+    await connectEntry(entry);
   }
 }
 

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -18,6 +18,7 @@ import { discoverExtensionResources } from "./extensions-discovery.js";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import {
   customToolsForProject as mcpCustomToolsForProject,
+  ensureGlobalLoaded as mcpEnsureGlobalLoaded,
   ensureProjectLoaded as mcpEnsureProjectLoaded,
   isGloballyEnabled as mcpIsGloballyEnabled,
 } from "./mcp/manager.js";
@@ -1809,13 +1810,16 @@ async function buildSessionSettingsManager(
  *
  * Honors the master `disabled` toggle in mcp.json: if MCP is globally
  * off, returns an empty array regardless of per-server state. Boot-
- * time `loadGlobal()` is called in index.ts; project-scope is loaded
- * lazily here on first session-create per project.
+ * time `loadGlobal()` is called in index.ts, but session creation also
+ * awaits the manager's global load/restart gate so a fast browser
+ * reconnect after container recreation does not create an AgentSession
+ * before persisted stdio MCP servers have respawned.
  */
 async function resolveMcpCustomTools(
   projectId: string,
   workspacePath: string,
 ): Promise<ReturnType<typeof mcpCustomToolsForProject>> {
+  await mcpEnsureGlobalLoaded().catch(() => undefined);
   if (!mcpIsGloballyEnabled()) return [];
   await mcpEnsureProjectLoaded(projectId, workspacePath).catch(() => undefined);
   return mcpCustomToolsForProject(projectId);

--- a/tests/test-mcp-stdio.ts
+++ b/tests/test-mcp-stdio.ts
@@ -5,6 +5,7 @@
  * at `tests/fixtures/mcp-stdio-fixture.mjs`. Coverage:
  *
  *   - global stdio entry: load → spawn → list tools → execute
+ *   - dispose/re-load (container-recreation shape) respawns persisted stdio tools
  *   - env redaction: GET returns sentinel; PUT round-trips real value
  *   - project stdio entry: gated by trust → `trust_required` state
  *   - POST /mcp/trust grants → reconnects → tools appear
@@ -85,9 +86,9 @@ async function main(): Promise<void> {
     resolve(repoRoot, "packages/server/dist/mcp/config.js")
   )) as typeof import("../packages/server/src/mcp/config.js");
 
-  // Wait for an entry to leave `connecting` (the manager fires
-  // connect attempts fire-and-forget from syncScope, so loadGlobal /
-  // upsert routes return before the subprocess handshake finishes).
+  // Wait for an entry to reach an expected state. Most manager loads now
+  // await connect attempts, but route-triggered reconnects still benefit
+  // from a small poll while the HTTP response and status view settle.
   type ConnectionState =
     | "idle"
     | "connecting"
@@ -128,7 +129,7 @@ async function main(): Promise<void> {
       },
     });
     await managerModule.loadGlobal();
-    const connected = await waitForState("local", "connected");
+    const connected = managerModule.getStatus().find((s) => s.name === "local");
     assert(
       "global stdio: state === connected",
       connected?.state === "connected",
@@ -173,7 +174,33 @@ async function main(): Promise<void> {
       assert("subprocess env: MCP_TEST_VAR_B passed through", out.includes("value-B"), out);
     }
 
-    /* ===== Case D: env values are redacted on the GET path ===== */
+    /* ===== Case D: dispose/re-load respawns persisted stdio tools ===== */
+    await managerModule.disposeAll();
+    await managerModule.loadGlobal();
+    const restarted = managerModule.getStatus().find((s) => s.name === "local");
+    assert(
+      "stdio restart: loadGlobal awaited connected state",
+      restarted?.state === "connected" && restarted.toolCount === 2,
+      JSON.stringify(restarted),
+    );
+    const restartedTools = managerModule.customToolsForProject("any-project-id");
+    const restartedEcho = restartedTools.find((t) => t.name === "local__echo");
+    assert("stdio restart: echo tool present after reload", restartedEcho !== undefined);
+    if (restartedEcho !== undefined) {
+      const result = await restartedEcho.execute(
+        "tcid-restart",
+        { text: "after-restart" },
+        undefined,
+        undefined,
+        {} as Parameters<typeof restartedEcho.execute>[4],
+      );
+      assert(
+        "stdio restart: restarted subprocess handles calls",
+        JSON.stringify(result).includes("after-restart"),
+      );
+    }
+
+    /* ===== Case E: env values are redacted on the GET path ===== */
     {
       const r = await jget(base, "/api/v1/mcp/servers");
       assert("GET /mcp/servers → 200", r.status === 200);
@@ -189,7 +216,7 @@ async function main(): Promise<void> {
       );
     }
 
-    /* ===== Case E: sentinel round-trip on save preserves prior value ===== */
+    /* ===== Case F: sentinel round-trip on save preserves prior value ===== */
     {
       // The UI sees `***REDACTED***`. Save without changing it.
       const r = await jsend(base, "PUT", "/api/v1/mcp/servers/local", {
@@ -217,7 +244,7 @@ async function main(): Promise<void> {
       );
     }
 
-    /* ===== Case F: one-of url/command validation ===== */
+    /* ===== Case G: one-of url/command validation ===== */
     {
       const both = await jsend(base, "PUT", "/api/v1/mcp/servers/bad-both", {
         url: "https://example.com",
@@ -234,7 +261,7 @@ async function main(): Promise<void> {
       );
     }
 
-    /* ===== Case G: crash-on-start surfaces in `error` state ===== */
+    /* ===== Case H: crash-on-start surfaces in `error` state ===== */
     {
       await jsend(base, "PUT", "/api/v1/mcp/servers/crasher", {
         command: "node",
@@ -249,7 +276,7 @@ async function main(): Promise<void> {
       );
     }
 
-    /* ===== Case H: project stdio entry is gated by trust ===== */
+    /* ===== Case I: project stdio entry is gated by trust ===== */
     // Create a project + drop a project .mcp.json with a stdio entry.
     const projRes = await jsend(base, "POST", "/api/v1/projects", {
       name: "stdio-trust-test",
@@ -297,7 +324,7 @@ async function main(): Promise<void> {
       );
     }
 
-    /* ===== Case I: granting trust spawns the subprocess + surfaces tools ===== */
+    /* ===== Case J: granting trust spawns the subprocess + surfaces tools ===== */
     {
       const grant = await jsend(base, "POST", `/api/v1/mcp/trust/${projectId}`);
       assert("POST /mcp/trust → 200", grant.status === 200);
@@ -320,7 +347,7 @@ async function main(): Promise<void> {
       );
     }
 
-    /* ===== Case J: revoke trust unloads the project pool ===== */
+    /* ===== Case K: revoke trust unloads the project pool ===== */
     {
       const revoke = await jsend(base, "DELETE", `/api/v1/mcp/trust/${projectId}`);
       assert("DELETE /mcp/trust → 200", revoke.status === 200);
@@ -352,7 +379,7 @@ async function main(): Promise<void> {
       );
     }
 
-    /* ===== Case K: project delete cascades the trust entry ===== */
+    /* ===== Case L: project delete cascades the trust entry ===== */
     {
       // Re-grant so the trust file actually has an entry to clear.
       await jsend(base, "POST", `/api/v1/mcp/trust/${projectId}`);


### PR DESCRIPTION
## Summary

Stdio MCP servers could be persisted in `FORGE_DATA_DIR/mcp.json` but not be available to a newly-created agent session after the pi-forge container/server was recreated. The global MCP bootstrap was fire-and-forget, so a fast reconnect/session creation path could capture `customTools` before persisted stdio servers had respawned and listed their tools.

This PR makes global MCP loading/reloading await connection attempts and adds a session creation guard that waits for the global MCP load gate before resolving MCP custom tools.

## Usage

No operator-facing changes. Existing persisted stdio MCP server entries continue to be configured through Settings → MCP / `mcp.json`; after a server or container restart they are respawned before new sessions collect MCP tools.

## What changed (3 files, +83/-19)

- `packages/server/src/mcp/manager.ts` — tracks global MCP load state, serializes concurrent loads, awaits connection attempts during scope sync, retries idle/error entries on reload, and resets load state on dispose.
- `packages/server/src/session-registry.ts` — waits for global MCP loading before building the MCP `customTools` list for a session.
- `tests/test-mcp-stdio.ts` — adds regression coverage for dispose/re-load restart behavior and verifies the respawned stdio MCP subprocess still executes tools.

## Test plan

- [x] `npm run check` (passes with existing unrelated ESLint warning in `packages/client/src/App.tsx:206`)
- [x] `scripts/run-tests.sh --only mcp-stdio,mcp`
- [x] Manual verification by user: started dev server, configured stdio MCP, killed/restarted server, and confirmed the MCP tool came back.
