### PR TITLE
chore(deps): bump pi sdk packages to 0.78.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2284,12 +2284,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.77.0.tgz",
-      "integrity": "sha512-l/mYLJPjpgiPDmcfnFIGdOBqICkWaf8IawCdAbae5guBrPXg+Z0o84l9OuHyRJPOb8RfedeGg8DtSnq8t7grOg==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.78.0.tgz",
+      "integrity": "sha512-xhWd59Qzd8yO88gYQw2S4dEQstJJEiUtxRP01//YzVJ61jCtUASMfcyAmYhgGYR4Onp7GmwEAbBBGOiV6Iwk9g==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.77.0",
+        "@earendil-works/pi-ai": "^0.78.0",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -2299,9 +2299,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.77.0.tgz",
-      "integrity": "sha512-H21BrQDPf3ydaeBmS5maNDHxUGFMiKBF/n3WnE+OTWloIZSayeL+/NVEgG3aKQw8fZL6HAMYAGpUIVJgFuKtnw==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.78.0.tgz",
+      "integrity": "sha512-q0hUrvT6ngT6cgBX0oIbzfQfmzztgdkZobP8OTL+sCOOBlnG6+1YRt8g7zO9CC/4NdeYEqa7uGqWdQhH0fjCLA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -2323,15 +2323,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.77.0.tgz",
-      "integrity": "sha512-huS+k+dhQRR9PlTK7crLfeSRUw3a96V6JYfP0ZH3Zkko/m10gsYk8dKQmwScSy5Dll516pXorz19BURfD6S2qQ==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.78.0.tgz",
+      "integrity": "sha512-gXt6pD3BoSG0yLwfLqb6844vz6qAO87PvNrv+YSDYKP3QliTjcwIld9v4ihmDcmBjO13QwKswubq/lYCvn4bkg==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.77.0",
-        "@earendil-works/pi-ai": "^0.77.0",
-        "@earendil-works/pi-tui": "^0.77.0",
+        "@earendil-works/pi-agent-core": "^0.78.0",
+        "@earendil-works/pi-ai": "^0.78.0",
+        "@earendil-works/pi-tui": "^0.78.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -2793,11 +2793,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.77.0.tgz",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.78.0.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.77.0",
+        "@earendil-works/pi-ai": "^0.78.0",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -2807,8 +2807,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.77.0.tgz",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.78.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -2830,8 +2830,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.77.0.tgz",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.78.0.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -16996,9 +16996,9 @@
       "name": "@pi-forge/server",
       "version": "1.3.5",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "0.77.0",
-        "@earendil-works/pi-ai": "0.77.0",
-        "@earendil-works/pi-coding-agent": "0.77.0",
+        "@earendil-works/pi-agent-core": "0.78.0",
+        "@earendil-works/pi-ai": "0.78.0",
+        "@earendil-works/pi-coding-agent": "0.78.0",
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^10.0.0",
         "@fastify/rate-limit": "^10.2.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,9 +9,9 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.77.0",
-    "@earendil-works/pi-ai": "0.77.0",
-    "@earendil-works/pi-coding-agent": "0.77.0",
+    "@earendil-works/pi-agent-core": "0.78.0",
+    "@earendil-works/pi-ai": "0.78.0",
+    "@earendil-works/pi-coding-agent": "0.78.0",
     "@fastify/cors": "^11.0.1",
     "@fastify/multipart": "^10.0.0",
     "@fastify/rate-limit": "^10.2.2",


### PR DESCRIPTION
## Summary

Batches the refreshed Dependabot pi SDK package updates from `0.77.0` to `0.78.0` with exact-pinned versions in `packages/server/package.json`.

The three pi packages are updated together so their matching `0.78.0` dependency expectations stay aligned.

## Usage

No user-facing usage changes. Developers should reinstall from the updated lockfile:

```bash
npm ci --workspaces --include-workspace-root
```

Compatibility notes:
- `@earendil-works/pi-*` `0.78.0` requires Node `>=22.19.0`; validation ran on Node `v22.22.3`.
- `@earendil-works/pi-ai` changed direct provider stream functions to require explicit `options.apiKey`; pi-forge does not call those direct provider functions.
- Repo search found no direct use of `@earendil-works/pi-ai`, `StreamOptions`, direct provider stream/complete calls, or Bedrock APIs.

## What changed (2 files)

- `packages/server/package.json` — exact-pins `@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-coding-agent` to `0.78.0`.
- `package-lock.json` — refreshes resolved pi SDK package versions and integrity hashes.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run test:ci` — all 40 tests passed
- [ ] CI green before merge
