### PR TITLE
fix: refresh MCP status and surface truncation warnings

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -211,6 +211,19 @@ The badge next to **Settings** shows a colored dot + `MCP X/Y`:
 
 Hidden when no servers are configured and in `MINIMAL_UI` mode.
 
+The header summary and any Settings → MCP project status list already opened by
+this browser tab refresh automatically on the shared MCP ticker. Unchanged status
+payloads keep their existing UI state to avoid unnecessary churn.
+
+## Tool result truncation
+
+Very large text results from MCP tools are capped before they enter the agent
+context. When truncation happens, the returned text starts with a concise
+`MCP_RESULT_TRUNCATED` warning that includes the omitted size and tells the model
+to retry with a smaller scope, narrower filter, or pagination. The visible payload
+then keeps the start and end of the original result with a marker where the middle
+was omitted.
+
 ## Troubleshooting
 
 **Status stuck in `error`** — Settings → MCP, expand the row, read

--- a/packages/client/src/store/mcp-store.ts
+++ b/packages/client/src/store/mcp-store.ts
@@ -9,6 +9,22 @@ import {
 
 const POLL_INTERVAL_MS = 30_000;
 
+function stableJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function sameSettings(a: McpSettingsResponse | undefined, b: McpSettingsResponse): boolean {
+  return a?.enabled === b.enabled && a.connected === b.connected && a.total === b.total;
+}
+
+function sameProjectData(a: ProjectScopeData | undefined, b: ProjectScopeData): boolean {
+  return (
+    a !== undefined &&
+    stableJson(a.status) === stableJson(b.status) &&
+    stableJson(a.stdioTrust) === stableJson(b.stdioTrust)
+  );
+}
+
 /**
  * Module-level stable empty array. Zustand selectors compare return
  * values by reference; returning a fresh `[]` from a `useMcpStore(s
@@ -49,7 +65,10 @@ export const EMPTY_STATUS: McpServerStatus[] = [];
  * Lifecycle: `startPolling()` is idempotent — called once from
  * App.tsx after auth. The interval is cleared on `stopPolling()`
  * (logout / unmount). Polling skips when `document.hidden` is true
- * so a backgrounded tab doesn't keep the pi-forge warm.
+ * so a backgrounded tab doesn't keep the pi-forge warm. Each tick
+ * refreshes the header summary plus any project status slices that
+ * a consumer has already loaded; unchanged payloads keep their
+ * existing references to avoid UI churn.
  */
 
 interface ProjectScopeData {
@@ -100,11 +119,22 @@ export const useMcpStore = create<McpState>((set, get) => ({
 
   startPolling: () => {
     if (get().pollHandle !== undefined) return;
+    let inFlight = false;
     const tick = (): void => {
       // Skip when the tab is in the background — don't burn cycles
       // (or our 30-call/min API budget) keeping a hidden tab warm.
       if (typeof document !== "undefined" && document.hidden) return;
-      void get().refreshSettings();
+      if (inFlight) return;
+      inFlight = true;
+      void (async () => {
+        try {
+          const projectIds = Object.keys(get().byProject);
+          await get().refreshSettings();
+          await Promise.all(projectIds.map((pid) => get().refreshProject(pid)));
+        } finally {
+          inFlight = false;
+        }
+      })();
     };
     void tick();
     const handle = window.setInterval(tick, POLL_INTERVAL_MS);
@@ -122,7 +152,9 @@ export const useMcpStore = create<McpState>((set, get) => ({
   refreshSettings: async () => {
     try {
       const r = await api.getMcpSettings();
-      set({ settings: r, error: undefined });
+      set((state) =>
+        sameSettings(state.settings, r) ? { error: undefined } : { settings: r, error: undefined },
+      );
     } catch (err) {
       // Network blips / 401 leave the prior `settings` value in place
       // so the badge doesn't flicker red on a transient error. The
@@ -142,14 +174,18 @@ export const useMcpStore = create<McpState>((set, get) => ({
       // so the Settings tab works without a project selected.
       try {
         const list = await api.listMcpServers();
-        set({ globalServers: list.servers, error: undefined });
+        set((state) =>
+          stableJson(state.globalServers) === stableJson(list.servers)
+            ? { error: undefined }
+            : { globalServers: list.servers, error: undefined },
+        );
       } catch (err) {
         if (err instanceof ApiError && err.status === 401) return;
         set({ error: describeError(err) });
       }
       return;
     }
-    set({ loading: true });
+    if (get().byProject[projectId] === undefined) set({ loading: true });
     try {
       const list = await api.listMcpServers(projectId);
       set((state) => {
@@ -158,11 +194,13 @@ export const useMcpStore = create<McpState>((set, get) => ({
           loadedAt: Date.now(),
         };
         if (list.stdioTrust !== undefined) entry.stdioTrust = list.stdioTrust;
+        const sameGlobal = stableJson(state.globalServers) === stableJson(list.servers);
+        const sameProject = sameProjectData(state.byProject[projectId], entry);
         return {
           loading: false,
           error: undefined,
-          globalServers: list.servers,
-          byProject: { ...state.byProject, [projectId]: entry },
+          ...(sameGlobal ? {} : { globalServers: list.servers }),
+          ...(sameProject ? {} : { byProject: { ...state.byProject, [projectId]: entry } }),
         };
       });
     } catch (err) {

--- a/packages/server/src/mcp/tool-bridge.ts
+++ b/packages/server/src/mcp/tool-bridge.ts
@@ -164,10 +164,11 @@ export function mcpResultToAgentResult(res: unknown): AgentToolResult<unknown> {
  * usually has the most recent / most relevant items in time-ordered
  * lists.
  *
- * Marker text is read by the agent and tells it (a) truncation
- * happened, (b) by how much, (c) what to do about it. Imperative
- * phrasing nudges the model to narrow scope rather than re-running
- * the same call.
+ * Warning text is placed at the very start of the returned text so
+ * even simple models notice it before consuming a large head/tail
+ * payload. It tells the agent (a) truncation happened, (b) by how
+ * much, and (c) what to do next. Imperative phrasing nudges the
+ * model to narrow scope rather than re-running the same call.
  *
  * No per-tool override yet — add when a real workload needs a higher
  * or lower cap. Hardcoded constant is the deliberate first cut.
@@ -197,11 +198,15 @@ export function capTextContent(blocks: ContentBlock[]): ContentBlock[] {
   const head = flat.slice(0, headLen);
   const tail = flat.slice(flat.length - tailLen);
   const omitted = flat.length - headLen - tailLen;
+  const warning =
+    `MCP_RESULT_TRUNCATED: ${omitted.toLocaleString()} characters ` +
+    `(~${Math.round(omitted / 4).toLocaleString()} tokens) were omitted from the middle of this tool result. ` +
+    `Do not assume the missing content was irrelevant. Next step: call the MCP tool again with a smaller scope, ` +
+    `narrower filter, or pagination to inspect the omitted content.\n\n`;
   const marker =
-    `\n\n[--- ${omitted.toLocaleString()} characters (~${Math.round(omitted / 4).toLocaleString()} tokens) ` +
-    `truncated to keep the result under the ${MCP_TEXT_CAP_CHARS.toLocaleString()}-char cap. ` +
-    `Refine the query (smaller scope, narrower filter, paginate if available) to see the missing middle. ---]\n\n`;
-  const truncatedText = head + marker + tail;
+    `\n\n[--- MCP_RESULT_TRUNCATED: omitted middle content. Use a smaller scope, narrower filter, ` +
+    `or pagination to inspect it. ---]\n\n`;
+  const truncatedText = warning + head + marker + tail;
   // Keep one text block with the truncated payload + every image
   // block from the original (in its original relative order). Drop
   // duplicate text blocks since they were already absorbed into

--- a/tests/test-mcp-store.ts
+++ b/tests/test-mcp-store.ts
@@ -1,0 +1,161 @@
+/**
+ * MCP client-store polling test.
+ *
+ * Verifies that the shared MCP polling ticker refreshes already-loaded
+ * project status slices (the Settings → MCP server status list) in addition
+ * to the header summary, and that unchanged project payloads keep their
+ * existing object reference to avoid unnecessary UI churn.
+ */
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), "..", "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+async function waitFor(label: string, predicate: () => boolean, budgetMs = 1000): Promise<void> {
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  assert(label, false, "timed out");
+}
+
+interface MockStatus {
+  scope: "global";
+  name: string;
+  kind: "remote";
+  url: string;
+  enabled: boolean;
+  state: "idle" | "connected" | "error";
+  toolCount: number;
+}
+
+async function main(): Promise<void> {
+  let intervalTick: (() => void) | undefined;
+  let settingsCalls = 0;
+  let projectCalls = 0;
+  let serverState: MockStatus["state"] = "idle";
+
+  (globalThis as unknown as { document: { hidden: boolean } }).document = { hidden: false };
+  const localStorageMock = {
+    getItem: () => null,
+    setItem: () => undefined,
+    removeItem: () => undefined,
+  };
+  (globalThis as unknown as { localStorage: typeof localStorageMock }).localStorage =
+    localStorageMock;
+  (globalThis as unknown as { window: unknown }).window = {
+    setInterval: (fn: () => void) => {
+      intervalTick = fn;
+      return 42;
+    },
+    clearInterval: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => true,
+  };
+
+  (globalThis as unknown as { fetch: (input: unknown) => Promise<Response> }).fetch = async (
+    input: unknown,
+  ) => {
+    const path = String(input);
+    if (path === "/api/v1/mcp/settings") {
+      settingsCalls += 1;
+      return new Response(
+        JSON.stringify({ enabled: true, connected: serverState === "connected" ? 1 : 0, total: 1 }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+    if (path === "/api/v1/mcp/servers?projectId=p1") {
+      projectCalls += 1;
+      const status: MockStatus[] = [
+        {
+          scope: "global",
+          name: "fixture",
+          kind: "remote",
+          url: "http://127.0.0.1/sse",
+          enabled: true,
+          state: serverState,
+          toolCount: serverState === "connected" ? 2 : 0,
+        },
+      ];
+      return new Response(JSON.stringify({ servers: {}, status, stdioTrust: { trusted: false } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ error: "unexpected_path", message: path }), {
+      status: 500,
+    });
+  };
+
+  const mod = (await import(resolve(repoRoot, "packages/client/src/store/mcp-store.ts"))) as {
+    useMcpStore: {
+      getState: () => {
+        byProject: Record<string, { status: MockStatus[] } | undefined>;
+        refreshProject: (projectId: string) => Promise<void>;
+        startPolling: () => void;
+        stopPolling: () => void;
+      };
+    };
+  };
+  const store = mod.useMcpStore;
+
+  await store.getState().refreshProject("p1");
+  assert(
+    "initial project refresh called /mcp/servers",
+    projectCalls === 1,
+    `calls=${projectCalls}`,
+  );
+  assert(
+    "initial project status is idle",
+    store.getState().byProject.p1?.status[0]?.state === "idle",
+    JSON.stringify(store.getState().byProject.p1?.status),
+  );
+
+  serverState = "connected";
+  store.getState().startPolling();
+  await waitFor("poll refreshed settings", () => settingsCalls >= 1);
+  await waitFor("poll refreshed cached project", () => projectCalls >= 2);
+  assert("poll interval registered", intervalTick !== undefined);
+  assert(
+    "cached project status auto-refreshes to connected",
+    store.getState().byProject.p1?.status[0]?.state === "connected",
+    JSON.stringify(store.getState().byProject.p1?.status),
+  );
+
+  const projectRef = store.getState().byProject.p1;
+  intervalTick?.();
+  await waitFor("second tick refreshed cached project", () => projectCalls >= 3);
+  assert(
+    "unchanged project payload keeps reference",
+    store.getState().byProject.p1 === projectRef,
+    "expected no byProject churn when status payload is unchanged",
+  );
+
+  store.getState().stopPolling();
+
+  console.log(
+    failures === 0
+      ? "\n[test-mcp-store] PASS"
+      : `\n[test-mcp-store] FAIL — ${failures} assertion(s) failed`,
+  );
+  if (failures > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("[test-mcp-store] uncaught error:", err);
+  process.exit(1);
+});

--- a/tests/test-mcp-truncation.ts
+++ b/tests/test-mcp-truncation.ts
@@ -8,9 +8,9 @@
  * Coverage:
  *   - Under-cap text: pass-through, no marker injected.
  *   - Exact-cap text (length === cap): pass-through, no marker.
- *   - Over-cap single text block: head + marker + tail; total length
- *     equals cap + marker length; head/tail slice math is correct;
- *     marker contains the truncated-byte count.
+ *   - Over-cap single text block: leading warning + head + marker + tail;
+ *     total length equals cap + warning/marker length; head/tail slice math
+ *     is correct; warning contains the truncated-byte count and guidance.
  *   - Over-cap multiple text blocks: flattened into one block
  *     containing head + marker + tail (sourced from the
  *     newline-joined original).
@@ -107,9 +107,14 @@ async function main(): Promise<void> {
     if (out[0]?.type === "text") {
       const t = out[0].text;
       assert(
+        "over-cap: leading warning is first thing models see",
+        t.startsWith("MCP_RESULT_TRUNCATED:"),
+        `prefix=${t.slice(0, 80)}`,
+      );
+      assert(
         "over-cap: head preserved (all A's)",
-        t.startsWith("A".repeat(headLen)),
-        `head=${t.slice(0, 16)}... headLen=${headLen}`,
+        t.includes("\n\n" + "A".repeat(100)),
+        `head sample not found; headLen=${headLen}`,
       );
       assert(
         "over-cap: tail preserved (all Z's)",
@@ -122,16 +127,20 @@ async function main(): Promise<void> {
         "marker fell INSIDE the original M run — slice math is off",
       );
       assert(
-        "over-cap: marker contains 'truncated'",
-        t.includes("truncated"),
-        `truncated text: ${t.slice(headLen, headLen + 200)}`,
+        "over-cap: warning contains machine-readable truncation marker",
+        t.includes("MCP_RESULT_TRUNCATED"),
+        `truncated text: ${t.slice(0, 200)}`,
       );
       assert(
-        "over-cap: marker reports the omitted byte count",
+        "over-cap: warning reports the omitted byte count",
         t.includes("50,000"),
         "expected 50,000 char count in marker",
       );
-      assert("over-cap: marker says 'refine'", t.toLowerCase().includes("refine"));
+      assert("over-cap: warning says 'Next step'", t.includes("Next step:"));
+      assert(
+        "over-cap: warning says paginate/filter",
+        t.includes("pagination") && t.includes("filter"),
+      );
     }
   }
 
@@ -149,11 +158,12 @@ async function main(): Promise<void> {
     if (out[0]?.type === "text") {
       const t = out[0].text;
       assert(
-        "multi-block: total length is cap + marker",
+        "multi-block: total length is cap + warning/marker",
         t.length > MCP_TEXT_CAP_CHARS && t.length < MCP_TEXT_CAP_CHARS + 1000,
-        `len=${t.length}, expected ~${MCP_TEXT_CAP_CHARS} + marker`,
+        `len=${t.length}, expected ~${MCP_TEXT_CAP_CHARS} + warning/marker`,
       );
-      assert("multi-block: head still 'P's", t.startsWith("P".repeat(100)));
+      assert("multi-block: leading warning present", t.startsWith("MCP_RESULT_TRUNCATED:"));
+      assert("multi-block: head still 'P's", t.includes("\n\n" + "P".repeat(100)));
       assert("multi-block: tail still 'P's", t.endsWith("P".repeat(100)));
     }
   }
@@ -177,7 +187,7 @@ async function main(): Promise<void> {
     assert("images-with-truncation: exactly one text block remains", textBlocks.length === 1);
     assert(
       "images-with-truncation: text block has truncation marker",
-      textBlocks[0]?.type === "text" && textBlocks[0].text.includes("truncated"),
+      textBlocks[0]?.type === "text" && textBlocks[0].text.includes("MCP_RESULT_TRUNCATED"),
     );
   }
 
@@ -203,8 +213,9 @@ async function main(): Promise<void> {
     if (out.content[0]?.type === "text") {
       const t = out.content[0].text;
       assert("e2e: under cap+marker overhead", t.length < MCP_TEXT_CAP_CHARS + 1000);
-      assert("e2e: contains truncation marker", t.includes("truncated"));
-      assert("e2e: head is Q's", t.startsWith("QQQQQQ"));
+      assert("e2e: contains truncation marker", t.includes("MCP_RESULT_TRUNCATED"));
+      assert("e2e: leading warning is first", t.startsWith("MCP_RESULT_TRUNCATED:"));
+      assert("e2e: head is Q's", t.includes("\n\nQQQQQQ"));
       assert("e2e: tail is Q's", t.endsWith("QQQQQQ"));
     }
   }
@@ -218,8 +229,10 @@ async function main(): Promise<void> {
     };
     const out = mcpResultToAgentResult(mcpResult);
     assert(
-      "isError + oversize: leading [error] marker preserved on truncated text",
-      out.content[0]?.type === "text" && out.content[0].text.startsWith("[error]"),
+      "isError + oversize: truncation warning remains first and [error] is preserved in visible head",
+      out.content[0]?.type === "text" &&
+        out.content[0].text.startsWith("MCP_RESULT_TRUNCATED:") &&
+        out.content[0].text.includes("[error]"),
     );
   }
 


### PR DESCRIPTION
## Summary

MCP status in Settings only refreshed when the tab loaded or after explicit mutations, because the shared MCP ticker updated only the header `/mcp/settings` summary. Large MCP tool results also placed truncation guidance in the middle of the returned text, where simple models could miss it while consuming a large head/tail payload.

This PR extends the existing MCP store ticker to refresh any already-loaded project status slices without overlapping polls or unnecessary reference churn. It also makes truncated MCP results start with a concise `MCP_RESULT_TRUNCATED` warning and next-step guidance before the large payload.

## Usage

No new operator controls. Existing Settings → MCP status rows now refresh automatically once loaded. When an MCP tool result is truncated, the agent sees a leading warning that says to retry with a smaller scope, narrower filter, or pagination.

## What changed (5 files)

- `packages/client/src/store/mcp-store.ts` — shared MCP polling now refreshes cached project status slices, skips overlapping ticks, and preserves unchanged state references.
- `packages/server/src/mcp/tool-bridge.ts` — truncation output now begins with `MCP_RESULT_TRUNCATED` plus concise omitted-size and next-step guidance.
- `tests/test-mcp-store.ts` — adds a store-level regression test for automatic project status refresh and no-churn unchanged payloads.
- `tests/test-mcp-truncation.ts` — updates truncation assertions for the leading warning and actionable guidance.
- `docs/mcp.md` — documents automatic status refresh and the visible truncation warning shape.

## Test plan

- [x] `npm run build`
- [x] `scripts/run-tests.sh --only mcp-store,mcp-truncation,mcp,tool-overrides`
- [x] `npm run check`
- [ ] CI green before merge