### PR TITLE
feat: add git pane worktree selector

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -203,7 +203,6 @@ export function App() {
   useEffect(() => {
     if (openEditorPaneSeq === 0) return;
     setEditorOpenPersisted(true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openEditorPaneSeq]);
 
   // Pane widths (px). Persisted on every drag-end via the ref; we keep

--- a/packages/client/src/components/GitPanel.tsx
+++ b/packages/client/src/components/GitPanel.tsx
@@ -46,9 +46,10 @@ import { laneColor, layoutCommits, type CommitLayout } from "../lib/git-graph";
  */
 export function GitPanel() {
   const project = useActiveProject();
+  const projectId = project?.id;
   const [worktrees, setWorktrees] = useState<GitWorktree[] | undefined>(undefined);
   const [selectedWorktreePath, setSelectedWorktreePath] = useState<string | undefined>(undefined);
-  const { status, error: statusError, refresh } = useGitStatus(project?.id, selectedWorktreePath);
+  const { status, error: statusError, refresh } = useGitStatus(projectId, selectedWorktreePath);
 
   const [commitMessage, setCommitMessage] = useState("");
   const [busy, setBusy] = useState(false);
@@ -235,9 +236,9 @@ export function GitPanel() {
     setBranches(undefined);
     setRemotes(undefined);
     setOpenDiffs({});
-    if (project === undefined) return;
+    if (projectId === undefined) return;
     void api
-      .gitWorktrees(project.id)
+      .gitWorktrees(projectId)
       .then((r) => {
         setWorktrees(r.worktrees);
         const current = r.worktrees.find((w) => w.current) ?? r.worktrees[0];
@@ -246,7 +247,7 @@ export function GitPanel() {
       .catch((err: unknown) =>
         setOpError(err instanceof ApiError ? err.code : (err as Error).message),
       );
-  }, [project?.id]);
+  }, [projectId]);
 
   useEffect(() => {
     setLog(undefined);

--- a/packages/client/src/components/GitPanel.tsx
+++ b/packages/client/src/components/GitPanel.tsx
@@ -19,6 +19,7 @@ import {
   type GitLogEntry,
   type GitBranch as GitBranchEntry,
   type GitRemote,
+  type GitWorktree,
 } from "../lib/api-client";
 import { useActiveProject } from "../store/project-store";
 import { useGitStatus } from "../hooks/useGitStatus";
@@ -45,7 +46,9 @@ import { laneColor, layoutCommits, type CommitLayout } from "../lib/git-graph";
  */
 export function GitPanel() {
   const project = useActiveProject();
-  const { status, error: statusError, refresh } = useGitStatus(project?.id);
+  const [worktrees, setWorktrees] = useState<GitWorktree[] | undefined>(undefined);
+  const [selectedWorktreePath, setSelectedWorktreePath] = useState<string | undefined>(undefined);
+  const { status, error: statusError, refresh } = useGitStatus(project?.id, selectedWorktreePath);
 
   const [commitMessage, setCommitMessage] = useState("");
   const [busy, setBusy] = useState(false);
@@ -80,7 +83,7 @@ export function GitPanel() {
   const reloadRemotes = async (): Promise<void> => {
     if (project === undefined) return;
     try {
-      const r = await api.gitRemotes(project.id);
+      const r = await api.gitRemotes(project.id, selectedWorktreePath);
       setRemotes(r.remotes);
     } catch (err) {
       setOpError(err instanceof ApiError ? err.code : (err as Error).message);
@@ -95,7 +98,7 @@ export function GitPanel() {
     setRemoteBusy(name);
     setOpError(undefined);
     try {
-      await api.gitRemoteAdd(project.id, name, url);
+      await api.gitRemoteAdd(project.id, name, url, selectedWorktreePath);
       setShowAddRemote(false);
       setNewRemoteName("");
       setNewRemoteUrl("");
@@ -114,7 +117,7 @@ export function GitPanel() {
     setRemoteBusy(name);
     setOpError(undefined);
     try {
-      await api.gitRemoteRemove(project.id, name);
+      await api.gitRemoteRemove(project.id, name, selectedWorktreePath);
       await reloadRemotes();
     } catch (err) {
       setOpError(err instanceof ApiError ? err.message || err.code : (err as Error).message);
@@ -126,7 +129,7 @@ export function GitPanel() {
   const reloadBranches = async (): Promise<void> => {
     if (project === undefined) return;
     try {
-      const r = await api.gitBranches(project.id);
+      const r = await api.gitBranches(project.id, selectedWorktreePath);
       setBranches(r.branches);
     } catch (err) {
       setOpError(err instanceof ApiError ? err.code : (err as Error).message);
@@ -138,7 +141,7 @@ export function GitPanel() {
     setBranchBusy(branch);
     setOpError(undefined);
     try {
-      await api.gitCheckout(project.id, branch);
+      await api.gitCheckout(project.id, branch, selectedWorktreePath);
       await reloadBranches();
       void refresh();
     } catch (err) {
@@ -157,7 +160,9 @@ export function GitPanel() {
       // Create + checkout in one step — matches what most UIs do
       // when the user clicks "New branch" while looking at the
       // branches panel.
-      await api.gitBranchCreate(project.id, name, { checkout: true });
+      const opts: { checkout: true; worktreePath?: string } = { checkout: true };
+      if (selectedWorktreePath !== undefined) opts.worktreePath = selectedWorktreePath;
+      await api.gitBranchCreate(project.id, name, opts);
       await reloadBranches();
       void refresh();
     } catch (err) {
@@ -174,7 +179,7 @@ export function GitPanel() {
     setBranchBusy(name);
     setOpError(undefined);
     try {
-      await api.gitBranchDelete(project.id, name, force);
+      await api.gitBranchDelete(project.id, name, force, selectedWorktreePath);
       await reloadBranches();
     } catch (err) {
       setOpError(err instanceof ApiError ? err.code : (err as Error).message);
@@ -222,6 +227,35 @@ export function GitPanel() {
       // ignore — choice still applies for this session
     }
   };
+
+  useEffect(() => {
+    setWorktrees(undefined);
+    setSelectedWorktreePath(undefined);
+    setLog(undefined);
+    setBranches(undefined);
+    setRemotes(undefined);
+    setOpenDiffs({});
+    if (project === undefined) return;
+    void api
+      .gitWorktrees(project.id)
+      .then((r) => {
+        setWorktrees(r.worktrees);
+        const current = r.worktrees.find((w) => w.current) ?? r.worktrees[0];
+        setSelectedWorktreePath(current?.path);
+      })
+      .catch((err: unknown) =>
+        setOpError(err instanceof ApiError ? err.code : (err as Error).message),
+      );
+  }, [project?.id]);
+
+  useEffect(() => {
+    setLog(undefined);
+    setBranches(undefined);
+    setRemotes(undefined);
+    setOpenDiffs({});
+    setOpResult(undefined);
+    setOpError(undefined);
+  }, [selectedWorktreePath]);
 
   // Prune diff cache entries whose file is no longer in the latest
   // status (e.g. user ran `git checkout -- file` from the integrated
@@ -352,7 +386,7 @@ export function GitPanel() {
     }
     setOpenDiffs((s) => ({ ...s, [key]: "loading" }));
     try {
-      const r = await api.gitDiffFile(project.id, file.path, staged);
+      const r = await api.gitDiffFile(project.id, file.path, staged, selectedWorktreePath);
       setOpenDiffs((s) => ({ ...s, [key]: r.diff }));
     } catch {
       // Diff fetch failed (file vanished, git error). State machine
@@ -367,7 +401,7 @@ export function GitPanel() {
     setBusy(true);
     setOpError(undefined);
     try {
-      await api.gitStage(project.id, paths);
+      await api.gitStage(project.id, paths, selectedWorktreePath);
       await refresh();
     } catch (err) {
       setOpError(err instanceof ApiError ? err.message : (err as Error).message);
@@ -387,7 +421,7 @@ export function GitPanel() {
     setOpError(undefined);
     setOpResult(undefined);
     try {
-      await api.gitRevert(project.id, paths);
+      await api.gitRevert(project.id, paths, selectedWorktreePath);
       setOpResult(paths.length === 1 ? `Reverted ${paths[0]}` : `Reverted ${paths.length} files`);
       await refresh();
     } catch (err) {
@@ -402,7 +436,7 @@ export function GitPanel() {
     setBusy(true);
     setOpError(undefined);
     try {
-      await api.gitUnstage(project.id, paths);
+      await api.gitUnstage(project.id, paths, selectedWorktreePath);
       await refresh();
     } catch (err) {
       setOpError(err instanceof ApiError ? err.message : (err as Error).message);
@@ -426,7 +460,13 @@ export function GitPanel() {
     setPendingHunkPath(file.path);
     setOpError(undefined);
     try {
-      const r = await api.gitApplyHunks(project.id, file.path, mode, [hunkIndex]);
+      const r = await api.gitApplyHunks(
+        project.id,
+        file.path,
+        mode,
+        [hunkIndex],
+        selectedWorktreePath,
+      );
       if (r.ok !== true) {
         // Surface the server's error code as the op-error banner so
         // the user sees "binary_or_no_hunks" / "git_apply_failed" /
@@ -451,7 +491,7 @@ export function GitPanel() {
     if (openDiffs[key] === undefined) return; // not currently shown — skip
     setOpenDiffs((s) => ({ ...s, [key]: "loading" }));
     try {
-      const r = await api.gitDiffFile(project.id, file.path, staged);
+      const r = await api.gitDiffFile(project.id, file.path, staged, selectedWorktreePath);
       setOpenDiffs((s) => {
         // Empty diff after an apply means "no more changes on this side";
         // drop the key so the inline section collapses naturally.
@@ -474,13 +514,13 @@ export function GitPanel() {
     setOpError(undefined);
     setOpResult(undefined);
     try {
-      const { hash } = await api.gitCommit(project.id, msg);
+      const { hash } = await api.gitCommit(project.id, msg, selectedWorktreePath);
       setCommitMessage("");
       setOpResult(`Committed ${hash.slice(0, 7)}`);
       await refresh();
       // Refresh log if the section is open so the new commit shows up.
       if (showLog) {
-        const r = await api.gitLog(project.id, 30);
+        const r = await api.gitLog(project.id, 30, selectedWorktreePath);
         setLog(r.commits);
       }
     } catch (err) {
@@ -523,8 +563,9 @@ export function GitPanel() {
     setOpError(undefined);
     setOpResult(undefined);
     try {
-      const opts: { remote?: string } = {};
+      const opts: { remote?: string; worktreePath?: string } = {};
       if (pushRemote !== undefined) opts.remote = pushRemote;
+      if (selectedWorktreePath !== undefined) opts.worktreePath = selectedWorktreePath;
       const { output } = await api.gitFetch(project.id, opts);
       setOpResult(
         output.trim().length > 0 ? (output.trim().split("\n").pop() ?? "Fetched") : "Fetched",
@@ -541,10 +582,11 @@ export function GitPanel() {
     setOpError(undefined);
     setOpResult(undefined);
     try {
-      const opts: { remote?: string; branch?: string } = {};
+      const opts: { remote?: string; branch?: string; worktreePath?: string } = {};
       if (pushRemote !== undefined) opts.remote = pushRemote;
       const overrideName = pushBranchOverride.trim();
       if (overrideName.length > 0) opts.branch = overrideName;
+      if (selectedWorktreePath !== undefined) opts.worktreePath = selectedWorktreePath;
       const { output } = await api.gitPull(project.id, opts);
       setOpResult(
         output.trim().length > 0 ? (output.trim().split("\n").pop() ?? "Pulled") : "Pulled",
@@ -564,11 +606,17 @@ export function GitPanel() {
     setOpError(undefined);
     setOpResult(undefined);
     try {
-      const opts: { remote?: string; branch?: string; setUpstream?: boolean } = {};
+      const opts: {
+        remote?: string;
+        branch?: string;
+        setUpstream?: boolean;
+        worktreePath?: string;
+      } = {};
       if (pushRemote !== undefined) opts.remote = pushRemote;
       const overrideName = pushBranchOverride.trim();
       if (overrideName.length > 0) opts.branch = overrideName;
       if (pushSetUpstream) opts.setUpstream = true;
+      if (selectedWorktreePath !== undefined) opts.worktreePath = selectedWorktreePath;
       const { output } = await api.gitPush(project.id, opts);
       setOpResult(
         output.trim().length > 0 ? (output.trim().split("\n").pop() ?? "Pushed") : "Pushed",
@@ -584,19 +632,54 @@ export function GitPanel() {
     }
   };
 
+  const worktreeLabel = (w: GitWorktree): string => {
+    const dirname = w.path.split(/[\\/]/).filter(Boolean).pop() ?? w.path;
+    if (w.branch !== undefined) return `${w.branch} — ${dirname}`;
+    if (w.detached && w.head !== undefined) return `${w.head.slice(0, 7)} — ${dirname}`;
+    return dirname;
+  };
+
   return (
     <div className="flex h-full flex-col text-xs text-neutral-300">
-      <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
-        <div className="flex items-center gap-2 font-medium text-neutral-200">
-          <GitBranch size={13} />
-          {status?.branch ?? "—"}
-          {status !== undefined && status.files.length > 0 && (
-            <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px] text-neutral-400">
-              {status.files.length}
-            </span>
-          )}
+      <div className="flex items-center justify-between gap-2 border-b border-neutral-800 px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 font-medium text-neutral-200">
+            <GitBranch size={13} className="shrink-0" />
+            <span className="truncate">{status?.branch ?? "—"}</span>
+            {status !== undefined && status.files.length > 0 && (
+              <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px] text-neutral-400">
+                {status.files.length}
+              </span>
+            )}
+          </div>
+          <label className="mt-1 flex items-center gap-1.5 text-[10px] text-neutral-500">
+            <span className="shrink-0 uppercase tracking-wider">Worktree</span>
+            <select
+              value={selectedWorktreePath ?? ""}
+              onChange={(e) => setSelectedWorktreePath(e.target.value || undefined)}
+              disabled={worktrees === undefined || worktrees.length <= 1}
+              className="min-w-0 flex-1 rounded border border-neutral-700 bg-neutral-950 px-1.5 py-0.5 text-[10px] text-neutral-200 outline-none hover:border-neutral-600 focus:border-neutral-500 disabled:cursor-not-allowed disabled:border-neutral-800 disabled:text-neutral-500"
+              title={
+                selectedWorktreePath !== undefined
+                  ? `Viewing git info for ${selectedWorktreePath}`
+                  : "Loading git worktrees"
+              }
+            >
+              {worktrees === undefined ? (
+                <option value="">Loading…</option>
+              ) : worktrees.length === 0 ? (
+                <option value="">No worktrees</option>
+              ) : (
+                worktrees.map((w) => (
+                  <option key={w.path} value={w.path}>
+                    {worktreeLabel(w)}
+                  </option>
+                ))
+              )}
+            </select>
+          </label>
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex shrink-0 items-center gap-1">
           <button
             onClick={() => setAndPersistDiffView(diffViewType === "split" ? "unified" : "split")}
             className="rounded p-1 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200"

--- a/packages/client/src/hooks/useGitStatus.ts
+++ b/packages/client/src/hooks/useGitStatus.ts
@@ -36,7 +36,10 @@ const POLL_INTERVAL_MS = 15_000;
  * in flight. (AbortController would also work but adds API surface
  * the api-client doesn't expose.)
  */
-export function useGitStatus(projectId: string | undefined): {
+export function useGitStatus(
+  projectId: string | undefined,
+  worktreePath?: string | undefined,
+): {
   status: GitStatus | undefined;
   error: string | undefined;
   refresh: () => Promise<void>;
@@ -64,7 +67,7 @@ export function useGitStatus(projectId: string | undefined): {
     const myEpoch = epochRef.current;
     const myProjectId = projectId;
     try {
-      const next = await api.gitStatus(myProjectId);
+      const next = await api.gitStatus(myProjectId, worktreePath);
       if (epochRef.current !== myEpoch) return; // stale — project switched
       setStatus(next);
       setError(undefined);
@@ -81,7 +84,7 @@ export function useGitStatus(projectId: string | undefined): {
     epochRef.current += 1;
     setStatus(undefined);
     setError(undefined);
-  }, [projectId]);
+  }, [projectId, worktreePath]);
 
   useEffect(() => {
     if (projectId === undefined) return undefined;
@@ -94,7 +97,7 @@ export function useGitStatus(projectId: string | undefined): {
       window.clearInterval(id);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectId, isStreaming]);
+  }, [projectId, worktreePath, isStreaming]);
 
   // Push refresh on every agent_end. The polling effect above pauses
   // during streaming and only fires once when isStreaming flips back
@@ -110,7 +113,7 @@ export function useGitStatus(projectId: string | undefined): {
     if (agentEndCount === 0) return; // initial value, no agent_end yet
     void refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectId, activeSessionId, agentEndCount]);
+  }, [projectId, worktreePath, activeSessionId, agentEndCount]);
 
   return { status, error, refresh };
 }

--- a/packages/client/src/hooks/useGitStatus.ts
+++ b/packages/client/src/hooks/useGitStatus.ts
@@ -38,7 +38,7 @@ const POLL_INTERVAL_MS = 15_000;
  */
 export function useGitStatus(
   projectId: string | undefined,
-  worktreePath?: string | undefined,
+  worktreePath?: string,
 ): {
   status: GitStatus | undefined;
   error: string | undefined;

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -48,6 +48,8 @@ import {
   type GitBranchesResponse,
   type GitRemote,
   type GitRemotesResponse,
+  type GitWorktree,
+  type GitWorktreesResponse,
   type SearchMatch,
   type SearchResponse,
   type SearchOptions,
@@ -1322,6 +1324,35 @@ function vGitRemotes(value: unknown, status: number): GitRemotesResponse {
   };
 }
 
+function vGitWorktrees(value: unknown, status: number): GitWorktreesResponse {
+  if (!isObject(value) || typeof value.isGitRepo !== "boolean" || !Array.isArray(value.worktrees)) {
+    fail(status, "expected GitWorktreesResponse");
+  }
+  return {
+    isGitRepo: value.isGitRepo,
+    worktrees: value.worktrees.map((w): GitWorktree => {
+      if (
+        !isObject(w) ||
+        typeof w.path !== "string" ||
+        typeof w.bare !== "boolean" ||
+        typeof w.detached !== "boolean" ||
+        typeof w.current !== "boolean"
+      ) {
+        fail(status, "expected GitWorktree");
+      }
+      const out: GitWorktree = {
+        path: w.path,
+        bare: w.bare,
+        detached: w.detached,
+        current: w.current,
+      };
+      if (typeof w.head === "string") out.head = w.head;
+      if (typeof w.branch === "string") out.branch = w.branch;
+      return out;
+    }),
+  };
+}
+
 function vPathOnly(value: unknown, status: number): { path: string } {
   if (!isObject(value) || typeof value.path !== "string") {
     fail(status, "expected { path: string }");
@@ -1465,6 +1496,19 @@ async function request<T>(
   }
 
   return validator(parsed.value, res.status);
+}
+
+function gitQuery(
+  projectId: string,
+  worktreePath?: string,
+  extra?: Record<string, string>,
+): string {
+  const qs = new URLSearchParams({ projectId });
+  if (worktreePath !== undefined) qs.set("worktreePath", worktreePath);
+  if (extra !== undefined) {
+    for (const [key, value] of Object.entries(extra)) qs.set(key, value);
+  }
+  return qs.toString();
 }
 
 export const api = {
@@ -2616,61 +2660,70 @@ export const api = {
       },
       { method: "POST", body: { projectId } },
     ),
-  gitStatus: (projectId: string) =>
-    request(`/api/v1/git/status?projectId=${encodeURIComponent(projectId)}`, vGitStatus),
-  gitDiff: (projectId: string) =>
-    request(`/api/v1/git/diff?projectId=${encodeURIComponent(projectId)}`, vGitDiff),
-  gitDiffStaged: (projectId: string) =>
-    request(`/api/v1/git/diff/staged?projectId=${encodeURIComponent(projectId)}`, vGitDiff),
-  gitDiffFile: (projectId: string, path: string, staged: boolean) => {
-    const qs = new URLSearchParams({ projectId, path });
-    if (staged) qs.set("staged", "1");
-    return request(`/api/v1/git/diff/file?${qs.toString()}`, vGitDiff);
+  gitStatus: (projectId: string, worktreePath?: string) =>
+    request(`/api/v1/git/status?${gitQuery(projectId, worktreePath)}`, vGitStatus),
+  gitWorktrees: (projectId: string) =>
+    request(`/api/v1/git/worktrees?${gitQuery(projectId)}`, vGitWorktrees),
+  gitDiff: (projectId: string, worktreePath?: string) =>
+    request(`/api/v1/git/diff?${gitQuery(projectId, worktreePath)}`, vGitDiff),
+  gitDiffStaged: (projectId: string, worktreePath?: string) =>
+    request(`/api/v1/git/diff/staged?${gitQuery(projectId, worktreePath)}`, vGitDiff),
+  gitDiffFile: (projectId: string, path: string, staged: boolean, worktreePath?: string) => {
+    const extra: Record<string, string> = { path };
+    if (staged) extra.staged = "1";
+    return request(`/api/v1/git/diff/file?${gitQuery(projectId, worktreePath, extra)}`, vGitDiff);
   },
-  gitLog: (projectId: string, limit?: number) => {
-    const qs = new URLSearchParams({ projectId });
-    if (limit !== undefined) qs.set("limit", String(limit));
-    return request(`/api/v1/git/log?${qs.toString()}`, vGitLog);
+  gitLog: (projectId: string, limit?: number, worktreePath?: string) => {
+    const extra: Record<string, string> = {};
+    if (limit !== undefined) extra.limit = String(limit);
+    return request(`/api/v1/git/log?${gitQuery(projectId, worktreePath, extra)}`, vGitLog);
   },
-  gitBranches: (projectId: string) =>
-    request(`/api/v1/git/branches?projectId=${encodeURIComponent(projectId)}`, vGitBranches),
-  gitRemotes: (projectId: string) =>
-    request(`/api/v1/git/remotes?projectId=${encodeURIComponent(projectId)}`, vGitRemotes),
-  gitRemoteAdd: (projectId: string, name: string, url: string) =>
+  gitBranches: (projectId: string, worktreePath?: string) =>
+    request(`/api/v1/git/branches?${gitQuery(projectId, worktreePath)}`, vGitBranches),
+  gitRemotes: (projectId: string, worktreePath?: string) =>
+    request(`/api/v1/git/remotes?${gitQuery(projectId, worktreePath)}`, vGitRemotes),
+  gitRemoteAdd: (projectId: string, name: string, url: string, worktreePath?: string) =>
     request(
       "/api/v1/git/remote/add",
       (v, s) => {
         if (!isObject(v) || v.ok !== true) fail(s, "expected { ok: true }");
         return { ok: true as const };
       },
-      { method: "POST", body: { projectId, name, url } },
+      {
+        method: "POST",
+        body: { projectId, name, url, ...(worktreePath !== undefined ? { worktreePath } : {}) },
+      },
     ),
-  gitRemoteRemove: (projectId: string, name: string) =>
+  gitRemoteRemove: (projectId: string, name: string, worktreePath?: string) =>
     request(
-      `/api/v1/git/remote/${encodeURIComponent(name)}?projectId=${encodeURIComponent(projectId)}`,
+      `/api/v1/git/remote/${encodeURIComponent(name)}?${gitQuery(projectId, worktreePath)}`,
       (v, s) => {
         if (!isObject(v) || v.ok !== true) fail(s, "expected { ok: true }");
         return { ok: true as const };
       },
       { method: "DELETE" },
     ),
-  gitCheckout: (projectId: string, branch: string) =>
+  gitCheckout: (projectId: string, branch: string, worktreePath?: string) =>
     request(
       "/api/v1/git/checkout",
       (v, s) => {
         if (!isObject(v) || v.ok !== true) fail(s, "expected { ok: true }");
         return { ok: true as const };
       },
-      { method: "POST", body: { projectId, branch } },
+      {
+        method: "POST",
+        body: { projectId, branch, ...(worktreePath !== undefined ? { worktreePath } : {}) },
+      },
     ),
   gitBranchCreate: (
     projectId: string,
     name: string,
-    opts?: { startPoint?: string; checkout?: boolean },
+    opts?: { startPoint?: string; checkout?: boolean; worktreePath?: string },
   ) => {
     const body: Record<string, unknown> = { projectId, name };
     if (opts?.startPoint !== undefined) body.startPoint = opts.startPoint;
     if (opts?.checkout !== undefined) body.checkout = opts.checkout;
+    if (opts?.worktreePath !== undefined) body.worktreePath = opts.worktreePath;
     return request(
       "/api/v1/git/branch/create",
       (v, s) => {
@@ -2680,11 +2733,11 @@ export const api = {
       { method: "POST", body },
     );
   },
-  gitBranchDelete: (projectId: string, name: string, force?: boolean) => {
-    const qs = new URLSearchParams({ projectId });
-    if (force === true) qs.set("force", "1");
+  gitBranchDelete: (projectId: string, name: string, force?: boolean, worktreePath?: string) => {
+    const extra: Record<string, string> = {};
+    if (force === true) extra.force = "1";
     return request(
-      `/api/v1/git/branch/${encodeURIComponent(name)}?${qs.toString()}`,
+      `/api/v1/git/branch/${encodeURIComponent(name)}?${gitQuery(projectId, worktreePath, extra)}`,
       (v, s) => {
         if (!isObject(v) || v.ok !== true) fail(s, "expected { ok: true }");
         return { ok: true as const };
@@ -2692,23 +2745,29 @@ export const api = {
       { method: "DELETE" },
     );
   },
-  gitStage: (projectId: string, paths: string[]) =>
+  gitStage: (projectId: string, paths: string[], worktreePath?: string) =>
     request(
       "/api/v1/git/stage",
       (v, s) => {
         if (!isObject(v) || v.ok !== true) fail(s, "expected { ok: true }");
         return { ok: true as const };
       },
-      { method: "POST", body: { projectId, paths } },
+      {
+        method: "POST",
+        body: { projectId, paths, ...(worktreePath !== undefined ? { worktreePath } : {}) },
+      },
     ),
-  gitUnstage: (projectId: string, paths: string[]) =>
+  gitUnstage: (projectId: string, paths: string[], worktreePath?: string) =>
     request(
       "/api/v1/git/unstage",
       (v, s) => {
         if (!isObject(v) || v.ok !== true) fail(s, "expected { ok: true }");
         return { ok: true as const };
       },
-      { method: "POST", body: { projectId, paths } },
+      {
+        method: "POST",
+        body: { projectId, paths, ...(worktreePath !== undefined ? { worktreePath } : {}) },
+      },
     ),
   /**
    * Stage or unstage selected hunks of a single file. Server returns
@@ -2722,6 +2781,7 @@ export const api = {
     path: string,
     mode: "stage" | "unstage",
     hunkIndices: number[],
+    worktreePath?: string,
   ) =>
     request<{ ok: boolean; error?: string; totalHunks?: number }>(
       "/api/v1/git/apply-hunks",
@@ -2734,30 +2794,49 @@ export const api = {
         if (typeof v.totalHunks === "number") out.totalHunks = v.totalHunks;
         return out;
       },
-      { method: "POST", body: { projectId, path, mode, hunkIndices } },
+      {
+        method: "POST",
+        body: {
+          projectId,
+          path,
+          mode,
+          hunkIndices,
+          ...(worktreePath !== undefined ? { worktreePath } : {}),
+        },
+      },
     ),
-  gitRevert: (projectId: string, paths: string[]) =>
+  gitRevert: (projectId: string, paths: string[], worktreePath?: string) =>
     request(
       "/api/v1/git/revert",
       (v, s) => {
         if (!isObject(v) || v.ok !== true) fail(s, "expected { ok: true }");
         return { ok: true as const };
       },
-      { method: "POST", body: { projectId, paths } },
+      {
+        method: "POST",
+        body: { projectId, paths, ...(worktreePath !== undefined ? { worktreePath } : {}) },
+      },
     ),
-  gitCommit: (projectId: string, message: string) =>
+  gitCommit: (projectId: string, message: string, worktreePath?: string) =>
     request(
       "/api/v1/git/commit",
       (v, s) => {
         if (!isObject(v) || typeof v.hash !== "string") fail(s, "expected { hash }");
         return { hash: v.hash };
       },
-      { method: "POST", body: { projectId, message } },
+      {
+        method: "POST",
+        body: { projectId, message, ...(worktreePath !== undefined ? { worktreePath } : {}) },
+      },
     ),
-  gitFetch: (projectId: string, opts?: { remote?: string; prune?: boolean }) => {
+  gitFetch: (
+    projectId: string,
+    opts?: { remote?: string; prune?: boolean; worktreePath?: string },
+  ) => {
     const body: Record<string, unknown> = { projectId };
     if (opts?.remote !== undefined) body.remote = opts.remote;
     if (opts?.prune !== undefined) body.prune = opts.prune;
+    if (opts?.worktreePath !== undefined) body.worktreePath = opts.worktreePath;
     return request(
       "/api/v1/git/fetch",
       (v, s) => {
@@ -2767,11 +2846,15 @@ export const api = {
       { method: "POST", body },
     );
   },
-  gitPull: (projectId: string, opts?: { remote?: string; branch?: string; rebase?: boolean }) => {
+  gitPull: (
+    projectId: string,
+    opts?: { remote?: string; branch?: string; rebase?: boolean; worktreePath?: string },
+  ) => {
     const body: Record<string, unknown> = { projectId };
     if (opts?.remote !== undefined) body.remote = opts.remote;
     if (opts?.branch !== undefined) body.branch = opts.branch;
     if (opts?.rebase !== undefined) body.rebase = opts.rebase;
+    if (opts?.worktreePath !== undefined) body.worktreePath = opts.worktreePath;
     return request(
       "/api/v1/git/pull",
       (v, s) => {
@@ -2783,12 +2866,13 @@ export const api = {
   },
   gitPush: (
     projectId: string,
-    opts?: { remote?: string; branch?: string; setUpstream?: boolean },
+    opts?: { remote?: string; branch?: string; setUpstream?: boolean; worktreePath?: string },
   ) => {
     const body: Record<string, unknown> = { projectId };
     if (opts?.remote !== undefined) body.remote = opts.remote;
     if (opts?.branch !== undefined) body.branch = opts.branch;
     if (opts?.setUpstream !== undefined) body.setUpstream = opts.setUpstream;
+    if (opts?.worktreePath !== undefined) body.worktreePath = opts.worktreePath;
     return request(
       "/api/v1/git/push",
       (v, s) => {

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -618,6 +618,20 @@ export interface GitRemotesResponse {
   remotes: GitRemote[];
 }
 
+export interface GitWorktree {
+  path: string;
+  head?: string;
+  branch?: string;
+  bare: boolean;
+  detached: boolean;
+  current: boolean;
+}
+
+export interface GitWorktreesResponse {
+  isGitRepo: boolean;
+  worktrees: GitWorktree[];
+}
+
 export interface SearchMatch {
   /** Project-relative POSIX path. */
   path: string;

--- a/packages/server/src/git-runner.ts
+++ b/packages/server/src/git-runner.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
@@ -115,6 +116,20 @@ export interface BranchesResult {
   isGitRepo: boolean;
   current: string | undefined;
   branches: BranchEntry[];
+}
+
+export interface WorktreeEntry {
+  path: string;
+  head: string | undefined;
+  branch: string | undefined;
+  bare: boolean;
+  detached: boolean;
+  current: boolean;
+}
+
+export interface WorktreesResult {
+  isGitRepo: boolean;
+  worktrees: WorktreeEntry[];
 }
 
 /* ----------------------------- helpers ----------------------------- */
@@ -582,6 +597,58 @@ export async function removeRemote(cwd: string, name: string): Promise<void> {
 }
 
 /* ----------------------------- branches ----------------------------- */
+
+export async function getWorktrees(cwd: string): Promise<WorktreesResult> {
+  if (!(await isGitRepo(cwd))) return { isGitRepo: false, worktrees: [] };
+  const currentPath = await canonicalPath(cwd);
+  const { stdout } = await runGit(cwd, ["worktree", "list", "--porcelain", "-z"]);
+  const worktrees: WorktreeEntry[] = [];
+  let entry: WorktreeEntry | undefined;
+  const finish = async (): Promise<void> => {
+    if (entry !== undefined) {
+      const path = await canonicalPath(entry.path);
+      worktrees.push({ ...entry, path, current: path === currentPath });
+      entry = undefined;
+    }
+  };
+  for (const token of stdout.split("\0")) {
+    if (token.length === 0) {
+      await finish();
+      continue;
+    }
+    if (token.startsWith("worktree ")) {
+      await finish();
+      const path = token.slice("worktree ".length);
+      entry = {
+        path,
+        head: undefined,
+        branch: undefined,
+        bare: false,
+        detached: false,
+        current: false,
+      };
+    } else if (entry !== undefined && token.startsWith("HEAD ")) {
+      entry.head = token.slice("HEAD ".length);
+    } else if (entry !== undefined && token.startsWith("branch ")) {
+      const branch = token.slice("branch ".length);
+      entry.branch = branch.startsWith("refs/heads/") ? branch.slice("refs/heads/".length) : branch;
+    } else if (entry !== undefined && token === "bare") {
+      entry.bare = true;
+    } else if (entry !== undefined && token === "detached") {
+      entry.detached = true;
+    }
+  }
+  await finish();
+  return { isGitRepo: true, worktrees };
+}
+
+async function canonicalPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return resolve(path);
+  }
+}
 
 export async function getBranches(cwd: string): Promise<BranchesResult> {
   if (!(await isGitRepo(cwd))) return { isGitRepo: false, current: undefined, branches: [] };

--- a/packages/server/src/routes/git.ts
+++ b/packages/server/src/routes/git.ts
@@ -17,6 +17,7 @@ import {
   getLog,
   getStagedDiff,
   getStatus,
+  getWorktrees,
   initRepo,
   isGitRepo,
   pull,
@@ -27,6 +28,7 @@ import {
 } from "../git-runner.js";
 import { applyHunks, HunkStagingError } from "../git-hunk-stager.js";
 import { config } from "../config.js";
+import { PathOutsideRootError } from "../file-manager.js";
 import { getProject } from "../project-manager.js";
 import { errorSchema } from "./_schemas.js";
 
@@ -141,6 +143,36 @@ const remotesSchema = {
   },
 } as const;
 
+const worktreesSchema = {
+  type: "object",
+  required: ["isGitRepo", "worktrees"],
+  properties: {
+    isGitRepo: { type: "boolean" },
+    worktrees: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["path", "bare", "detached", "current"],
+        properties: {
+          path: { type: "string" },
+          head: { type: "string" },
+          branch: { type: "string" },
+          bare: { type: "boolean" },
+          detached: { type: "boolean" },
+          current: { type: "boolean" },
+        },
+      },
+    },
+  },
+} as const;
+
+class InvalidWorktreePathError extends Error {
+  constructor(path: string) {
+    super(`invalid worktree path: ${path}`);
+    this.name = "InvalidWorktreePathError";
+  }
+}
+
 /* ----------------------------- error mapping ----------------------------- */
 
 function mapError(reply: FastifyReply, err: unknown): FastifyReply {
@@ -152,6 +184,12 @@ function mapError(reply: FastifyReply, err: unknown): FastifyReply {
   }
   if (err instanceof InvalidBranchNameError) {
     return reply.code(400).send({ error: "invalid_branch_name", message: err.message });
+  }
+  if (err instanceof InvalidWorktreePathError) {
+    return reply.code(400).send({ error: "invalid_worktree_path", message: err.message });
+  }
+  if (err instanceof PathOutsideRootError) {
+    return reply.code(403).send({ error: "path_not_allowed", message: "path outside workspace" });
   }
   if (err instanceof GitCommandError) {
     // Git "rejected" / "non-fast-forward" / commit hook failures /
@@ -216,6 +254,44 @@ async function withProject<T>(
   }
 }
 
+async function resolveGitCwd(
+  project: { path: string },
+  worktreePath: string | undefined,
+): Promise<string> {
+  if (worktreePath === undefined) return project.path;
+  const listed = await getWorktrees(project.path);
+  const match = listed.worktrees.find((w) => w.path === worktreePath);
+  if (match === undefined) throw new InvalidWorktreePathError(worktreePath);
+  return match.path;
+}
+
+async function withGitCwd<T>(
+  projectId: string,
+  worktreePath: string | undefined,
+  reply: FastifyReply,
+  fn: (cwd: string) => Promise<T>,
+): Promise<T | FastifyReply | undefined> {
+  const project = await resolveProject(projectId, reply);
+  if (project === undefined) return reply;
+  try {
+    const cwd = await resolveGitCwd(project, worktreePath);
+    return await fn(cwd);
+  } catch (err) {
+    return mapError(reply, err);
+  }
+}
+
+const projectWorktreeQuerySchema = {
+  type: "object",
+  required: ["projectId"],
+  properties: {
+    projectId: { type: "string", minLength: 1 },
+    worktreePath: { type: "string", minLength: 1 },
+  },
+} as const;
+
+const worktreeBodyProperty = { worktreePath: { type: "string", minLength: 1 } } as const;
+
 /* ----------------------------- routes ----------------------------- */
 
 export const gitRoutes: FastifyPluginAsync = async (fastify) => {
@@ -265,7 +341,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
   );
 
-  fastify.get<{ Querystring: { projectId: string } }>(
+  fastify.get<{ Querystring: { projectId: string; worktreePath?: string } }>(
     "/git/status",
     {
       // Polled by the client every ~15s while a project is open. We
@@ -281,60 +357,91 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
           "`{ isGitRepo: false, files: [] }` (NOT 500) so the panel can sit " +
           "quiet on plain folders.",
         tags: ["git"],
+        querystring: projectWorktreeQuerySchema,
+        response: {
+          200: statusSchema,
+          400: errorSchema,
+          403: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) =>
+      withGitCwd(req.query.projectId, req.query.worktreePath, reply, (cwd) => getStatus(cwd)),
+  );
+
+  fastify.get<{ Querystring: { projectId: string } }>(
+    "/git/worktrees",
+    {
+      schema: {
+        description:
+          "List registered git worktrees for the project's repository. Returned absolute paths " +
+          "can be passed back as `worktreePath` to git routes and are accepted only if still registered.",
+        tags: ["git"],
         querystring: {
           type: "object",
           required: ["projectId"],
           properties: { projectId: { type: "string", minLength: 1 } },
         },
-        response: { 200: statusSchema, 400: errorSchema, 404: errorSchema, 500: errorSchema },
+        response: {
+          200: worktreesSchema,
+          400: errorSchema,
+          403: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
+        },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return reply;
-      try {
-        return await getStatus(project.path);
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+    async (req, reply) =>
+      withProject(req.query.projectId, reply, async (p) => {
+        return getWorktrees(p.path);
+      }),
   );
 
-  fastify.get<{ Querystring: { projectId: string } }>(
+  fastify.get<{ Querystring: { projectId: string; worktreePath?: string } }>(
     "/git/diff",
     {
       schema: {
         description: "Unstaged unified diff for the project (working tree vs index).",
         tags: ["git"],
-        querystring: {
-          type: "object",
-          required: ["projectId"],
-          properties: { projectId: { type: "string", minLength: 1 } },
+        querystring: projectWorktreeQuerySchema,
+        response: {
+          200: diffSchema,
+          400: errorSchema,
+          403: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
         },
-        response: { 200: diffSchema, 400: errorSchema, 404: errorSchema, 500: errorSchema },
       },
     },
-    async (req, reply) => withProject(req.query.projectId, reply, (p) => getDiff(p.path)),
+    async (req, reply) =>
+      withGitCwd(req.query.projectId, req.query.worktreePath, reply, (cwd) => getDiff(cwd)),
   );
 
-  fastify.get<{ Querystring: { projectId: string } }>(
+  fastify.get<{ Querystring: { projectId: string; worktreePath?: string } }>(
     "/git/diff/staged",
     {
       schema: {
         description: "Staged unified diff (index vs HEAD).",
         tags: ["git"],
-        querystring: {
-          type: "object",
-          required: ["projectId"],
-          properties: { projectId: { type: "string", minLength: 1 } },
+        querystring: projectWorktreeQuerySchema,
+        response: {
+          200: diffSchema,
+          400: errorSchema,
+          403: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
         },
-        response: { 200: diffSchema, 400: errorSchema, 404: errorSchema, 500: errorSchema },
       },
     },
-    async (req, reply) => withProject(req.query.projectId, reply, (p) => getStagedDiff(p.path)),
+    async (req, reply) =>
+      withGitCwd(req.query.projectId, req.query.worktreePath, reply, (cwd) => getStagedDiff(cwd)),
   );
 
-  fastify.get<{ Querystring: { projectId: string; path: string; staged?: string } }>(
+  fastify.get<{
+    Querystring: { projectId: string; path: string; staged?: string; worktreePath?: string };
+  }>(
     "/git/diff/file",
     {
       schema: {
@@ -349,20 +456,27 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
             projectId: { type: "string", minLength: 1 },
             path: { type: "string", minLength: 1 },
             staged: { type: "string", enum: ["0", "1", "true", "false"] },
+            worktreePath: { type: "string", minLength: 1 },
           },
         },
-        response: { 200: diffSchema, 400: errorSchema, 404: errorSchema, 500: errorSchema },
+        response: {
+          200: diffSchema,
+          400: errorSchema,
+          403: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
+        },
       },
     },
     async (req, reply) => {
       const staged = req.query.staged === "1" || req.query.staged === "true";
-      return withProject(req.query.projectId, reply, (p) =>
-        getFileDiff(p.path, req.query.path, staged),
+      return withGitCwd(req.query.projectId, req.query.worktreePath, reply, (cwd) =>
+        getFileDiff(cwd, req.query.path, staged),
       );
     },
   );
 
-  fastify.get<{ Querystring: { projectId: string; limit?: string } }>(
+  fastify.get<{ Querystring: { projectId: string; limit?: string; worktreePath?: string } }>(
     "/git/log",
     {
       schema: {
@@ -375,9 +489,16 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
           properties: {
             projectId: { type: "string", minLength: 1 },
             limit: { type: "string", pattern: "^[0-9]+$" },
+            worktreePath: { type: "string", minLength: 1 },
           },
         },
-        response: { 200: logSchema, 400: errorSchema, 404: errorSchema, 500: errorSchema },
+        response: {
+          200: logSchema,
+          400: errorSchema,
+          403: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
+        },
       },
     },
     async (req, reply) => {
@@ -385,28 +506,33 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         req.query.limit !== undefined
           ? Math.min(1000, Math.max(1, Number.parseInt(req.query.limit, 10)))
           : 30;
-      return withProject(req.query.projectId, reply, (p) => getLog(p.path, limit));
+      return withGitCwd(req.query.projectId, req.query.worktreePath, reply, (cwd) =>
+        getLog(cwd, limit),
+      );
     },
   );
 
-  fastify.get<{ Querystring: { projectId: string } }>(
+  fastify.get<{ Querystring: { projectId: string; worktreePath?: string } }>(
     "/git/branches",
     {
       schema: {
         description: "Local + remote branch list with `current` flag.",
         tags: ["git"],
-        querystring: {
-          type: "object",
-          required: ["projectId"],
-          properties: { projectId: { type: "string", minLength: 1 } },
+        querystring: projectWorktreeQuerySchema,
+        response: {
+          200: branchesSchema,
+          400: errorSchema,
+          403: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
         },
-        response: { 200: branchesSchema, 400: errorSchema, 404: errorSchema, 500: errorSchema },
       },
     },
-    async (req, reply) => withProject(req.query.projectId, reply, (p) => getBranches(p.path)),
+    async (req, reply) =>
+      withGitCwd(req.query.projectId, req.query.worktreePath, reply, (cwd) => getBranches(cwd)),
   );
 
-  fastify.get<{ Querystring: { projectId: string } }>(
+  fastify.get<{ Querystring: { projectId: string; worktreePath?: string } }>(
     "/git/remotes",
     {
       schema: {
@@ -414,18 +540,21 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
           "Configured git remotes with their fetch + push URLs. " +
           "Empty array for non-git projects or repos with no remotes.",
         tags: ["git"],
-        querystring: {
-          type: "object",
-          required: ["projectId"],
-          properties: { projectId: { type: "string", minLength: 1 } },
+        querystring: projectWorktreeQuerySchema,
+        response: {
+          200: remotesSchema,
+          400: errorSchema,
+          403: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
         },
-        response: { 200: remotesSchema, 400: errorSchema, 404: errorSchema, 500: errorSchema },
       },
     },
-    async (req, reply) => withProject(req.query.projectId, reply, (p) => getRemotes(p.path)),
+    async (req, reply) =>
+      withGitCwd(req.query.projectId, req.query.worktreePath, reply, (cwd) => getRemotes(cwd)),
   );
 
-  fastify.post<{ Body: { projectId: string; name: string; url: string } }>(
+  fastify.post<{ Body: { projectId: string; name: string; url: string; worktreePath?: string } }>(
     "/git/remote/add",
     {
       schema: {
@@ -443,6 +572,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
             projectId: { type: "string", minLength: 1 },
             name: { type: "string", minLength: 1 },
             url: { type: "string", minLength: 1, maxLength: 1024 },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -453,19 +583,17 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
-      try {
-        await addRemote(project.path, req.body.name, req.body.url);
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
+        await addRemote(cwd, req.body.name, req.body.url);
         return { ok: true };
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 
-  fastify.delete<{ Params: { name: string }; Querystring: { projectId: string } }>(
+  fastify.delete<{
+    Params: { name: string };
+    Querystring: { projectId: string; worktreePath?: string };
+  }>(
     "/git/remote/:name",
     {
       schema: {
@@ -478,11 +606,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
           required: ["name"],
           properties: { name: { type: "string", minLength: 1 } },
         },
-        querystring: {
-          type: "object",
-          required: ["projectId"],
-          properties: { projectId: { type: "string", minLength: 1 } },
-        },
+        querystring: projectWorktreeQuerySchema,
         response: {
           200: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
           400: errorSchema,
@@ -491,19 +615,14 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return reply;
-      try {
-        await removeRemote(project.path, req.params.name);
+    async (req, reply) =>
+      withGitCwd(req.query.projectId, req.query.worktreePath, reply, async (cwd) => {
+        await removeRemote(cwd, req.params.name);
         return { ok: true };
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 
-  fastify.post<{ Body: { projectId: string; branch: string } }>(
+  fastify.post<{ Body: { projectId: string; branch: string; worktreePath?: string } }>(
     "/git/checkout",
     {
       schema: {
@@ -520,6 +639,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
           properties: {
             projectId: { type: "string", minLength: 1 },
             branch: { type: "string", minLength: 1 },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -530,20 +650,21 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
-      try {
-        await checkoutBranch(project.path, req.body.branch);
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
+        await checkoutBranch(cwd, req.body.branch);
         return { ok: true };
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 
   fastify.post<{
-    Body: { projectId: string; name: string; startPoint?: string; checkout?: boolean };
+    Body: {
+      projectId: string;
+      name: string;
+      startPoint?: string;
+      checkout?: boolean;
+      worktreePath?: string;
+    };
   }>(
     "/git/branch/create",
     {
@@ -562,6 +683,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
             name: { type: "string", minLength: 1 },
             startPoint: { type: "string", minLength: 1 },
             checkout: { type: "boolean" },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -572,22 +694,20 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
-      try {
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
         const opts: { startPoint?: string; checkout?: boolean } = {};
         if (req.body.startPoint !== undefined) opts.startPoint = req.body.startPoint;
         if (req.body.checkout !== undefined) opts.checkout = req.body.checkout;
-        await createBranch(project.path, req.body.name, opts);
+        await createBranch(cwd, req.body.name, opts);
         return { ok: true };
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 
-  fastify.delete<{ Querystring: { projectId: string; force?: string }; Params: { name: string } }>(
+  fastify.delete<{
+    Querystring: { projectId: string; force?: string; worktreePath?: string };
+    Params: { name: string };
+  }>(
     "/git/branch/:name",
     {
       schema: {
@@ -607,6 +727,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
           properties: {
             projectId: { type: "string", minLength: 1 },
             force: { type: "string", enum: ["0", "1", "true", "false"] },
+            worktreePath: { type: "string", minLength: 1 },
           },
         },
         response: {
@@ -618,19 +739,15 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const project = await resolveProject(req.query.projectId, reply);
-      if (project === undefined) return reply;
-      try {
-        const force = req.query.force === "1" || req.query.force === "true";
-        await deleteBranch(project.path, req.params.name, { force });
+      const force = req.query.force === "1" || req.query.force === "true";
+      return withGitCwd(req.query.projectId, req.query.worktreePath, reply, async (cwd) => {
+        await deleteBranch(cwd, req.params.name, { force });
         return { ok: true };
-      } catch (err) {
-        return mapError(reply, err);
-      }
+      });
     },
   );
 
-  fastify.post<{ Body: { projectId: string; paths: string[] } }>(
+  fastify.post<{ Body: { projectId: string; paths: string[]; worktreePath?: string } }>(
     "/git/stage",
     {
       schema: {
@@ -653,6 +770,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
               // even a very wide repo land well under 1000 paths.
               maxItems: 1000,
             },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -663,19 +781,14 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
-      try {
-        await stagePaths(project.path, req.body.paths);
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
+        await stagePaths(cwd, req.body.paths);
         return { ok: true };
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 
-  fastify.post<{ Body: { projectId: string; paths: string[] } }>(
+  fastify.post<{ Body: { projectId: string; paths: string[]; worktreePath?: string } }>(
     "/git/unstage",
     {
       schema: {
@@ -698,6 +811,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
               // even a very wide repo land well under 1000 paths.
               maxItems: 1000,
             },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -708,16 +822,11 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
-      try {
-        await unstagePaths(project.path, req.body.paths);
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
+        await unstagePaths(cwd, req.body.paths);
         return { ok: true };
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 
   fastify.post<{
@@ -726,6 +835,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
       path: string;
       mode: "stage" | "unstage";
       hunkIndices: number[];
+      worktreePath?: string;
     };
   }>(
     "/git/apply-hunks",
@@ -754,6 +864,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
               minItems: 1,
               maxItems: 1_000,
             },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -772,31 +883,30 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
-      try {
-        const { totalHunks } = await applyHunks(
-          project.path,
-          req.body.path,
-          req.body.hunkIndices,
-          req.body.mode,
-        );
-        return { ok: true, totalHunks };
-      } catch (err) {
-        // HunkStagingError carries a code suitable for the UI to show
-        // (binary_or_no_hunks, no_diff, hunk_index_out_of_range,
-        // git_apply_failed). Return as ok:false so the panel can render
-        // a banner rather than a generic toast.
-        if (err instanceof HunkStagingError) {
-          return { ok: false, error: err.code, totalHunks: 0 };
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
+        try {
+          const { totalHunks } = await applyHunks(
+            cwd,
+            req.body.path,
+            req.body.hunkIndices,
+            req.body.mode,
+          );
+          return { ok: true, totalHunks };
+        } catch (err) {
+          // HunkStagingError carries a code suitable for the UI to show
+          // (binary_or_no_hunks, no_diff, hunk_index_out_of_range,
+          // git_apply_failed). Return as ok:false so the panel can render
+          // a banner rather than a generic toast.
+          if (err instanceof HunkStagingError) {
+            return { ok: false, error: err.code, totalHunks: 0 };
+          }
+          throw err;
         }
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 
-  fastify.post<{ Body: { projectId: string; paths: string[] } }>(
+  fastify.post<{ Body: { projectId: string; paths: string[]; worktreePath?: string } }>(
     "/git/revert",
     {
       schema: {
@@ -825,6 +935,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
               // even a very wide repo land well under 1000 paths.
               maxItems: 1000,
             },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -835,19 +946,14 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
-      try {
-        await revertPaths(project.path, req.body.paths);
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
+        await revertPaths(cwd, req.body.paths);
         return { ok: true };
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 
-  fastify.post<{ Body: { projectId: string; message: string } }>(
+  fastify.post<{ Body: { projectId: string; message: string; worktreePath?: string } }>(
     "/git/commit",
     {
       schema: {
@@ -863,6 +969,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
           properties: {
             projectId: { type: "string", minLength: 1 },
             message: { type: "string", minLength: 1 },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -878,21 +985,19 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
       const message = req.body.message.trim();
       if (message.length === 0) {
         return reply.code(400).send({ error: "empty_message" });
       }
-      try {
-        return await commit(project.path, message);
-      } catch (err) {
-        return mapError(reply, err);
-      }
+      return withGitCwd(req.body.projectId, req.body.worktreePath, reply, (cwd) =>
+        commit(cwd, message),
+      );
     },
   );
 
-  fastify.post<{ Body: { projectId: string; remote?: string; prune?: boolean } }>(
+  fastify.post<{
+    Body: { projectId: string; remote?: string; prune?: boolean; worktreePath?: string };
+  }>(
     "/git/fetch",
     {
       schema: {
@@ -909,6 +1014,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
             projectId: { type: "string", minLength: 1 },
             remote: { type: "string", minLength: 1 },
             prune: { type: "boolean" },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -919,23 +1025,24 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
-      try {
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
         const opts: { remote?: string; prune?: boolean } = {};
         if (req.body.remote !== undefined) opts.remote = req.body.remote;
         if (req.body.prune !== undefined) opts.prune = req.body.prune;
-        const { stdout } = await fetch(project.path, opts);
+        const { stdout } = await fetch(cwd, opts);
         return { output: stdout };
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 
   fastify.post<{
-    Body: { projectId: string; remote?: string; branch?: string; rebase?: boolean };
+    Body: {
+      projectId: string;
+      remote?: string;
+      branch?: string;
+      rebase?: boolean;
+      worktreePath?: string;
+    };
   }>(
     "/git/pull",
     {
@@ -955,6 +1062,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
             remote: { type: "string", minLength: 1 },
             branch: { type: "string", minLength: 1 },
             rebase: { type: "boolean" },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -965,24 +1073,25 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
-      try {
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
         const opts: { remote?: string; branch?: string; rebase?: boolean } = {};
         if (req.body.remote !== undefined) opts.remote = req.body.remote;
         if (req.body.branch !== undefined) opts.branch = req.body.branch;
         if (req.body.rebase !== undefined) opts.rebase = req.body.rebase;
-        const { stdout } = await pull(project.path, opts);
+        const { stdout } = await pull(cwd, opts);
         return { output: stdout };
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 
   fastify.post<{
-    Body: { projectId: string; remote?: string; branch?: string; setUpstream?: boolean };
+    Body: {
+      projectId: string;
+      remote?: string;
+      branch?: string;
+      setUpstream?: boolean;
+      worktreePath?: string;
+    };
   }>(
     "/git/push",
     {
@@ -1010,6 +1119,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
             remote: { type: "string", minLength: 1 },
             branch: { type: "string", minLength: 1 },
             setUpstream: { type: "boolean" },
+            ...worktreeBodyProperty,
           },
         },
         response: {
@@ -1024,19 +1134,14 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
-      const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
-      try {
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
         const opts: { remote?: string; branch?: string; setUpstream?: boolean } = {};
         if (req.body.remote !== undefined) opts.remote = req.body.remote;
         if (req.body.branch !== undefined) opts.branch = req.body.branch;
         if (req.body.setUpstream !== undefined) opts.setUpstream = req.body.setUpstream;
-        const { stdout } = await push(project.path, opts);
+        const { stdout } = await push(cwd, opts);
         return { output: stdout };
-      } catch (err) {
-        return mapError(reply, err);
-      }
-    },
+      }),
   );
 };

--- a/tests/test-git.ts
+++ b/tests/test-git.ts
@@ -99,6 +99,7 @@ async function main(): Promise<void> {
   const workspacePath = await mkdtemp(join(tmpdir(), "pi-git-ws-"));
   const configDir = await mkdtemp(join(tmpdir(), "pi-git-cfg-"));
   const dataDir = await mkdtemp(join(tmpdir(), "pi-git-data-"));
+  const externalWorktreeRoot = await mkdtemp(join(tmpdir(), "pi-git-external-wt-"));
 
   // ---- Real git repo with one commit ----
   const projectPath = join(workspacePath, "demo");
@@ -110,6 +111,8 @@ async function main(): Promise<void> {
   await fsWrite(join(projectPath, "README.md"), "# demo\n", "utf8");
   await git(projectPath, ["add", "."]);
   await git(projectPath, ["commit", "-q", "-m", "initial"]);
+  const siblingWorktreePath = join(externalWorktreeRoot, "demo-feature");
+  await git(projectPath, ["worktree", "add", "-q", "-b", "feature/worktree", siblingWorktreePath]);
 
   // ---- Plain (non-git) project ----
   const nonGitPath = join(workspacePath, "plain");
@@ -191,6 +194,52 @@ async function main(): Promise<void> {
         "non-git: commits === []",
         Array.isArray((log.body as { commits: unknown[] }).commits) &&
           (log.body as { commits: unknown[] }).commits.length === 0,
+      );
+    }
+
+    // ---- worktree discovery + selected worktree status ----
+    {
+      const r = await jget(
+        `${base}/api/v1/git/worktrees?projectId=${encodeURIComponent(gitProjectId)}`,
+        auth,
+      );
+      assert("worktrees → 200", r.status === 200);
+      const body = r.body as { worktrees: { path: string; branch?: string; current: boolean }[] };
+      assert(
+        "worktrees include main + sibling",
+        body.worktrees.some((w) => w.path === projectPath && w.current) &&
+          body.worktrees.some(
+            (w) => w.path === siblingWorktreePath && w.branch === "feature/worktree",
+          ),
+      );
+      assert(
+        "registered worktree outside WORKSPACE_PATH is included",
+        body.worktrees.some(
+          (w) => w.path === siblingWorktreePath && w.branch === "feature/worktree",
+        ),
+      );
+
+      await fsWrite(join(siblingWorktreePath, "worktree-only.txt"), "from sibling\n", "utf8");
+      const qs = new URLSearchParams({
+        projectId: gitProjectId,
+        worktreePath: siblingWorktreePath,
+      }).toString();
+      const selected = await jget(`${base}/api/v1/git/status?${qs}`, auth);
+      assert("selected worktree status → 200", selected.status === 200);
+      const selectedFiles = (selected.body as { branch?: string; files: { path: string }[] }).files;
+      assert(
+        "selected worktree sees its own untracked file",
+        selectedFiles.some((f) => f.path === "worktree-only.txt"),
+      );
+
+      const mainStatus = await jget(
+        `${base}/api/v1/git/status?projectId=${encodeURIComponent(gitProjectId)}`,
+        auth,
+      );
+      const mainFiles = (mainStatus.body as { files: { path: string }[] }).files;
+      assert(
+        "main worktree does not see sibling-only file",
+        !mainFiles.some((f) => f.path === "worktree-only.txt"),
       );
     }
 
@@ -538,6 +587,7 @@ async function main(): Promise<void> {
     await rm(workspacePath, { recursive: true, force: true });
     await rm(configDir, { recursive: true, force: true });
     await rm(dataDir, { recursive: true, force: true });
+    await rm(externalWorktreeRoot, { recursive: true, force: true });
   }
 
   if (failures > 0) {


### PR DESCRIPTION
## Summary

Adds a visible worktree selector to the Git pane so users can view status, diffs, logs, branches, remotes, and perform git actions against a selected registered git worktree.

The selector uses `git worktree list --porcelain -z` only. It no longer filters registered worktrees by `WORKSPACE_PATH`; instead, selected worktree paths are accepted only if they exactly match a registered worktree for that repository.

## Usage

Open the **Git** tab. The header now includes a **Worktree** dropdown under the branch name. Select a worktree to refresh the pane and view diffs/status for that worktree.

## What changed (7 files)

- `packages/client/src/components/GitPanel.tsx` — adds always-visible Worktree dropdown and passes selected worktree to git operations.
- `packages/client/src/hooks/useGitStatus.ts` — supports polling status for a selected worktree.
- `packages/client/src/lib/api-client/index.ts` — adds `gitWorktrees` and optional `worktreePath` support to git APIs.
- `packages/client/src/lib/api-client/types.ts` — adds worktree response types.
- `packages/server/src/git-runner.ts` — parses registered worktrees from `git worktree list`.
- `packages/server/src/routes/git.ts` — adds `/git/worktrees` and validates selected worktree paths against registered worktrees.
- `tests/test-git.ts` — covers registered worktree discovery and selected-worktree status isolation.

## Test plan

- [x] `npm run build`
- [x] `scripts/run-tests.sh --only git`
- [x] `npm run format:check`
- [x] Manual: confirmed selector appears and registered test worktrees are selectable
