### PR TITLE
fix: clean up killed orchestration sessions

### DIFF
--- a/packages/server/src/orchestration/tools.ts
+++ b/packages/server/src/orchestration/tools.ts
@@ -36,6 +36,7 @@ import {
   registerWorker,
   unregisterWorker,
 } from "./store.js";
+import { killWorkerAndArchive } from "./worker-lifecycle.js";
 
 // ---- result shape helpers ----
 
@@ -746,9 +747,9 @@ const killSchema = {
     deleteOnDisk: {
       type: "boolean",
       description:
-        "When true, also delete the worker's .jsonl from disk (the session " +
-        "is gone from the sidebar). Default false — keeps the transcript " +
-        "for later inspection.",
+        "Deprecated compatibility flag. Killed workers are always moved out " +
+        "of the live session tree and preserved in the 7-day archive so they " +
+        "disappear from the sidebar without losing the transcript.",
     },
   },
 } as const;
@@ -759,24 +760,27 @@ function createKillWorker(supervisorId: string): ToolDefinition {
     label: "Kill worker",
     description:
       "Dispose the worker session (terminate any in-flight turn, close " +
-      "SSE clients) and unregister it from this supervisor. By default " +
-      "the .jsonl transcript stays on disk; pass `deleteOnDisk: true` " +
-      "to also remove it.",
+      "SSE clients), move its transcript into the 7-day archive so it " +
+      "disappears from the sidebar, and unregister it from this supervisor.",
     parameters: Type.Unsafe<Record<string, unknown>>(killSchema),
     async execute(_toolCallId, params) {
       const p = params as { workerId: string; deleteOnDisk?: boolean };
       const guard = await assertOwns(supervisorId, p.workerId);
       if (guard !== undefined) return guard;
-      const wasLive = await disposeSession(p.workerId);
-      let diskDeleted = false;
-      if (p.deleteOnDisk === true) {
-        const r = await deleteColdSession(p.workerId).catch(() => "not_found" as const);
-        diskDeleted = r === "deleted";
-      }
-      await unregisterWorker(p.workerId);
+      const result = await killWorkerAndArchive({ supervisorId, workerId: p.workerId });
       return ok(
-        { workerId: p.workerId, wasLive, diskDeleted },
-        `Killed worker ${p.workerId}${diskDeleted ? " (and deleted from disk)" : ""}.`,
+        {
+          workerId: p.workerId,
+          wasLive: result.wasLive,
+          archiveStatus: result.archiveStatus,
+          // Backward-compatible detail for older consumers that looked for
+          // the pre-archive flag name. "Deleted" means gone from live
+          // discovery, not purged from the retention archive.
+          diskDeleted: result.archiveStatus === "archived",
+        },
+        `Killed worker ${p.workerId}${
+          result.archiveStatus === "archived" ? " (transcript archived)" : ""
+        }.`,
       );
     },
   } satisfies ToolDefinition;

--- a/packages/server/src/orchestration/worker-lifecycle.ts
+++ b/packages/server/src/orchestration/worker-lifecycle.ts
@@ -1,0 +1,99 @@
+import {
+  deleteColdSession,
+  disposeSession,
+  findProjectIdForSession,
+  getSession,
+} from "../session-registry.js";
+import { bridgeWorkerDeleted } from "./event-bridge.js";
+import { disableSupervisor, getWorkerIds, unregisterWorker } from "./store.js";
+
+export type WorkerArchiveStatus = "archived" | "not_found";
+
+export interface KillWorkerResult {
+  wasLive: boolean;
+  archiveStatus: WorkerArchiveStatus;
+}
+
+export interface CleanupSupervisorWorkersResult {
+  workerIds: string[];
+  results: Record<string, KillWorkerResult>;
+}
+
+function notifySupervisorSessionListChanged(args: {
+  supervisorId: string;
+  workerId: string;
+  projectId?: string;
+  reason: string;
+}): void {
+  const supervisor = getSession(args.supervisorId);
+  if (supervisor === undefined) return;
+  const projectId = args.projectId ?? supervisor.projectId;
+  for (const client of supervisor.clients) {
+    try {
+      client.send({
+        type: "session_list_changed",
+        reason: args.reason,
+        projectId,
+        sessionId: args.workerId,
+      });
+    } catch {
+      // SSE client already dropped; the registry will prune it on the next event.
+    }
+  }
+}
+
+/**
+ * Kill a worker and move its transcript out of the live session tree.
+ *
+ * Orchestration workers are top-level pi sessions on disk. Merely disposing and
+ * unregistering one turns it into a standalone cold session, which leaves it in
+ * the sidebar. The intended kill semantics are "not live and not listed", while
+ * still preserving the JSONL via deleteColdSession's 7-day archive.
+ */
+export async function killWorkerAndArchive(args: {
+  supervisorId: string;
+  workerId: string;
+}): Promise<KillWorkerResult> {
+  const projectId =
+    (await findProjectIdForSession(args.workerId)) ??
+    (await findProjectIdForSession(args.supervisorId));
+  const wasLive = await disposeSession(args.workerId);
+
+  let archive = await deleteColdSession(args.workerId);
+  if (archive === "live") {
+    await disposeSession(args.workerId);
+    archive = await deleteColdSession(args.workerId);
+  }
+
+  // Fire before unregistering so the bridge can still resolve the supervisor.
+  await bridgeWorkerDeleted(args.workerId, { wasLive }).catch(() => undefined);
+  await unregisterWorker(args.workerId);
+  notifySupervisorSessionListChanged({
+    supervisorId: args.supervisorId,
+    workerId: args.workerId,
+    ...(projectId !== undefined ? { projectId } : {}),
+    reason: "kill_worker",
+  });
+
+  return {
+    wasLive,
+    archiveStatus: archive === "deleted" ? "archived" : "not_found",
+  };
+}
+
+/**
+ * Delete every registered worker under a supervisor, then remove the
+ * supervisor topology record. Used when the supervisor session itself is
+ * deleted through the normal session DELETE route.
+ */
+export async function cleanupWorkersForDeletedSupervisor(
+  supervisorId: string,
+): Promise<CleanupSupervisorWorkersResult> {
+  const workerIds = await getWorkerIds(supervisorId);
+  const results: Record<string, KillWorkerResult> = {};
+  for (const workerId of workerIds) {
+    results[workerId] = await killWorkerAndArchive({ supervisorId, workerId });
+  }
+  await disableSupervisor(supervisorId);
+  return { workerIds, results };
+}

--- a/packages/server/src/routes/orchestration.ts
+++ b/packages/server/src/routes/orchestration.ts
@@ -21,7 +21,6 @@
  */
 import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import {
-  disposeSession,
   findProjectIdForSession,
   getSession,
   rebuildAgentSessionForTools,
@@ -44,6 +43,7 @@ import {
 } from "../orchestration/store.js";
 import { clearInbox, pendingInboxCount, readAllInbox } from "../orchestration/store.js";
 import { MAX_DEPTH } from "../orchestration/types.js";
+import { killWorkerAndArchive } from "../orchestration/worker-lifecycle.js";
 import { errorSchema } from "./_schemas.js";
 
 function gate(reply: FastifyReply): FastifyReply | undefined {
@@ -476,9 +476,9 @@ export const orchestrationRoutes: FastifyPluginAsync = async (fastify) => {
     {
       schema: {
         description:
-          "UI control: dispose the worker session AND unregister it from this " +
-          "supervisor. Does NOT delete the .jsonl from disk — use DELETE " +
-          "/sessions/:id for that.",
+          "UI control: dispose the worker session, move its transcript into " +
+          "the 7-day archive so it disappears from the live session list, " +
+          "and unregister it from this supervisor.",
         tags: ["orchestration"],
         params: {
           type: "object",
@@ -489,7 +489,10 @@ export const orchestrationRoutes: FastifyPluginAsync = async (fastify) => {
           200: {
             type: "object",
             required: ["wasLive"],
-            properties: { wasLive: { type: "boolean" } },
+            properties: {
+              wasLive: { type: "boolean" },
+              archiveStatus: { type: "string", enum: ["archived", "not_found"] },
+            },
           },
           403: errorSchema,
           404: errorSchema,
@@ -503,9 +506,7 @@ export const orchestrationRoutes: FastifyPluginAsync = async (fastify) => {
       if (rec === undefined || rec.supervisorId !== req.params.id) {
         return reply.code(404).send({ error: "worker_not_linked" });
       }
-      const wasLive = await disposeSession(req.params.wid);
-      await unregisterWorker(req.params.wid);
-      return { wasLive };
+      return killWorkerAndArchive({ supervisorId: req.params.id, workerId: req.params.wid });
     },
   );
 

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -12,8 +12,11 @@ import {
   type UnifiedSession,
 } from "../session-registry.js";
 import { bridgeSessionDeleted } from "../webhooks/event-bridge.js";
-import { bridgeWorkerDeleted } from "../orchestration/event-bridge.js";
-import { unregisterWorker } from "../orchestration/store.js";
+import { isSupervisor, getWorkerRecord } from "../orchestration/store.js";
+import {
+  cleanupWorkersForDeletedSupervisor,
+  killWorkerAndArchive,
+} from "../orchestration/worker-lifecycle.js";
 import { errorSchema, liveSummaryBody, liveSummarySchema } from "./_schemas.js";
 import { buildTurnDiff } from "../turn-diff-builder.js";
 import { buildCompactionHistory } from "../compaction-history.js";
@@ -800,6 +803,34 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       // session — both `getSession` and the on-disk lookup go away
       // mid-flow. Used for the session_deleted webhook payload.
       const projectIdForWebhook = await findProjectIdForSession(req.params.id);
+      const workerRecord = await getWorkerRecord(req.params.id);
+      if (workerRecord !== undefined) {
+        try {
+          const result = await killWorkerAndArchive({
+            supervisorId: workerRecord.supervisorId,
+            workerId: req.params.id,
+          });
+          bridgeSessionDeleted({
+            sessionId: req.params.id,
+            ...(projectIdForWebhook !== undefined ? { projectId: projectIdForWebhook } : {}),
+            wasLive: result.wasLive,
+          });
+          return reply.code(204).send();
+        } catch (err) {
+          req.log.error({ err }, "killWorkerAndArchive failed during session delete");
+          return reply.code(500).send({ error: "session_delete_failed" });
+        }
+      }
+
+      if (await isSupervisor(req.params.id)) {
+        try {
+          await cleanupWorkersForDeletedSupervisor(req.params.id);
+        } catch (err) {
+          req.log.error({ err }, "cleanupWorkersForDeletedSupervisor failed during session delete");
+          return reply.code(500).send({ error: "session_delete_failed" });
+        }
+      }
+
       const wasLive = await disposeSession(req.params.id);
       // Always soft-delete: dispose (above) + move JSONL into the 7-day
       // archive (below). After dispose, the registry no longer has the entry;
@@ -819,11 +850,6 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
           ...(projectIdForWebhook !== undefined ? { projectId: projectIdForWebhook } : {}),
           wasLive,
         });
-        // Fire the worker.deleted inbox event BEFORE unregistering
-        // so the bridge can still resolve the supervisor link.
-        // Best-effort: a failure here doesn't undo the delete.
-        void bridgeWorkerDeleted(req.params.id, { wasLive });
-        void unregisterWorker(req.params.id).catch(() => undefined);
         return reply.code(204).send();
       }
       if (r === "live") {
@@ -844,8 +870,6 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
                 ...(projectIdForWebhook !== undefined ? { projectId: projectIdForWebhook } : {}),
                 wasLive: true,
               });
-              void bridgeWorkerDeleted(req.params.id, { wasLive: true });
-              void unregisterWorker(req.params.id).catch(() => undefined);
               return reply.code(204).send();
             }
           } catch (err) {
@@ -869,8 +893,6 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
           ...(projectIdForWebhook !== undefined ? { projectId: projectIdForWebhook } : {}),
           wasLive: true,
         });
-        void bridgeWorkerDeleted(req.params.id, { wasLive: true });
-        void unregisterWorker(req.params.id).catch(() => undefined);
         return reply.code(204).send();
       }
       return notFound(reply);

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -22,9 +22,10 @@
  * thin wrappers around the same store / inbox / session-registry
  * functions covered below.
  */
+import { randomUUID } from "node:crypto";
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer, type Server } from "node:net";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -661,6 +662,398 @@ async function main(): Promise<void> {
       unnestedList.status === 200 && unnestedWorker?.parentSessionId === undefined,
       `parentSessionId=${unnestedWorker?.parentSessionId}`,
     );
+
+    // Regression: killing an orchestration worker should remove it from the
+    // live session list instead of merely unregistering it into a standalone
+    // cold session. The transcript is soft-deleted into the 7-day archive.
+    const reEn = await jsend(
+      onSrv.base,
+      "POST",
+      `/api/v1/orchestration/sessions/${realSid}/enable`,
+    );
+    assert("re-enable real supervisor for kill regression → 200", reEn.status === 200);
+    const workerSessionDir = join(sharedWs, ".pi", "sessions", realProjectId);
+    const workerBasename = `kill-regression-${realWorkerId}`;
+    const childRunId = `run-${randomUUID().slice(0, 8)}`;
+    const workerSubagentId = randomUUID();
+    await mkdir(workerSessionDir, { recursive: true });
+    await writeFile(
+      join(workerSessionDir, `${workerBasename}.jsonl`),
+      JSON.stringify({
+        type: "session",
+        version: 1,
+        id: realWorkerId,
+        timestamp: new Date().toISOString(),
+        cwd: sharedWs,
+      }) + "\n",
+      "utf8",
+    );
+    const workerSubagentDir = join(workerSessionDir, workerBasename, childRunId);
+    await mkdir(workerSubagentDir, { recursive: true });
+    await writeFile(
+      join(workerSubagentDir, `${workerSubagentId}.jsonl`),
+      JSON.stringify({
+        type: "session",
+        version: 1,
+        id: workerSubagentId,
+        timestamp: new Date().toISOString(),
+        cwd: sharedWs,
+      }) + "\n",
+      "utf8",
+    );
+    await store.registerWorker({ supervisorId: realSid, workerId: realWorkerId });
+    const preKillNestedList = await jsend(
+      onSrv.base,
+      "GET",
+      `/api/v1/sessions?projectId=${encodeURIComponent(realProjectId)}`,
+    );
+    const preKillSessions =
+      (preKillNestedList.body as { sessions?: { sessionId: string; parentSessionId?: string }[] })
+        .sessions ?? [];
+    assert(
+      "worker subagent child is listed before kill",
+      preKillNestedList.status === 200 &&
+        preKillSessions.some(
+          (s) => s.sessionId === workerSubagentId && s.parentSessionId === realWorkerId,
+        ),
+      JSON.stringify(preKillNestedList.body),
+    );
+    const childSseAc = new AbortController();
+    const childSseRes = await fetch(`${onSrv.base}/api/v1/sessions/${workerSubagentId}/stream`, {
+      signal: childSseAc.signal,
+    });
+    assert(
+      "worker subagent child can be made live before kill",
+      childSseRes.status === 200,
+      `got ${childSseRes.status}`,
+    );
+    const killRes = await jsend(
+      onSrv.base,
+      "POST",
+      `/api/v1/orchestration/sessions/${realSid}/workers/${realWorkerId}/kill`,
+    );
+    assert(
+      "kill worker archives transcript",
+      killRes.status === 200 &&
+        (killRes.body as { wasLive?: boolean; archiveStatus?: string }).wasLive === true &&
+        (killRes.body as { wasLive?: boolean; archiveStatus?: string }).archiveStatus ===
+          "archived",
+      JSON.stringify(killRes.body),
+    );
+    const afterKillList = await jsend(
+      onSrv.base,
+      "GET",
+      `/api/v1/sessions?projectId=${encodeURIComponent(realProjectId)}`,
+    );
+    const afterKillSessions =
+      (afterKillList.body as { sessions?: { sessionId: string }[] }).sessions ?? [];
+    const killedWorkerStillListed = afterKillSessions.some((s) => s.sessionId === realWorkerId);
+    const workerSubagentStillListed = afterKillSessions.some(
+      (s) => s.sessionId === workerSubagentId,
+    );
+    assert(
+      "killed worker no longer appears in session list",
+      afterKillList.status === 200 && killedWorkerStillListed === false,
+      JSON.stringify(afterKillList.body),
+    );
+    assert(
+      "killed worker's subagent child no longer appears in session list",
+      afterKillList.status === 200 && workerSubagentStillListed === false,
+      JSON.stringify(afterKillList.body),
+    );
+    const childAfterKill = await jsend(onSrv.base, "GET", `/api/v1/sessions/${workerSubagentId}`);
+    assert(
+      "live worker subagent child is disposed during kill",
+      childAfterKill.status === 404,
+      `got ${childAfterKill.status}`,
+    );
+    const archiveEntries = await readdir(join(sharedData, "archived-sessions"));
+    const workerArchiveEntry = archiveEntries.find((name) => name.includes(realWorkerId));
+    assert(
+      "killed worker transcript has archive entry",
+      workerArchiveEntry !== undefined,
+      archiveEntries.join(","),
+    );
+    if (workerArchiveEntry !== undefined) {
+      const archivedChildFiles = await readdir(
+        join(sharedData, "archived-sessions", workerArchiveEntry, "subagents", childRunId),
+      );
+      assert(
+        "killed worker archive includes subagent child directory",
+        archivedChildFiles.includes(`${workerSubagentId}.jsonl`),
+        archivedChildFiles.join(","),
+      );
+    }
+    childSseAc.abort();
+    try {
+      await childSseRes.body?.cancel();
+    } catch {
+      // ignore — body cancel after abort can throw
+    }
+
+    // Same cleanup contract through the normal DELETE /sessions/:id route:
+    // if the target is a registered orchestration worker, it should use the
+    // shared kill/archive helper rather than the standalone delete path.
+    const deleteWorker = await jsend(onSrv.base, "POST", "/api/v1/sessions", {
+      projectId: realProjectId,
+    });
+    assert(
+      "create delete-route worker session → 201",
+      deleteWorker.status === 201 &&
+        typeof (deleteWorker.body as { sessionId: string }).sessionId === "string",
+    );
+    const deleteWorkerId = (deleteWorker.body as { sessionId: string }).sessionId;
+    const deleteWorkerBasename = `delete-regression-${deleteWorkerId}`;
+    const deleteChildRunId = `run-${randomUUID().slice(0, 8)}`;
+    const deleteWorkerSubagentId = randomUUID();
+    await writeFile(
+      join(workerSessionDir, `${deleteWorkerBasename}.jsonl`),
+      JSON.stringify({
+        type: "session",
+        version: 1,
+        id: deleteWorkerId,
+        timestamp: new Date().toISOString(),
+        cwd: sharedWs,
+      }) + "\n",
+      "utf8",
+    );
+    const deleteWorkerSubagentDir = join(workerSessionDir, deleteWorkerBasename, deleteChildRunId);
+    await mkdir(deleteWorkerSubagentDir, { recursive: true });
+    await writeFile(
+      join(deleteWorkerSubagentDir, `${deleteWorkerSubagentId}.jsonl`),
+      JSON.stringify({
+        type: "session",
+        version: 1,
+        id: deleteWorkerSubagentId,
+        timestamp: new Date().toISOString(),
+        cwd: sharedWs,
+      }) + "\n",
+      "utf8",
+    );
+    await store.registerWorker({ supervisorId: realSid, workerId: deleteWorkerId });
+    const deleteChildSseAc = new AbortController();
+    const deleteChildSseRes = await fetch(
+      `${onSrv.base}/api/v1/sessions/${deleteWorkerSubagentId}/stream`,
+      { signal: deleteChildSseAc.signal },
+    );
+    assert(
+      "delete-route worker subagent child can be made live before delete",
+      deleteChildSseRes.status === 200,
+      `got ${deleteChildSseRes.status}`,
+    );
+    const deleteWorkerRes = await jsend(onSrv.base, "DELETE", `/api/v1/sessions/${deleteWorkerId}`);
+    assert("DELETE /sessions/:id for worker returns 204", deleteWorkerRes.status === 204);
+    const afterDeleteWorkerList = await jsend(
+      onSrv.base,
+      "GET",
+      `/api/v1/sessions?projectId=${encodeURIComponent(realProjectId)}`,
+    );
+    const afterDeleteWorkerSessions =
+      (afterDeleteWorkerList.body as { sessions?: { sessionId: string }[] }).sessions ?? [];
+    assert(
+      "DELETE worker no longer appears in session list",
+      afterDeleteWorkerList.status === 200 &&
+        !afterDeleteWorkerSessions.some((s) => s.sessionId === deleteWorkerId),
+      JSON.stringify(afterDeleteWorkerList.body),
+    );
+    assert(
+      "DELETE worker's subagent child no longer appears in session list",
+      afterDeleteWorkerList.status === 200 &&
+        !afterDeleteWorkerSessions.some((s) => s.sessionId === deleteWorkerSubagentId),
+      JSON.stringify(afterDeleteWorkerList.body),
+    );
+    const deleteChildAfterKill = await jsend(
+      onSrv.base,
+      "GET",
+      `/api/v1/sessions/${deleteWorkerSubagentId}`,
+    );
+    assert(
+      "DELETE worker disposes live subagent child",
+      deleteChildAfterKill.status === 404,
+      `got ${deleteChildAfterKill.status}`,
+    );
+    const archiveEntriesAfterDelete = await readdir(join(sharedData, "archived-sessions"));
+    const deleteWorkerArchiveEntry = archiveEntriesAfterDelete.find((name) =>
+      name.includes(deleteWorkerId),
+    );
+    assert(
+      "DELETE worker transcript has archive entry",
+      deleteWorkerArchiveEntry !== undefined,
+      archiveEntriesAfterDelete.join(","),
+    );
+    if (deleteWorkerArchiveEntry !== undefined) {
+      const deleteArchivedChildFiles = await readdir(
+        join(
+          sharedData,
+          "archived-sessions",
+          deleteWorkerArchiveEntry,
+          "subagents",
+          deleteChildRunId,
+        ),
+      );
+      assert(
+        "DELETE worker archive includes subagent child directory",
+        deleteArchivedChildFiles.includes(`${deleteWorkerSubagentId}.jsonl`),
+        deleteArchivedChildFiles.join(","),
+      );
+    }
+    deleteChildSseAc.abort();
+    try {
+      await deleteChildSseRes.body?.cancel();
+    } catch {
+      // ignore — body cancel after abort can throw
+    }
+
+    // Deleting the supervisor itself should cascade through the same worker
+    // cleanup path: registered workers (and their subagent children) are
+    // archived out of live discovery and unregistered before the supervisor is
+    // removed.
+    const cascadeWorkerA = await jsend(onSrv.base, "POST", "/api/v1/sessions", {
+      projectId: realProjectId,
+    });
+    const cascadeWorkerB = await jsend(onSrv.base, "POST", "/api/v1/sessions", {
+      projectId: realProjectId,
+    });
+    assert(
+      "create cascade worker sessions → 201",
+      cascadeWorkerA.status === 201 && cascadeWorkerB.status === 201,
+    );
+    const cascadeWorkerAId = (cascadeWorkerA.body as { sessionId: string }).sessionId;
+    const cascadeWorkerBId = (cascadeWorkerB.body as { sessionId: string }).sessionId;
+    const cascadeWorkerABasename = `cascade-worker-${cascadeWorkerAId}`;
+    const cascadeWorkerBBasename = `cascade-worker-${cascadeWorkerBId}`;
+    const cascadeChildRunId = `run-${randomUUID().slice(0, 8)}`;
+    const cascadeWorkerSubagentId = randomUUID();
+    await writeFile(
+      join(workerSessionDir, `${cascadeWorkerABasename}.jsonl`),
+      JSON.stringify({
+        type: "session",
+        version: 1,
+        id: cascadeWorkerAId,
+        timestamp: new Date().toISOString(),
+        cwd: sharedWs,
+      }) + "\n",
+      "utf8",
+    );
+    await writeFile(
+      join(workerSessionDir, `${cascadeWorkerBBasename}.jsonl`),
+      JSON.stringify({
+        type: "session",
+        version: 1,
+        id: cascadeWorkerBId,
+        timestamp: new Date().toISOString(),
+        cwd: sharedWs,
+      }) + "\n",
+      "utf8",
+    );
+    const cascadeWorkerSubagentDir = join(
+      workerSessionDir,
+      cascadeWorkerABasename,
+      cascadeChildRunId,
+    );
+    await mkdir(cascadeWorkerSubagentDir, { recursive: true });
+    await writeFile(
+      join(cascadeWorkerSubagentDir, `${cascadeWorkerSubagentId}.jsonl`),
+      JSON.stringify({
+        type: "session",
+        version: 1,
+        id: cascadeWorkerSubagentId,
+        timestamp: new Date().toISOString(),
+        cwd: sharedWs,
+      }) + "\n",
+      "utf8",
+    );
+    await store.registerWorker({ supervisorId: realSid, workerId: cascadeWorkerAId });
+    await store.registerWorker({ supervisorId: realSid, workerId: cascadeWorkerBId });
+    const cascadeChildSseAc = new AbortController();
+    const cascadeChildSseRes = await fetch(
+      `${onSrv.base}/api/v1/sessions/${cascadeWorkerSubagentId}/stream`,
+      { signal: cascadeChildSseAc.signal },
+    );
+    assert(
+      "cascade worker subagent child can be made live before supervisor delete",
+      cascadeChildSseRes.status === 200,
+      `got ${cascadeChildSseRes.status}`,
+    );
+    const deleteSupervisorRes = await jsend(onSrv.base, "DELETE", `/api/v1/sessions/${realSid}`);
+    assert("DELETE /sessions/:id for supervisor returns 204", deleteSupervisorRes.status === 204);
+    const afterSupervisorDeleteList = await jsend(
+      onSrv.base,
+      "GET",
+      `/api/v1/sessions?projectId=${encodeURIComponent(realProjectId)}`,
+    );
+    const afterSupervisorDeleteSessions =
+      (afterSupervisorDeleteList.body as { sessions?: { sessionId: string }[] }).sessions ?? [];
+    assert(
+      "deleted supervisor no longer appears in session list",
+      afterSupervisorDeleteList.status === 200 &&
+        !afterSupervisorDeleteSessions.some((s) => s.sessionId === realSid),
+      JSON.stringify(afterSupervisorDeleteList.body),
+    );
+    assert(
+      "deleted supervisor's workers no longer appear in session list",
+      afterSupervisorDeleteList.status === 200 &&
+        !afterSupervisorDeleteSessions.some(
+          (s) => s.sessionId === cascadeWorkerAId || s.sessionId === cascadeWorkerBId,
+        ),
+      JSON.stringify(afterSupervisorDeleteList.body),
+    );
+    assert(
+      "deleted supervisor worker's subagent child no longer appears in session list",
+      afterSupervisorDeleteList.status === 200 &&
+        !afterSupervisorDeleteSessions.some((s) => s.sessionId === cascadeWorkerSubagentId),
+      JSON.stringify(afterSupervisorDeleteList.body),
+    );
+    assert(
+      "deleted supervisor workers are unregistered",
+      (await store.getWorkerIds(realSid)).length === 0,
+    );
+    const cascadeChildAfterDelete = await jsend(
+      onSrv.base,
+      "GET",
+      `/api/v1/sessions/${cascadeWorkerSubagentId}`,
+    );
+    assert(
+      "deleted supervisor disposes live worker subagent child",
+      cascadeChildAfterDelete.status === 404,
+      `got ${cascadeChildAfterDelete.status}`,
+    );
+    const archiveEntriesAfterSupervisorDelete = await readdir(
+      join(sharedData, "archived-sessions"),
+    );
+    const cascadeWorkerAArchiveEntry = archiveEntriesAfterSupervisorDelete.find((name) =>
+      name.includes(cascadeWorkerAId),
+    );
+    const cascadeWorkerBArchiveEntry = archiveEntriesAfterSupervisorDelete.find((name) =>
+      name.includes(cascadeWorkerBId),
+    );
+    assert(
+      "deleted supervisor's workers have archive entries",
+      cascadeWorkerAArchiveEntry !== undefined && cascadeWorkerBArchiveEntry !== undefined,
+      archiveEntriesAfterSupervisorDelete.join(","),
+    );
+    if (cascadeWorkerAArchiveEntry !== undefined) {
+      const cascadeArchivedChildFiles = await readdir(
+        join(
+          sharedData,
+          "archived-sessions",
+          cascadeWorkerAArchiveEntry,
+          "subagents",
+          cascadeChildRunId,
+        ),
+      );
+      assert(
+        "deleted supervisor worker archive includes subagent child directory",
+        cascadeArchivedChildFiles.includes(`${cascadeWorkerSubagentId}.jsonl`),
+        cascadeArchivedChildFiles.join(","),
+      );
+    }
+    cascadeChildSseAc.abort();
+    try {
+      await cascadeChildSseRes.body?.cancel();
+    } catch {
+      // ignore — body cancel after abort can throw
+    }
 
     // Plant some workers + inbox items via the store (since real
     // spawn_worker requires a live agent session).


### PR DESCRIPTION
## Summary

Killing an orchestration worker disposed the live session but could leave the worker transcript in the normal session tree, so killed workers stayed visible in the sessions pane as cold standalone sessions. The normal `DELETE /sessions/:id` path also had separate worker cleanup logic, and deleting a supervisor did not cascade to registered workers.

This PR centralizes orchestration worker cleanup so worker kill/delete paths archive transcripts out of live discovery, preserve the archived JSONL, remove worker subagent trees, and nudge the sessions pane to refresh. Deleting a supervisor now first cleans all registered workers through the same helper before deleting the supervisor session.

## Usage

No new user-facing API is required. Existing actions now clean up consistently:

```bash
# Worker UI/API kill
POST /api/v1/orchestration/sessions/:supervisorId/workers/:workerId/kill

# Normal session delete when :id is a registered worker or supervisor
DELETE /api/v1/sessions/:id
```

Killed/deleted worker transcripts are soft-deleted into the existing 7-day archive rather than permanently purged immediately.

## What changed (5 files)

- `packages/server/src/orchestration/worker-lifecycle.ts` — added shared helpers for worker archive cleanup and supervisor worker cascade cleanup.
- `packages/server/src/orchestration/tools.ts` — routes `orchestrate_kill_worker` through the shared archive helper and reports archived status while keeping backward-compatible details.
- `packages/server/src/routes/orchestration.ts` — routes REST worker kill through the shared helper.
- `packages/server/src/routes/sessions.ts` — routes normal DELETE of registered workers through the helper and cascades supervisor deletion to registered workers before deleting the supervisor.
- `tests/test-orchestration.ts` — adds regressions for worker kill, normal worker DELETE, worker subagent cleanup, live child disposal, archives, and supervisor deletion cascading to registered workers.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only orchestration`
- [ ] CI green before merge
