### PR TITLE
fix(orchestration): suppress worker process alert escalation

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -119,7 +119,7 @@ types:
 | `worker.ended` | Worker's AgentSession emitted `agent_end` |
 | `worker.ask_user` | Worker called `ask_user_question` |
 | `worker.auto_retry_failed` | Worker's SDK auto-retry exhausted on a provider error |
-| `worker.process_alert` | A background process the worker spawned exited (success / failure / external kill) |
+| `worker.process_alert` | Not enqueued for worker process alerts; process success/failure/kill notifications stay in the worker session and do not wake the supervisor |
 | `worker.deleted` | Worker's session was deleted (cold or live) |
 
 When an event lands, the bridge enqueues it AND tries to wake the
@@ -259,8 +259,8 @@ supervisor. v1 disallows this by design — depth is capped at 1.
   agent events" surface. Webhooks fan out OVER HTTPS to external
   systems; orchestration fans IN to a supervisor session.
 - [`processes.md`](./processes.md) — workers can spawn background
-  processes the same way standalone sessions can; process alerts
-  fed back into the supervisor's inbox as `worker.process_alert`.
+  processes the same way standalone sessions can; process alerts stay
+  local to the worker session and do not wake the supervisor.
 - [`ask-user-question.md`](./ask-user-question.md) — when a worker
   calls this tool, the supervisor sees a `worker.ask_user` inbox
   item and can answer via `orchestrate_send_to_worker`.

--- a/packages/server/src/orchestration/event-bridge.ts
+++ b/packages/server/src/orchestration/event-bridge.ts
@@ -11,7 +11,7 @@
  *     - `ask_user_question` → inbox `worker.ask_user`
  *
  *   processManager (forge-native):
- *     - `process_alert`     → inbox `worker.process_alert`
+ *     - `process_alert` is intentionally not bridged to the supervisor inbox
  *
  *   session-registry lifecycle (sessions DELETE route):
  *     - cold/hot delete    → inbox `worker.deleted`
@@ -125,11 +125,22 @@ export async function bridgeWorkerAskUserQuestion(
   });
 }
 
+export function shouldBridgeWorkerProcessAlert(_reason: ProcessAlertReason): boolean {
+  // Worker process alerts are intentionally not escalated to the
+  // supervisor inbox. The worker session itself still receives the
+  // in-chat process alert because it explicitly requested an
+  // alertOn* notification, and the running worker agent can react
+  // locally. Waking the orchestrator for process success/failure/kill
+  // outcomes has proven too noisy and duplicative.
+  return false;
+}
+
 export async function bridgeWorkerProcessAlert(
   sessionId: string,
   info: ProcessInfo,
   reason: ProcessAlertReason,
 ): Promise<void> {
+  if (!shouldBridgeWorkerProcessAlert(reason)) return;
   await bridgeWorkerEvent(sessionId, "worker.process_alert", {
     reason,
     processId: info.id,

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -74,6 +74,23 @@ interface InboxModule {
   ) => Promise<{ id: string } | undefined>;
 }
 
+interface ProcessInfoStub {
+  id: string;
+  name: string;
+  pid: number | null;
+  exitCode: number | null;
+  success: boolean;
+}
+
+interface EventBridgeModule {
+  bridgeWorkerProcessAlert: (
+    workerId: string,
+    info: ProcessInfoStub,
+    reason: "success" | "failure" | "killed",
+  ) => Promise<void>;
+  shouldBridgeWorkerProcessAlert: (reason: "success" | "failure" | "killed") => boolean;
+}
+
 interface ToolResult {
   content: { type: string; text?: string }[];
   details?: unknown;
@@ -228,6 +245,9 @@ async function main(): Promise<void> {
   const inbox = (await import(
     resolve(repoRoot, "packages/server/dist/orchestration/inbox.js")
   )) as unknown as InboxModule;
+  const eventBridge = (await import(
+    resolve(repoRoot, "packages/server/dist/orchestration/event-bridge.js")
+  )) as unknown as EventBridgeModule;
 
   // ===== enable / disable supervisor =====
   await store.enableSupervisor("sup-1");
@@ -300,12 +320,51 @@ async function main(): Promise<void> {
   const all = await store.readAllInbox("sup-1");
   assert("history retains drained items", all.length === 2);
 
-  // pendingInboxCount
+  // pendingInboxCount + process alert noise reduction
   const cnt = await store.pendingInboxCount("sup-1");
   assert("pendingInboxCount = 0 after drain", cnt === 0);
-  await inbox.bridgeWorkerEvent("w-2", "worker.process_alert", { reason: "exit" });
+  assert(
+    "success process alerts are not supervisor-worthy",
+    !eventBridge.shouldBridgeWorkerProcessAlert("success"),
+  );
+  assert(
+    "failure process alerts are not supervisor-worthy",
+    !eventBridge.shouldBridgeWorkerProcessAlert("failure"),
+  );
+  assert(
+    "killed process alerts are not supervisor-worthy",
+    !eventBridge.shouldBridgeWorkerProcessAlert("killed"),
+  );
+  const procInfo: ProcessInfoStub = {
+    id: "p1",
+    name: "build",
+    pid: 123,
+    exitCode: 0,
+    success: true,
+  };
+  await eventBridge.bridgeWorkerProcessAlert("w-2", procInfo, "success");
+  const cntAfterSuccess = await store.pendingInboxCount("sup-1");
+  assert(
+    "worker process success alert does not enqueue inbox item",
+    cntAfterSuccess === 0,
+    `got ${cntAfterSuccess}`,
+  );
+  await eventBridge.bridgeWorkerProcessAlert(
+    "w-2",
+    { ...procInfo, id: "p2", exitCode: 1, success: false },
+    "failure",
+  );
+  await eventBridge.bridgeWorkerProcessAlert(
+    "w-2",
+    { ...procInfo, id: "p3", exitCode: null, success: false },
+    "killed",
+  );
   const cnt2 = await store.pendingInboxCount("sup-1");
-  assert("pendingInboxCount = 1 after new event", cnt2 === 1);
+  assert(
+    "worker process failure/kill alerts do not enqueue inbox items",
+    cnt2 === 0,
+    `got ${cnt2}`,
+  );
 
   // Clear inbox
   await store.clearInbox("sup-1");


### PR DESCRIPTION
## Summary

Worker sessions can request process notifications for background processes through the process tool. Those notifications already arrive in the worker's own chat, but pi-forge also forwarded worker `process_alert` events into the supervisor/orchestrator inbox. That caused noisy orchestrator wake-ups for process exits that the active worker session can handle locally.

This PR stops escalating worker `process_alert` events to the orchestrator inbox for success, failure, and external-kill outcomes. Worker-local process notifications remain unchanged, and other worker events such as `worker.ended`, `worker.ask_user`, and `worker.auto_retry_failed` are preserved.

## Usage

No new operator-facing configuration is required. Existing worker process notifications continue to appear in the worker session that requested them; supervisors will no longer receive inbox/mail wake-ups for worker process alerts.

## What changed (3 files, +77/-7)

- `packages/server/src/orchestration/event-bridge.ts` — added an explicit process-alert bridge predicate that suppresses all worker process alert escalation to the supervisor inbox.
- `tests/test-orchestration.ts` — added coverage for success, failure, and killed process alerts to verify none enqueue supervisor inbox items.
- `docs/orchestration.md` — documented that worker process alerts stay local to worker sessions and do not wake supervisors.

## Test plan

- [x] `npm run build`
- [x] `npm run check` (passes with existing unrelated eslint warning in `packages/client/src/App.tsx`)
- [x] `scripts/run-tests.sh --only orchestration`
- [ ] CI green before merge
