### PR TITLE
chore(release): v1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,52 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.3.6] — 2026-05-29
+
+### Added
+
+- **Git pane worktree selector.** The Git tab now exposes a visible Worktree
+  dropdown backed by registered `git worktree list` entries so status, diffs,
+  logs, branches, remotes, and git actions can target a selected worktree.
+
 ### Changed
 
 - **Container images now use Python 3.12.** The Docker runtime, container docs,
   and Docker smoke test now pin Python 3.12 for agent tooling and native-module
   rebuild support.
+- **Tool batching no longer stops at ten calls.** Chat keeps the existing
+  batching behavior and natural breakpoints while removing the hard batch-size
+  cap.
+- **Worker process alerts no longer wake the orchestrator.** Worker-local
+  process notifications remain available in the worker session, but process
+  success/failure/kill alerts are no longer escalated into the supervisor inbox.
+- **Pi SDK packages were updated to 0.78.0.** The pinned pi SDK trio and related
+  npm dependencies were refreshed for this release.
+
+### Fixed
+
+- **Terminal tab close now terminates its process.** Explicit terminal tab closes
+  kill the backing PTY/process tree while ordinary WebSocket disconnects still
+  preserve reattach behavior.
+- **Worker-created sessions refresh reliably.** `session_list_changed` events now
+  pass through the SSE bridge and are padded so buffering proxies deliver worker
+  spawn refreshes promptly.
+- **Orchestrator, worker, and subagent sessions nest correctly.** The sessions
+  pane now renders recursive hierarchies such as `orchestrator → worker →
+  subagent` with capped indentation.
+- **Compaction history keeps tool calls paired with results.** Archived and
+  provider-variant tool call/result shapes are normalized so batched tool inputs
+  and outputs render together instead of drifting apart.
+- **Stdio MCP tools restart after server/container recreation.** Persisted global
+  stdio MCP servers are loaded and connected before sessions capture custom
+  tools, restoring tools after restart.
+- **Empty success responses are accepted by the browser API client.** `204 No
+  Content` responses, including the abort endpoint, no longer surface as invalid
+  response bodies.
+- **Killing or deleting orchestration sessions cleans up descendants.** Worker
+  kill, normal worker deletion, and supervisor deletion now archive worker
+  transcripts, remove them from the live session tree, unregister topology, and
+  clean up worker subagent children.
 
 ## [1.3.5] — 2026-05-28
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "workspaces": [
         "packages/*"
       ],
@@ -8107,6 +8107,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -11150,6 +11151,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -16948,7 +16950,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -16994,7 +16996,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.78.0",
         "@earendil-works/pi-ai": "0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump pi-forge package versions from 1.3.5 to 1.3.6.
- Roll CHANGELOG.md Unreleased notes into the 1.3.6 release section.
- Refresh package-lock.json via the release bump script.

## Usage

After this PR merges, tag the merge commit from updated main:

```bash
git checkout main && git pull --ff-only
git tag v1.3.6
git push origin v1.3.6
```

## What changed

- Ran `scripts/bump-version.sh 1.3.6` after syncing main.
- Added release notes for merged changes since v1.3.5.

## Test plan

- `npm run format:check` ✅