### PR TITLE
feat: add LDAP login integration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,10 +70,11 @@ are documented in [`deployment.md`](./deployment.md).
 ### LDAP browser login
 
 LDAP is opt-in and off by default. When `LDAP_ENABLED=true`, pi-forge's
-login form asks for a username and password. Username `admin` (and
-password-only API calls) always use the local pi-forge admin password
-from `UI_PASSWORD`, `UI_PASSWORD_FILE`, or the persisted password hash;
-all other usernames use LDAP. The server binds with the
+login form defaults the username to `admin` so the regular local
+pi-forge admin password remains the first-class login path. Username
+`admin` (and password-only API calls) always use the local pi-forge
+admin password from `UI_PASSWORD`, `UI_PASSWORD_FILE`, or the persisted
+password hash; all other usernames use LDAP. The server binds with the
 configured service account, searches under `LDAP_BASE_DN` using
 `LDAP_USER_FILTER`, optionally checks the returned user's `memberOf`
 (or `LDAP_GROUP_ATTRIBUTE`) against `LDAP_REQUIRED_GROUP_DN`, and then
@@ -104,9 +105,11 @@ form instead.
 
 If both LDAP and local `UI_PASSWORD` / `UI_PASSWORD_FILE` / stored-password
 auth are present, username `admin` and password-only login use the local
-pi-forge password. Other usernames use LDAP. This preserves existing
-single-tenant admin access while allowing LDAP to be enabled during
-migration.
+pi-forge password. Other usernames use LDAP. The username `admin` is
+reserved for local pi-forge admin auth while LDAP is enabled; an LDAP
+account named `admin` cannot be used unless this policy changes later.
+This preserves existing single-tenant admin access while allowing LDAP
+to be enabled during migration.
 
 ## Pi SDK config files
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,7 @@ in `cli.ts`). The most-touched ones:
 | `LDAP_REQUIRED_GROUP_DN` | (unset) | Optional required group DN. When set, the user's `memberOf` values must include it. |
 | `LDAP_GROUP_ATTRIBUTE` | `memberOf` | User attribute checked for group DNs. Change only for directories that expose group membership under a different attribute. |
 | `LDAP_TIMEOUT_MS` | `5000` | LDAP connect/operation timeout in milliseconds. |
+| `LDAP_TLS_REJECT_UNAUTHORIZED` | `true` | Reject untrusted TLS certificates for `ldaps://` connections. Set `false` only for local/self-signed testing. |
 | `MINIMAL_UI` | `false` | Hide terminal / git / last-turn / providers / agent-settings panels. Frontend gate; server routes unchanged. ALSO hard-disables webhook configuration, session orchestration, and the quick-actions runner. |
 | `TRUST_PROXY` | `false` | Set when behind a reverse proxy so `req.ip` is the real client (required for per-user login rate limits). |
 | `ORCHESTRATION_ENABLED` | `false` | Surface the chat-view `Orch` toggle so sessions can opt in to supervisor mode (`orchestrate_*` tool group, worker spawning, inbox). Hard-disabled under `MINIMAL_UI` regardless. See [`orchestration.md`](./orchestration.md). |
@@ -70,11 +71,10 @@ are documented in [`deployment.md`](./deployment.md).
 ### LDAP browser login
 
 LDAP is opt-in and off by default. When `LDAP_ENABLED=true`, pi-forge's
-login form defaults the username to `admin` so the regular local
-pi-forge admin password remains the first-class login path. Username
-`admin` (and password-only API calls) always use the local pi-forge
-admin password from `UI_PASSWORD`, `UI_PASSWORD_FILE`, or the persisted
-password hash; all other usernames use LDAP. The server binds with the
+login form asks for a username and password. Username `admin` (and
+password-only API calls) always use the local pi-forge admin password
+from `UI_PASSWORD`, `UI_PASSWORD_FILE`, or the persisted password hash;
+all other usernames use LDAP. The server binds with the
 configured service account, searches under `LDAP_BASE_DN` using
 `LDAP_USER_FILTER`, optionally checks the returned user's `memberOf`
 (or `LDAP_GROUP_ATTRIBUTE`) against `LDAP_REQUIRED_GROUP_DN`, and then
@@ -92,6 +92,8 @@ LDAP_BIND_DN='cn=pi-forge,ou=svc,dc=example,dc=com'
 LDAP_BIND_PASSWORD_FILE=/run/secrets/ldap-bind-password
 LDAP_BASE_DN='ou=people,dc=example,dc=com'
 LDAP_REQUIRED_GROUP_DN='cn=pi-forge-users,ou=groups,dc=example,dc=com'
+# Local/self-signed test only:
+# LDAP_TLS_REJECT_UNAUTHORIZED=false
 ```
 
 `LDAP_BIND_PASSWORD_FILE` is intended for Kubernetes/OpenShift mounted
@@ -109,7 +111,9 @@ pi-forge password. Other usernames use LDAP. The username `admin` is
 reserved for local pi-forge admin auth while LDAP is enabled; an LDAP
 account named `admin` cannot be used unless this policy changes later.
 This preserves existing single-tenant admin access while allowing LDAP
-to be enabled during migration.
+to be enabled during migration. LDAP login attempts write sanitized
+`[ldap]` lines to the server logs with the URL, base DN, username, TLS
+validation mode, and failure category; passwords are not logged.
 
 ## Pi SDK config files
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,17 @@ in `cli.ts`). The most-touched ones:
 | `FORGE_DATA_DIR` | `~/.pi-forge` | Pi-forge state — `projects.json`, override files, `jwt-secret`, `password-hash`. |
 | `UI_PASSWORD` | (unset) | Enables browser JWT auth. After the user changes it via the UI, a scrypt hash is persisted to `${FORGE_DATA_DIR}/password-hash` and the env value is ignored. |
 | `API_KEY` | (unset) | Static bearer token for programmatic access. |
-| `JWT_SECRET` | (auto-generated) | HS256 signing key. Auto-generated and persisted to `${FORGE_DATA_DIR}/jwt-secret` (mode 0600) when `UI_PASSWORD` or `password-hash` is in play. Set explicitly (`openssl rand -hex 32`) to override; delete the file to rotate. |
+| `JWT_SECRET` | (auto-generated) | HS256 signing key. Auto-generated and persisted to `${FORGE_DATA_DIR}/jwt-secret` (mode 0600) when `UI_PASSWORD`, LDAP auth, or `password-hash` is in play. Set explicitly (`openssl rand -hex 32`) to override; delete the file to rotate. |
+| `LDAP_ENABLED` | `false` | Enables LDAP username/password browser login. Requires the LDAP variables below. |
+| `LDAP_URL` | (unset) | LDAP server URL, e.g. `ldap://ldap.example.com:389` or `ldaps://ldap.example.com:636`. |
+| `LDAP_BIND_DN` | (unset) | Service-account bind DN used only to search for the user entry. |
+| `LDAP_BIND_PASSWORD` | (unset) | Service-account bind password. Prefer `LDAP_BIND_PASSWORD_FILE` or `--ldap-bind-password @/path` for secret mounts. |
+| `LDAP_BIND_PASSWORD_FILE` | (unset) | File containing the service-account password (for Kubernetes/OpenShift mounted Secrets). Takes precedence over `LDAP_BIND_PASSWORD`. |
+| `LDAP_BASE_DN` | (unset) | Base DN for user searches. |
+| `LDAP_USER_FILTER` | `(|(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))` | Search filter. `{{username}}` is escaped per RFC4515 before substitution. Must match exactly one user. |
+| `LDAP_REQUIRED_GROUP_DN` | (unset) | Optional required group DN. When set, the user's `memberOf` values must include it. |
+| `LDAP_GROUP_ATTRIBUTE` | `memberOf` | User attribute checked for group DNs. Change only for directories that expose group membership under a different attribute. |
+| `LDAP_TIMEOUT_MS` | `5000` | LDAP connect/operation timeout in milliseconds. |
 | `MINIMAL_UI` | `false` | Hide terminal / git / last-turn / providers / agent-settings panels. Frontend gate; server routes unchanged. ALSO hard-disables webhook configuration, session orchestration, and the quick-actions runner. |
 | `TRUST_PROXY` | `false` | Set when behind a reverse proxy so `req.ip` is the real client (required for per-user login rate limits). |
 | `ORCHESTRATION_ENABLED` | `false` | Surface the chat-view `Orch` toggle so sessions can opt in to supervisor mode (`orchestrate_*` tool group, worker spawning, inbox). Hard-disabled under `MINIMAL_UI` regardless. See [`orchestration.md`](./orchestration.md). |
@@ -53,6 +63,41 @@ in `cli.ts`). The most-touched ones:
 
 Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
 are documented in [`deployment.md`](./deployment.md).
+
+### LDAP browser login
+
+LDAP is opt-in and off by default. When `LDAP_ENABLED=true`, pi-forge's
+login form asks for a username and password. The server binds with the
+configured service account, searches under `LDAP_BASE_DN` using
+`LDAP_USER_FILTER`, optionally checks the returned user's `memberOf`
+(or `LDAP_GROUP_ATTRIBUTE`) against `LDAP_REQUIRED_GROUP_DN`, and then
+binds as the returned user DN with the presented password. A successful
+LDAP bind issues the same pi-forge JWT used by local `UI_PASSWORD`
+login. API-key auth is unchanged, and protected routes still require a
+valid bearer JWT or API key.
+
+Minimal example:
+
+```bash
+LDAP_ENABLED=true
+LDAP_URL=ldaps://ldap.example.com:636
+LDAP_BIND_DN='cn=pi-forge,ou=svc,dc=example,dc=com'
+LDAP_BIND_PASSWORD_FILE=/run/secrets/ldap-bind-password
+LDAP_BASE_DN='ou=people,dc=example,dc=com'
+LDAP_REQUIRED_GROUP_DN='cn=pi-forge-users,ou=groups,dc=example,dc=com'
+```
+
+`LDAP_BIND_PASSWORD_FILE` is intended for Kubernetes/OpenShift mounted
+Secrets and takes precedence over `LDAP_BIND_PASSWORD`. The password is
+read only in `config.ts`, never returned by any API, and redacted from
+request logs. Do not put service-account passwords in container images
+or command-line history; use a mounted secret file or the CLI
+`--ldap-bind-password @/path/to/file` form instead.
+
+If both LDAP and local `UI_PASSWORD` / stored password auth are present,
+username+password login uses LDAP; password-only login continues to use
+the local pi-forge password. This preserves existing single-tenant
+password deployments while allowing LDAP to be enabled during migration.
 
 ## Pi SDK config files
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,9 +21,11 @@ pi-forge --no-expose-docs --minimal-ui
 pi-forge --api-key @/run/secrets/api-key   # @<path> reads from file
 ```
 
-- **Sensitive flags** (`--ui-password`, `--api-key`, `--jwt-secret`)
-  accept `@<path>` to read from a file (keeps secrets out of shell
-  history and `ps`).
+- **Sensitive flags** (`--ui-password`, `--api-key`, `--jwt-secret`,
+  `--ldap-bind-password`) accept `@<path>` to read from a file (keeps
+  secrets out of shell history and `ps`). Environment variables do not
+  use `@` expansion; use the dedicated `*_FILE` env vars for mounted
+  secret files.
 - **Boolean flags** accept `true|false|on|off|1|0|yes|no`. Bare
   `--flag` means `true`; `--no-flag` means `false`.
 
@@ -43,13 +45,14 @@ in `cli.ts`). The most-touched ones:
 | `WORKSPACE_PATH` | `~/.pi-forge/workspace` | Where project code lives. Point at an existing dir (e.g. `~/Code`) to reuse code on disk. |
 | `PI_CONFIG_DIR` | `~/.pi/agent` | Pi SDK config dir (`auth.json`, `models.json`, `settings.json`). |
 | `FORGE_DATA_DIR` | `~/.pi-forge` | Pi-forge state — `projects.json`, override files, `jwt-secret`, `password-hash`. |
-| `UI_PASSWORD` | (unset) | Enables browser JWT auth. After the user changes it via the UI, a scrypt hash is persisted to `${FORGE_DATA_DIR}/password-hash` and the env value is ignored. |
+| `UI_PASSWORD` | (unset) | Enables browser JWT auth. Literal env value only; it does not expand `@/path`. After the user changes it via the UI, a scrypt hash is persisted to `${FORGE_DATA_DIR}/password-hash` and the env value is ignored. |
+| `UI_PASSWORD_FILE` | (unset) | File containing the browser login password (for Kubernetes/OpenShift mounted Secrets). Takes precedence over `UI_PASSWORD`. Equivalent CLI: `--ui-password-file`; CLI `--ui-password @/path` is also supported. |
 | `API_KEY` | (unset) | Static bearer token for programmatic access. |
 | `JWT_SECRET` | (auto-generated) | HS256 signing key. Auto-generated and persisted to `${FORGE_DATA_DIR}/jwt-secret` (mode 0600) when `UI_PASSWORD`, LDAP auth, or `password-hash` is in play. Set explicitly (`openssl rand -hex 32`) to override; delete the file to rotate. |
 | `LDAP_ENABLED` | `false` | Enables LDAP username/password browser login. Requires the LDAP variables below. |
 | `LDAP_URL` | (unset) | LDAP server URL, e.g. `ldap://ldap.example.com:389` or `ldaps://ldap.example.com:636`. |
 | `LDAP_BIND_DN` | (unset) | Service-account bind DN used only to search for the user entry. |
-| `LDAP_BIND_PASSWORD` | (unset) | Service-account bind password. Prefer `LDAP_BIND_PASSWORD_FILE` or `--ldap-bind-password @/path` for secret mounts. |
+| `LDAP_BIND_PASSWORD` | (unset) | Service-account bind password. Literal env value only; it does not expand `@/path`. Prefer `LDAP_BIND_PASSWORD_FILE` or `--ldap-bind-password @/path` for secret mounts. |
 | `LDAP_BIND_PASSWORD_FILE` | (unset) | File containing the service-account password (for Kubernetes/OpenShift mounted Secrets). Takes precedence over `LDAP_BIND_PASSWORD`. |
 | `LDAP_BASE_DN` | (unset) | Base DN for user searches. |
 | `LDAP_USER_FILTER` | `(|(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))` | Search filter. `{{username}}` is escaped per RFC4515 before substitution. Must match exactly one user. |
@@ -67,7 +70,10 @@ are documented in [`deployment.md`](./deployment.md).
 ### LDAP browser login
 
 LDAP is opt-in and off by default. When `LDAP_ENABLED=true`, pi-forge's
-login form asks for a username and password. The server binds with the
+login form asks for a username and password. Username `admin` (and
+password-only API calls) always use the local pi-forge admin password
+from `UI_PASSWORD`, `UI_PASSWORD_FILE`, or the persisted password hash;
+all other usernames use LDAP. The server binds with the
 configured service account, searches under `LDAP_BASE_DN` using
 `LDAP_USER_FILTER`, optionally checks the returned user's `memberOf`
 (or `LDAP_GROUP_ATTRIBUTE`) against `LDAP_REQUIRED_GROUP_DN`, and then
@@ -88,16 +94,19 @@ LDAP_REQUIRED_GROUP_DN='cn=pi-forge-users,ou=groups,dc=example,dc=com'
 ```
 
 `LDAP_BIND_PASSWORD_FILE` is intended for Kubernetes/OpenShift mounted
-Secrets and takes precedence over `LDAP_BIND_PASSWORD`. The password is
-read only in `config.ts`, never returned by any API, and redacted from
-request logs. Do not put service-account passwords in container images
-or command-line history; use a mounted secret file or the CLI
-`--ldap-bind-password @/path/to/file` form instead.
+Secrets and takes precedence over `LDAP_BIND_PASSWORD`. `LDAP_BIND_PASSWORD`
+is always a literal password value; unlike CLI sensitive flags, env vars
+are not `@`-expanded. The password is read only in `config.ts`, never
+returned by any API, and redacted from request logs. Do not put
+service-account passwords in container images or command-line history;
+use a mounted secret file or the CLI `--ldap-bind-password @/path/to/file`
+form instead.
 
-If both LDAP and local `UI_PASSWORD` / stored password auth are present,
-username+password login uses LDAP; password-only login continues to use
-the local pi-forge password. This preserves existing single-tenant
-password deployments while allowing LDAP to be enabled during migration.
+If both LDAP and local `UI_PASSWORD` / `UI_PASSWORD_FILE` / stored-password
+auth are present, username `admin` and password-only login use the local
+pi-forge password. Other usernames use LDAP. This preserves existing
+single-tenant admin access while allowing LDAP to be enabled during
+migration.
 
 ## Pi SDK config files
 

--- a/kubernetes/DEPLOY.md
+++ b/kubernetes/DEPLOY.md
@@ -133,6 +133,12 @@ in [`docs/configuration.md`](../docs/configuration.md) and
   `${FORGE_DATA_DIR}/jwt-secret` on the data PVC, so tokens survive
   pod restarts. Override by adding a `JWT_SECRET` key to the secret
   if you want to manage rotation out-of-band.
+- **LDAP / OpenShift credentials.** For LDAP login, add the non-secret
+  settings (`LDAP_ENABLED`, `LDAP_URL`, `LDAP_BIND_DN`, `LDAP_BASE_DN`,
+  optional `LDAP_REQUIRED_GROUP_DN`) as env vars and provide the service
+  account password either as a Secret env key (`LDAP_BIND_PASSWORD`) or,
+  preferably, as a mounted Secret file with `LDAP_BIND_PASSWORD_FILE`
+  pointing at the mount path. See `docs/configuration.md#ldap-browser-login`.
 - **Resource defaults** per pod: requests 512 Mi / 250 m CPU; limits
   2 Gi / 1 CPU. Memory is the typical ceiling for long agent
   contexts or compiling inside the integrated terminal.

--- a/kubernetes/DEPLOY.md
+++ b/kubernetes/DEPLOY.md
@@ -125,7 +125,9 @@ in [`docs/configuration.md`](../docs/configuration.md) and
 
 - **Secrets are managed via `pi-forge-secret`.** Edit with
   `kubectl edit secret pi-forge-secret -n pi-forge` and roll the
-  deployment to pick up changes.
+  deployment to pick up changes. Browser admin passwords can be supplied
+  as the `UI_PASSWORD` env key or as a mounted Secret file with
+  `UI_PASSWORD_FILE` pointing at the mount path.
 - **`TRUST_PROXY=true`** is appropriate when traffic flows through
   ingress / Route. The shipped manifests default `false` to avoid
   trusting a header from upstream that hasn't been validated.
@@ -138,7 +140,8 @@ in [`docs/configuration.md`](../docs/configuration.md) and
   optional `LDAP_REQUIRED_GROUP_DN`) as env vars and provide the service
   account password either as a Secret env key (`LDAP_BIND_PASSWORD`) or,
   preferably, as a mounted Secret file with `LDAP_BIND_PASSWORD_FILE`
-  pointing at the mount path. See `docs/configuration.md#ldap-browser-login`.
+  pointing at the mount path. `LDAP_BIND_PASSWORD` itself is a literal
+  env value; it does not expand `@/path`. See `docs/configuration.md#ldap-browser-login`.
 - **Resource defaults** per pod: requests 512 Mi / 250 m CPU; limits
   2 Gi / 1 CPU. Memory is the typical ceiling for long agent
   contexts or compiling inside the integrated terminal.

--- a/kubernetes/openshift/deployment.yaml
+++ b/kubernetes/openshift/deployment.yaml
@@ -125,6 +125,9 @@ spec:
                   name: pi-forge-secret
                   key: UI_PASSWORD
                   optional: true
+            # Alternatively mount a Secret as a file and set
+            # UI_PASSWORD_FILE to that mount path. When set, it takes
+            # precedence over UI_PASSWORD.
             - name: API_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/openshift/deployment.yaml
+++ b/kubernetes/openshift/deployment.yaml
@@ -131,6 +131,18 @@ spec:
                   name: pi-forge-secret
                   key: API_KEY
                   optional: true
+            # LDAP is opt-in. Set LDAP_ENABLED/LDAP_URL/LDAP_BIND_DN/
+            # LDAP_BASE_DN/LDAP_REQUIRED_GROUP_DN here or via an overlay.
+            # The bind password can come from this OpenShift Secret key,
+            # or from a mounted Secret file by setting LDAP_BIND_PASSWORD_FILE.
+            - name: LDAP_ENABLED
+              value: "false"
+            - name: LDAP_BIND_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pi-forge-secret
+                  key: LDAP_BIND_PASSWORD
+                  optional: true
           livenessProbe:
             httpGet:
               path: /api/v1/health

--- a/kubernetes/openshift/secret.sh
+++ b/kubernetes/openshift/secret.sh
@@ -4,8 +4,9 @@
 #
 #   ./kubernetes/openshift/secret.sh
 #
-# Defaults: empty UI_PASSWORD and API_KEY (auth disabled). JWT_SECRET
-# is intentionally NOT set here — when UI_PASSWORD is enabled, the
+# Defaults: empty UI_PASSWORD/API_KEY/LDAP_BIND_PASSWORD (auth disabled
+# unless you set UI_PASSWORD, API_KEY, or LDAP_ENABLED plus LDAP_* settings).
+# JWT_SECRET is intentionally NOT set here — when UI_PASSWORD or LDAP is enabled, the
 # server auto-generates one on first boot and persists it to
 # ${FORGE_DATA_DIR}/jwt-secret on the data-dir PVC, so issued
 # tokens survive pod restarts.
@@ -21,4 +22,5 @@ kubectl create secret generic pi-forge-secret \
   --namespace=pi-forge \
   --from-literal=UI_PASSWORD="" \
   --from-literal=API_KEY="" \
+  --from-literal=LDAP_BIND_PASSWORD="" \
   --dry-run=client -o yaml | oc apply -f -

--- a/package-lock.json
+++ b/package-lock.json
@@ -11482,6 +11482,18 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/ldapts": {
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/ldapts/-/ldapts-8.1.8.tgz",
+      "integrity": "sha512-Wpdvo+/0DREIynYf2he2efHtjptr5zD7dpesSkZWJqfQdMEgSTytEIsSZVuoDSiiE1+SpXf3emZ7ewxGBTo7Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "strict-event-emitter-types": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -15045,6 +15057,12 @@
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "license": "MIT"
     },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -17012,6 +17030,7 @@
         "exceljs": "^4.4.0",
         "fastify": "^5.3.2",
         "jsonwebtoken": "^9.0.2",
+        "ldapts": "^8.1.8",
         "mammoth": "^1.12.0",
         "node-pty": "^1.0.0",
         "pdf-parse": "^2.4.5",

--- a/packages/client/src/components/LoginScreen.tsx
+++ b/packages/client/src/components/LoginScreen.tsx
@@ -2,7 +2,7 @@ import { useState, type FormEvent } from "react";
 import { useAuthStore } from "../store/auth-store";
 
 export function LoginScreen() {
-  const [username, setUsername] = useState("admin");
+  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const login = useAuthStore((s) => s.login);
   const ldapEnabled = useAuthStore((s) => s.ldapEnabled);
@@ -29,7 +29,7 @@ export function LoginScreen() {
           </div>
           <p className="text-sm text-neutral-400">
             {ldapEnabled
-              ? "Sign in as admin with the local pi-forge password, or replace admin with your LDAP username."
+              ? "Enter your LDAP username and password, or username admin for the local pi-forge password."
               : "Enter the pi-forge password to continue."}
           </p>
         </header>
@@ -40,6 +40,7 @@ export function LoginScreen() {
               type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
+              autoFocus
               autoComplete="username"
               className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm outline-none focus:border-neutral-500"
             />
@@ -51,7 +52,7 @@ export function LoginScreen() {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            autoFocus
+            autoFocus={!ldapEnabled}
             autoComplete="current-password"
             className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm outline-none focus:border-neutral-500"
           />

--- a/packages/client/src/components/LoginScreen.tsx
+++ b/packages/client/src/components/LoginScreen.tsx
@@ -29,7 +29,7 @@ export function LoginScreen() {
           </div>
           <p className="text-sm text-neutral-400">
             {ldapEnabled
-              ? "Enter your LDAP username and password to continue."
+              ? "Enter your LDAP username and password, or username admin for the local pi-forge password."
               : "Enter the pi-forge password to continue."}
           </p>
         </header>
@@ -61,7 +61,7 @@ export function LoginScreen() {
           <p role="alert" className="text-sm text-red-400">
             {error === "invalid_password"
               ? ldapEnabled
-                ? "Incorrect username/password or unauthorized LDAP group."
+                ? "Incorrect username/password, local admin password, or LDAP group."
                 : "Incorrect password."
               : error === "username_required"
                 ? "Username is required."

--- a/packages/client/src/components/LoginScreen.tsx
+++ b/packages/client/src/components/LoginScreen.tsx
@@ -2,15 +2,18 @@ import { useState, type FormEvent } from "react";
 import { useAuthStore } from "../store/auth-store";
 
 export function LoginScreen() {
+  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const login = useAuthStore((s) => s.login);
+  const ldapEnabled = useAuthStore((s) => s.ldapEnabled);
   const pending = useAuthStore((s) => s.loginPending);
   const error = useAuthStore((s) => s.loginError);
 
   const onSubmit = (e: FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
     if (password.length === 0) return;
-    void login(password);
+    if (ldapEnabled && username.trim().length === 0) return;
+    void login(password, ldapEnabled ? username.trim() : undefined);
   };
 
   return (
@@ -24,27 +27,52 @@ export function LoginScreen() {
             <img src="/icons/icon.svg" alt="" className="h-6 w-6" aria-hidden="true" />
             <h1 className="text-xl font-semibold tracking-tight">pi-forge</h1>
           </div>
-          <p className="text-sm text-neutral-400">Enter the pi-forge password to continue.</p>
+          <p className="text-sm text-neutral-400">
+            {ldapEnabled
+              ? "Enter your LDAP username and password to continue."
+              : "Enter the pi-forge password to continue."}
+          </p>
         </header>
+        {ldapEnabled && (
+          <label className="block space-y-1.5">
+            <span className="text-sm font-medium text-neutral-300">Username</span>
+            <input
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              autoFocus
+              autoComplete="username"
+              className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm outline-none focus:border-neutral-500"
+            />
+          </label>
+        )}
         <label className="block space-y-1.5">
           <span className="text-sm font-medium text-neutral-300">Password</span>
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            autoFocus
+            autoFocus={!ldapEnabled}
             autoComplete="current-password"
             className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm outline-none focus:border-neutral-500"
           />
         </label>
         {error !== undefined && (
           <p role="alert" className="text-sm text-red-400">
-            {error === "invalid_password" ? "Incorrect password." : `Login failed: ${error}`}
+            {error === "invalid_password"
+              ? ldapEnabled
+                ? "Incorrect username/password or unauthorized LDAP group."
+                : "Incorrect password."
+              : error === "username_required"
+                ? "Username is required."
+                : `Login failed: ${error}`}
           </p>
         )}
         <button
           type="submit"
-          disabled={pending || password.length === 0}
+          disabled={
+            pending || password.length === 0 || (ldapEnabled && username.trim().length === 0)
+          }
           className="w-full rounded-md bg-neutral-100 px-3 py-2 text-sm font-medium text-neutral-900 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
         >
           {pending ? "Signing in…" : "Sign in"}

--- a/packages/client/src/components/LoginScreen.tsx
+++ b/packages/client/src/components/LoginScreen.tsx
@@ -2,7 +2,7 @@ import { useState, type FormEvent } from "react";
 import { useAuthStore } from "../store/auth-store";
 
 export function LoginScreen() {
-  const [username, setUsername] = useState("");
+  const [username, setUsername] = useState("admin");
   const [password, setPassword] = useState("");
   const login = useAuthStore((s) => s.login);
   const ldapEnabled = useAuthStore((s) => s.ldapEnabled);
@@ -29,7 +29,7 @@ export function LoginScreen() {
           </div>
           <p className="text-sm text-neutral-400">
             {ldapEnabled
-              ? "Enter your LDAP username and password, or username admin for the local pi-forge password."
+              ? "Sign in as admin with the local pi-forge password, or replace admin with your LDAP username."
               : "Enter the pi-forge password to continue."}
           </p>
         </header>
@@ -40,7 +40,6 @@ export function LoginScreen() {
               type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              autoFocus
               autoComplete="username"
               className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm outline-none focus:border-neutral-500"
             />
@@ -52,7 +51,7 @@ export function LoginScreen() {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            autoFocus={!ldapEnabled}
+            autoFocus
             autoComplete="current-password"
             className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm outline-none focus:border-neutral-500"
           />

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -103,7 +103,10 @@ function vAuthStatus(value: unknown, status: number): AuthStatusResponse {
   if (!isObject(value) || typeof value.authEnabled !== "boolean") {
     fail(status, "expected { authEnabled: boolean }");
   }
-  return { authEnabled: value.authEnabled };
+  return {
+    authEnabled: value.authEnabled,
+    ldapEnabled: typeof value.ldapEnabled === "boolean" ? value.ldapEnabled : false,
+  };
 }
 
 function vLogin(value: unknown, status: number): LoginResponse {
@@ -1514,10 +1517,10 @@ function gitQuery(
 
 export const api = {
   authStatus: () => request("/api/v1/auth/status", vAuthStatus, { skipAuth: true }),
-  login: (password: string) =>
+  login: (password: string, username?: string) =>
     request("/api/v1/auth/login", vLogin, {
       method: "POST",
-      body: { password },
+      body: username === undefined ? { password } : { username, password },
       skipAuth: true,
     }),
   changePassword: (currentPassword: string, newPassword: string) =>

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -25,6 +25,7 @@ export class ApiError extends Error {
 
 export interface AuthStatusResponse {
   authEnabled: boolean;
+  ldapEnabled: boolean;
 }
 
 export interface LoginResponse {

--- a/packages/client/src/store/auth-store.ts
+++ b/packages/client/src/store/auth-store.ts
@@ -7,6 +7,8 @@ interface AuthState {
   ready: boolean;
   /** True when the server reports auth is required. */
   authRequired: boolean;
+  /** True when the server has LDAP username/password login enabled. */
+  ldapEnabled: boolean;
   /** True when we have a valid stored token (or auth is not required). */
   isAuthenticated: boolean;
   /**
@@ -21,7 +23,7 @@ interface AuthState {
   changePasswordError: string | undefined;
   changePasswordPending: boolean;
   bootstrap: () => Promise<void>;
-  login: (password: string) => Promise<void>;
+  login: (password: string, username?: string) => Promise<void>;
   changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
   logout: () => void;
 }
@@ -29,6 +31,7 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set, get) => ({
   ready: false,
   authRequired: false,
+  ldapEnabled: false,
   isAuthenticated: false,
   mustChangePassword: false,
   loginError: undefined,
@@ -37,11 +40,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   changePasswordPending: false,
   bootstrap: async () => {
     try {
-      const { authEnabled } = await api.authStatus();
+      const { authEnabled, ldapEnabled } = await api.authStatus();
       if (!authEnabled) {
         set({
           ready: true,
           authRequired: false,
+          ldapEnabled,
           isAuthenticated: true,
           mustChangePassword: false,
         });
@@ -51,6 +55,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       set({
         ready: true,
         authRequired: true,
+        ldapEnabled,
         isAuthenticated: stored !== undefined,
         mustChangePassword: stored?.mustChangePassword ?? false,
       });
@@ -58,17 +63,18 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       set({
         ready: true,
         authRequired: true,
+        ldapEnabled: false,
         isAuthenticated: false,
         mustChangePassword: false,
         loginError: err instanceof Error ? err.message : "bootstrap_failed",
       });
     }
   },
-  login: async (password: string) => {
+  login: async (password: string, username?: string) => {
     if (get().loginPending) return;
     set({ loginPending: true, loginError: undefined });
     try {
-      const res = await api.login(password);
+      const res = await api.login(password, username);
       setStoredToken({
         token: res.token,
         expiresAt: res.expiresAt,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,6 +23,7 @@
     "exceljs": "^4.4.0",
     "fastify": "^5.3.2",
     "jsonwebtoken": "^9.0.2",
+    "ldapts": "^8.1.8",
     "mammoth": "^1.12.0",
     "node-pty": "^1.0.0",
     "pdf-parse": "^2.4.5",

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -250,6 +250,14 @@ const FLAGS: readonly FlagDef[] = [
     desc: "LDAP connect/operation timeout (ms)",
     defaultText: "5000",
   },
+  {
+    name: "ldap-tls-reject-unauthorized",
+    env: "LDAP_TLS_REJECT_UNAUTHORIZED",
+    type: "boolean",
+    group: "auth",
+    desc: "Reject untrusted LDAP TLS certificates; set false only for local/self-signed testing",
+    defaultText: "true",
+  },
   // features
   {
     name: "log-level",

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -161,6 +161,87 @@ const FLAGS: readonly FlagDef[] = [
     desc: "Require user to change password on first login (set when --ui-password is sealed-secret)",
     defaultText: "false",
   },
+  {
+    name: "ldap-enabled",
+    env: "LDAP_ENABLED",
+    type: "boolean",
+    group: "auth",
+    desc: "Enable LDAP username/password browser login",
+    defaultText: "false",
+  },
+  {
+    name: "ldap-url",
+    env: "LDAP_URL",
+    type: "string",
+    group: "auth",
+    desc: "LDAP server URL (ldap:// or ldaps://)",
+    defaultText: "(unset)",
+  },
+  {
+    name: "ldap-bind-dn",
+    env: "LDAP_BIND_DN",
+    type: "string",
+    group: "auth",
+    desc: "LDAP service-account bind DN used to search users",
+    defaultText: "(unset)",
+  },
+  {
+    name: "ldap-bind-password",
+    env: "LDAP_BIND_PASSWORD",
+    type: "string",
+    group: "auth",
+    desc: "LDAP service-account bind password. Use @<path> to read from a file.",
+    defaultText: "(unset)",
+    sensitive: true,
+  },
+  {
+    name: "ldap-bind-password-file",
+    env: "LDAP_BIND_PASSWORD_FILE",
+    type: "string",
+    group: "auth",
+    desc: "Path to LDAP bind password file (OpenShift/Kubernetes secret mount)",
+    defaultText: "(unset)",
+  },
+  {
+    name: "ldap-base-dn",
+    env: "LDAP_BASE_DN",
+    type: "string",
+    group: "auth",
+    desc: "LDAP search base DN for users",
+    defaultText: "(unset)",
+  },
+  {
+    name: "ldap-user-filter",
+    env: "LDAP_USER_FILTER",
+    type: "string",
+    group: "auth",
+    desc: "LDAP user search filter; use {{username}} placeholder",
+    defaultText: "(|(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))",
+  },
+  {
+    name: "ldap-required-group-dn",
+    env: "LDAP_REQUIRED_GROUP_DN",
+    type: "string",
+    group: "auth",
+    desc: "Optional required group DN checked against memberOf",
+    defaultText: "(unset)",
+  },
+  {
+    name: "ldap-group-attribute",
+    env: "LDAP_GROUP_ATTRIBUTE",
+    type: "string",
+    group: "auth",
+    desc: "LDAP user attribute containing group DNs",
+    defaultText: "memberOf",
+  },
+  {
+    name: "ldap-timeout-ms",
+    env: "LDAP_TIMEOUT_MS",
+    type: "number",
+    group: "auth",
+    desc: "LDAP connect/operation timeout (ms)",
+    defaultText: "5000",
+  },
   // features
   {
     name: "log-level",
@@ -554,7 +635,7 @@ export function buildHelpText(version: string): string {
   out.push("");
   out.push("Boolean flags accept true/false/on/off/1/0/yes/no, or use --no-<flag> for false.");
   out.push(
-    "Sensitive flags (--ui-password, --api-key, --jwt-secret) accept @<path> to read from file.",
+    "Sensitive flags (--ui-password, --api-key, --jwt-secret, --ldap-bind-password) accept @<path> to read from file.",
   );
   out.push("");
   out.push("Examples:");

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -128,6 +128,14 @@ const FLAGS: readonly FlagDef[] = [
     sensitive: true,
   },
   {
+    name: "ui-password-file",
+    env: "UI_PASSWORD_FILE",
+    type: "string",
+    group: "auth",
+    desc: "Path to browser login password file (OpenShift/Kubernetes secret mount)",
+    defaultText: "(unset)",
+  },
+  {
     name: "api-key",
     env: "API_KEY",
     type: "string",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -305,6 +305,7 @@ export const config = Object.freeze({
       requiredGroupDn: readEnv("LDAP_REQUIRED_GROUP_DN"),
       groupAttribute: readEnv("LDAP_GROUP_ATTRIBUTE") ?? "memberOf",
       timeoutMs: readInt("LDAP_TIMEOUT_MS", 5000),
+      tlsRejectUnauthorized: readBool("LDAP_TLS_REJECT_UNAUTHORIZED", true),
     }),
     jwtExpiresInSeconds: readInt("JWT_EXPIRES_IN_SECONDS", 60 * 60 * 24 * 7),
     loginRateLimitMax: readInt("RATE_LIMIT_LOGIN_MAX", 10),

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -110,7 +110,10 @@ const CLIENT_DIST_PATH = resolve(
     join(dirname(fileURLToPath(import.meta.url)), "..", "..", "client", "dist"),
 );
 
-const UI_PASSWORD = readEnv("UI_PASSWORD");
+const UI_PASSWORD_FILE = readEnv("UI_PASSWORD_FILE");
+const UI_PASSWORD = UI_PASSWORD_FILE
+  ? readSecretFile(UI_PASSWORD_FILE, "UI_PASSWORD_FILE")
+  : readEnv("UI_PASSWORD");
 const API_KEY = readEnv("API_KEY");
 const CORS_ORIGIN = readEnv("CORS_ORIGIN");
 const PASSWORD_HASH_FILE = join(FORGE_DATA_DIR, "password-hash");
@@ -286,6 +289,7 @@ export const config = Object.freeze({
   exposeDocs: readBool("EXPOSE_DOCS", true),
   auth: Object.freeze({
     uiPassword: UI_PASSWORD,
+    uiPasswordFile: UI_PASSWORD_FILE,
     jwtSecret: JWT_SECRET,
     apiKey: API_KEY,
     ldap: Object.freeze({

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -31,6 +31,21 @@ function readStringList(key: string): string[] {
     .filter((s) => s.length > 0);
 }
 
+function readSecretFile(path: string, envKey: string): string {
+  try {
+    const value = readFileSync(path, "utf8").trim();
+    if (value.length === 0) {
+      throw new Error("file is empty");
+    }
+    return value;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`config: failed to read ${envKey} from file ${path}: ${message}`, {
+      cause: err,
+    });
+  }
+}
+
 function readBool(key: string, fallback: boolean): boolean {
   const v = readEnv(key)?.toLowerCase();
   if (v === undefined) return fallback;
@@ -99,6 +114,11 @@ const UI_PASSWORD = readEnv("UI_PASSWORD");
 const API_KEY = readEnv("API_KEY");
 const CORS_ORIGIN = readEnv("CORS_ORIGIN");
 const PASSWORD_HASH_FILE = join(FORGE_DATA_DIR, "password-hash");
+const LDAP_ENABLED = readBool("LDAP_ENABLED", false);
+const LDAP_BIND_PASSWORD_FILE = readEnv("LDAP_BIND_PASSWORD_FILE");
+const LDAP_BIND_PASSWORD = LDAP_BIND_PASSWORD_FILE
+  ? readSecretFile(LDAP_BIND_PASSWORD_FILE, "LDAP_BIND_PASSWORD_FILE")
+  : readEnv("LDAP_BIND_PASSWORD");
 
 /**
  * Load a JWT signing key from `${FORGE_DATA_DIR}/jwt-secret`, or
@@ -108,8 +128,8 @@ const PASSWORD_HASH_FILE = join(FORGE_DATA_DIR, "password-hash");
  * valid. Setting `JWT_SECRET` env explicitly skips this entirely.
  *
  * Invoked when ANY browser-auth credential is in play: an env-supplied
- * `UI_PASSWORD`, or a previously-persisted password-hash file (the
- * latter survives env rotation, the same way jwt-secret does).
+ * `UI_PASSWORD`, LDAP login, or a previously-persisted password-hash
+ * file (the latter survives env rotation, the same way jwt-secret does).
  * Without this, a deployment that booted with `UI_PASSWORD` once and
  * then dropped it after the user changed their password would be left
  * with a hash on disk but no signing key — login would 500 trying to
@@ -138,7 +158,7 @@ function loadOrGenerateJwtSecret(dataDir: string): string {
 
 const JWT_SECRET =
   readEnv("JWT_SECRET") ??
-  (UI_PASSWORD !== undefined || existsSync(PASSWORD_HASH_FILE)
+  (UI_PASSWORD !== undefined || LDAP_ENABLED || existsSync(PASSWORD_HASH_FILE)
     ? loadOrGenerateJwtSecret(FORGE_DATA_DIR)
     : undefined);
 
@@ -268,6 +288,20 @@ export const config = Object.freeze({
     uiPassword: UI_PASSWORD,
     jwtSecret: JWT_SECRET,
     apiKey: API_KEY,
+    ldap: Object.freeze({
+      enabled: LDAP_ENABLED,
+      url: readEnv("LDAP_URL"),
+      bindDn: readEnv("LDAP_BIND_DN"),
+      bindPassword: LDAP_BIND_PASSWORD,
+      bindPasswordFile: LDAP_BIND_PASSWORD_FILE,
+      baseDn: readEnv("LDAP_BASE_DN"),
+      userFilter:
+        readEnv("LDAP_USER_FILTER") ??
+        "(|(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))",
+      requiredGroupDn: readEnv("LDAP_REQUIRED_GROUP_DN"),
+      groupAttribute: readEnv("LDAP_GROUP_ATTRIBUTE") ?? "memberOf",
+      timeoutMs: readInt("LDAP_TIMEOUT_MS", 5000),
+    }),
     jwtExpiresInSeconds: readInt("JWT_EXPIRES_IN_SECONDS", 60 * 60 * 24 * 7),
     loginRateLimitMax: readInt("RATE_LIMIT_LOGIN_MAX", 10),
     loginRateLimitWindowMs: readInt("RATE_LIMIT_LOGIN_WINDOW_MS", 60_000),
@@ -381,6 +415,7 @@ export function authEnabled(): boolean {
   return (
     config.auth.uiPassword !== undefined ||
     config.auth.apiKey !== undefined ||
+    config.auth.ldap.enabled ||
     existsSync(config.auth.passwordHashFile)
   );
 }

--- a/packages/server/src/ldap-auth.ts
+++ b/packages/server/src/ldap-auth.ts
@@ -25,6 +25,9 @@ function createLdapClient(): LdapClientLike {
     url: config.auth.ldap.url ?? "ldap://127.0.0.1:389",
     timeout: config.auth.ldap.timeoutMs,
     connectTimeout: config.auth.ldap.timeoutMs,
+    tlsOptions: {
+      rejectUnauthorized: config.auth.ldap.tlsRejectUnauthorized,
+    },
   });
 }
 
@@ -46,13 +49,19 @@ export async function verifyLdapLogin(
 ): Promise<LdapLoginResult> {
   const ldap = config.auth.ldap;
   if (!ldap.enabled) return { ok: false, error: "disabled" };
-  if (!ldapConfigured()) return { ok: false, error: "misconfigured" };
+  if (!ldapConfigured()) {
+    console.warn("[ldap] login skipped: LDAP is enabled but required config is missing");
+    return { ok: false, error: "misconfigured" };
+  }
   if (username.trim().length === 0 || password.length === 0) {
     return { ok: false, error: "invalid_credentials" };
   }
 
   const client = factory();
   try {
+    console.info(
+      `[ldap] login attempt: url=${ldap.url}, baseDn=${ldap.baseDn}, username=${username}, tlsRejectUnauthorized=${ldap.tlsRejectUnauthorized}`,
+    );
     await client.bind(ldap.bindDn!, ldap.bindPassword);
     const filter = renderUserFilter(ldap.userFilter, username);
     const attributes = [ldap.groupAttribute];
@@ -64,14 +73,16 @@ export async function verifyLdapLogin(
     });
 
     if (result.searchEntries.length !== 1) {
-      return {
-        ok: false,
-        error: result.searchEntries.length === 0 ? "user_not_found" : "ldap_error",
-      };
+      const error = result.searchEntries.length === 0 ? "user_not_found" : "ldap_error";
+      console.warn(
+        `[ldap] login failed before user bind: username=${username}, reason=${error}, matches=${result.searchEntries.length}`,
+      );
+      return { ok: false, error };
     }
 
     const entry = result.searchEntries[0];
     if (entry === undefined || typeof entry.dn !== "string" || entry.dn.length === 0) {
+      console.warn(`[ldap] login failed: username=${username}, reason=missing_user_dn`);
       return { ok: false, error: "ldap_error" };
     }
 
@@ -79,12 +90,18 @@ export async function verifyLdapLogin(
       ldap.requiredGroupDn !== undefined &&
       !entryHasGroup(entry, ldap.groupAttribute, ldap.requiredGroupDn)
     ) {
+      console.warn(`[ldap] login failed: username=${username}, reason=group_required`);
       return { ok: false, error: "group_required" };
     }
 
     await client.bind(entry.dn, password);
+    console.info(`[ldap] login succeeded: username=${username}`);
     return { ok: true };
-  } catch {
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[ldap] login failed: username=${username}, reason=bind_or_search_error, error=${message}`,
+    );
     return { ok: false, error: "invalid_credentials" };
   } finally {
     await client.unbind().catch(() => undefined);

--- a/packages/server/src/ldap-auth.ts
+++ b/packages/server/src/ldap-auth.ts
@@ -1,0 +1,126 @@
+import { Client, type Entry, type SearchOptions } from "ldapts";
+import { config } from "./config.js";
+
+export interface LdapClientLike {
+  bind(dn: string, password?: string): Promise<void>;
+  search(baseDn: string, options?: SearchOptions): Promise<{ searchEntries: Entry[] }>;
+  unbind(): Promise<void>;
+}
+
+export interface LdapLoginResult {
+  ok: boolean;
+  error?:
+    | "disabled"
+    | "misconfigured"
+    | "invalid_credentials"
+    | "user_not_found"
+    | "group_required"
+    | "ldap_error";
+}
+
+export type LdapClientFactory = () => LdapClientLike;
+
+function createLdapClient(): LdapClientLike {
+  return new Client({
+    url: config.auth.ldap.url ?? "ldap://127.0.0.1:389",
+    timeout: config.auth.ldap.timeoutMs,
+    connectTimeout: config.auth.ldap.timeoutMs,
+  });
+}
+
+export function ldapConfigured(): boolean {
+  const ldap = config.auth.ldap;
+  return (
+    ldap.enabled &&
+    ldap.url !== undefined &&
+    ldap.bindDn !== undefined &&
+    ldap.bindPassword !== undefined &&
+    ldap.baseDn !== undefined
+  );
+}
+
+export async function verifyLdapLogin(
+  username: string,
+  password: string,
+  factory: LdapClientFactory = createLdapClient,
+): Promise<LdapLoginResult> {
+  const ldap = config.auth.ldap;
+  if (!ldap.enabled) return { ok: false, error: "disabled" };
+  if (!ldapConfigured()) return { ok: false, error: "misconfigured" };
+  if (username.trim().length === 0 || password.length === 0) {
+    return { ok: false, error: "invalid_credentials" };
+  }
+
+  const client = factory();
+  try {
+    await client.bind(ldap.bindDn!, ldap.bindPassword);
+    const filter = renderUserFilter(ldap.userFilter, username);
+    const attributes = [ldap.groupAttribute];
+    const result = await client.search(ldap.baseDn!, {
+      scope: "sub",
+      filter,
+      sizeLimit: 2,
+      attributes,
+    });
+
+    if (result.searchEntries.length !== 1) {
+      return {
+        ok: false,
+        error: result.searchEntries.length === 0 ? "user_not_found" : "ldap_error",
+      };
+    }
+
+    const entry = result.searchEntries[0];
+    if (entry === undefined || typeof entry.dn !== "string" || entry.dn.length === 0) {
+      return { ok: false, error: "ldap_error" };
+    }
+
+    if (
+      ldap.requiredGroupDn !== undefined &&
+      !entryHasGroup(entry, ldap.groupAttribute, ldap.requiredGroupDn)
+    ) {
+      return { ok: false, error: "group_required" };
+    }
+
+    await client.bind(entry.dn, password);
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "invalid_credentials" };
+  } finally {
+    await client.unbind().catch(() => undefined);
+  }
+}
+
+export function renderUserFilter(template: string, username: string): string {
+  return template.replaceAll("{{username}}", escapeLdapFilterValue(username));
+}
+
+export function escapeLdapFilterValue(value: string): string {
+  let escaped = "";
+  for (const ch of value) {
+    switch (ch) {
+      case "\\":
+        escaped += "\\5c";
+        break;
+      case "*":
+        escaped += "\\2a";
+        break;
+      case "(":
+        escaped += "\\28";
+        break;
+      case ")":
+        escaped += "\\29";
+        break;
+      default:
+        escaped += ch.charCodeAt(0) === 0 ? "\\00" : ch;
+        break;
+    }
+  }
+  return escaped;
+}
+
+function entryHasGroup(entry: Entry, attribute: string, requiredGroupDn: string): boolean {
+  const raw = entry[attribute];
+  const values = Array.isArray(raw) ? raw : raw === undefined ? [] : [raw];
+  return values.some((value) => String(value).toLowerCase() === requiredGroupDn.toLowerCase());
+}

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -8,9 +8,11 @@ import {
   verifyPasswordWithSource,
   verifyToken,
 } from "../auth.js";
+import { verifyLdapLogin } from "../ldap-auth.js";
 import { errorSchema } from "./_schemas.js";
 
 interface LoginBody {
+  username?: string;
   password: string;
 }
 
@@ -34,15 +36,16 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
         response: {
           200: {
             type: "object",
-            required: ["authEnabled"],
+            required: ["authEnabled", "ldapEnabled"],
             properties: {
               authEnabled: { type: "boolean" },
+              ldapEnabled: { type: "boolean" },
             },
           },
         },
       },
     },
-    async () => ({ authEnabled: authEnabled() }),
+    async () => ({ authEnabled: authEnabled(), ldapEnabled: config.auth.ldap.enabled }),
   );
 
   fastify.post<{ Body: LoginBody }>(
@@ -57,11 +60,10 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
       },
       schema: {
         description:
-          "Exchange a password for a short-lived JWT. Returns 401 if the password is wrong, " +
-          "or 503 if browser password auth is not configured (no UI_PASSWORD set and no " +
-          "stored password hash). When the password matched the env-supplied " +
-          "UI_PASSWORD AND no stored hash exists yet, `mustChangePassword` is true on " +
-          "the response and the issued token may only call POST /auth/change-password.",
+          "Exchange a local password or LDAP username/password for a short-lived JWT. " +
+          "LDAP is opt-in and requires `username`; local UI_PASSWORD / stored-hash " +
+          "logins continue to accept password-only requests. Returns 401 if the " +
+          "credentials are wrong, or 503 if the selected auth backend is not configured.",
         tags: ["auth"],
         security: [],
         body: {
@@ -69,6 +71,7 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
           required: ["password"],
           additionalProperties: false,
           properties: {
+            username: { type: "string", minLength: 1, maxLength: 256 },
             password: { type: "string", minLength: 1, maxLength: MAX_PASSWORD_LENGTH },
           },
         },
@@ -82,19 +85,47 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
               mustChangePassword: { type: "boolean" },
             },
           },
+          400: errorSchema,
           401: errorSchema,
           503: errorSchema,
         },
       },
     },
     async (req, reply) => {
+      const { username, password } = req.body;
+
+      if (config.auth.ldap.enabled && username !== undefined) {
+        const result = await verifyLdapLogin(username, password);
+        if (result.error === "misconfigured") {
+          return reply.code(503).send({
+            error: "ldap_not_configured",
+            message:
+              "LDAP login is enabled but LDAP_URL, LDAP_BIND_DN, " +
+              "LDAP_BIND_PASSWORD(_FILE), or LDAP_BASE_DN is missing",
+          });
+        }
+        if (!result.ok) {
+          return reply.code(401).send({
+            error: "invalid_password",
+            message: "the username or password did not match, or the user is not authorized",
+          });
+        }
+        const issued = generateToken({ mustChangePassword: false });
+        return { ...issued, mustChangePassword: false };
+      }
+
       if (!passwordConfigured()) {
+        if (config.auth.ldap.enabled) {
+          return reply.code(400).send({
+            error: "username_required",
+            message: "LDAP login requires a username",
+          });
+        }
         return reply.code(503).send({
           error: "ui_password_not_configured",
           message: "browser login is disabled (no UI_PASSWORD set and no stored password hash)",
         });
       }
-      const { password } = req.body;
       const result = await verifyPasswordWithSource(password);
       if (!result.ok) {
         return reply.code(401).send({

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -60,9 +60,9 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
       },
       schema: {
         description:
-          "Exchange a local password or LDAP username/password for a short-lived JWT. " +
-          "LDAP is opt-in and requires `username`; local UI_PASSWORD / stored-hash " +
-          "logins continue to accept password-only requests. Returns 401 if the " +
+          "Exchange a local admin password or LDAP username/password for a short-lived JWT. " +
+          "LDAP is opt-in; username `admin` and password-only requests use local " +
+          "UI_PASSWORD / stored-hash auth, while other usernames use LDAP. Returns 401 if the " +
           "credentials are wrong, or 503 if the selected auth backend is not configured.",
         tags: ["auth"],
         security: [],
@@ -93,8 +93,9 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const { username, password } = req.body;
+      const loginAsLocalAdmin = username === undefined || username.toLowerCase() === "admin";
 
-      if (config.auth.ldap.enabled && username !== undefined) {
+      if (config.auth.ldap.enabled && !loginAsLocalAdmin) {
         const result = await verifyLdapLogin(username, password);
         if (result.error === "misconfigured") {
           return reply.code(503).send({
@@ -115,15 +116,10 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       if (!passwordConfigured()) {
-        if (config.auth.ldap.enabled) {
-          return reply.code(400).send({
-            error: "username_required",
-            message: "LDAP login requires a username",
-          });
-        }
         return reply.code(503).send({
           error: "ui_password_not_configured",
-          message: "browser login is disabled (no UI_PASSWORD set and no stored password hash)",
+          message:
+            "browser local admin login is disabled (no UI_PASSWORD set and no stored password hash)",
         });
       }
       const result = await verifyPasswordWithSource(password);

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -5,6 +5,7 @@
  *   A) UI_PASSWORD set, JWT_SECRET set, no API_KEY  → password+JWT path
  *   B) API_KEY set, no UI_PASSWORD                  → API-key-only path
  *   C) Neither set                                  → auth fully disabled
+ *   E) LDAP enabled, no local password              → auth enabled; login requires username
  *
  * Asserts the matrix of expected status codes plus a deterministic rate-limit
  * check (RATE_LIMIT_LOGIN_MAX=3 → 4th login attempt returns 429).
@@ -19,7 +20,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
 import { randomBytes } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -278,6 +279,47 @@ async function scenarioAuthDisabled(): Promise<void> {
   }
 }
 
+async function scenarioLdapEnabledRequiresUsername(): Promise<void> {
+  console.log("\n[scenario E] LDAP enabled without local password");
+  const ldapSecretDir = await mkdtemp(join(tmpdir(), "pi-forge-test-ldap-secret-"));
+  const ldapSecretFile = join(ldapSecretDir, "bind-password");
+  await writeFile(ldapSecretFile, "service-secret\n", "utf8");
+  const srv = await startServer({
+    UI_PASSWORD: undefined,
+    JWT_SECRET: undefined,
+    API_KEY: undefined,
+    LDAP_ENABLED: "true",
+    LDAP_URL: "ldaps://ldap.example.test",
+    LDAP_BIND_DN: "cn=pi-forge,ou=svc,dc=example,dc=test",
+    LDAP_BIND_PASSWORD: undefined,
+    LDAP_BIND_PASSWORD_FILE: ldapSecretFile,
+    LDAP_BASE_DN: "ou=people,dc=example,dc=test",
+  });
+  try {
+    const status = (await (await fetch(`${srv.base}/api/v1/auth/status`)).json()) as {
+      authEnabled: boolean;
+      ldapEnabled?: boolean;
+    };
+    assert("auth/status reports authEnabled=true (ldap)", status.authEnabled === true);
+    assert("auth/status reports ldapEnabled=true", status.ldapEnabled === true);
+
+    const login = await jsonPost(`${srv.base}/api/v1/auth/login`, { password: "anything" });
+    assert("password-only login → 400 when LDAP is the only browser auth", login.status === 400);
+    const body = (await login.json()) as { error?: string };
+    assert(
+      "  error is username_required",
+      body.error === "username_required",
+      JSON.stringify(body),
+    );
+
+    const probeNoToken = await fetch(`${srv.base}/api/v1/__protected_probe`);
+    assert("protected probe with no token → 401", probeNoToken.status === 401);
+  } finally {
+    await srv.stop();
+    await rm(ldapSecretDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
 /**
  * Scenario D — persisted password-hash but NO env credentials.
  *
@@ -382,6 +424,7 @@ async function main(): Promise<void> {
   await scenarioApiKeyOnly();
   await scenarioAuthDisabled();
   await scenarioPersistedHashOnly();
+  await scenarioLdapEnabledRequiresUsername();
 
   if (failures > 0) {
     console.log(`\n[test-auth] FAIL — ${failures} assertion(s) failed`);

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -5,7 +5,8 @@
  *   A) UI_PASSWORD set, JWT_SECRET set, no API_KEY  → password+JWT path
  *   B) API_KEY set, no UI_PASSWORD                  → API-key-only path
  *   C) Neither set                                  → auth fully disabled
- *   E) LDAP enabled, no local password              → auth enabled; login requires username
+ *   E) LDAP enabled, no local password              → auth enabled; local login unavailable
+ *   F) LDAP enabled + UI_PASSWORD_FILE              → admin/password-only use local auth
  *
  * Asserts the matrix of expected status codes plus a deterministic rate-limit
  * check (RATE_LIMIT_LOGIN_MAX=3 → 4th login attempt returns 429).
@@ -279,7 +280,7 @@ async function scenarioAuthDisabled(): Promise<void> {
   }
 }
 
-async function scenarioLdapEnabledRequiresUsername(): Promise<void> {
+async function scenarioLdapEnabledWithoutLocalPassword(): Promise<void> {
   console.log("\n[scenario E] LDAP enabled without local password");
   const ldapSecretDir = await mkdtemp(join(tmpdir(), "pi-forge-test-ldap-secret-"));
   const ldapSecretFile = join(ldapSecretDir, "bind-password");
@@ -304,11 +305,11 @@ async function scenarioLdapEnabledRequiresUsername(): Promise<void> {
     assert("auth/status reports ldapEnabled=true", status.ldapEnabled === true);
 
     const login = await jsonPost(`${srv.base}/api/v1/auth/login`, { password: "anything" });
-    assert("password-only login → 400 when LDAP is the only browser auth", login.status === 400);
+    assert("password-only local login → 503 when no local password exists", login.status === 503);
     const body = (await login.json()) as { error?: string };
     assert(
-      "  error is username_required",
-      body.error === "username_required",
+      "  error is ui_password_not_configured",
+      body.error === "ui_password_not_configured",
       JSON.stringify(body),
     );
 
@@ -317,6 +318,49 @@ async function scenarioLdapEnabledRequiresUsername(): Promise<void> {
   } finally {
     await srv.stop();
     await rm(ldapSecretDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+async function scenarioLdapAdminUsesLocalPassword(): Promise<void> {
+  console.log("\n[scenario F] LDAP enabled, admin username uses local password file");
+  const secretDir = await mkdtemp(join(tmpdir(), "pi-forge-test-ui-secret-"));
+  const uiPasswordFile = join(secretDir, "ui-password");
+  const localPassword = "local-admin-secret";
+  await writeFile(uiPasswordFile, `${localPassword}\n`, "utf8");
+  const srv = await startServer({
+    UI_PASSWORD: undefined,
+    UI_PASSWORD_FILE: uiPasswordFile,
+    JWT_SECRET: undefined,
+    API_KEY: undefined,
+    LDAP_ENABLED: "true",
+    LDAP_URL: "ldaps://ldap.example.test",
+    LDAP_BIND_DN: "cn=pi-forge,ou=svc,dc=example,dc=test",
+    LDAP_BIND_PASSWORD: "service-secret",
+    LDAP_BASE_DN: "ou=people,dc=example,dc=test",
+    REQUIRE_PASSWORD_CHANGE: "false",
+  });
+  try {
+    const passwordOnly = await jsonPost(`${srv.base}/api/v1/auth/login`, {
+      password: localPassword,
+    });
+    assert("password-only login uses local admin password", passwordOnly.status === 200);
+
+    const admin = await jsonPost(`${srv.base}/api/v1/auth/login`, {
+      username: "admin",
+      password: localPassword,
+    });
+    assert("username admin uses local admin password", admin.status === 200);
+    const issued = (await admin.json()) as { token: string };
+    assert("admin login issued a JWT", typeof issued.token === "string" && issued.token.length > 0);
+
+    const adminWrong = await jsonPost(`${srv.base}/api/v1/auth/login`, {
+      username: "admin",
+      password: "wrong",
+    });
+    assert("username admin with wrong local password → 401", adminWrong.status === 401);
+  } finally {
+    await srv.stop();
+    await rm(secretDir, { recursive: true, force: true }).catch(() => undefined);
   }
 }
 
@@ -424,7 +468,8 @@ async function main(): Promise<void> {
   await scenarioApiKeyOnly();
   await scenarioAuthDisabled();
   await scenarioPersistedHashOnly();
-  await scenarioLdapEnabledRequiresUsername();
+  await scenarioLdapEnabledWithoutLocalPassword();
+  await scenarioLdapAdminUsesLocalPassword();
 
   if (failures > 0) {
     console.log(`\n[test-auth] FAIL — ${failures} assertion(s) failed`);

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -332,11 +332,10 @@ async function scenarioLdapAdminUsesLocalPassword(): Promise<void> {
     UI_PASSWORD_FILE: uiPasswordFile,
     JWT_SECRET: undefined,
     API_KEY: undefined,
+    // Deliberately omit LDAP_URL/BIND_DN/BIND_PASSWORD/BASE_DN:
+    // username "admin" and password-only login must stay local and
+    // must not depend on LDAP being fully configured.
     LDAP_ENABLED: "true",
-    LDAP_URL: "ldaps://ldap.example.test",
-    LDAP_BIND_DN: "cn=pi-forge,ou=svc,dc=example,dc=test",
-    LDAP_BIND_PASSWORD: "service-secret",
-    LDAP_BASE_DN: "ou=people,dc=example,dc=test",
     REQUIRE_PASSWORD_CHANGE: "false",
   });
   try {
@@ -358,6 +357,17 @@ async function scenarioLdapAdminUsesLocalPassword(): Promise<void> {
       password: "wrong",
     });
     assert("username admin with wrong local password → 401", adminWrong.status === 401);
+
+    const ldapUser = await jsonPost(`${srv.base}/api/v1/auth/login`, {
+      username: "alice",
+      password: localPassword,
+    });
+    assert(
+      "non-admin username still uses LDAP → 503 when LDAP config missing",
+      ldapUser.status === 503,
+    );
+    const ldapBody = (await ldapUser.json()) as { error?: string };
+    assert("  error is ldap_not_configured", ldapBody.error === "ldap_not_configured");
   } finally {
     await srv.stop();
     await rm(secretDir, { recursive: true, force: true }).catch(() => undefined);

--- a/tests/test-ldap-auth.ts
+++ b/tests/test-ldap-auth.ts
@@ -1,0 +1,160 @@
+/**
+ * LDAP auth unit coverage without a live LDAP server.
+ *
+ * Imports the compiled ldap-auth module after pinning LDAP_* env and injects
+ * a fake LDAP client factory. This covers filter escaping, service-account
+ * search, memberOf authorization, and user-bind credential verification.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-ldap-auth-"));
+process.env.NODE_ENV = "test";
+process.env.FORGE_DATA_DIR = dataDir;
+process.env.WORKSPACE_PATH = join(dataDir, "workspace");
+process.env.LDAP_ENABLED = "true";
+process.env.LDAP_URL = "ldaps://ldap.example.test";
+process.env.LDAP_BIND_DN = "cn=pi-forge,ou=svc,dc=example,dc=test";
+process.env.LDAP_BIND_PASSWORD = "service-secret";
+process.env.LDAP_BASE_DN = "ou=people,dc=example,dc=test";
+process.env.LDAP_REQUIRED_GROUP_DN = "cn=pi-forge-users,ou=groups,dc=example,dc=test";
+delete process.env.UI_PASSWORD;
+delete process.env.API_KEY;
+
+interface SearchCall {
+  baseDn: string;
+  filter?: unknown;
+  attributes?: string[];
+  sizeLimit?: number;
+}
+
+class FakeLdapClient {
+  readonly searchEntries: Record<string, unknown>[];
+  readonly userPassword: string;
+  readonly binds: { dn: string; password: string | undefined }[] = [];
+  readonly searches: SearchCall[] = [];
+  unbound = false;
+
+  constructor(searchEntries: Record<string, unknown>[], userPassword = "user-secret") {
+    this.searchEntries = searchEntries;
+    this.userPassword = userPassword;
+  }
+
+  async bind(dn: string, password?: string): Promise<void> {
+    this.binds.push({ dn, password });
+    if (dn === process.env.LDAP_BIND_DN && password === process.env.LDAP_BIND_PASSWORD) return;
+    if (dn === "uid=alice,ou=people,dc=example,dc=test" && password === this.userPassword) return;
+    throw new Error("invalid credentials");
+  }
+
+  async search(
+    baseDn: string,
+    options?: SearchCall,
+  ): Promise<{ searchEntries: Record<string, unknown>[] }> {
+    this.searches.push({ baseDn, ...options });
+    return { searchEntries: this.searchEntries };
+  }
+
+  async unbind(): Promise<void> {
+    this.unbound = true;
+  }
+}
+
+try {
+  const ldapModule = (await import(resolve(repoRoot, "packages/server/dist/ldap-auth.js"))) as {
+    escapeLdapFilterValue: (value: string) => string;
+    renderUserFilter: (template: string, username: string) => string;
+    verifyLdapLogin: (
+      username: string,
+      password: string,
+      factory: () => FakeLdapClient,
+    ) => Promise<{ ok: boolean; error?: string }>;
+  };
+
+  assert(
+    "LDAP filter values are escaped per RFC4515",
+    ldapModule.escapeLdapFilterValue("a*b(c)d\\e\u0000") === "a\\2ab\\28c\\29d\\5ce\\00",
+  );
+  assert(
+    "user filter substitutes escaped username",
+    ldapModule.renderUserFilter("(uid={{username}})", "a*)") === "(uid=a\\2a\\29)",
+  );
+
+  const allowed = new FakeLdapClient([
+    {
+      dn: "uid=alice,ou=people,dc=example,dc=test",
+      memberOf: ["cn=pi-forge-users,ou=groups,dc=example,dc=test"],
+    },
+  ]);
+  const ok = await ldapModule.verifyLdapLogin("alice", "user-secret", () => allowed);
+  assert("valid service bind, memberOf, and user bind succeeds", ok.ok === true, ok.error);
+  assert("service account bind happened first", allowed.binds[0]?.dn === process.env.LDAP_BIND_DN);
+  assert(
+    "user DN bind happened after search",
+    allowed.binds[1]?.dn === "uid=alice,ou=people,dc=example,dc=test",
+  );
+  assert(
+    "search used configured base DN",
+    allowed.searches[0]?.baseDn === process.env.LDAP_BASE_DN,
+  );
+  assert(
+    "search requested memberOf",
+    allowed.searches[0]?.attributes?.includes("memberOf") === true,
+  );
+  assert("LDAP client unbound after success", allowed.unbound === true);
+
+  const denied = new FakeLdapClient([
+    {
+      dn: "uid=alice,ou=people,dc=example,dc=test",
+      memberOf: ["cn=other,ou=groups,dc=example,dc=test"],
+    },
+  ]);
+  const groupFail = await ldapModule.verifyLdapLogin("alice", "user-secret", () => denied);
+  assert(
+    "missing required memberOf group is rejected",
+    groupFail.ok === false && groupFail.error === "group_required",
+  );
+  assert("LDAP client unbound after group failure", denied.unbound === true);
+
+  const wrongPw = new FakeLdapClient([
+    {
+      dn: "uid=alice,ou=people,dc=example,dc=test",
+      memberOf: ["cn=pi-forge-users,ou=groups,dc=example,dc=test"],
+    },
+  ]);
+  const bad = await ldapModule.verifyLdapLogin("alice", "wrong", () => wrongPw);
+  assert(
+    "wrong user password is rejected",
+    bad.ok === false && bad.error === "invalid_credentials",
+  );
+
+  const none = new FakeLdapClient([]);
+  const notFound = await ldapModule.verifyLdapLogin("nobody", "user-secret", () => none);
+  assert(
+    "missing LDAP user is rejected",
+    notFound.ok === false && notFound.error === "user_not_found",
+  );
+} finally {
+  await rm(dataDir, { recursive: true, force: true });
+}
+
+if (failures > 0) {
+  console.log(`\n[test-ldap-auth] FAIL — ${failures} assertion(s) failed`);
+  process.exit(1);
+}
+console.log("\n[test-ldap-auth] PASS");


### PR DESCRIPTION
## Summary

Adds opt-in LDAP username/password login for single-tenant pi-forge deployments without weakening the existing JWT/API-key gate. LDAP is disabled by default. When enabled, the server uses a configured service account to search for a user, checks optional `memberOf` group membership, then verifies the presented password by binding as the user DN. Successful LDAP login issues the same browser JWT used by local `UI_PASSWORD` login.

## Usage

```bash
LDAP_ENABLED=true
LDAP_URL=ldaps://ldap.example.com:636
LDAP_BIND_DN='cn=pi-forge,ou=svc,dc=example,dc=com'
LDAP_BIND_PASSWORD_FILE=/run/secrets/ldap-bind-password
LDAP_BASE_DN='ou=people,dc=example,dc=com'
LDAP_REQUIRED_GROUP_DN='cn=pi-forge-users,ou=groups,dc=example,dc=com'
```

Equivalent CLI flags are available, including `--ldap-bind-password @/path/to/file`. If both LDAP and local password auth are configured, username+password login uses LDAP and password-only login continues to use local pi-forge password auth.

## What changed

- `packages/server/src/ldap-auth.ts` — adds LDAP client integration with safe filter escaping, service-account search, optional `memberOf` group check, user bind verification, and fake-client test hooks.
- `packages/server/src/config.ts` / `cli.ts` — adds all `LDAP_*` env vars plus CLI flags, including `LDAP_BIND_PASSWORD_FILE` for OpenShift/Kubernetes mounted Secrets.
- `packages/server/src/routes/auth.ts` — accepts optional `username` on login, exposes `ldapEnabled` in auth status, and preserves existing UI password/JWT/API-key behavior.
- `packages/client/src/*auth*` / `LoginScreen.tsx` — switches login UI to username+password when LDAP is enabled.
- `docs/configuration.md`, `kubernetes/DEPLOY.md`, `kubernetes/openshift/*` — documents LDAP configuration and OpenShift Secret credential paths.
- `tests/test-auth.ts`, `tests/test-cli-flags.ts`, `tests/test-ldap-auth.ts` — covers LDAP auth status/username-required behavior, CLI env mapping, password-file config, filter escaping, memberOf checks, and fake LDAP binds.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only auth,ldap-auth,cli-flags`
- [x] `npm run test:ci` (all 41 tests passed; one unrelated transient MCP EPIPE was printed while the suite continued and passed)
- [ ] CI green before merge
