### PR TITLE
fix: pair archived tool calls in compaction history

### DIFF
--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -36,6 +36,12 @@ import { useQuickActionRunsStore } from "../store/quick-actions-store";
 import { parseSubagentDetails, type SubagentResult } from "../lib/subagent-parser";
 import { OrchestrationPanel } from "./OrchestrationPanel";
 import { useUiConfigStore } from "../store/ui-config-store";
+import {
+  buildToolCallPairing,
+  getToolCallId,
+  isPairedToolResult,
+  isToolCallBlock,
+} from "../lib/tool-call-pairing";
 
 /**
  * Per-ChatView diff view-type preference. Each diff-rendering surface
@@ -376,21 +382,8 @@ export function ChatView({ sessionId }: Props) {
               // of two separate boxes. Loose toolResults — orphans
               // from older sessions, or results whose call we never
               // saw — still render via the standalone path.
-              const toolResultsById = new Map<string, AgentMessageLike>();
-              const pairedIds = new Set<string>();
-              for (const m of messages) {
-                if (m.role === "toolResult" && typeof m.toolCallId === "string") {
-                  toolResultsById.set(m.toolCallId, m);
-                }
-              }
-              for (const m of messages) {
-                if (m.role !== "assistant" || !Array.isArray(m.content)) continue;
-                for (const block of m.content as Record<string, unknown>[]) {
-                  if (block.type === "toolCall" && typeof block.id === "string") {
-                    pairedIds.add(block.id);
-                  }
-                }
-              }
+              const toolPairing = buildToolCallPairing(messages);
+              const { toolResultsById } = toolPairing;
               // Group compactions by `insertBeforeIndex` so each
               // render-loop tick can ask "any cards land here?" in O(1).
               // Multiple compactions can share insertBeforeIndex=0 —
@@ -403,10 +396,9 @@ export function ChatView({ sessionId }: Props) {
                 list.push(ev);
                 compactionsAt.set(ev.insertBeforeIndex, list);
               }
-              const renderArchived = (ev: CompactionEvent): React.ReactNode =>
-                ev.archivedMessages.map((am, i) => (
-                  <Message key={i} message={am} toolResultsById={toolResultsById} />
-                ));
+              const renderArchived = (ev: CompactionEvent): React.ReactNode => (
+                <ArchivedMessages messages={ev.archivedMessages} />
+              );
               const out: React.ReactNode[] = [];
               let pendingBatch: ToolBatchEntry[] = [];
               let pendingBatchStartIndex = 0;
@@ -502,11 +494,7 @@ export function ChatView({ sessionId }: Props) {
               for (let i = 0; i < messages.length; i++) {
                 const m = messages[i]!;
                 renderCardsAt(i);
-                if (
-                  m.role === "toolResult" &&
-                  typeof m.toolCallId === "string" &&
-                  pairedIds.has(m.toolCallId)
-                ) {
+                if (isPairedToolResult(toolPairing, m)) {
                   continue; // rendered inline next to its toolCall
                 }
                 // Hide the SDK-synthesized compaction summary message
@@ -872,6 +860,92 @@ function FileRefBadge({ ref: r }: { ref: FileRef }) {
   );
 }
 
+function ArchivedMessages({ messages }: { messages: AgentMessageLike[] }) {
+  const toolPairing = buildToolCallPairing(messages);
+  const { toolResultsById } = toolPairing;
+  const out: React.ReactNode[] = [];
+  let pendingBatch: ToolBatchEntry[] = [];
+  let pendingBatchStartIndex = 0;
+  let renderedBatchSerial = 0;
+
+  const renderToolEntries = (entries: ToolBatchEntry[], key: string): React.ReactNode => {
+    const toolCount = countToolBatchCalls(entries);
+    const toolEntry = entries.find((entry) => entry.kind === "tool");
+    const hasThinking = entries.some((entry) => entry.kind === "thinking");
+    if (toolCount === 1 && !hasThinking && toolEntry !== undefined) {
+      return <ToolCallEntry key={key} block={toolEntry.block} result={toolEntry.result} />;
+    }
+    return <ToolCallBatchCard key={key} entries={entries} />;
+  };
+
+  const flushPendingBatch = (): void => {
+    if (pendingBatch.length === 0) return;
+    let chunk: ToolBatchEntry[] = [];
+    let chunkStart = pendingBatchStartIndex;
+    const pushChunk = (): void => {
+      if (chunk.length === 0) return;
+      const batchKey = `archived-tool-batch-${renderedBatchSerial}`;
+      out.push(
+        <div key={batchKey} data-message-index={chunkStart}>
+          {renderToolEntries(chunk, `${batchKey}-card`)}
+        </div>,
+      );
+      chunk = [];
+      renderedBatchSerial += 1;
+    };
+    for (const entry of pendingBatch) {
+      if (entry.kind === "tool" && countToolBatchCalls(chunk) >= MAX_TOOL_BATCH_SIZE) {
+        pushChunk();
+        chunkStart = pendingBatchStartIndex;
+      }
+      chunk.push(entry);
+    }
+    pushChunk();
+    pendingBatch = [];
+  };
+
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i]!;
+    if (isPairedToolResult(toolPairing, m)) continue;
+    if (m.role === "assistant" && Array.isArray(m.content)) {
+      const segments = splitAssistantToolSegments(
+        m.content as Record<string, unknown>[],
+        toolResultsById,
+      );
+      if (segments !== undefined) {
+        for (const [segmentIndex, segment] of segments.entries()) {
+          if (segment.kind === "tools" && segment.batchable) {
+            if (pendingBatch.length === 0) pendingBatchStartIndex = i;
+            pendingBatch.push(...segment.entries);
+            continue;
+          }
+          flushPendingBatch();
+          out.push(
+            <div key={`${i}-${segment.kind}-${segmentIndex}`} data-message-index={i}>
+              <AssistantRenderSegmentView
+                segment={segment}
+                message={m}
+                toolResultsById={toolResultsById}
+                showRaw={undefined}
+                setShowRaw={undefined}
+              />
+            </div>,
+          );
+        }
+        continue;
+      }
+    }
+    flushPendingBatch();
+    out.push(
+      <div key={i} data-message-index={i}>
+        <Message message={m} toolResultsById={toolResultsById} />
+      </div>,
+    );
+  }
+  flushPendingBatch();
+  return <>{out}</>;
+}
+
 function Message({
   message,
   toolResultsById,
@@ -1210,7 +1284,7 @@ function splitAssistantToolSegments(
     sawToolSegment = true;
 
     if (!isBatchableToolCall(block)) {
-      const id = typeof block.id === "string" ? block.id : undefined;
+      const id = getToolCallId(block);
       segments.push({
         kind: "tools",
         batchable: false,
@@ -1241,7 +1315,7 @@ function splitAssistantToolSegments(
         continue;
       }
       if (!isBatchableToolCall(current)) break;
-      const id = typeof current.id === "string" ? current.id : undefined;
+      const id = getToolCallId(current);
       entries.push({
         kind: "tool",
         block: current,
@@ -1285,11 +1359,11 @@ type ToolBatchEntry =
   | { kind: "thinking"; block: Record<string, unknown> };
 
 function isToolCall(block: Record<string, unknown> | undefined): boolean {
-  return block?.type === "toolCall";
+  return isToolCallBlock(block);
 }
 
 function isBatchableToolCall(block: Record<string, unknown> | undefined): boolean {
-  return block?.type === "toolCall" && !NON_BATCHABLE_TOOL_NAMES.has(String(block.name ?? ""));
+  return isToolCallBlock(block) && !NON_BATCHABLE_TOOL_NAMES.has(String(block.name ?? ""));
 }
 
 function isToolBatchThinkingBlock(block: Record<string, unknown> | undefined): boolean {
@@ -1442,8 +1516,8 @@ function AssistantBlock({
     );
   }
 
-  if (type === "toolCall") {
-    const id = typeof block.id === "string" ? block.id : undefined;
+  if (isToolCallBlock(block)) {
+    const id = getToolCallId(block);
     const result = id !== undefined ? toolResultsById?.get(id) : undefined;
     return <ToolCallEntry block={block} result={result} />;
   }

--- a/packages/client/src/lib/tool-call-pairing.ts
+++ b/packages/client/src/lib/tool-call-pairing.ts
@@ -1,0 +1,65 @@
+export interface PairableAgentMessage {
+  role?: string;
+  type?: string;
+  content?: unknown;
+  toolCallId?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Build the assistant-tool-call ↔ tool-result relationship for a transcript
+ * slice. Pi stores tool calls as `toolCall` blocks inside assistant messages
+ * and stores outputs as standalone `role: "toolResult"` messages keyed by
+ * `toolCallId`.
+ */
+export interface ToolCallPairing {
+  /** Tool result keyed by the assistant-side tool call id. */
+  toolResultsById: Map<string, PairableAgentMessage>;
+  /** Assistant-side tool call ids that have a matched standalone result. */
+  pairedIds: Set<string>;
+  /** Result message object identities that have been paired and should not render standalone. */
+  pairedResultMessages: Set<PairableAgentMessage>;
+}
+
+export function buildToolCallPairing(messages: readonly PairableAgentMessage[]): ToolCallPairing {
+  const toolResultsById = new Map<string, PairableAgentMessage>();
+  const pairedIds = new Set<string>();
+  const pairedResultMessages = new Set<PairableAgentMessage>();
+
+  const callIds = new Set<string>();
+  for (const m of messages) {
+    if (m.role !== "assistant" || !Array.isArray(m.content)) continue;
+    for (const block of m.content as Record<string, unknown>[]) {
+      if (!isToolCallBlock(block)) continue;
+      const id = getToolCallId(block);
+      if (id !== undefined) callIds.add(id);
+    }
+  }
+
+  for (const m of messages) {
+    if (m.role !== "toolResult" || typeof m.toolCallId !== "string") continue;
+    if (!callIds.has(m.toolCallId)) continue;
+    toolResultsById.set(m.toolCallId, m);
+    pairedIds.add(m.toolCallId);
+    pairedResultMessages.add(m);
+  }
+
+  return { toolResultsById, pairedIds, pairedResultMessages };
+}
+
+export function isPairedToolResult(
+  pairing: ToolCallPairing,
+  message: PairableAgentMessage,
+): boolean {
+  return pairing.pairedResultMessages.has(message);
+}
+
+export function isToolCallBlock(
+  block: Record<string, unknown> | undefined,
+): block is Record<string, unknown> {
+  return block?.type === "toolCall";
+}
+
+export function getToolCallId(block: Record<string, unknown>): string | undefined {
+  return typeof block.id === "string" && block.id.length > 0 ? block.id : undefined;
+}

--- a/tests/test-tool-call-pairing.ts
+++ b/tests/test-tool-call-pairing.ts
@@ -1,0 +1,108 @@
+import {
+  buildToolCallPairing,
+  isPairedToolResult,
+  type PairableAgentMessage,
+} from "../packages/client/src/lib/tool-call-pairing";
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`PASS ${label}`);
+    return;
+  }
+  failures += 1;
+  console.error(`FAIL ${label}${detail !== undefined ? ` — ${detail}` : ""}`);
+}
+
+function assistantToolCalls(ids: string[], names = ["grep", "read"]): PairableAgentMessage {
+  return {
+    role: "assistant",
+    content: ids.map((id, index) => ({
+      type: "toolCall",
+      id,
+      name: names[index] ?? "tool",
+      arguments: { path: `file-${index}.ts` },
+    })),
+  };
+}
+
+function toolResult(id: string, text: string, toolName = "grep"): PairableAgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: id,
+    toolName,
+    content: [{ type: "text", text }],
+  };
+}
+
+function visibleMessages(
+  messages: PairableAgentMessage[],
+  pairing = buildToolCallPairing(messages),
+) {
+  return messages.filter((m) => !isPairedToolResult(pairing, m));
+}
+
+async function main(): Promise<void> {
+  console.log("[test-tool-call-pairing] canonical tool call pairing");
+
+  const batchedMessages: PairableAgentMessage[] = [
+    { role: "user", content: [{ type: "text", text: "inspect files" }] },
+    assistantToolCalls(["call-a", "call-b"], ["grep", "read"]),
+    toolResult("call-a", "grep output", "grep"),
+    toolResult("call-b", "read output", "read"),
+  ];
+  const batchedPairing = buildToolCallPairing(batchedMessages);
+  assert("pairs first batched tool result", batchedPairing.toolResultsById.has("call-a"));
+  assert("pairs second batched tool result", batchedPairing.toolResultsById.has("call-b"));
+  assert("marks first result suppressible", batchedPairing.pairedIds.has("call-a"));
+  assert("marks second result suppressible", batchedPairing.pairedIds.has("call-b"));
+  assert(
+    "standalone paired outputs are suppressed",
+    visibleMessages(batchedMessages, batchedPairing).length === 2,
+    `visible length ${visibleMessages(batchedMessages, batchedPairing).length}`,
+  );
+
+  const archivedOneToolTurns: PairableAgentMessage[] = [
+    assistantToolCalls(["todo-1"], ["todo"]),
+    toolResult("todo-1", "Created #1", "todo"),
+    assistantToolCalls(["subagent-1"], ["subagent"]),
+    toolResult("subagent-1", "delegate finished", "subagent"),
+  ];
+  const archivedPairing = buildToolCallPairing(archivedOneToolTurns);
+  assert("pairs archived todo one-tool turn", archivedPairing.toolResultsById.has("todo-1"));
+  assert(
+    "pairs archived subagent one-tool turn",
+    archivedPairing.toolResultsById.has("subagent-1"),
+  );
+  assert(
+    "suppresses archived one-tool-turn outputs before batching render",
+    visibleMessages(archivedOneToolTurns, archivedPairing).length === 2,
+    `visible length ${visibleMessages(archivedOneToolTurns, archivedPairing).length}`,
+  );
+
+  const orphanMessages: PairableAgentMessage[] = [toolResult("orphan", "loose output")];
+  const orphanPairing = buildToolCallPairing(orphanMessages);
+  assert("orphan result stays visible", !isPairedToolResult(orphanPairing, orphanMessages[0]!));
+
+  const mismatchedIdMessages: PairableAgentMessage[] = [
+    assistantToolCalls(["call-real"], ["grep"]),
+    toolResult("call-replayed-different-id", "grep output after replay", "grep"),
+  ];
+  const mismatchedPairing = buildToolCallPairing(mismatchedIdMessages);
+  assert(
+    "does not pair mismatched ids by name/order",
+    !mismatchedPairing.toolResultsById.has("call-real"),
+  );
+  assert(
+    "mismatched result remains visible",
+    visibleMessages(mismatchedIdMessages, mismatchedPairing).length === 2,
+  );
+
+  if (failures > 0) {
+    console.log(`\n[test-tool-call-pairing] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-tool-call-pairing] PASS");
+}
+
+void main();


### PR DESCRIPTION
## Summary

Compaction history could show tool call inputs and outputs as separate entries, especially for pi-forge custom/plugin tools like `todo`, `process`, and `subagent`. The archived compaction drawer rendered each archived message directly through `Message`, bypassing the main chat timeline's tool-result pairing and consecutive-tool batching loop. Built-in tools sometimes still looked correct when multiple calls were emitted in one assistant message, but one-tool custom/plugin turns did not collapse consistently.

This PR extracts canonical tool call/result pairing into a shared helper and renders archived compaction messages through an `ArchivedMessages` timeline renderer that mirrors the main chat batching behavior.

## Usage

No new user-facing controls. Open a session with compaction history and expand a compaction card; archived tool calls/results now render as paired, collapsible tool entries, including consecutive one-tool turns from `todo` and `subagent`.

## What changed (3 files)

- `packages/client/src/components/ChatView.tsx` — uses shared tool-call pairing and adds `ArchivedMessages` so compaction drawers use the same consecutive-tool batching path as the main transcript.
- `packages/client/src/lib/tool-call-pairing.ts` — adds a small canonical helper for exact `toolCall.id` ↔ `toolResult.toolCallId` pairing and paired-result suppression.
- `tests/test-tool-call-pairing.ts` — adds focused regression coverage for canonical multi-call pairing, archived one-tool `todo`/`subagent` turns, orphan results, and mismatched IDs remaining unpaired.

## Test plan

- [x] `scripts/run-tests.sh --only tool-call-pairing`
- [x] `npm run build -w packages/client`
- [ ] CI green before merge
