### PR TITLE
fix: keep async worker wakeups deliverable

### DIFF
--- a/packages/client/src/lib/sse-client.ts
+++ b/packages/client/src/lib/sse-client.ts
@@ -18,8 +18,8 @@ import { clearStoredToken, getStoredToken } from "./auth-client";
  *     suppresses reconnect.
  *
  * Reconnect policy:
- *   - 401 / 404 are treated as terminal (auth gone, session deleted) — do
- *     not retry; reject immediately.
+ *   - 401 / 404 / 410 are treated as terminal (auth gone, session deleted,
+ *     or recently disposed/tombstoned) — do not retry; reject immediately.
  *   - Any other non-2xx, network-level error, or post-200 stream EOF
  *     triggers a backoff (1s → 2s → 4s → 8s → 16s, capped at 30s).
  *     `onReconnect` is invoked between attempts so the UI can show a
@@ -45,7 +45,7 @@ export interface StreamSSEOptions<T> {
   maxReconnects?: number;
 }
 
-const TERMINAL_STATUS = new Set([401, 404]);
+const TERMINAL_STATUS = new Set([401, 404, 410]);
 const MAX_BACKOFF_MS = 30_000;
 
 function backoffDelay(attempt: number): number {

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -547,12 +547,13 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       // errors reach here.
       // Cross-tab session deletion: another tab (or a script) called
       // DELETE /sessions/:id, the server disposed, our SSE attempt
-      // got a 404 on reconnect. Drop the session from local state so
-      // the sidebar list / chat view clear immediately, matching the
-      // experience of a same-tab delete. Without this the deleted
-      // session lingered in the list with a stale "stream error"
-      // banner until the user manually refreshed.
-      if (err instanceof ApiError && err.status === 404) {
+      // got a 404 (archived/not found) or 410 (dispose tombstone) on
+      // reconnect. Drop the session from local state so the sidebar
+      // list / chat view clear immediately, matching the experience
+      // of a same-tab delete. Without this the deleted session
+      // lingered in the list with a stale "stream error" banner until
+      // the user manually refreshed.
+      if (err instanceof ApiError && (err.status === 404 || err.status === 410)) {
         set((s) => removeSessionFromState(s, sessionId));
         if (get().activeSessionId === undefined) {
           localStorage.removeItem(ACTIVE_SESSION_KEY);

--- a/packages/server/src/orchestration/inbox.ts
+++ b/packages/server/src/orchestration/inbox.ts
@@ -48,7 +48,7 @@ import type { InboxEventType, InboxItem } from "./types.js";
  *   - On supervisor dispose (handled in session-registry) — clear
  *     so a re-resumed session can wake again.
  */
-const pendingWakePush = new Set<string>();
+const pendingWakePush = new Map<string, number>();
 
 /**
  * Per-supervisor sequence number for wake-up prompts. Surfaces in
@@ -61,6 +61,20 @@ function nextWakeCounter(supervisorId: string): number {
   const n = (wakeCounters.get(supervisorId) ?? 0) + 1;
   wakeCounters.set(supervisorId, n);
   return n;
+}
+
+function clearPendingWakeIfCurrent(supervisorId: string, seq: number): boolean {
+  if (pendingWakePush.get(supervisorId) !== seq) return false;
+  pendingWakePush.delete(supervisorId);
+  return true;
+}
+
+/**
+ * Diagnostic/test helper: true when a supervisor already has a wake-up
+ * prompt in flight for the current idle window.
+ */
+export function hasPendingWakePush(supervisorId: string): boolean {
+  return pendingWakePush.has(supervisorId);
 }
 
 function logInbox(level: "info" | "warn", payload: Record<string, unknown>): void {
@@ -114,9 +128,15 @@ async function tryWakeSupervisor(supervisorId: string): Promise<boolean> {
   const pending = await pendingInboxCount(supervisorId);
   if (pending === 0) return false;
 
-  pendingWakePush.add(supervisorId);
   const seq = nextWakeCounter(supervisorId);
+  pendingWakePush.set(supervisorId, seq);
   const text = buildWakeText(pending);
+  logInbox("info", {
+    msg: "orchestration-wake-started",
+    supervisorId,
+    pending,
+    seq,
+  });
   // Fire-and-forget. The SDK's session.prompt is async; we let it
   // run in the background so the event-bridge caller (often the
   // hot path of an AgentSessionEvent subscriber) returns
@@ -127,19 +147,29 @@ async function tryWakeSupervisor(supervisorId: string): Promise<boolean> {
   live.session
     .prompt(text)
     .then(() => {
+      const cleared = clearPendingWakeIfCurrent(supervisorId, seq);
       logInbox("info", {
         msg: "orchestration-wake-delivered",
         supervisorId,
         pending,
         seq,
+        clearedPendingWake: cleared,
       });
+      // Defense in depth: agent_end normally calls notifySupervisorIdle,
+      // clears the same marker, and re-wakes when pending items remain.
+      // Some SDK/extension failure paths can resolve/reject prompt()
+      // without an agent_end; re-run the idle check here so async worker
+      // completions do not get stranded behind a stale dedupe marker.
+      void tryWakeSupervisor(supervisorId);
     })
     .catch((err: unknown) => {
+      const cleared = clearPendingWakeIfCurrent(supervisorId, seq);
       logInbox("warn", {
         msg: "orchestration-wake-failed",
         supervisorId,
         pending,
         seq,
+        clearedPendingWake: cleared,
         err: err instanceof Error ? err.message : String(err),
       });
     });

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -73,6 +73,15 @@ interface InboxModule {
     type: string,
     data: Record<string, unknown>,
   ) => Promise<{ id: string } | undefined>;
+  hasPendingWakePush: (supervisorId: string) => boolean;
+}
+
+interface RegistryModule {
+  createSession: (
+    projectId: string,
+    workspacePath: string,
+  ) => Promise<{ sessionId: string; session: { prompt: (text: string) => Promise<unknown> } }>;
+  disposeAllSessions: () => Promise<void>;
 }
 
 interface ProcessInfoStub {
@@ -140,6 +149,15 @@ async function waitFor(url: string, timeoutMs = 10_000): Promise<void> {
     }
   }
   throw new Error(`timeout waiting for ${url}`);
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 2_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return predicate();
 }
 
 interface RunningServer {
@@ -238,6 +256,7 @@ async function main(): Promise<void> {
   process.env.WORKSPACE_PATH = sharedWs;
   process.env.PI_CONFIG_DIR = sharedCfg;
   process.env.FORGE_DATA_DIR = sharedData;
+  process.env.SESSION_DIR = join(sharedWs, ".pi", "sessions");
 
   console.log("[test-orchestration] store layer");
   const store = (await import(
@@ -249,6 +268,9 @@ async function main(): Promise<void> {
   const eventBridge = (await import(
     resolve(repoRoot, "packages/server/dist/orchestration/event-bridge.js")
   )) as unknown as EventBridgeModule;
+  const registry = (await import(
+    resolve(repoRoot, "packages/server/dist/session-registry.js")
+  )) as unknown as RegistryModule;
 
   // ===== enable / disable supervisor =====
   await store.enableSupervisor("sup-1");
@@ -371,6 +393,45 @@ async function main(): Promise<void> {
   await store.clearInbox("sup-1");
   const allAfterClear = await store.readAllInbox("sup-1");
   assert("clearInbox wipes history", allAfterClear.length === 0);
+
+  // ===== Wake-up dedupe recovery =====
+  // A rejected wake prompt used to leave the per-supervisor dedupe flag
+  // stuck forever, so later async worker completions stayed queued in the
+  // inbox without ever nudging the supervisor again. Use a real live
+  // session whose prompt method is stubbed to deterministically reject,
+  // then assert the dedupe marker clears.
+  const wakeSup = await registry.createSession("wake-proj", sharedWs);
+  let wakePromptCalls = 0;
+  wakeSup.session.prompt = async () => {
+    wakePromptCalls += 1;
+    await new Promise((r) => setTimeout(r, 75));
+    throw new Error("test wake rejection");
+  };
+  await store.enableSupervisor(wakeSup.sessionId);
+  await store.registerWorker({ supervisorId: wakeSup.sessionId, workerId: "wake-worker" });
+  await inbox.bridgeWorkerEvent("wake-worker", "worker.ended", { stopReason: "end_turn" });
+  const wakeStarted = await waitUntil(() => inbox.hasPendingWakePush(wakeSup.sessionId), 1_000);
+  assert(
+    "wake prompt dedupe marker is set while prompt is in flight",
+    wakeStarted && wakePromptCalls === 1,
+    `pending=${inbox.hasPendingWakePush(wakeSup.sessionId)} calls=${wakePromptCalls}`,
+  );
+  const wakeCleared = await waitUntil(() => !inbox.hasPendingWakePush(wakeSup.sessionId), 2_000);
+  assert(
+    "wake prompt rejection clears dedupe marker",
+    wakeCleared,
+    "pending wake marker stayed set after rejected prompt",
+  );
+  await inbox.bridgeWorkerEvent("wake-worker", "worker.ended", { stopReason: "second" });
+  const wakeRetried = await waitUntil(() => wakePromptCalls >= 2, 1_000);
+  assert(
+    "later worker event can wake supervisor again after rejection",
+    wakeRetried,
+    `calls=${wakePromptCalls}`,
+  );
+  await waitUntil(() => !inbox.hasPendingWakePush(wakeSup.sessionId), 2_000);
+  await store.disableSupervisor(wakeSup.sessionId);
+  await registry.disposeAllSessions();
 
   // ===== Tool-result text carries the data (not just details) =====
   // The supervisor LLM reads `content[0].text`; `details` is for


### PR DESCRIPTION
## Summary

Async orchestration worker completions could get stranded in the supervisor inbox when the wake-up prompt failed or resolved without the usual `agent_end` cleanup path. The per-supervisor wake dedupe marker was only cleared by `agent_end`/dispose, so one failed wake left future worker completion events queued but unable to trigger another supervisor turn.

This PR makes wake-up state sequence-aware, clears the marker from the prompt completion/rejection path, and logs whether the marker was cleared. It also treats SSE 410 tombstone responses as terminal on the browser side so disposed sessions stop reconnecting and clear like 404-deleted sessions.

## Usage

No new user-facing controls. Operators get additional JSON-line diagnostics for orchestration wake attempts:

```text
orchestration-wake-started
orchestration-wake-delivered
orchestration-wake-failed
```

## What changed (4 files, +103/-11)

- `packages/server/src/orchestration/inbox.ts` — replaced the wake dedupe set with a sequence map, clear current wake state on prompt settle, and added safe structured diagnostics plus a helper for regression coverage.
- `packages/client/src/lib/sse-client.ts` — treats HTTP 410 as a terminal stream status.
- `packages/client/src/store/session-store.ts` — removes local session state on SSE 410 the same way as 404.
- `tests/test-orchestration.ts` — adds deterministic regression coverage for rejected wake prompts clearing the dedupe marker and permitting a later worker event to wake again.

## Test plan

- [x] `npm run build`
- [x] `scripts/run-tests.sh --only orchestration,sse,subagent-discovery,subagent-parser`
- [x] `npm run check`
- [x] `npm run test:ci`
- [ ] CI green before merge