### PR TITLE
fix(client): accept empty success responses

### DIFF
--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -88,7 +88,7 @@ function isObject(v: unknown): v is Record<string, unknown> {
 }
 
 const vVoid: Validator<undefined> = (value, status) => {
-  if (value !== undefined) fail(status, "expected empty body");
+  if (value !== undefined && value !== null) fail(status, "expected empty body");
   return undefined;
 };
 
@@ -1492,6 +1492,7 @@ async function request<T>(
   }
 
   if (!parsed.ok) {
+    if (text.length === 0) return validator(undefined, res.status);
     throw new ApiError(res.status, "invalid_response_body", "server returned non-JSON 2xx body");
   }
 


### PR DESCRIPTION
## Summary

This is a defensive client-side fix for successful empty HTTP responses from session control routes such as `POST /api/v1/sessions/:id/abort`. The server abort route returns `204 No Content`, but the shared browser API client treated any non-JSON 2xx response as `invalid_response_body`. That could make the Abort button path look failed even when the provider-agnostic server abort request succeeded.

The request helper now accepts an empty successful response body and validates it as `undefined`, and the void validator also tolerates parsed JSON `null` for compatibility with no-content style responses.

## Usage

No user-facing usage change. Pressing Abort still calls:

```bash
POST /api/v1/sessions/<sessionId>/abort
```

The browser client now treats the route's empty `204 No Content` response as a successful void response instead of a malformed response body.

## What changed (1 file, +2/-1)

- `packages/client/src/lib/api-client/index.ts` — allow empty successful response bodies to flow through the endpoint validator as `undefined`, and allow `vVoid` to accept `null` as an empty response equivalent.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only api`
- [ ] CI green before merge
