### PR TITLE
fix: loosen npm pi sdk version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Pi SDK trio (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-agent-core`,
 `@earendil-works/pi-ai` — formerly under the `@mariozechner/*` scope through
-v1.1.4; see the v1.1.5 entry for the scope migration) is pinned to exact
-versions; any breaking SDK absorption is called out in its own release notes
+v1.1.4; see the v1.1.5 entry for the scope migration) uses a compatible patch
+range; any breaking SDK absorption is called out in its own release notes
 section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
+
+### Changed
+
+- **npm installs can receive compatible pi SDK patch updates.** The published
+  package now declares the pi SDK trio with a caret range (for example,
+  `^0.78.0`, which npm resolves as `>=0.78.0 <0.79.0` while pi remains `0.x`)
+  instead of exact patch pins, so npm users are not unnecessarily held to one
+  SDK patch version within pi-forge's tested minor compatibility window.
 
 ## [1.3.6] — 2026-05-29
 

--- a/README.md
+++ b/README.md
@@ -171,10 +171,13 @@ The full feature grid (with categories and screenshots) is on the
 
 ## Versions
 
-Each pi-forge release pins exact patch versions of the pi SDK trio
-(`pi-coding-agent`, `pi-agent-core`, `pi-ai`) — no caret/tilde — so a
-transparent SDK upgrade can't surprise an existing install. Pinned versions
-live in [`packages/server/package.json`](./packages/server/package.json).
+Each pi-forge release declares a compatible patch range for the pi SDK trio
+(`pi-coding-agent`, `pi-agent-core`, `pi-ai`). While pi is still `0.x`, npm's
+caret range for `^0.78.0` resolves to `>=0.78.0 <0.79.0`: users can receive
+compatible SDK patch fixes without being moved across the next pi minor line.
+The supported range lives in
+[`packages/server/package.json`](./packages/server/package.json) and is hoisted
+verbatim into the published npm package.
 
 Only the latest tag is supported. Breaking SDK changes pi-forge had to absorb
 appear in the release notes' **Changed** section. Per-tag notes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16998,9 +16998,9 @@
       "name": "@pi-forge/server",
       "version": "1.3.6",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "0.78.0",
-        "@earendil-works/pi-ai": "0.78.0",
-        "@earendil-works/pi-coding-agent": "0.78.0",
+        "@earendil-works/pi-agent-core": "^0.78.0",
+        "@earendil-works/pi-ai": "^0.78.0",
+        "@earendil-works/pi-coding-agent": "^0.78.0",
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^10.0.0",
         "@fastify/rate-limit": "^10.2.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,9 +9,9 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.78.0",
-    "@earendil-works/pi-ai": "0.78.0",
-    "@earendil-works/pi-coding-agent": "0.78.0",
+    "@earendil-works/pi-agent-core": "^0.78.0",
+    "@earendil-works/pi-ai": "^0.78.0",
+    "@earendil-works/pi-coding-agent": "^0.78.0",
     "@fastify/cors": "^11.0.1",
     "@fastify/multipart": "^10.0.0",
     "@fastify/rate-limit": "^10.2.2",

--- a/scripts/build-publish-dir.mjs
+++ b/scripts/build-publish-dir.mjs
@@ -205,6 +205,12 @@ This package version (\`${version}\`) tracks the [GitHub release](https://github
 of the same name. Docker images and the npm package are published in
 lockstep on each \`v*\` tag.
 
+pi-forge declares a compatible patch range for the pi SDK trio it embeds
+(for example, \`^0.78.0\`, which npm resolves as \`>=0.78.0 <0.79.0\`
+while pi remains \`0.x\`). That lets npm installs receive compatible pi
+SDK patch fixes without being pinned to one exact SDK patch or moved across
+the next pi minor line before pi-forge has absorbed it.
+
 ## License
 
 MIT — see [LICENSE](./LICENSE).

--- a/tests/test-publish-package.ts
+++ b/tests/test-publish-package.ts
@@ -7,6 +7,7 @@
  *      publish/package.json).
  *   2. The synthetic package.json has the right shape — name, version
  *      from root, bin entry, deps hoisted from the server workspace,
+ *      pi SDK deps kept as compatible ranges rather than exact pins,
  *      provenance enabled, public access.
  *   3. `node publish/bin/pi-forge.mjs` boots the workbench, serves
  *      `/api/v1/health`, and serves the embedded SPA (`/`).
@@ -48,6 +49,11 @@ const rootPkg = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf8
 const serverPkg = JSON.parse(
   readFileSync(resolve(repoRoot, "packages/server/package.json"), "utf8"),
 ) as { dependencies: Record<string, string> };
+const piSdkDeps = [
+  "@earendil-works/pi-agent-core",
+  "@earendil-works/pi-ai",
+  "@earendil-works/pi-coding-agent",
+] as const;
 
 let failures = 0;
 
@@ -185,6 +191,14 @@ async function main(): Promise<void> {
   // Every server runtime dep must be present in the synthetic package
   // (we hoist verbatim — a missing entry means the bin would fail to
   // import on a real `npm i pi-forge` install).
+  for (const dep of piSdkDeps) {
+    const version = serverPkg.dependencies[dep];
+    assert(
+      `${dep} uses a compatible patch range, not an exact pin`,
+      version !== undefined && /^\^0\.\d+\.\d+$/.test(version),
+      `got ${version ?? "<missing>"}`,
+    );
+  }
   for (const [dep, version] of Object.entries(serverPkg.dependencies)) {
     assert(
       `synth dependencies has ${dep}@${version}`,


### PR DESCRIPTION
## Summary

npm installs of pi-forge were unnecessarily constrained to one exact pi SDK patch because the server manifest pinned the pi SDK trio to `0.78.0`. The publish script hoists those runtime dependencies verbatim into the npm package, so npm consumers could not receive compatible pi SDK patch fixes without a new pi-forge release.

This PR switches the pi SDK trio to npm caret ranges (currently `^0.78.0`, which is `>=0.78.0 <0.79.0` for `0.x` packages). That keeps npm users on the pi minor line pi-forge has absorbed while allowing compatible patch updates.

## Usage

No new commands. For npm consumers, future installs resolve the pi SDK trio within pi-forge's declared compatible patch range:

```bash
npm i -g pi-forge
# pi SDK deps resolve from pi-forge's package.json, e.g. ^0.78.0 => >=0.78.0 <0.79.0
```

This intentionally avoids peerDependencies/optional peer resolution because pi-forge embeds and imports the SDK directly; requiring users to install matching peers would add friction and make `npx pi-forge` less reliable.

## What changed (6 files, +43/-12)

- `packages/server/package.json` — changes `@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-coding-agent` from exact pins to compatible caret ranges.
- `package-lock.json` — records the workspace dependency range while retaining the resolved/tested `0.78.0` artifacts.
- `scripts/build-publish-dir.mjs` — documents the npm-published package behavior in the generated README.
- `tests/test-publish-package.ts` — asserts the publish package preserves compatible pi SDK ranges and still hoists all server runtime deps verbatim.
- `README.md` — updates the Versions policy for the new npm range strategy.
- `CHANGELOG.md` — adds an Unreleased entry for the versioning behavior change.

## Test plan

- [x] `npm install --include=dev` (repair isolated worktree dependencies after the first validation showed missing dev packages)
- [x] `scripts/run-tests.sh --only publish-package`
- [x] `npm run check`
- [ ] CI green before merge
