### PR TITLE
fix: remove tool batch size cap

### DIFF
--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1351,7 +1351,7 @@ function renderAssistantBlocks(
   });
 }
 
-const MAX_TOOL_BATCH_SIZE = 10;
+const MAX_TOOL_BATCH_SIZE = Number.POSITIVE_INFINITY;
 const NON_BATCHABLE_TOOL_NAMES = new Set(["edit", "write"]);
 
 type ToolBatchEntry =


### PR DESCRIPTION
## Summary

Tool-call batches in chat were capped at 10 calls, which split long consecutive tool runs into multiple batch cards. This removes the numeric cap while preserving the existing batching behavior and natural split points such as assistant prose and non-batchable edit/write tools.

## Usage

No user-facing usage changes. Long consecutive ordinary tool calls now remain in one batch card instead of splitting every 10 calls.

## What changed (1 file, +1/-1)

- `packages/client/src/components/ChatView.tsx` — changed `MAX_TOOL_BATCH_SIZE` from `10` to `Number.POSITIVE_INFINITY` so the existing batching logic remains intact without a size cap.

## Test plan

- [x] `npx prettier --check packages/client/src/components/ChatView.tsx`
- [x] `cd packages/client && npm run check`
- [x] `scripts/run-tests.sh --only tool-call-pairing`
- [ ] CI green before merge
