### PR TITLE
fix: render pi-subagents async updates

### DIFF
--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -33,7 +33,11 @@ import { SessionTreePanel } from "./SessionTreePanel";
 import { QuickActionsMenu } from "./QuickActionsMenu";
 import { QuickActionRunCard } from "./QuickActionRunCard";
 import { useQuickActionRunsStore } from "../store/quick-actions-store";
-import { parseSubagentDetails, type SubagentResult } from "../lib/subagent-parser";
+import {
+  parseSubagentDetails,
+  parseSubagentNotify,
+  type SubagentResult,
+} from "../lib/subagent-parser";
 import { OrchestrationPanel } from "./OrchestrationPanel";
 import { useUiConfigStore } from "../store/ui-config-store";
 import {
@@ -1113,6 +1117,10 @@ function Message({
     return <BashExecution message={message} />;
   }
 
+  if (message.role === "custom") {
+    return <CustomMessage message={message} />;
+  }
+
   // Fallback: stringify so we can see what we missed.
   return (
     <details className="rounded-lg border border-neutral-800 bg-neutral-900/40 px-3 py-2 text-xs text-neutral-400">
@@ -1880,6 +1888,50 @@ function SubagentInflightOrResult({
   );
 }
 
+function useOpenSubagentSessionByFile(): (sessionFile: string | undefined) => Promise<void> {
+  const setActiveSession = useSessionStore((s) => s.setActiveSession);
+  const setActiveProject = useProjectStore((s) => s.setActive);
+  const byProject = useSessionStore((s) => s.byProject);
+
+  const loadedSessionByPath = useMemo(() => {
+    const map = new Map<string, { sessionId: string; projectId: string }>();
+    for (const list of Object.values(byProject)) {
+      for (const s of list) {
+        if (typeof s.path === "string" && s.path.length > 0) {
+          map.set(s.path, { sessionId: s.sessionId, projectId: s.projectId });
+        }
+      }
+    }
+    return map;
+  }, [byProject]);
+
+  return async (sessionFile: string | undefined): Promise<void> => {
+    if (sessionFile === undefined) {
+      console.warn("[subagent] Open clicked but result has no sessionFile");
+      return;
+    }
+    let match = loadedSessionByPath.get(sessionFile);
+    if (match === undefined) {
+      try {
+        const { sessions } = await api.listSessions();
+        const fresh = sessions.find((s) => s.path === sessionFile);
+        if (fresh !== undefined) match = { sessionId: fresh.sessionId, projectId: fresh.projectId };
+      } catch (err) {
+        console.warn("[subagent] Open: session-list refetch failed", err);
+      }
+    }
+    if (match === undefined) {
+      console.warn(
+        "[subagent] Open: sessionFile not found in any project's session list",
+        sessionFile,
+      );
+      return;
+    }
+    setActiveProject(match.projectId);
+    setActiveSession(match.sessionId);
+  };
+}
+
 function SubagentResultCard({
   message,
   argsText,
@@ -1891,48 +1943,7 @@ function SubagentResultCard({
   outputText: string;
   isError: boolean;
 }) {
-  const setActiveSession = useSessionStore((s) => s.setActiveSession);
-  const setActiveProject = useProjectStore((s) => s.setActive);
-  const byProject = useSessionStore((s) => s.byProject);
-  // Resolve a tool-result `sessionFile` (absolute path) back to its
-  // canonical sessionId by scanning the loaded session list. pi-subagents
-  // writes children as a literal `session.jsonl`, so the filename's
-  // stem is the string "session" — useless for navigation. Server-side
-  // discovery reads the JSONL header for the real id and surfaces both
-  // path AND sessionId on UnifiedSession; we look up by path here.
-  const sessionByPath = useMemo(() => {
-    const map = new Map<string, { sessionId: string; projectId: string }>();
-    for (const list of Object.values(byProject)) {
-      for (const s of list) {
-        if (typeof s.path === "string" && s.path.length > 0) {
-          map.set(s.path, { sessionId: s.sessionId, projectId: s.projectId });
-        }
-      }
-    }
-    return map;
-  }, [byProject]);
-  const openByFile = (sessionFile: string | undefined): void => {
-    if (sessionFile === undefined) {
-      console.warn("[subagent] Open clicked but result has no sessionFile");
-      return;
-    }
-    const match = sessionByPath.get(sessionFile);
-    console.info("[subagent] Open clicked", { sessionFile, match });
-    if (match === undefined) {
-      // The child wasn't in any project's session list — most likely
-      // because the project sidebar hasn't been refreshed since the
-      // sub-agent ran. Reload the active project's list and retry.
-      // For now: surface a console warning rather than silently doing
-      // nothing. (A future revision could trigger a refetch + retry.)
-      console.warn(
-        "[subagent] Open: sessionFile not found in any project's session list",
-        sessionFile,
-      );
-      return;
-    }
-    setActiveProject(match.projectId);
-    setActiveSession(match.sessionId);
-  };
+  const openByFile = useOpenSubagentSessionByFile();
   const parsed = parseSubagentDetails(message.details);
   const isManagement = parsed.mode === "management";
   const count = parsed.results.length;
@@ -1975,7 +1986,7 @@ function SubagentResultCard({
         </div>
         {parsed.results.length === 1 && parsed.results[0]!.sessionFile !== undefined && (
           <button
-            onClick={() => openByFile(parsed.results[0]!.sessionFile)}
+            onClick={() => void openByFile(parsed.results[0]!.sessionFile)}
             className="inline-flex min-h-11 shrink-0 items-center gap-1 rounded border border-sky-700/60 px-2 py-1 text-[12px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100 light:border-sky-400 light:text-sky-800 light:hover:border-sky-600 light:hover:bg-sky-100 light:hover:text-sky-900 md:min-h-0 md:px-1.5 md:py-0.5 md:text-[10px]"
             title={`Open sub-agent session — ${parsed.results[0]!.sessionFile}`}
           >
@@ -2036,7 +2047,7 @@ function SubagentResultRow({
   onOpenFile,
 }: {
   result: SubagentResult;
-  onOpenFile: (sessionFile: string | undefined) => void;
+  onOpenFile: (sessionFile: string | undefined) => void | Promise<void>;
 }) {
   const failed = result.exitCode !== 0;
   return (
@@ -2062,7 +2073,7 @@ function SubagentResultRow({
       </div>
       {result.sessionFile !== undefined && (
         <button
-          onClick={() => onOpenFile(result.sessionFile)}
+          onClick={() => void onOpenFile(result.sessionFile)}
           className="inline-flex shrink-0 items-center gap-1 rounded border border-sky-700/60 px-1.5 py-0.5 text-[10px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100 light:border-sky-400 light:text-sky-800 light:hover:border-sky-600 light:hover:bg-sky-100 light:hover:text-sky-900"
           title={result.sessionFile}
         >
@@ -2070,6 +2081,100 @@ function SubagentResultRow({
           Open
         </button>
       )}
+    </div>
+  );
+}
+
+function CustomMessage({ message }: { message: AgentMessageLike }) {
+  const customType = typeof message.customType === "string" ? message.customType : "custom";
+  const content = message.content;
+  const text =
+    typeof content === "string"
+      ? content
+      : Array.isArray(content)
+        ? content
+            .map((block) => {
+              const b = block as { type?: unknown; text?: unknown };
+              return b.type === "text" && typeof b.text === "string" ? b.text : "";
+            })
+            .filter((part) => part.length > 0)
+            .join("\n")
+        : "";
+
+  if (customType === "subagent-notify") {
+    return <SubagentNotifyCard message={message} text={text} />;
+  }
+
+  return (
+    <div className="message-bubble group rounded-lg border border-violet-800/50 bg-violet-950/20 px-4 py-3 text-sm light:border-violet-300 light:bg-violet-50">
+      <div className="mb-1 flex items-center gap-2">
+        <span className="text-[10px] uppercase tracking-wider text-violet-300 light:text-violet-700">
+          {customType}
+        </span>
+        <MessageTimestamp ts={(message as { timestamp?: unknown }).timestamp} />
+      </div>
+      {text.length > 0 ? <ChatMarkdown text={text} /> : <RawText text={JSON.stringify(message)} />}
+    </div>
+  );
+}
+
+function SubagentNotifyCard({ message, text }: { message: AgentMessageLike; text: string }) {
+  const details = parseSubagentNotify(text, message.details);
+  const openByFile = useOpenSubagentSessionByFile();
+  if (details === undefined) {
+    return (
+      <div className="rounded border border-sky-800/50 bg-sky-950/20 px-3 py-2 text-xs text-sky-100 light:border-sky-300 light:bg-sky-50 light:text-sky-900">
+        <ChatMarkdown text={text.length > 0 ? text : "Sub-agent notification"} />
+      </div>
+    );
+  }
+  const failed = details.status === "failed";
+  const paused = details.status === "paused";
+  const sessionFile = details.sessionLabel === "session file" ? details.sessionValue : undefined;
+  const borderColors = failed
+    ? "border-red-700/50 border-l-red-400 bg-red-950/15 light:border-red-300 light:border-l-red-600 light:bg-red-50"
+    : paused
+      ? "border-amber-700/50 border-l-amber-400 bg-amber-950/15 light:border-amber-300 light:border-l-amber-600 light:bg-amber-50"
+      : "border-sky-700/50 border-l-sky-400 bg-sky-950/15 light:border-sky-300 light:border-l-sky-600 light:bg-sky-50";
+  return (
+    <div className={`overflow-hidden rounded border border-l-2 ${borderColors} text-xs`}>
+      <div className="flex items-center justify-between gap-2 px-2.5 py-1.5">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Users size={11} className="shrink-0 text-sky-300 light:text-sky-700" />
+          <span className="truncate font-medium text-sky-100 light:text-sky-900">
+            Background sub-agent: {details.agent}
+          </span>
+          <span className="shrink-0 rounded bg-neutral-900/50 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-neutral-300 light:bg-neutral-100 light:text-neutral-700">
+            {details.status}
+          </span>
+          {details.taskInfo !== undefined && (
+            <span className="text-[10px] text-neutral-400 light:text-neutral-600">
+              {details.taskInfo}
+            </span>
+          )}
+        </div>
+        {sessionFile !== undefined && (
+          <button
+            onClick={() => void openByFile(sessionFile)}
+            className="inline-flex min-h-11 shrink-0 items-center gap-1 rounded border border-sky-700/60 px-2 py-1 text-[12px] font-medium text-sky-200 hover:border-sky-500 hover:bg-sky-900/30 hover:text-sky-100 light:border-sky-400 light:text-sky-800 light:hover:border-sky-600 light:hover:bg-sky-100 light:hover:text-sky-900 md:min-h-0 md:px-1.5 md:py-0.5 md:text-[10px]"
+            title={`Open sub-agent session — ${sessionFile}`}
+          >
+            <ExternalLink size={12} />
+            Open
+          </button>
+        )}
+      </div>
+      <div className="border-t border-sky-900/30 px-2.5 py-2 text-neutral-200 light:text-neutral-800">
+        <ChatMarkdown text={details.resultPreview} />
+        {details.sessionLabel !== undefined && details.sessionValue !== undefined && (
+          <div
+            className="mt-1 truncate font-mono text-[10px] text-neutral-500"
+            title={details.sessionValue}
+          >
+            {details.sessionLabel}: {details.sessionValue}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -456,7 +456,16 @@ function SessionRow(props: SessionRowProps) {
           className="flex-1 truncate text-left"
           title={`${s.sessionId} — double-click to rename, Cmd/Ctrl+click to select for bulk delete`}
         >
-          {s.isLive && <span className="mr-1 text-emerald-500 light:text-emerald-700">●</span>}
+          {(s.isLive || s.isExternalLive === true) && (
+            <span
+              className="mr-1 text-emerald-500 light:text-emerald-700"
+              title={
+                s.isExternalLive === true && !s.isLive ? "External sub-agent is active" : undefined
+              }
+            >
+              ●
+            </span>
+          )}
           {depth > 0 && (
             <span
               className="mr-1 text-purple-400 light:text-purple-700"

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -303,6 +303,7 @@ function vSessionSummary(value: unknown, status: number): SessionSummary {
     messageCount: value.messageCount,
     isStreaming: value.isStreaming,
   };
+  if (typeof value.isExternalLive === "boolean") out.isExternalLive = value.isExternalLive;
   if (typeof value.name === "string") out.name = value.name;
   if (typeof value.thinkingLevel === "string") out.thinkingLevel = value.thinkingLevel;
   if (typeof value.modelProvider === "string") out.modelProvider = value.modelProvider;

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -264,6 +264,7 @@ function vUnifiedSession(value: unknown, status: number): UnifiedSession {
     messageCount: value.messageCount,
     firstMessage: value.firstMessage,
   };
+  if (typeof value.isExternalLive === "boolean") out.isExternalLive = value.isExternalLive;
   if (typeof value.name === "string") out.name = value.name;
   if (typeof value.parentSessionId === "string") out.parentSessionId = value.parentSessionId;
   if (typeof value.runId === "string") out.runId = value.runId;

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -284,6 +284,7 @@ export interface UnifiedSession {
   sessionId: string;
   projectId: string;
   isLive: boolean;
+  isExternalLive?: boolean;
   name?: string;
   workspacePath: string;
   lastActivityAt: string;

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -320,6 +320,7 @@ export interface SessionSummary {
   createdAt: string;
   lastActivityAt: string;
   isLive: boolean;
+  isExternalLive?: boolean;
   name?: string;
   messageCount: number;
   isStreaming: boolean;

--- a/packages/client/src/lib/sse-client.ts
+++ b/packages/client/src/lib/sse-client.ts
@@ -45,7 +45,7 @@ export interface StreamSSEOptions<T> {
   maxReconnects?: number;
 }
 
-const TERMINAL_STATUS = new Set([401, 404]);
+const TERMINAL_STATUS = new Set([401, 404, 409, 410]);
 const MAX_BACKOFF_MS = 30_000;
 
 function backoffDelay(attempt: number): number {

--- a/packages/client/src/lib/subagent-parser.ts
+++ b/packages/client/src/lib/subagent-parser.ts
@@ -34,6 +34,16 @@ export interface SubagentDetails {
   results: SubagentResult[];
 }
 
+export interface SubagentNotifyDetails {
+  agent: string;
+  status: "completed" | "failed" | "paused";
+  taskInfo?: string;
+  resultPreview: string;
+  durationMs?: number;
+  sessionLabel?: string;
+  sessionValue?: string;
+}
+
 const VALID_MODES: ReadonlySet<SubagentMode> = new Set([
   "single",
   "parallel",
@@ -55,6 +65,76 @@ function sessionIdFromFile(file: string): string | undefined {
   const stem = base.slice(0, -".jsonl".length);
   if (stem.length === 0) return undefined;
   return stem;
+}
+
+export function parseSubagentNotify(
+  content: unknown,
+  details?: unknown,
+): SubagentNotifyDetails | undefined {
+  if (typeof details === "object" && details !== null) {
+    const d = details as {
+      agent?: unknown;
+      status?: unknown;
+      taskInfo?: unknown;
+      resultPreview?: unknown;
+      durationMs?: unknown;
+      sessionLabel?: unknown;
+      sessionValue?: unknown;
+    };
+    if (
+      typeof d.agent === "string" &&
+      (d.status === "completed" || d.status === "failed" || d.status === "paused") &&
+      typeof d.resultPreview === "string"
+    ) {
+      const out: SubagentNotifyDetails = {
+        agent: d.agent,
+        status: d.status,
+        resultPreview: d.resultPreview,
+      };
+      if (typeof d.taskInfo === "string") out.taskInfo = d.taskInfo;
+      if (typeof d.durationMs === "number") out.durationMs = d.durationMs;
+      if (typeof d.sessionLabel === "string") out.sessionLabel = d.sessionLabel;
+      if (typeof d.sessionValue === "string") out.sessionValue = d.sessionValue;
+      return out;
+    }
+  }
+
+  if (typeof content !== "string") return undefined;
+  const lines = content.split("\n");
+  const header = lines[0] ?? "";
+  const match =
+    /^Background task (completed|failed|paused): \*\*(.+?)\*\*(?:\s+(\([^)]*\)))?$/.exec(header);
+  if (match === null) return undefined;
+  const body = lines.slice(2);
+  let sessionIndex = -1;
+  for (let i = body.length - 1; i >= 1; i--) {
+    if (
+      body[i - 1]?.trim() === "" &&
+      /^(Session|Session file|Session share error):\s+/.test(body[i]!)
+    ) {
+      sessionIndex = i;
+      break;
+    }
+  }
+  const sessionLine = sessionIndex >= 0 ? body[sessionIndex] : undefined;
+  const resultLines = sessionIndex >= 0 ? body.slice(0, sessionIndex) : body;
+  const resultPreview = resultLines.join("\n").trim() || "(no output)";
+  let sessionLabel: string | undefined;
+  let sessionValue: string | undefined;
+  if (sessionLine !== undefined) {
+    const separator = sessionLine.indexOf(":");
+    sessionLabel = sessionLine.slice(0, separator).toLowerCase();
+    sessionValue = sessionLine.slice(separator + 1).trim();
+  }
+  return {
+    agent: match[2]!,
+    status: match[1] as SubagentNotifyDetails["status"],
+    ...(match[3] !== undefined ? { taskInfo: match[3] } : {}),
+    resultPreview,
+    ...(sessionLabel !== undefined && sessionValue !== undefined
+      ? { sessionLabel, sessionValue }
+      : {}),
+  };
 }
 
 export function parseSubagentDetails(details: unknown): SubagentDetails {

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -65,6 +65,13 @@ const refetchState = new Map<string, RefetchState>();
  * through `set()`.
  */
 const controllers = new Map<string, AbortController>();
+const readOnlySnapshotIntervals = new Map<string, ReturnType<typeof setInterval>>();
+
+function stopReadOnlySnapshotRefresh(sessionId: string): void {
+  const interval = readOnlySnapshotIntervals.get(sessionId);
+  if (interval !== undefined) clearInterval(interval);
+  readOnlySnapshotIntervals.delete(sessionId);
+}
 
 /**
  * Phase 8 keeps the message type loose — pi's AgentMessage union is rich
@@ -172,6 +179,7 @@ function findProjectIdForSession(state: SessionState, sessionId: string): string
 }
 
 function removeSessionFromState(current: SessionState, sessionId: string): Partial<SessionState> {
+  stopReadOnlySnapshotRefresh(sessionId);
   const stale = current.messagesBySession[sessionId];
   if (stale !== undefined) revokeOptimisticBlobUrls(stale);
   const nextMessages = { ...current.messagesBySession };
@@ -561,30 +569,55 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         return;
       }
       if (err instanceof ApiError && err.status === 409) {
-        void api
-          .getMessages(sessionId)
-          .then(({ messages }) => {
-            set((s) => ({
-              messagesBySession: { ...s.messagesBySession, [sessionId]: messages },
-              streamingBySession: { ...s.streamingBySession, [sessionId]: false },
-              activeToolBySession: { ...s.activeToolBySession, [sessionId]: undefined },
-              bannerBySession: {
-                ...s.bannerBySession,
-                [sessionId]:
-                  "This sub-agent is still running in an external pi-subagents process. Showing a read-only snapshot; reopen it after completion for live controls.",
-              },
-            }));
-          })
-          .catch(() => {
-            set((s) => ({
-              bannerBySession: {
-                ...s.bannerBySession,
-                [sessionId]:
-                  "This sub-agent is still running externally. Wait for it to finish, then reopen the session.",
-              },
-            }));
-          });
         onTerminate();
+        const refreshReadOnlySnapshot = async (): Promise<void> => {
+          const [{ messages }, summary] = await Promise.all([
+            api.getMessages(sessionId),
+            api.getSession(sessionId).catch(() => undefined),
+          ]);
+          const stillExternal = summary?.isExternalLive === true;
+          set((s) => ({
+            messagesBySession: { ...s.messagesBySession, [sessionId]: messages },
+            streamingBySession: { ...s.streamingBySession, [sessionId]: stillExternal },
+            activeToolBySession: {
+              ...s.activeToolBySession,
+              [sessionId]: stillExternal
+                ? { name: "subagent", summary: "externally executing" }
+                : undefined,
+            },
+            bannerBySession: {
+              ...s.bannerBySession,
+              [sessionId]: stillExternal
+                ? "External sub-agent is still running. Showing a read-only snapshot and refreshing it automatically…"
+                : undefined,
+            },
+          }));
+          if (!stillExternal) {
+            stopReadOnlySnapshotRefresh(sessionId);
+            get().openStream(sessionId);
+          }
+        };
+        void refreshReadOnlySnapshot().catch(() => {
+          set((s) => ({
+            streamingBySession: { ...s.streamingBySession, [sessionId]: true },
+            activeToolBySession: {
+              ...s.activeToolBySession,
+              [sessionId]: { name: "subagent", summary: "externally executing" },
+            },
+            bannerBySession: {
+              ...s.bannerBySession,
+              [sessionId]:
+                "External sub-agent is still running. Waiting for the next read-only snapshot refresh…",
+            },
+          }));
+        });
+        stopReadOnlySnapshotRefresh(sessionId);
+        readOnlySnapshotIntervals.set(
+          sessionId,
+          setInterval(() => {
+            void refreshReadOnlySnapshot().catch(() => undefined);
+          }, 2000),
+        );
         return;
       }
       const code = err instanceof ApiError ? err.code : (err as Error).message;
@@ -596,6 +629,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   },
 
   closeStream: (sessionId) => {
+    stopReadOnlySnapshotRefresh(sessionId);
     const ctrl = controllers.get(sessionId);
     if (ctrl !== undefined) {
       ctrl.abort();

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -560,6 +560,33 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         onTerminate();
         return;
       }
+      if (err instanceof ApiError && err.status === 409) {
+        void api
+          .getMessages(sessionId)
+          .then(({ messages }) => {
+            set((s) => ({
+              messagesBySession: { ...s.messagesBySession, [sessionId]: messages },
+              streamingBySession: { ...s.streamingBySession, [sessionId]: false },
+              activeToolBySession: { ...s.activeToolBySession, [sessionId]: undefined },
+              bannerBySession: {
+                ...s.bannerBySession,
+                [sessionId]:
+                  "This sub-agent is still running in an external pi-subagents process. Showing a read-only snapshot; reopen it after completion for live controls.",
+              },
+            }));
+          })
+          .catch(() => {
+            set((s) => ({
+              bannerBySession: {
+                ...s.bannerBySession,
+                [sessionId]:
+                  "This sub-agent is still running externally. Wait for it to finish, then reopen the session.",
+              },
+            }));
+          });
+        onTerminate();
+        return;
+      }
       const code = err instanceof ApiError ? err.code : (err as Error).message;
       set((s) => ({
         bannerBySession: { ...s.bannerBySession, [sessionId]: `stream error: ${code}` },

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -870,7 +870,7 @@ function applyEvent(
     // first arg/key otherwise. The renderer falls back to bare
     // `running <name>` when summary is undefined.
     const name = typeof event.toolName === "string" ? event.toolName : "tool";
-    const input = (event.input ?? {}) as Record<string, unknown>;
+    const input = (event.input ?? event.args ?? {}) as Record<string, unknown>;
     const summary = summarizeToolInput(name, input);
     const tool: ActiveTool = summary !== undefined ? { name, summary } : { name };
     set((s) => ({

--- a/packages/server/src/routes/_schemas.ts
+++ b/packages/server/src/routes/_schemas.ts
@@ -44,6 +44,7 @@ export const liveSummarySchema = {
     createdAt: { type: "string", format: "date-time" },
     lastActivityAt: { type: "string", format: "date-time" },
     isLive: { type: "boolean" },
+    isExternalLive: { type: "boolean" },
     name: { type: "string" },
     messageCount: { type: "integer", minimum: 0 },
     isStreaming: { type: "boolean" },
@@ -85,6 +86,7 @@ export function liveSummaryBody(args: {
   messageCount: number;
   isStreaming: boolean;
   isLive?: boolean;
+  isExternalLive?: boolean | undefined;
   thinkingLevel?: string;
   // `string | undefined` (not just `?: string`) so callers can pass
   // `session.model?.provider` directly without an upstream guard —
@@ -103,6 +105,7 @@ export function liveSummaryBody(args: {
     messageCount: args.messageCount,
     isStreaming: args.isStreaming,
   };
+  if (args.isExternalLive === true) out.isExternalLive = true;
   if (args.name !== undefined) out.name = args.name;
   if (args.thinkingLevel !== undefined) out.thinkingLevel = args.thinkingLevel;
   if (args.modelProvider !== undefined) out.modelProvider = args.modelProvider;

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -6,8 +6,10 @@ import {
   disposeSession,
   findProjectIdForSession,
   findSessionLocation,
+  getExternallyActiveSubagentChild,
   getSession,
   listSessionsForProject,
+  readSessionMessagesFromDisk,
   resumeSessionById,
   type UnifiedSession,
 } from "../session-registry.js";
@@ -306,8 +308,11 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const live = getSession(req.params.id);
-      if (live === undefined) return notFound(reply);
-      return { messages: live.session.messages };
+      if (live !== undefined) return { messages: live.session.messages };
+
+      const activeChild = await getExternallyActiveSubagentChild(req.params.id);
+      if (activeChild === undefined) return notFound(reply);
+      return { messages: await readSessionMessagesFromDisk(activeChild.path) };
     },
   );
 

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -10,6 +10,8 @@ import {
   listSessionsForProject,
   readSessionMessagesSnapshotById,
   resumeSessionById,
+  ExternallyActiveSubagentChildError,
+  getExternallyActiveSubagentChild,
   type UnifiedSession,
 } from "../session-registry.js";
 import { bridgeSessionDeleted } from "../webhooks/event-bridge.js";
@@ -239,6 +241,24 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
+      const activeChild = await getExternallyActiveSubagentChild(req.params.id);
+      if (activeChild !== undefined) {
+        const list = await listSessionsForProject(activeChild.projectId, activeChild.workspacePath);
+        const match = list.find((s) => s.sessionId === req.params.id);
+        if (match === undefined) return notFound(reply);
+        return liveSummaryBody({
+          sessionId: match.sessionId,
+          projectId: match.projectId,
+          workspacePath: match.workspacePath,
+          createdAt: match.createdAt,
+          lastActivityAt: match.lastActivityAt,
+          name: match.name,
+          messageCount: match.messageCount,
+          isStreaming: false,
+          isLive: false,
+          isExternalLive: true,
+        });
+      }
       const live = getSession(req.params.id);
       if (live !== undefined) {
         return liveSummaryBody({
@@ -375,6 +395,9 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
+      if ((await getExternallyActiveSubagentChild(req.params.id)) !== undefined) {
+        return reply.code(409).send({ error: "subagent_child_externally_active" });
+      }
       const live = getSession(req.params.id);
       if (live === undefined) return notFound(reply);
       return { compactions: buildCompactionHistory(live.session) };
@@ -425,6 +448,9 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
+      if ((await getExternallyActiveSubagentChild(req.params.id)) !== undefined) {
+        return reply.code(409).send({ error: "subagent_child_externally_active" });
+      }
       const live = getSession(req.params.id);
       if (live === undefined) return notFound(reply);
       const entries = await buildTurnDiff(
@@ -489,17 +515,20 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
+      if ((await getExternallyActiveSubagentChild(req.params.id)) !== undefined) {
+        return reply.code(409).send({ error: "subagent_child_externally_active" });
+      }
       let live = getSession(req.params.id);
       if (live === undefined) {
         try {
           live = await resumeSessionById(req.params.id);
-        } catch {
+        } catch (err) {
+          if (err instanceof ExternallyActiveSubagentChildError) {
+            return reply.code(409).send({ error: "subagent_child_externally_active" });
+          }
           // SessionNotFoundError, SessionTombstonedError, or SDK
-          // resume failure all collapse to 404 here — the tree route
-          // doesn't need to distinguish (clients can't act on it
-          // differently). The SSE stream route DOES distinguish
-          // (it returns 410 on tombstone) since that signals "stop
-          // reconnecting" specifically.
+          // resume failure all collapse to 404 here. The SSE stream route
+          // distinguishes tombstones since that signals "stop reconnecting".
           return notFound(reply);
         }
       }
@@ -634,15 +663,17 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
+      if ((await getExternallyActiveSubagentChild(req.params.id)) !== undefined) {
+        return reply.code(409).send({ error: "subagent_child_externally_active" });
+      }
       let live = getSession(req.params.id);
       if (live === undefined) {
         try {
           live = await resumeSessionById(req.params.id);
-        } catch {
-          // Same handling as the /tree route above — collapse all
-          // resume failures (not_found, tombstoned, SDK throw) to a
-          // 404. The /context route's caller can't act on the
-          // distinction.
+        } catch (err) {
+          if (err instanceof ExternallyActiveSubagentChildError) {
+            return reply.code(409).send({ error: "subagent_child_externally_active" });
+          }
           return notFound(reply);
         }
       }

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -37,6 +37,7 @@ const unifiedSchema = {
     sessionId: { type: "string" },
     projectId: { type: "string" },
     isLive: { type: "boolean" },
+    isExternalLive: { type: "boolean" },
     name: { type: "string" },
     workspacePath: { type: "string" },
     lastActivityAt: { type: "string", format: "date-time" },
@@ -75,6 +76,7 @@ function unifiedFromUnified(u: UnifiedSession): Record<string, unknown> {
     messageCount: u.messageCount,
     firstMessage: u.firstMessage,
   };
+  if (u.isExternalLive === true) out.isExternalLive = true;
   if (u.name !== undefined) out.name = u.name;
   if (u.parentSessionId !== undefined) out.parentSessionId = u.parentSessionId;
   if (u.runId !== undefined) out.runId = u.runId;

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -6,10 +6,9 @@ import {
   disposeSession,
   findProjectIdForSession,
   findSessionLocation,
-  getExternallyActiveSubagentChild,
   getSession,
   listSessionsForProject,
-  readSessionMessagesFromDisk,
+  readSessionMessagesSnapshotById,
   resumeSessionById,
   type UnifiedSession,
 } from "../session-registry.js";
@@ -272,6 +271,7 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
         messageCount: match.messageCount,
         isStreaming: false,
         isLive: false,
+        isExternalLive: match.isExternalLive,
       });
     },
   );
@@ -307,12 +307,9 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const live = getSession(req.params.id);
-      if (live !== undefined) return { messages: live.session.messages };
-
-      const activeChild = await getExternallyActiveSubagentChild(req.params.id);
-      if (activeChild === undefined) return notFound(reply);
-      return { messages: await readSessionMessagesFromDisk(activeChild.path) };
+      const messages = await readSessionMessagesSnapshotById(req.params.id);
+      if (messages === undefined) return notFound(reply);
+      return { messages };
     },
   );
 

--- a/packages/server/src/routes/stream.ts
+++ b/packages/server/src/routes/stream.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync } from "fastify";
 import {
+  ExternallyActiveSubagentChildError,
   resumeSessionById,
   SessionNotFoundError,
   SessionTombstonedError,
@@ -59,6 +60,9 @@ export const streamRoutes: FastifyPluginAsync = async (fastify) => {
       } catch (err) {
         if (err instanceof SessionNotFoundError) {
           return reply.code(404).send({ error: "session_not_found" });
+        }
+        if (err instanceof ExternallyActiveSubagentChildError) {
+          return reply.code(409).send({ error: "subagent_child_externally_active" });
         }
         if (err instanceof SessionTombstonedError) {
           // The session was disposed within the tombstone window

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, watch, type FSWatcher } from "node:fs";
 import { mkdir, readFile, readdir } from "node:fs/promises";
-import { tmpdir, userInfo } from "node:os";
+import { homedir, tmpdir, userInfo } from "node:os";
 import { basename, dirname, join } from "node:path";
 import {
   AgentSession,
@@ -220,8 +220,16 @@ function resolvePiSubagentsTempRoot(): string {
   } catch {
     // Fall through to HOME-based scoping.
   }
-  const homedir = process.env.USERPROFILE ?? process.env.HOME;
-  if (homedir) return join(tmpdir(), `pi-subagents-home-${sanitizeTempScopeSegment(homedir)}`);
+  const envHomedir = process.env.USERPROFILE ?? process.env.HOME;
+  if (envHomedir)
+    return join(tmpdir(), `pi-subagents-home-${sanitizeTempScopeSegment(envHomedir)}`);
+  try {
+    const fallbackHomedir = homedir();
+    if (fallbackHomedir)
+      return join(tmpdir(), `pi-subagents-home-${sanitizeTempScopeSegment(fallbackHomedir)}`);
+  } catch {
+    // Fall through to shared last-resort scope.
+  }
   return join(tmpdir(), "pi-subagents-shared");
 }
 
@@ -703,9 +711,18 @@ function startActiveSubagentParentArtifactObservers(live: LiveSession): void {
   scheduleActiveSubagentArtifactCheck(live, 1500);
 }
 
-function getAsyncSubagentRunId(result: unknown): string | undefined {
-  if (typeof result !== "object" || result === null) return undefined;
-  const details = (result as { details?: unknown }).details;
+function getSubagentToolDetails(resultOrEvent: unknown): unknown {
+  if (typeof resultOrEvent !== "object" || resultOrEvent === null) return undefined;
+  const candidate = resultOrEvent as { details?: unknown; result?: unknown };
+  if (candidate.details !== undefined) return candidate.details;
+  if (typeof candidate.result === "object" && candidate.result !== null) {
+    return (candidate.result as { details?: unknown }).details;
+  }
+  return undefined;
+}
+
+function getAsyncSubagentRunId(resultOrEvent: unknown): string | undefined {
+  const details = getSubagentToolDetails(resultOrEvent);
   if (typeof details !== "object" || details === null) return undefined;
   const d = details as {
     id?: unknown;
@@ -721,10 +738,9 @@ function getAsyncSubagentRunId(result: unknown): string | undefined {
   return undefined;
 }
 
-function isAsyncSubagentToolResult(result: unknown): boolean {
-  if (getAsyncSubagentRunId(result) !== undefined) return true;
-  if (typeof result !== "object" || result === null) return false;
-  const details = (result as { details?: unknown }).details;
+function isAsyncSubagentToolResult(resultOrEvent: unknown): boolean {
+  if (getAsyncSubagentRunId(resultOrEvent) !== undefined) return true;
+  const details = getSubagentToolDetails(resultOrEvent);
   if (typeof details !== "object" || details === null) return false;
   const d = details as { asyncDir?: unknown; results?: unknown };
   return (
@@ -1148,6 +1164,12 @@ function makeSubscribeHandler(live: LiveSession): () => void {
         isAsync ? "subagent_async_started" : "subagent_end",
         [500, 1500],
       );
+    } else if (toolEv.type === "tool_result" && toolEv.toolName === "subagent") {
+      const isAsync = isAsyncSubagentToolResult(toolEv);
+      if (isAsync) {
+        markActiveSubagentParent(live.sessionId, getAsyncSubagentRunId(toolEv));
+        scheduleSubagentSessionListChanged(live, "subagent_async_started", [500, 1500]);
+      }
     } else if (isSubagentCompletionCustomMessage(event)) {
       clearActiveSubagentParent(live.sessionId);
       scheduleSubagentSessionListChanged(live, "subagent_async_complete", [250, 1000, 2500]);

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -276,23 +276,37 @@ function readSubagentResultFile(resultPath: string): SubagentResultFileData | un
   }
 }
 
-function hasTerminalSubagentStatusFile(child: DiscoveredSession): boolean {
-  if (child.parentSessionId === undefined || child.runId === undefined) return false;
+function readMatchingSubagentStatusFile(
+  child: DiscoveredSession,
+): { statusPath: string; status: SubagentStatusFileData } | undefined {
+  if (child.parentSessionId === undefined || child.runId === undefined) return undefined;
   const statusPath = join(
     resolvePiSubagentsTempRoot(),
     "async-subagent-runs",
     child.runId,
     "status.json",
   );
-  if (!existsSync(statusPath)) return false;
+  if (!existsSync(statusPath)) return undefined;
   const status = readSubagentStatusFile(statusPath);
-  if (status === undefined) return false;
-  if (typeof status.sessionId === "string" && status.sessionId !== child.parentSessionId)
-    return false;
-  if (!isTerminalSubagentState(status.state)) return false;
-  const parentLive = registry.get(child.parentSessionId);
+  if (status === undefined) return undefined;
+  if (typeof status.sessionId === "string" && status.sessionId !== child.parentSessionId) {
+    return undefined;
+  }
+  return { statusPath, status };
+}
+
+function hasActiveSubagentStatusFile(child: DiscoveredSession): boolean {
+  const match = readMatchingSubagentStatusFile(child);
+  return match !== undefined && isActiveSubagentState(match.status.state);
+}
+
+function hasTerminalSubagentStatusFile(child: DiscoveredSession): boolean {
+  const match = readMatchingSubagentStatusFile(child);
+  if (match === undefined) return false;
+  if (!isTerminalSubagentState(match.status.state)) return false;
+  const parentLive = child.parentSessionId ? registry.get(child.parentSessionId) : undefined;
   if (parentLive !== undefined) {
-    void bridgeSubagentStatusFileToParent(parentLive, statusPath).catch(() => undefined);
+    void bridgeSubagentStatusFileToParent(parentLive, match.statusPath).catch(() => undefined);
   }
   return true;
 }
@@ -330,16 +344,16 @@ function hasCompletedSubagentResultFile(child: DiscoveredSession): boolean {
 
 function isSubagentChildExternallyLive(child: DiscoveredSession): boolean {
   if (child.parentSessionId === undefined) return false;
-  const active = activeSubagentParents.get(child.parentSessionId);
-  if (active === undefined) return false;
-  if (active.runIds.size > 0 && (child.runId === undefined || !active.runIds.has(child.runId))) {
-    return false;
-  }
   if (hasCompletedSubagentResultFile(child) || hasTerminalSubagentStatusFile(child)) {
-    clearActiveSubagentParent(child.parentSessionId);
+    if (child.runId !== undefined) finishActiveSubagentRun(child.parentSessionId, child.runId);
+    else clearActiveSubagentParent(child.parentSessionId);
     return false;
   }
-  return true;
+  const active = activeSubagentParents.get(child.parentSessionId);
+  const isMarkedActive =
+    active !== undefined &&
+    (active.runIds.size === 0 || (child.runId !== undefined && active.runIds.has(child.runId)));
+  return isMarkedActive || hasActiveSubagentStatusFile(child);
 }
 
 export interface ExternallyActiveSubagentChild {
@@ -424,6 +438,10 @@ function readSubagentStatusFile(statusPath: string): SubagentStatusFileData | un
 
 function isTerminalSubagentState(state: unknown): state is "complete" | "failed" | "paused" {
   return state === "complete" || state === "failed" || state === "paused";
+}
+
+function isActiveSubagentState(state: unknown): state is "queued" | "running" {
+  return state === "queued" || state === "running";
 }
 
 function finishActiveSubagentRun(parentSessionId: string, runId: string): void {

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { mkdir, readFile, readdir } from "node:fs/promises";
 import { tmpdir, userInfo } from "node:os";
 import { basename, dirname, join } from "node:path";
@@ -168,13 +168,22 @@ export class EntryNotFoundError extends Error {
 const registry = new Map<string, LiveSession>();
 
 const activeSubagentParents = new Set<string>();
+const activeSubagentParentPollers = new Map<string, NodeJS.Timeout>();
+const activeSubagentParentFileState = new Map<string, { mtimeMs: number; size: number }>();
+const bridgedSubagentResultKeys = new Set<string>();
 
 export function clearActiveSubagentParent(parentSessionId: string): void {
   activeSubagentParents.delete(parentSessionId);
+  const poller = activeSubagentParentPollers.get(parentSessionId);
+  if (poller !== undefined) clearInterval(poller);
+  activeSubagentParentPollers.delete(parentSessionId);
+  activeSubagentParentFileState.delete(parentSessionId);
 }
 
 export function markActiveSubagentParent(parentSessionId: string): void {
   activeSubagentParents.add(parentSessionId);
+  const live = registry.get(parentSessionId);
+  if (live !== undefined) startActiveSubagentParentPoller(live);
 }
 
 function sanitizeTempScopeSegment(value: string): string {
@@ -217,6 +226,35 @@ function isMatchingSessionFile(candidate: unknown, child: DiscoveredSession): bo
   );
 }
 
+interface SubagentResultFileChild {
+  agent?: string;
+  output?: string;
+  error?: string;
+  success?: boolean;
+  sessionFile?: string;
+}
+
+interface SubagentResultFileData {
+  id?: string;
+  runId?: string;
+  agent?: string;
+  success?: boolean;
+  state?: string;
+  summary?: string;
+  results?: SubagentResultFileChild[];
+  sessionId?: string;
+  sessionFile?: string;
+  durationMs?: number;
+}
+
+function readSubagentResultFile(resultPath: string): SubagentResultFileData | undefined {
+  try {
+    return JSON.parse(readFileSync(resultPath, "utf8")) as SubagentResultFileData;
+  } catch {
+    return undefined;
+  }
+}
+
 function hasCompletedSubagentResultFile(child: DiscoveredSession): boolean {
   if (child.parentSessionId === undefined) return false;
   const resultsDir = join(resolvePiSubagentsTempRoot(), "async-subagent-results");
@@ -227,17 +265,18 @@ function hasCompletedSubagentResultFile(child: DiscoveredSession): boolean {
     const resultPath = join(resultsDir, file);
     if (!existsSync(resultPath)) continue;
     try {
-      const data = JSON.parse(readFileSync(resultPath, "utf8")) as {
-        sessionId?: unknown;
-        sessionFile?: unknown;
-        results?: { sessionFile?: unknown }[];
-      };
+      const data = readSubagentResultFile(resultPath);
+      if (data === undefined) continue;
       if (typeof data.sessionId === "string" && data.sessionId !== child.parentSessionId) continue;
-      if (isMatchingSessionFile(data.sessionFile, child)) return true;
-      if (
-        Array.isArray(data.results) &&
-        data.results.some((r) => isMatchingSessionFile(r.sessionFile, child))
-      ) {
+      const matchesChild =
+        isMatchingSessionFile(data.sessionFile, child) ||
+        (Array.isArray(data.results) &&
+          data.results.some((r) => isMatchingSessionFile(r.sessionFile, child)));
+      if (matchesChild) {
+        const parentLive = registry.get(child.parentSessionId);
+        if (parentLive !== undefined) {
+          void bridgeSubagentResultFileToParent(parentLive, resultPath).catch(() => undefined);
+        }
         return true;
       }
     } catch {
@@ -308,6 +347,173 @@ export async function readSessionMessagesSnapshotById(
     if (found !== undefined) return readSessionMessagesFromDisk(found.path);
   }
   return undefined;
+}
+
+function sendSnapshotToClients(live: LiveSession, messages: unknown[]): void {
+  const snapshot = {
+    type: "snapshot" as const,
+    sessionId: live.sessionId,
+    projectId: live.projectId,
+    messages,
+    isStreaming: live.session.isStreaming,
+  };
+  for (const client of live.clients) {
+    try {
+      client.send(snapshot);
+    } catch {
+      live.clients.delete(client);
+    }
+  }
+}
+
+function hasSubagentNotifyMessage(messages: unknown[]): boolean {
+  return messages.some((message) => {
+    if (typeof message !== "object" || message === null) return false;
+    const m = message as { role?: unknown; customType?: unknown };
+    return m.role === "custom" && m.customType === "subagent-notify";
+  });
+}
+
+function getLiveSessionFile(live: LiveSession): string | undefined {
+  const file = (live.session as { sessionFile?: unknown }).sessionFile;
+  return typeof file === "string" && file.length > 0 ? file : undefined;
+}
+
+function formatSubagentResultSummary(data: SubagentResultFileData): string {
+  if (typeof data.summary === "string" && data.summary.trim().length > 0) return data.summary;
+  if (Array.isArray(data.results) && data.results.length > 0) {
+    return data.results
+      .map((result, index) => {
+        const agent = result.agent ?? `step-${index + 1}`;
+        const output = result.success === false && result.error ? result.error : result.output;
+        return `### ${agent}\n${typeof output === "string" && output.trim() ? output : "(no output)"}`;
+      })
+      .join("\n\n");
+  }
+  return "(no output)";
+}
+
+function firstSessionFile(data: SubagentResultFileData): string | undefined {
+  if (typeof data.sessionFile === "string" && data.sessionFile.length > 0) return data.sessionFile;
+  const result = data.results?.find(
+    (item) => typeof item.sessionFile === "string" && item.sessionFile.length > 0,
+  );
+  return result?.sessionFile;
+}
+
+function buildSubagentNotifyFromResult(data: SubagentResultFileData): {
+  content: string;
+  details: {
+    agent: string;
+    status: "completed" | "failed" | "paused";
+    resultPreview: string;
+    durationMs?: number;
+    sessionLabel?: string;
+    sessionValue?: string;
+  };
+} {
+  const paused =
+    data.success === false &&
+    (data.state === "paused" ||
+      formatSubagentResultSummary(data).startsWith("Paused after interrupt."));
+  const status = paused ? "paused" : data.success === false ? "failed" : "completed";
+  const agent = data.agent ?? data.results?.[0]?.agent ?? "unknown";
+  const resultPreview = formatSubagentResultSummary(data);
+  const sessionFile = firstSessionFile(data);
+  const sessionLine = sessionFile !== undefined ? `Session file: ${sessionFile}` : undefined;
+  const content = [
+    `Background task ${status}: **${agent}**`,
+    "",
+    resultPreview,
+    sessionLine !== undefined ? "" : undefined,
+    sessionLine,
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
+  const details: ReturnType<typeof buildSubagentNotifyFromResult>["details"] = {
+    agent,
+    status,
+    resultPreview,
+  };
+  if (typeof data.durationMs === "number") details.durationMs = data.durationMs;
+  if (sessionFile !== undefined) {
+    details.sessionLabel = "session file";
+    details.sessionValue = sessionFile;
+  }
+  return { content, details };
+}
+
+async function bridgeSubagentResultFileToParent(
+  live: LiveSession,
+  resultPath: string,
+): Promise<boolean> {
+  const data = readSubagentResultFile(resultPath);
+  if (data === undefined) return false;
+  if (typeof data.sessionId === "string" && data.sessionId !== live.sessionId) return false;
+  const runId = data.runId ?? data.id ?? basename(resultPath).replace(/\.json$/i, "");
+  const key = `${live.sessionId}:${runId}`;
+  if (bridgedSubagentResultKeys.has(key)) return false;
+  bridgedSubagentResultKeys.add(key);
+  const notify = buildSubagentNotifyFromResult(data);
+  await live.session.sendCustomMessage(
+    {
+      customType: "subagent-notify",
+      content: notify.content,
+      display: true,
+      details: notify.details,
+    },
+    { triggerTurn: false },
+  );
+  clearActiveSubagentParent(live.sessionId);
+  scheduleSubagentSessionListChanged(live, "subagent_async_complete", [250, 1000, 2500]);
+  return true;
+}
+
+async function pollActiveSubagentParent(live: LiveSession): Promise<void> {
+  if (!activeSubagentParents.has(live.sessionId)) return;
+
+  const resultsDir = join(resolvePiSubagentsTempRoot(), "async-subagent-results");
+  if (existsSync(resultsDir)) {
+    for (const file of readdirSync(resultsDir).filter((candidate) => candidate.endsWith(".json"))) {
+      if (await bridgeSubagentResultFileToParent(live, join(resultsDir, file))) return;
+    }
+  }
+
+  const sessionFile = getLiveSessionFile(live);
+  if (sessionFile === undefined || !existsSync(sessionFile)) return;
+  const stat = statSync(sessionFile);
+  const previous = activeSubagentParentFileState.get(live.sessionId);
+  activeSubagentParentFileState.set(live.sessionId, { mtimeMs: stat.mtimeMs, size: stat.size });
+  if (previous === undefined || (previous.mtimeMs === stat.mtimeMs && previous.size === stat.size))
+    return;
+
+  const messages = await readSessionMessagesFromDisk(sessionFile);
+  sendSnapshotToClients(live, messages);
+  if (hasSubagentNotifyMessage(messages)) {
+    clearActiveSubagentParent(live.sessionId);
+    scheduleSubagentSessionListChanged(live, "subagent_async_complete", [250, 1000, 2500]);
+  }
+}
+
+function startActiveSubagentParentPoller(live: LiveSession): void {
+  if (activeSubagentParentPollers.has(live.sessionId)) return;
+  const sessionFile = getLiveSessionFile(live);
+  if (sessionFile !== undefined && existsSync(sessionFile)) {
+    const stat = statSync(sessionFile);
+    activeSubagentParentFileState.set(live.sessionId, { mtimeMs: stat.mtimeMs, size: stat.size });
+  }
+  const interval = setInterval(() => {
+    void pollActiveSubagentParent(live).catch((error: unknown) => {
+      logAgentEvent("warn", {
+        msg: "subagent parent poll failed",
+        sessionId: live.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }, 1000);
+  interval.unref?.();
+  activeSubagentParentPollers.set(live.sessionId, interval);
+  void pollActiveSubagentParent(live).catch(() => undefined);
 }
 
 function isAsyncSubagentToolResult(result: unknown): boolean {
@@ -1274,6 +1480,7 @@ export async function disposeSession(sessionId: string): Promise<boolean> {
     // because we await it last.
     await processManager.disposeSession(sessionId).catch(() => undefined);
   } finally {
+    clearActiveSubagentParent(sessionId);
     registry.delete(sessionId);
     // Tombstone the id so a polling SSE client can't re-resume the
     // session before deleteColdSession's file unlink runs. The

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -1,4 +1,6 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { mkdir, readFile, readdir } from "node:fs/promises";
+import { tmpdir, userInfo } from "node:os";
 import { basename, dirname, join } from "node:path";
 import {
   AgentSession,
@@ -165,30 +167,94 @@ export class EntryNotFoundError extends Error {
 
 const registry = new Map<string, LiveSession>();
 
-const SUBAGENT_CHILD_ACTIVE_TTL_MS = 10 * 60 * 1000;
-const SUBAGENT_ASYNC_PARENT_TTL_MS = 12 * 60 * 60 * 1000;
-const activeSubagentParentTimers = new Map<string, NodeJS.Timeout>();
+const activeSubagentParents = new Set<string>();
 
-function clearActiveSubagentParent(parentSessionId: string): void {
-  const existing = activeSubagentParentTimers.get(parentSessionId);
-  if (existing !== undefined) clearTimeout(existing);
-  activeSubagentParentTimers.delete(parentSessionId);
+export function clearActiveSubagentParent(parentSessionId: string): void {
+  activeSubagentParents.delete(parentSessionId);
 }
 
-export function markActiveSubagentParent(
-  parentSessionId: string,
-  ttlMs = SUBAGENT_CHILD_ACTIVE_TTL_MS,
-): void {
-  clearActiveSubagentParent(parentSessionId);
-  const timer = setTimeout(() => activeSubagentParentTimers.delete(parentSessionId), ttlMs);
-  timer.unref?.();
-  activeSubagentParentTimers.set(parentSessionId, timer);
+export function markActiveSubagentParent(parentSessionId: string): void {
+  activeSubagentParents.add(parentSessionId);
+}
+
+function sanitizeTempScopeSegment(value: string): string {
+  const sanitized = value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized || "unknown";
+}
+
+function resolvePiSubagentsTempRoot(): string {
+  if (typeof process.getuid === "function")
+    return join(tmpdir(), `pi-subagents-uid-${process.getuid()}`);
+  for (const key of ["USERNAME", "USER", "LOGNAME"] as const) {
+    const value = process.env[key];
+    if (value) return join(tmpdir(), `pi-subagents-user-${sanitizeTempScopeSegment(value)}`);
+  }
+  try {
+    const username = userInfo().username;
+    if (username) return join(tmpdir(), `pi-subagents-user-${sanitizeTempScopeSegment(username)}`);
+  } catch {
+    // Fall through to HOME-based scoping.
+  }
+  const homedir = process.env.USERPROFILE ?? process.env.HOME;
+  if (homedir) return join(tmpdir(), `pi-subagents-home-${sanitizeTempScopeSegment(homedir)}`);
+  return join(tmpdir(), "pi-subagents-shared");
+}
+
+function normalizePathForCompare(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function isMatchingSessionFile(candidate: unknown, child: DiscoveredSession): boolean {
+  if (typeof candidate !== "string" || candidate.length === 0) return false;
+  const normalizedCandidate = normalizePathForCompare(candidate);
+  const normalizedChildPath = normalizePathForCompare(child.path);
+  return (
+    normalizedCandidate === normalizedChildPath ||
+    basename(normalizedCandidate) === `${child.sessionId}.jsonl`
+  );
+}
+
+function hasCompletedSubagentResultFile(child: DiscoveredSession): boolean {
+  if (child.parentSessionId === undefined) return false;
+  const resultsDir = join(resolvePiSubagentsTempRoot(), "async-subagent-results");
+  if (!existsSync(resultsDir)) return false;
+  const resultFiles = child.runId !== undefined ? [`${child.runId}.json`] : readdirSync(resultsDir);
+  for (const file of resultFiles) {
+    if (!file.endsWith(".json")) continue;
+    const resultPath = join(resultsDir, file);
+    if (!existsSync(resultPath)) continue;
+    try {
+      const data = JSON.parse(readFileSync(resultPath, "utf8")) as {
+        sessionId?: unknown;
+        sessionFile?: unknown;
+        results?: { sessionFile?: unknown }[];
+      };
+      if (typeof data.sessionId === "string" && data.sessionId !== child.parentSessionId) continue;
+      if (isMatchingSessionFile(data.sessionFile, child)) return true;
+      if (
+        Array.isArray(data.results) &&
+        data.results.some((r) => isMatchingSessionFile(r.sessionFile, child))
+      ) {
+        return true;
+      }
+    } catch {
+      // Ignore partial/non-JSON files; pi-subagents writes authoritative completion as JSON.
+    }
+  }
+  return false;
 }
 
 function isSubagentChildExternallyLive(child: DiscoveredSession): boolean {
   if (child.parentSessionId === undefined) return false;
-  if (!activeSubagentParentTimers.has(child.parentSessionId)) return false;
-  return Date.now() - child.modifiedAt.getTime() <= SUBAGENT_CHILD_ACTIVE_TTL_MS;
+  if (!activeSubagentParents.has(child.parentSessionId)) return false;
+  if (hasCompletedSubagentResultFile(child)) {
+    clearActiveSubagentParent(child.parentSessionId);
+    return false;
+  }
+  return true;
 }
 
 export interface ExternallyActiveSubagentChild {
@@ -228,6 +294,20 @@ export async function readSessionMessagesFromDisk(sessionFile: string): Promise<
     (entry): entry is SessionEntry => entry.type !== "session",
   );
   return buildSessionContext(entries).messages;
+}
+
+export async function readSessionMessagesSnapshotById(
+  sessionId: string,
+): Promise<unknown[] | undefined> {
+  const live = getSession(sessionId);
+  if (live !== undefined) return live.session.messages;
+  const projects = await readProjects();
+  for (const project of projects) {
+    const discovered = await discoverSessionsOnDisk(project.id, project.path);
+    const found = discovered.find((s) => s.sessionId === sessionId);
+    if (found !== undefined) return readSessionMessagesFromDisk(found.path);
+  }
+  return undefined;
 }
 
 function isAsyncSubagentToolResult(result: unknown): boolean {
@@ -648,9 +728,9 @@ function makeSubscribeHandler(live: LiveSession): () => void {
     } else if (toolEv.type === "tool_execution_end" && toolEv.toolName === "subagent") {
       const isAsync = isAsyncSubagentToolResult(toolEv.result);
       if (isAsync) {
-        markActiveSubagentParent(live.sessionId, SUBAGENT_ASYNC_PARENT_TTL_MS);
+        markActiveSubagentParent(live.sessionId);
       } else {
-        markActiveSubagentParent(live.sessionId, 3000);
+        clearActiveSubagentParent(live.sessionId);
       }
       scheduleSubagentSessionListChanged(
         live,
@@ -658,8 +738,8 @@ function makeSubscribeHandler(live: LiveSession): () => void {
         [500, 1500],
       );
     } else if (isSubagentCompletionCustomMessage(event)) {
-      markActiveSubagentParent(live.sessionId, 3000);
-      scheduleSubagentSessionListChanged(live, "subagent_async_complete", [500, 1500]);
+      clearActiveSubagentParent(live.sessionId);
+      scheduleSubagentSessionListChanged(live, "subagent_async_complete", [250, 1000, 2500]);
     }
 
     // Webhook fan-out. Filters internally for the 3 SDK events

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -116,6 +116,8 @@ export interface UnifiedSession {
   projectId: string;
   /** True when the session is in the in-memory registry (subscribable). */
   isLive: boolean;
+  /** True when an external pi-subagents child process appears to still be writing this child JSONL. */
+  isExternalLive?: boolean;
   name: string | undefined;
   workspacePath: string;
   /** Last activity timestamp (live: lastActivityAt; disk: modifiedAt). */
@@ -159,6 +161,52 @@ export class EntryNotFoundError extends Error {
 }
 
 const registry = new Map<string, LiveSession>();
+
+const SUBAGENT_CHILD_ACTIVE_TTL_MS = 10 * 60 * 1000;
+const SUBAGENT_ASYNC_PARENT_TTL_MS = 12 * 60 * 60 * 1000;
+const activeSubagentParentTimers = new Map<string, NodeJS.Timeout>();
+
+function clearActiveSubagentParent(parentSessionId: string): void {
+  const existing = activeSubagentParentTimers.get(parentSessionId);
+  if (existing !== undefined) clearTimeout(existing);
+  activeSubagentParentTimers.delete(parentSessionId);
+}
+
+function markActiveSubagentParent(
+  parentSessionId: string,
+  ttlMs = SUBAGENT_CHILD_ACTIVE_TTL_MS,
+): void {
+  clearActiveSubagentParent(parentSessionId);
+  const timer = setTimeout(() => activeSubagentParentTimers.delete(parentSessionId), ttlMs);
+  timer.unref?.();
+  activeSubagentParentTimers.set(parentSessionId, timer);
+}
+
+function isSubagentChildExternallyLive(child: DiscoveredSession): boolean {
+  if (child.parentSessionId === undefined) return false;
+  if (!activeSubagentParentTimers.has(child.parentSessionId)) return false;
+  return Date.now() - child.modifiedAt.getTime() <= SUBAGENT_CHILD_ACTIVE_TTL_MS;
+}
+
+function isAsyncSubagentToolResult(result: unknown): boolean {
+  if (typeof result !== "object" || result === null) return false;
+  const details = (result as { details?: unknown }).details;
+  if (typeof details !== "object" || details === null) return false;
+  const d = details as { asyncId?: unknown; asyncDir?: unknown; results?: unknown };
+  return (
+    (typeof d.asyncId === "string" && d.asyncId.length > 0) ||
+    (typeof d.asyncDir === "string" &&
+      d.asyncDir.length > 0 &&
+      Array.isArray(d.results) &&
+      d.results.length === 0)
+  );
+}
+
+function isSubagentCompletionCustomMessage(event: AgentSessionEvent): boolean {
+  if (event.type !== "message_end") return false;
+  const message = (event as { message?: { role?: unknown; customType?: unknown } }).message;
+  return message?.role === "custom" && message.customType === "subagent-notify";
+}
 
 /**
  * Built-in pi tools we activate on every session. Pi's SDK ships
@@ -327,6 +375,36 @@ function findLastAssistantErrorMessage(messages: readonly unknown[]): string | u
     return undefined;
   }
   return undefined;
+}
+
+function sendSubagentSessionListChanged(live: LiveSession, reason: string): void {
+  const refresh = {
+    type: "session_list_changed" as const,
+    reason,
+    projectId: live.projectId,
+  };
+  for (const client of live.clients) {
+    try {
+      client.send(refresh);
+    } catch {
+      // SSE client already gone; safe to ignore — its entry gets cleaned up on the next event.
+    }
+  }
+}
+
+function scheduleSubagentSessionListChanged(
+  live: LiveSession,
+  reason: string,
+  delaysMs: readonly number[],
+): void {
+  sendSubagentSessionListChanged(live, reason);
+  for (const delayMs of delaysMs) {
+    const timer = setTimeout(() => {
+      if (registry.get(live.sessionId) !== live) return;
+      sendSubagentSessionListChanged(live, reason);
+    }, delayMs);
+    timer.unref?.();
+  }
 }
 
 function makeSubscribeHandler(live: LiveSession): () => void {
@@ -521,24 +599,25 @@ function makeSubscribeHandler(live: LiveSession): () => void {
     // session_list_changed itself from inside execute() — sync with
     // the actual createSession call, no need to wait for SDK lifecycle
     // events.
-    const toolEv = event as unknown as { type?: string; toolName?: string };
-    if (
-      (toolEv.type === "tool_execution_start" || toolEv.type === "tool_execution_end") &&
-      toolEv.toolName === "subagent"
-    ) {
-      const refresh = {
-        type: "session_list_changed" as const,
-        reason: toolEv.type === "tool_execution_start" ? "subagent_start" : "subagent_end",
-        projectId: live.projectId,
-      };
-      for (const client of live.clients) {
-        try {
-          client.send(refresh);
-        } catch {
-          // SSE client already gone; safe to ignore — its entry
-          // gets cleaned up on the next event.
-        }
+    const toolEv = event as unknown as { type?: string; toolName?: string; result?: unknown };
+    if (toolEv.type === "tool_execution_start" && toolEv.toolName === "subagent") {
+      markActiveSubagentParent(live.sessionId);
+      scheduleSubagentSessionListChanged(live, "subagent_start", [250, 1000, 2500]);
+    } else if (toolEv.type === "tool_execution_end" && toolEv.toolName === "subagent") {
+      const isAsync = isAsyncSubagentToolResult(toolEv.result);
+      if (isAsync) {
+        markActiveSubagentParent(live.sessionId, SUBAGENT_ASYNC_PARENT_TTL_MS);
+      } else {
+        markActiveSubagentParent(live.sessionId, 3000);
       }
+      scheduleSubagentSessionListChanged(
+        live,
+        isAsync ? "subagent_async_started" : "subagent_end",
+        [500, 1500],
+      );
+    } else if (isSubagentCompletionCustomMessage(event)) {
+      markActiveSubagentParent(live.sessionId, 3000);
+      scheduleSubagentSessionListChanged(live, "subagent_async_complete", [500, 1500]);
     }
 
     // Webhook fan-out. Filters internally for the 3 SDK events
@@ -1342,6 +1421,7 @@ export async function listSessionsForProject(
       merged.firstMessage = d.firstMessage;
       if (d.parentSessionId !== undefined) merged.parentSessionId = d.parentSessionId;
       if (d.runId !== undefined) merged.runId = d.runId;
+      if (isSubagentChildExternallyLive(d)) merged.isExternalLive = true;
       merged.path = d.path;
       continue;
     }
@@ -1359,6 +1439,7 @@ export async function listSessionsForProject(
     };
     if (d.parentSessionId !== undefined) u.parentSessionId = d.parentSessionId;
     if (d.runId !== undefined) u.runId = d.runId;
+    if (isSubagentChildExternallyLive(d)) u.isExternalLive = true;
     liveById.set(d.sessionId, u);
   }
 

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -1,11 +1,14 @@
-import { mkdir, readdir } from "node:fs/promises";
+import { mkdir, readFile, readdir } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import {
   AgentSession,
   type AgentSessionEvent,
+  buildSessionContext,
   createAgentSession,
+  parseSessionEntries,
   SessionManager,
   SettingsManager,
+  type SessionEntry,
   type SessionInfo,
 } from "@earendil-works/pi-coding-agent";
 import { buildForgeResourceLoader } from "./agent-resource-loader.js";
@@ -172,7 +175,7 @@ function clearActiveSubagentParent(parentSessionId: string): void {
   activeSubagentParentTimers.delete(parentSessionId);
 }
 
-function markActiveSubagentParent(
+export function markActiveSubagentParent(
   parentSessionId: string,
   ttlMs = SUBAGENT_CHILD_ACTIVE_TTL_MS,
 ): void {
@@ -186,6 +189,45 @@ function isSubagentChildExternallyLive(child: DiscoveredSession): boolean {
   if (child.parentSessionId === undefined) return false;
   if (!activeSubagentParentTimers.has(child.parentSessionId)) return false;
   return Date.now() - child.modifiedAt.getTime() <= SUBAGENT_CHILD_ACTIVE_TTL_MS;
+}
+
+export interface ExternallyActiveSubagentChild {
+  sessionId: string;
+  projectId: string;
+  workspacePath: string;
+  path: string;
+  parentSessionId: string;
+  runId?: string;
+}
+
+export async function getExternallyActiveSubagentChild(
+  sessionId: string,
+): Promise<ExternallyActiveSubagentChild | undefined> {
+  const projects = await readProjects();
+  for (const project of projects) {
+    const discovered = await discoverSessionsOnDisk(project.id, project.path);
+    const child = discovered.find((s) => s.sessionId === sessionId);
+    if (child?.parentSessionId === undefined) continue;
+    if (!isSubagentChildExternallyLive(child)) continue;
+    const active: ExternallyActiveSubagentChild = {
+      sessionId,
+      projectId: project.id,
+      workspacePath: project.path,
+      path: child.path,
+      parentSessionId: child.parentSessionId,
+    };
+    if (child.runId !== undefined) active.runId = child.runId;
+    return active;
+  }
+  return undefined;
+}
+
+export async function readSessionMessagesFromDisk(sessionFile: string): Promise<unknown[]> {
+  const raw = await readFile(sessionFile, "utf8");
+  const entries = parseSessionEntries(raw).filter(
+    (entry): entry is SessionEntry => entry.type !== "session",
+  );
+  return buildSessionContext(entries).messages;
 }
 
 function isAsyncSubagentToolResult(result: unknown): boolean {
@@ -836,6 +878,13 @@ export class SessionTombstonedError extends Error {
   constructor(sessionId: string) {
     super(`session ${sessionId} was just disposed`);
     this.name = "SessionTombstonedError";
+  }
+}
+
+export class ExternallyActiveSubagentChildError extends Error {
+  constructor(sessionId: string) {
+    super(`subagent child ${sessionId} is externally active`);
+    this.name = "ExternallyActiveSubagentChildError";
   }
 }
 
@@ -1530,6 +1579,8 @@ export async function findSessionLocation(
 export async function resumeSessionById(sessionId: string): Promise<LiveSession> {
   const existing = registry.get(sessionId);
   if (existing) return existing;
+  const activeChild = await getExternallyActiveSubagentChild(sessionId);
+  if (activeChild !== undefined) throw new ExternallyActiveSubagentChildError(sessionId);
   const loc = await findSessionLocation(sessionId);
   if (loc === undefined) throw new SessionNotFoundError(sessionId);
   return resumeSession(sessionId, loc.projectId, loc.workspacePath);

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, watch, type FSWatcher } from "node:fs";
 import { mkdir, readFile, readdir } from "node:fs/promises";
 import { tmpdir, userInfo } from "node:os";
 import { basename, dirname, join } from "node:path";
@@ -167,23 +167,36 @@ export class EntryNotFoundError extends Error {
 
 const registry = new Map<string, LiveSession>();
 
-const activeSubagentParents = new Set<string>();
-const activeSubagentParentPollers = new Map<string, NodeJS.Timeout>();
-const activeSubagentParentFileState = new Map<string, { mtimeMs: number; size: number }>();
-const bridgedSubagentResultKeys = new Set<string>();
-
-export function clearActiveSubagentParent(parentSessionId: string): void {
-  activeSubagentParents.delete(parentSessionId);
-  const poller = activeSubagentParentPollers.get(parentSessionId);
-  if (poller !== undefined) clearInterval(poller);
-  activeSubagentParentPollers.delete(parentSessionId);
-  activeSubagentParentFileState.delete(parentSessionId);
+interface ActiveSubagentParentState {
+  runIds: Set<string>;
+  watchers: FSWatcher[];
+  timers: NodeJS.Timeout[];
 }
 
-export function markActiveSubagentParent(parentSessionId: string): void {
-  activeSubagentParents.add(parentSessionId);
+const activeSubagentParents = new Map<string, ActiveSubagentParentState>();
+const bridgedSubagentResultKeys = new Set<string>();
+
+function makeActiveSubagentParentState(): ActiveSubagentParentState {
+  return { runIds: new Set<string>(), watchers: [], timers: [] };
+}
+
+function stopActiveSubagentArtifactObservers(state: ActiveSubagentParentState): void {
+  for (const watcher of state.watchers.splice(0)) watcher.close();
+  for (const timer of state.timers.splice(0)) clearTimeout(timer);
+}
+
+export function clearActiveSubagentParent(parentSessionId: string): void {
+  const state = activeSubagentParents.get(parentSessionId);
+  if (state !== undefined) stopActiveSubagentArtifactObservers(state);
+  activeSubagentParents.delete(parentSessionId);
+}
+
+export function markActiveSubagentParent(parentSessionId: string, runId?: string): void {
+  const existing = activeSubagentParents.get(parentSessionId) ?? makeActiveSubagentParentState();
+  if (runId !== undefined && runId.length > 0) existing.runIds.add(runId);
+  activeSubagentParents.set(parentSessionId, existing);
   const live = registry.get(parentSessionId);
-  if (live !== undefined) startActiveSubagentParentPoller(live);
+  if (live !== undefined) startActiveSubagentParentArtifactObservers(live);
 }
 
 function sanitizeTempScopeSegment(value: string): string {
@@ -255,6 +268,27 @@ function readSubagentResultFile(resultPath: string): SubagentResultFileData | un
   }
 }
 
+function hasTerminalSubagentStatusFile(child: DiscoveredSession): boolean {
+  if (child.parentSessionId === undefined || child.runId === undefined) return false;
+  const statusPath = join(
+    resolvePiSubagentsTempRoot(),
+    "async-subagent-runs",
+    child.runId,
+    "status.json",
+  );
+  if (!existsSync(statusPath)) return false;
+  const status = readSubagentStatusFile(statusPath);
+  if (status === undefined) return false;
+  if (typeof status.sessionId === "string" && status.sessionId !== child.parentSessionId)
+    return false;
+  if (!isTerminalSubagentState(status.state)) return false;
+  const parentLive = registry.get(child.parentSessionId);
+  if (parentLive !== undefined) {
+    void bridgeSubagentStatusFileToParent(parentLive, statusPath).catch(() => undefined);
+  }
+  return true;
+}
+
 function hasCompletedSubagentResultFile(child: DiscoveredSession): boolean {
   if (child.parentSessionId === undefined) return false;
   const resultsDir = join(resolvePiSubagentsTempRoot(), "async-subagent-results");
@@ -288,8 +322,12 @@ function hasCompletedSubagentResultFile(child: DiscoveredSession): boolean {
 
 function isSubagentChildExternallyLive(child: DiscoveredSession): boolean {
   if (child.parentSessionId === undefined) return false;
-  if (!activeSubagentParents.has(child.parentSessionId)) return false;
-  if (hasCompletedSubagentResultFile(child)) {
+  const active = activeSubagentParents.get(child.parentSessionId);
+  if (active === undefined) return false;
+  if (active.runIds.size > 0 && (child.runId === undefined || !active.runIds.has(child.runId))) {
+    return false;
+  }
+  if (hasCompletedSubagentResultFile(child) || hasTerminalSubagentStatusFile(child)) {
     clearActiveSubagentParent(child.parentSessionId);
     return false;
   }
@@ -349,34 +387,42 @@ export async function readSessionMessagesSnapshotById(
   return undefined;
 }
 
-function sendSnapshotToClients(live: LiveSession, messages: unknown[]): void {
-  const snapshot = {
-    type: "snapshot" as const,
-    sessionId: live.sessionId,
-    projectId: live.projectId,
-    messages,
-    isStreaming: live.session.isStreaming,
-  };
-  for (const client of live.clients) {
-    try {
-      client.send(snapshot);
-    } catch {
-      live.clients.delete(client);
-    }
+interface SubagentStatusFileStep {
+  agent?: string;
+  status?: string;
+  sessionFile?: string;
+  recentOutput?: unknown[];
+}
+
+interface SubagentStatusFileData {
+  runId?: string;
+  sessionId?: string;
+  mode?: string;
+  state?: "queued" | "running" | "complete" | "failed" | "paused";
+  summary?: string;
+  error?: string;
+  durationMs?: number;
+  sessionFile?: string;
+  steps?: SubagentStatusFileStep[];
+}
+
+function readSubagentStatusFile(statusPath: string): SubagentStatusFileData | undefined {
+  try {
+    return JSON.parse(readFileSync(statusPath, "utf8")) as SubagentStatusFileData;
+  } catch {
+    return undefined;
   }
 }
 
-function hasSubagentNotifyMessage(messages: unknown[]): boolean {
-  return messages.some((message) => {
-    if (typeof message !== "object" || message === null) return false;
-    const m = message as { role?: unknown; customType?: unknown };
-    return m.role === "custom" && m.customType === "subagent-notify";
-  });
+function isTerminalSubagentState(state: unknown): state is "complete" | "failed" | "paused" {
+  return state === "complete" || state === "failed" || state === "paused";
 }
 
-function getLiveSessionFile(live: LiveSession): string | undefined {
-  const file = (live.session as { sessionFile?: unknown }).sessionFile;
-  return typeof file === "string" && file.length > 0 ? file : undefined;
+function finishActiveSubagentRun(parentSessionId: string, runId: string): void {
+  const active = activeSubagentParents.get(parentSessionId);
+  if (active === undefined) return;
+  if (active.runIds.size > 0) active.runIds.delete(runId);
+  if (active.runIds.size === 0) clearActiveSubagentParent(parentSessionId);
 }
 
 function formatSubagentResultSummary(data: SubagentResultFileData): string {
@@ -399,6 +445,49 @@ function firstSessionFile(data: SubagentResultFileData): string | undefined {
     (item) => typeof item.sessionFile === "string" && item.sessionFile.length > 0,
   );
   return result?.sessionFile;
+}
+
+function resultDataFromStatus(status: SubagentStatusFileData): SubagentResultFileData {
+  const state = status.state;
+  const success =
+    state === "complete" ? true : state === "failed" || state === "paused" ? false : undefined;
+  const summary =
+    typeof status.summary === "string" && status.summary.trim().length > 0
+      ? status.summary
+      : typeof status.error === "string" && status.error.trim().length > 0
+        ? status.error
+        : state === "paused"
+          ? "Paused after interrupt. Waiting for explicit next action."
+          : state === "failed"
+            ? "Async sub-agent failed."
+            : "Async sub-agent completed.";
+  const data: SubagentResultFileData = { summary };
+  if (status.runId !== undefined) {
+    data.id = status.runId;
+    data.runId = status.runId;
+  }
+  if (status.steps?.[0]?.agent !== undefined) data.agent = status.steps[0].agent;
+  if (success !== undefined) data.success = success;
+  if (state !== undefined) data.state = state;
+  if (status.steps !== undefined) {
+    data.results = status.steps.map((step) => {
+      const result: SubagentResultFileChild = { output: summary };
+      if (step.agent !== undefined) result.agent = step.agent;
+      const stepSuccess =
+        step.status === "completed" || step.status === "complete"
+          ? true
+          : step.status === "failed"
+            ? false
+            : success;
+      if (stepSuccess !== undefined) result.success = stepSuccess;
+      if (step.sessionFile !== undefined) result.sessionFile = step.sessionFile;
+      return result;
+    });
+  }
+  if (status.sessionId !== undefined) data.sessionId = status.sessionId;
+  if (status.sessionFile !== undefined) data.sessionFile = status.sessionFile;
+  if (status.durationMs !== undefined) data.durationMs = status.durationMs;
+  return data;
 }
 
 function buildSubagentNotifyFromResult(data: SubagentResultFileData): {
@@ -451,6 +540,7 @@ async function bridgeSubagentResultFileToParent(
   if (data === undefined) return false;
   if (typeof data.sessionId === "string" && data.sessionId !== live.sessionId) return false;
   const runId = data.runId ?? data.id ?? basename(resultPath).replace(/\.json$/i, "");
+  if (!isActiveSubagentRun(live, runId)) return false;
   const key = `${live.sessionId}:${runId}`;
   if (bridgedSubagentResultKeys.has(key)) return false;
   bridgedSubagentResultKeys.add(key);
@@ -464,69 +554,184 @@ async function bridgeSubagentResultFileToParent(
     },
     { triggerTurn: false },
   );
-  clearActiveSubagentParent(live.sessionId);
+  finishActiveSubagentRun(live.sessionId, runId);
   scheduleSubagentSessionListChanged(live, "subagent_async_complete", [250, 1000, 2500]);
   return true;
 }
 
-async function pollActiveSubagentParent(live: LiveSession): Promise<void> {
-  if (!activeSubagentParents.has(live.sessionId)) return;
+async function bridgeSubagentStatusFileToParent(
+  live: LiveSession,
+  statusPath: string,
+): Promise<boolean> {
+  const status = readSubagentStatusFile(statusPath);
+  if (status === undefined) return false;
+  if (!isTerminalSubagentState(status.state)) return false;
+  if (typeof status.sessionId === "string" && status.sessionId !== live.sessionId) return false;
+  const runId = status.runId ?? basename(dirname(statusPath));
+  const active = activeSubagentParents.get(live.sessionId);
+  if (active?.runIds.size && !active.runIds.has(runId)) return false;
+  const key = `${live.sessionId}:${runId}`;
+  if (bridgedSubagentResultKeys.has(key)) return false;
+  bridgedSubagentResultKeys.add(key);
+  const notify = buildSubagentNotifyFromResult(resultDataFromStatus(status));
+  await live.session.sendCustomMessage(
+    {
+      customType: "subagent-notify",
+      content: notify.content,
+      display: true,
+      details: notify.details,
+    },
+    { triggerTurn: false },
+  );
+  finishActiveSubagentRun(live.sessionId, runId);
+  scheduleSubagentSessionListChanged(live, "subagent_async_complete", [250, 1000, 2500]);
+  return true;
+}
 
-  const resultsDir = join(resolvePiSubagentsTempRoot(), "async-subagent-results");
+function isActiveSubagentRun(live: LiveSession, runId: string): boolean {
+  const active = activeSubagentParents.get(live.sessionId);
+  if (active === undefined) return false;
+  return active.runIds.size === 0 || active.runIds.has(runId);
+}
+
+async function checkActiveSubagentArtifacts(live: LiveSession): Promise<void> {
+  const active = activeSubagentParents.get(live.sessionId);
+  if (active === undefined) return;
+
+  const root = resolvePiSubagentsTempRoot();
+  const resultsDir = join(root, "async-subagent-results");
   if (existsSync(resultsDir)) {
-    for (const file of readdirSync(resultsDir).filter((candidate) => candidate.endsWith(".json"))) {
-      if (await bridgeSubagentResultFileToParent(live, join(resultsDir, file))) return;
+    const resultFiles =
+      active.runIds.size > 0
+        ? [...active.runIds].map((runId) => `${runId}.json`)
+        : readdirSync(resultsDir).filter((candidate) => candidate.endsWith(".json"));
+    for (const file of resultFiles) {
+      const resultPath = join(resultsDir, file);
+      if (existsSync(resultPath) && (await bridgeSubagentResultFileToParent(live, resultPath)))
+        return;
     }
   }
 
-  const sessionFile = getLiveSessionFile(live);
-  if (sessionFile === undefined || !existsSync(sessionFile)) return;
-  const stat = statSync(sessionFile);
-  const previous = activeSubagentParentFileState.get(live.sessionId);
-  activeSubagentParentFileState.set(live.sessionId, { mtimeMs: stat.mtimeMs, size: stat.size });
-  if (previous === undefined || (previous.mtimeMs === stat.mtimeMs && previous.size === stat.size))
-    return;
-
-  const messages = await readSessionMessagesFromDisk(sessionFile);
-  sendSnapshotToClients(live, messages);
-  if (hasSubagentNotifyMessage(messages)) {
-    clearActiveSubagentParent(live.sessionId);
-    scheduleSubagentSessionListChanged(live, "subagent_async_complete", [250, 1000, 2500]);
+  const asyncRunsDir = join(root, "async-subagent-runs");
+  if (!existsSync(asyncRunsDir)) return;
+  const runIds = active.runIds.size > 0 ? [...active.runIds] : readdirSync(asyncRunsDir);
+  for (const runId of runIds) {
+    const statusPath = join(asyncRunsDir, runId, "status.json");
+    if (existsSync(statusPath) && (await bridgeSubagentStatusFileToParent(live, statusPath)))
+      return;
   }
 }
 
-function startActiveSubagentParentPoller(live: LiveSession): void {
-  if (activeSubagentParentPollers.has(live.sessionId)) return;
-  const sessionFile = getLiveSessionFile(live);
-  if (sessionFile !== undefined && existsSync(sessionFile)) {
-    const stat = statSync(sessionFile);
-    activeSubagentParentFileState.set(live.sessionId, { mtimeMs: stat.mtimeMs, size: stat.size });
-  }
-  const interval = setInterval(() => {
-    void pollActiveSubagentParent(live).catch((error: unknown) => {
+function scheduleActiveSubagentArtifactCheck(live: LiveSession, delayMs = 0): void {
+  const active = activeSubagentParents.get(live.sessionId);
+  if (active === undefined) return;
+  const timer = setTimeout(() => {
+    const current = activeSubagentParents.get(live.sessionId);
+    if (current === undefined) return;
+    current.timers = current.timers.filter((candidate) => candidate !== timer);
+    void checkActiveSubagentArtifacts(live).catch((error: unknown) => {
       logAgentEvent("warn", {
-        msg: "subagent parent poll failed",
+        msg: "subagent artifact check failed",
         sessionId: live.sessionId,
         error: error instanceof Error ? error.message : String(error),
       });
     });
-  }, 1000);
-  interval.unref?.();
-  activeSubagentParentPollers.set(live.sessionId, interval);
-  void pollActiveSubagentParent(live).catch(() => undefined);
+  }, delayMs);
+  timer.unref?.();
+  active.timers.push(timer);
+}
+
+function addActiveSubagentWatcher(
+  live: LiveSession,
+  directory: string,
+  onEvent: (fileName: string) => void,
+): void {
+  const active = activeSubagentParents.get(live.sessionId);
+  if (active === undefined) return;
+  try {
+    mkdirSync(directory, { recursive: true });
+    const watcher = watch(directory, (_event, file) => {
+      if (file === null) return;
+      onEvent(file.toString());
+    });
+    watcher.on("error", () => scheduleActiveSubagentArtifactCheck(live, 250));
+    watcher.unref?.();
+    active.watchers.push(watcher);
+  } catch {
+    scheduleActiveSubagentArtifactCheck(live, 250);
+  }
+}
+
+function startActiveSubagentParentArtifactObservers(live: LiveSession): void {
+  const active = activeSubagentParents.get(live.sessionId);
+  if (active === undefined) return;
+  stopActiveSubagentArtifactObservers(active);
+
+  const root = resolvePiSubagentsTempRoot();
+  const resultsDir = join(root, "async-subagent-results");
+  addActiveSubagentWatcher(live, resultsDir, (fileName) => {
+    if (!fileName.endsWith(".json")) return;
+    const runId = fileName.replace(/\.json$/i, "");
+    if (!isActiveSubagentRun(live, runId)) return;
+    scheduleActiveSubagentArtifactCheck(live, 100);
+  });
+
+  const asyncRunsDir = join(root, "async-subagent-runs");
+  addActiveSubagentWatcher(live, asyncRunsDir, (fileName) => {
+    if (!isActiveSubagentRun(live, fileName)) return;
+    startActiveSubagentParentArtifactObservers(live);
+    scheduleActiveSubagentArtifactCheck(live, 100);
+  });
+
+  const runIds =
+    active.runIds.size > 0
+      ? [...active.runIds]
+      : existsSync(asyncRunsDir)
+        ? readdirSync(asyncRunsDir)
+        : [];
+  for (const runId of runIds) {
+    addActiveSubagentWatcher(live, join(asyncRunsDir, runId), (fileName) => {
+      if (fileName !== "status.json") return;
+      scheduleActiveSubagentArtifactCheck(live, 100);
+    });
+  }
+
+  // One-shot artifact checks handle files that already existed before watchers started
+  // and missed fs.watch notifications. They inspect only pi-subagents result/status
+  // artifacts; they never infer liveness from parent JSONL mtime/size or elapsed time.
+  scheduleActiveSubagentArtifactCheck(live, 0);
+  scheduleActiveSubagentArtifactCheck(live, 1500);
+}
+
+function getAsyncSubagentRunId(result: unknown): string | undefined {
+  if (typeof result !== "object" || result === null) return undefined;
+  const details = (result as { details?: unknown }).details;
+  if (typeof details !== "object" || details === null) return undefined;
+  const d = details as {
+    id?: unknown;
+    asyncId?: unknown;
+    runId?: unknown;
+    asyncDir?: unknown;
+    results?: unknown;
+  };
+  if (typeof d.id === "string" && d.id.length > 0) return d.id;
+  if (typeof d.asyncId === "string" && d.asyncId.length > 0) return d.asyncId;
+  if (typeof d.runId === "string" && d.runId.length > 0) return d.runId;
+  if (typeof d.asyncDir === "string" && d.asyncDir.length > 0) return basename(d.asyncDir);
+  return undefined;
 }
 
 function isAsyncSubagentToolResult(result: unknown): boolean {
+  if (getAsyncSubagentRunId(result) !== undefined) return true;
   if (typeof result !== "object" || result === null) return false;
   const details = (result as { details?: unknown }).details;
   if (typeof details !== "object" || details === null) return false;
-  const d = details as { asyncId?: unknown; asyncDir?: unknown; results?: unknown };
+  const d = details as { asyncDir?: unknown; results?: unknown };
   return (
-    (typeof d.asyncId === "string" && d.asyncId.length > 0) ||
-    (typeof d.asyncDir === "string" &&
-      d.asyncDir.length > 0 &&
-      Array.isArray(d.results) &&
-      d.results.length === 0)
+    typeof d.asyncDir === "string" &&
+    d.asyncDir.length > 0 &&
+    Array.isArray(d.results) &&
+    d.results.length === 0
   );
 }
 
@@ -934,7 +1139,7 @@ function makeSubscribeHandler(live: LiveSession): () => void {
     } else if (toolEv.type === "tool_execution_end" && toolEv.toolName === "subagent") {
       const isAsync = isAsyncSubagentToolResult(toolEv.result);
       if (isAsync) {
-        markActiveSubagentParent(live.sessionId);
+        markActiveSubagentParent(live.sessionId, getAsyncSubagentRunId(toolEv.result));
       } else {
         clearActiveSubagentParent(live.sessionId);
       }

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -398,6 +398,8 @@ export async function readSessionMessagesFromDisk(sessionFile: string): Promise<
 export async function readSessionMessagesSnapshotById(
   sessionId: string,
 ): Promise<unknown[] | undefined> {
+  const activeChild = await getExternallyActiveSubagentChild(sessionId);
+  if (activeChild !== undefined) return readSessionMessagesFromDisk(activeChild.path);
   const live = getSession(sessionId);
   if (live !== undefined) return live.session.messages;
   const projects = await readProjects();
@@ -1454,6 +1456,9 @@ export async function resumeSession(
   projectId: string,
   workspacePath: string,
 ): Promise<LiveSession> {
+  const activeChild = await getExternallyActiveSubagentChild(sessionId);
+  if (activeChild !== undefined) throw new ExternallyActiveSubagentChildError(sessionId);
+
   const existing = registry.get(sessionId);
   if (existing) return existing;
 
@@ -1464,6 +1469,9 @@ export async function resumeSession(
   }
 
   return resumeInflight(sessionId, async () => {
+    const lockedActiveChild = await getExternallyActiveSubagentChild(sessionId);
+    if (lockedActiveChild !== undefined) throw new ExternallyActiveSubagentChildError(sessionId);
+
     // Re-check after lock acquisition: another resume may have raced
     // ahead and populated the registry while we were queued.
     const raced = registry.get(sessionId);
@@ -2002,7 +2010,10 @@ export async function listSessionsForProject(
       merged.firstMessage = d.firstMessage;
       if (d.parentSessionId !== undefined) merged.parentSessionId = d.parentSessionId;
       if (d.runId !== undefined) merged.runId = d.runId;
-      if (isSubagentChildExternallyLive(d)) merged.isExternalLive = true;
+      if (isSubagentChildExternallyLive(d)) {
+        merged.isExternalLive = true;
+        merged.isLive = false;
+      }
       merged.path = d.path;
       continue;
     }
@@ -2109,10 +2120,10 @@ export async function findSessionLocation(
  * receive projectId in the URL (the stream route specifically).
  */
 export async function resumeSessionById(sessionId: string): Promise<LiveSession> {
-  const existing = registry.get(sessionId);
-  if (existing) return existing;
   const activeChild = await getExternallyActiveSubagentChild(sessionId);
   if (activeChild !== undefined) throw new ExternallyActiveSubagentChildError(sessionId);
+  const existing = registry.get(sessionId);
+  if (existing) return existing;
   const loc = await findSessionLocation(sessionId);
   if (loc === undefined) throw new SessionNotFoundError(sessionId);
   return resumeSession(sessionId, loc.projectId, loc.workspacePath);

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -39,37 +39,30 @@ function sanitizeTempScopeSegment(value: string): string {
   return sanitized || "unknown";
 }
 
-function piSubagentsResultsDir(): string {
+function piSubagentsTempRoot(): string {
   if (typeof process.getuid === "function")
-    return join(tmpdir(), `pi-subagents-uid-${process.getuid()}`, "async-subagent-results");
+    return join(tmpdir(), `pi-subagents-uid-${process.getuid()}`);
   for (const key of ["USERNAME", "USER", "LOGNAME"] as const) {
     const value = process.env[key];
-    if (value)
-      return join(
-        tmpdir(),
-        `pi-subagents-user-${sanitizeTempScopeSegment(value)}`,
-        "async-subagent-results",
-      );
+    if (value) return join(tmpdir(), `pi-subagents-user-${sanitizeTempScopeSegment(value)}`);
   }
   try {
     const username = userInfo().username;
-    if (username)
-      return join(
-        tmpdir(),
-        `pi-subagents-user-${sanitizeTempScopeSegment(username)}`,
-        "async-subagent-results",
-      );
+    if (username) return join(tmpdir(), `pi-subagents-user-${sanitizeTempScopeSegment(username)}`);
   } catch {
     // Fall through to HOME-based scoping.
   }
   const homedir = process.env.USERPROFILE ?? process.env.HOME;
-  if (homedir)
-    return join(
-      tmpdir(),
-      `pi-subagents-home-${sanitizeTempScopeSegment(homedir)}`,
-      "async-subagent-results",
-    );
-  return join(tmpdir(), "pi-subagents-shared", "async-subagent-results");
+  if (homedir) return join(tmpdir(), `pi-subagents-home-${sanitizeTempScopeSegment(homedir)}`);
+  return join(tmpdir(), "pi-subagents-shared");
+}
+
+function piSubagentsResultsDir(): string {
+  return join(piSubagentsTempRoot(), "async-subagent-results");
+}
+
+function piSubagentsAsyncRunsDir(): string {
+  return join(piSubagentsTempRoot(), "async-subagent-runs");
 }
 
 let failures = 0;
@@ -142,7 +135,7 @@ interface TestRegistry {
   disposeAllSessions: () => Promise<void>;
   resumeSession: (id: string, projectId: string, workspacePath: string) => Promise<TestLive>;
   resumeSessionById: (id: string) => Promise<TestLive>;
-  markActiveSubagentParent: (parentSessionId: string) => void;
+  markActiveSubagentParent: (parentSessionId: string, runId?: string) => void;
   clearActiveSubagentParent: (parentSessionId: string) => void;
   discoverSessionsOnDisk: (projectId: string, workspacePath: string) => Promise<TestDiscovered[]>;
   listSessionsForProject: (
@@ -412,7 +405,62 @@ async function main(): Promise<void> {
       registry.getSession(childB) !== undefined,
     );
     await registry.disposeSession(childB);
+
+    const statusRunId = "run-" + randomUUID().slice(0, 8);
+    const statusChildId = randomUUID();
+    const statusChildPath = join(
+      projectSessionDir,
+      parent.sessionId,
+      statusRunId,
+      `${statusChildId}.jsonl`,
+    );
+    await writeChildSessionFile(statusChildPath, statusChildId, project.path);
+    registry.markActiveSubagentParent(parent.sessionId, statusRunId);
+    const statusActiveList = await registry.listSessionsForProject(project.id, project.path);
+    const statusActiveChild = statusActiveList.find((s) => s.sessionId === statusChildId);
+    assert(
+      "status-tracked async child is marked externally live",
+      statusActiveChild?.isExternalLive === true,
+      `isExternalLive=${statusActiveChild?.isExternalLive}`,
+    );
+    const statusDir = join(piSubagentsAsyncRunsDir(), statusRunId);
+    await mkdir(statusDir, { recursive: true });
+    await writeFile(
+      join(statusDir, "status.json"),
+      `${JSON.stringify({
+        runId: statusRunId,
+        sessionId: parent.sessionId,
+        state: "complete",
+        summary: "status done",
+        sessionFile: statusChildPath,
+        steps: [{ agent: "worker", status: "completed", sessionFile: statusChildPath }],
+      })}\n`,
+    );
+    const parentGotStatusNotify = await waitFor(() =>
+      parent.session.messages.some((message) => {
+        if (typeof message !== "object" || message === null) return false;
+        const m = message as { role?: unknown; customType?: unknown; content?: unknown };
+        return (
+          m.role === "custom" &&
+          m.customType === "subagent-notify" &&
+          typeof m.content === "string" &&
+          m.content.includes("status done")
+        );
+      }),
+    );
+    assert(
+      "terminal status.json is bridged into parent custom notification",
+      parentGotStatusNotify,
+    );
+    const statusCompletedList = await registry.listSessionsForProject(project.id, project.path);
+    const statusCompletedChild = statusCompletedList.find((s) => s.sessionId === statusChildId);
+    assert(
+      "terminal status.json clears external-live child state",
+      statusCompletedChild?.isExternalLive !== true,
+      `isExternalLive=${statusCompletedChild?.isExternalLive}`,
+    );
     await rm(resultsDir, { recursive: true, force: true });
+    await rm(piSubagentsAsyncRunsDir(), { recursive: true, force: true });
 
     // 6. resumeSession opens the child as a LiveSession (registry hit)
     //    once called directly for a child that is not under test for

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -157,6 +157,7 @@ interface TestRegistry {
   ) => Promise<{ projectId: string; workspacePath: string } | undefined>;
   deleteColdSession: (id: string) => Promise<"deleted" | "live" | "not_found">;
   getSession: (id: string) => TestLive | undefined;
+  sessionCount: () => number;
 }
 interface TestProjectManager {
   createProject: (name: string, path: string) => Promise<{ id: string; path: string }>;
@@ -455,6 +456,25 @@ async function main(): Promise<void> {
       statusOnlySummary.isExternalLive === true && statusOnlySummary.isLive === false,
       `summary=${JSON.stringify(statusOnlySummary)}`,
     );
+    const statusOnlySessionCount = registry.sessionCount();
+    assert(
+      "session metadata does not live-resume status-only child",
+      registry.getSession(statusOnlyChildId) === undefined &&
+        registry.sessionCount() === statusOnlySessionCount,
+      `sessionCount=${registry.sessionCount()} before=${statusOnlySessionCount}`,
+    );
+    let directResumeBlocked = false;
+    try {
+      await registry.resumeSession(statusOnlyChildId, project.id, project.path);
+    } catch (err) {
+      directResumeBlocked =
+        err instanceof Error && err.name === "ExternallyActiveSubagentChildError";
+    }
+    assert(
+      "direct resumeSession blocks status-only externally active child",
+      directResumeBlocked && registry.getSession(statusOnlyChildId) === undefined,
+      `sessionCount=${registry.sessionCount()} before=${statusOnlySessionCount}`,
+    );
     const statusOnlyStreamBlocked = await fetch(
       `${listenAddr}/api/v1/sessions/${statusOnlyChildId}/stream`,
       { headers: { Accept: "text/event-stream" } },
@@ -473,9 +493,46 @@ async function main(): Promise<void> {
       statusOnlyMessages.status === 200,
       `status=${statusOnlyMessages.status}`,
     );
+    const statusOnlyTree = await fetch(`${listenAddr}/api/v1/sessions/${statusOnlyChildId}/tree`);
     assert(
-      "status-only read-only open did not live-resume child",
-      registry.getSession(statusOnlyChildId) === undefined,
+      "tree route rejects status-only active child without live-resume",
+      statusOnlyTree.status === 409,
+      `status=${statusOnlyTree.status}`,
+    );
+    const statusOnlyContext = await fetch(
+      `${listenAddr}/api/v1/sessions/${statusOnlyChildId}/context`,
+    );
+    assert(
+      "context route rejects status-only active child without live-resume",
+      statusOnlyContext.status === 409,
+      `status=${statusOnlyContext.status}`,
+    );
+    const statusOnlyCompactions = await fetch(
+      `${listenAddr}/api/v1/sessions/${statusOnlyChildId}/compactions`,
+    );
+    assert(
+      "compactions route rejects status-only active child without live-resume",
+      statusOnlyCompactions.status === 409,
+      `status=${statusOnlyCompactions.status}`,
+    );
+    const statusOnlyTurnDiff = await fetch(
+      `${listenAddr}/api/v1/sessions/${statusOnlyChildId}/turn-diff`,
+    );
+    assert(
+      "turn-diff route rejects status-only active child without live-resume",
+      statusOnlyTurnDiff.status === 409,
+      `status=${statusOnlyTurnDiff.status}`,
+    );
+    const statusOnlyAfterViewList = await registry.listSessionsForProject(project.id, project.path);
+    const statusOnlyAfterViewChild = statusOnlyAfterViewList.find(
+      (s) => s.sessionId === statusOnlyChildId,
+    );
+    assert(
+      "status-only UI view routes did not live-resume child",
+      registry.getSession(statusOnlyChildId) === undefined &&
+        registry.sessionCount() === statusOnlySessionCount &&
+        statusOnlyAfterViewChild?.isExternalLive === true,
+      `sessionCount=${registry.sessionCount()} before=${statusOnlySessionCount} isExternalLive=${statusOnlyAfterViewChild?.isExternalLive}`,
     );
     await writeFile(
       join(statusOnlyDir, "status.json"),

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -119,6 +119,7 @@ interface TestLive {
   session: {
     sessionId: string;
     sessionFile?: string;
+    messages: unknown[];
     sessionManager: { appendMessage: (msg: unknown) => string };
   };
   sessionId: string;
@@ -160,6 +161,15 @@ interface TestProjectManager {
 interface TestOrchestrationStore {
   enableSupervisor: (sessionId: string) => Promise<unknown>;
   registerWorker: (opts: { supervisorId: string; workerId: string }) => Promise<void>;
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 3000): Promise<boolean> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (condition()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return condition();
 }
 
 function appendFixtureMessage(live: TestLive, text: string): void {
@@ -368,6 +378,19 @@ async function main(): Promise<void> {
         results: [{ agent: "worker", success: true, output: "done", sessionFile: childBPath }],
       })}\n`,
     );
+    const parentGotNotify = await waitFor(() =>
+      parent.session.messages.some((message) => {
+        if (typeof message !== "object" || message === null) return false;
+        const m = message as { role?: unknown; customType?: unknown; content?: unknown };
+        return (
+          m.role === "custom" &&
+          m.customType === "subagent-notify" &&
+          typeof m.content === "string" &&
+          m.content.includes("Background task completed")
+        );
+      }),
+    );
+    assert("async result file is bridged into parent custom notification", parentGotNotify);
     const completedList = await registry.listSessionsForProject(project.id, project.path);
     const completedChild = completedList.find((s) => s.sessionId === childB);
     assert(

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -22,7 +22,7 @@
  * project session dir as a child.
  */
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { tmpdir, userInfo } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
@@ -30,6 +30,47 @@ import { randomUUID } from "node:crypto";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const repoRoot = resolve(__dirname, "..");
+
+function sanitizeTempScopeSegment(value: string): string {
+  const sanitized = value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized || "unknown";
+}
+
+function piSubagentsResultsDir(): string {
+  if (typeof process.getuid === "function")
+    return join(tmpdir(), `pi-subagents-uid-${process.getuid()}`, "async-subagent-results");
+  for (const key of ["USERNAME", "USER", "LOGNAME"] as const) {
+    const value = process.env[key];
+    if (value)
+      return join(
+        tmpdir(),
+        `pi-subagents-user-${sanitizeTempScopeSegment(value)}`,
+        "async-subagent-results",
+      );
+  }
+  try {
+    const username = userInfo().username;
+    if (username)
+      return join(
+        tmpdir(),
+        `pi-subagents-user-${sanitizeTempScopeSegment(username)}`,
+        "async-subagent-results",
+      );
+  } catch {
+    // Fall through to HOME-based scoping.
+  }
+  const homedir = process.env.USERPROFILE ?? process.env.HOME;
+  if (homedir)
+    return join(
+      tmpdir(),
+      `pi-subagents-home-${sanitizeTempScopeSegment(homedir)}`,
+      "async-subagent-results",
+    );
+  return join(tmpdir(), "pi-subagents-shared", "async-subagent-results");
+}
 
 let failures = 0;
 function assert(label: string, ok: boolean, detail?: string): void {
@@ -100,7 +141,8 @@ interface TestRegistry {
   disposeAllSessions: () => Promise<void>;
   resumeSession: (id: string, projectId: string, workspacePath: string) => Promise<TestLive>;
   resumeSessionById: (id: string) => Promise<TestLive>;
-  markActiveSubagentParent: (parentSessionId: string, ttlMs?: number) => void;
+  markActiveSubagentParent: (parentSessionId: string) => void;
+  clearActiveSubagentParent: (parentSessionId: string) => void;
   discoverSessionsOnDisk: (projectId: string, workspacePath: string) => Promise<TestDiscovered[]>;
   listSessionsForProject: (
     projectId: string,
@@ -267,7 +309,7 @@ async function main(): Promise<void> {
     //    create a pi-forge AgentSession for the same JSONL. The stream
     //    route blocks live SSE resume with 409, while /messages offers
     //    a read-only snapshot for the chat view.
-    registry.markActiveSubagentParent(parent.sessionId, 60_000);
+    registry.markActiveSubagentParent(parent.sessionId);
     const activeList = await registry.listSessionsForProject(project.id, project.path);
     const activeChild = activeList.find((s) => s.sessionId === childB);
     assert(
@@ -312,6 +354,42 @@ async function main(): Promise<void> {
       "read-only snapshot did not live-resume the child",
       registry.getSession(childB) === undefined,
     );
+
+    const resultsDir = piSubagentsResultsDir();
+    await mkdir(resultsDir, { recursive: true });
+    await writeFile(
+      join(resultsDir, `${runId}.json`),
+      `${JSON.stringify({
+        id: runId,
+        runId,
+        sessionId: parent.sessionId,
+        success: true,
+        summary: "done",
+        results: [{ agent: "worker", success: true, output: "done", sessionFile: childBPath }],
+      })}\n`,
+    );
+    const completedList = await registry.listSessionsForProject(project.id, project.path);
+    const completedChild = completedList.find((s) => s.sessionId === childB);
+    assert(
+      "authoritative result file clears external-live child state",
+      completedChild?.isExternalLive !== true,
+      `isExternalLive=${completedChild?.isExternalLive}`,
+    );
+    const streamAfterComplete = await fetch(`${listenAddr}/api/v1/sessions/${childB}/stream`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    assert(
+      "stream route no longer blocks after authoritative result file",
+      streamAfterComplete.status === 200,
+      `status=${streamAfterComplete.status}`,
+    );
+    await streamAfterComplete.body?.cancel();
+    assert(
+      "stream after completion resumes the child normally",
+      registry.getSession(childB) !== undefined,
+    );
+    await registry.disposeSession(childB);
+    await rm(resultsDir, { recursive: true, force: true });
 
     // 6. resumeSession opens the child as a LiveSession (registry hit)
     //    once called directly for a child that is not under test for

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -416,6 +416,99 @@ async function main(): Promise<void> {
     );
     await registry.disposeSession(childB);
 
+    const statusOnlyRunId = "run-" + randomUUID().slice(0, 8);
+    const statusOnlyChildId = randomUUID();
+    const statusOnlyChildPath = join(
+      projectSessionDir,
+      parent.sessionId,
+      statusOnlyRunId,
+      `${statusOnlyChildId}.jsonl`,
+    );
+    await writeChildSessionFile(statusOnlyChildPath, statusOnlyChildId, project.path);
+    const statusOnlyDir = join(piSubagentsAsyncRunsDir(), statusOnlyRunId);
+    await mkdir(statusOnlyDir, { recursive: true });
+    await writeFile(
+      join(statusOnlyDir, "status.json"),
+      `${JSON.stringify({
+        runId: statusOnlyRunId,
+        sessionId: parent.sessionId,
+        state: "running",
+        summary: "status-only running",
+        sessionFile: statusOnlyChildPath,
+        steps: [{ agent: "worker", status: "running", sessionFile: statusOnlyChildPath }],
+      })}\n`,
+    );
+    const statusOnlyActiveList = await registry.listSessionsForProject(project.id, project.path);
+    const statusOnlyActiveChild = statusOnlyActiveList.find(
+      (s) => s.sessionId === statusOnlyChildId,
+    );
+    assert(
+      "running status.json marks child externally live without in-memory parent state",
+      statusOnlyActiveChild?.isExternalLive === true,
+      `isExternalLive=${statusOnlyActiveChild?.isExternalLive}`,
+    );
+    const statusOnlySummary = (await (
+      await fetch(`${listenAddr}/api/v1/sessions/${statusOnlyChildId}`)
+    ).json()) as { isExternalLive?: boolean; isLive?: boolean };
+    assert(
+      "session metadata exposes status-only external live child",
+      statusOnlySummary.isExternalLive === true && statusOnlySummary.isLive === false,
+      `summary=${JSON.stringify(statusOnlySummary)}`,
+    );
+    const statusOnlyStreamBlocked = await fetch(
+      `${listenAddr}/api/v1/sessions/${statusOnlyChildId}/stream`,
+      { headers: { Accept: "text/event-stream" } },
+    );
+    assert(
+      "stream route returns 409 for status-only externally active child",
+      statusOnlyStreamBlocked.status === 409,
+      `status=${statusOnlyStreamBlocked.status}`,
+    );
+    await statusOnlyStreamBlocked.body?.cancel();
+    const statusOnlyMessages = await fetch(
+      `${listenAddr}/api/v1/sessions/${statusOnlyChildId}/messages`,
+    );
+    assert(
+      "messages route returns read-only snapshot for status-only active child",
+      statusOnlyMessages.status === 200,
+      `status=${statusOnlyMessages.status}`,
+    );
+    assert(
+      "status-only read-only open did not live-resume child",
+      registry.getSession(statusOnlyChildId) === undefined,
+    );
+    await writeFile(
+      join(statusOnlyDir, "status.json"),
+      `${JSON.stringify({
+        runId: statusOnlyRunId,
+        sessionId: parent.sessionId,
+        state: "complete",
+        summary: "status-only done",
+        sessionFile: statusOnlyChildPath,
+        steps: [{ agent: "worker", status: "completed", sessionFile: statusOnlyChildPath }],
+      })}\n`,
+    );
+    const statusOnlyCompletedList = await registry.listSessionsForProject(project.id, project.path);
+    const statusOnlyCompletedChild = statusOnlyCompletedList.find(
+      (s) => s.sessionId === statusOnlyChildId,
+    );
+    assert(
+      "terminal status.json clears status-only external-live child state",
+      statusOnlyCompletedChild?.isExternalLive !== true,
+      `isExternalLive=${statusOnlyCompletedChild?.isExternalLive}`,
+    );
+    const statusOnlyStreamAfterComplete = await fetch(
+      `${listenAddr}/api/v1/sessions/${statusOnlyChildId}/stream`,
+      { headers: { Accept: "text/event-stream" } },
+    );
+    assert(
+      "stream route allows status-only child after terminal status.json",
+      statusOnlyStreamAfterComplete.status === 200,
+      `status=${statusOnlyStreamAfterComplete.status}`,
+    );
+    await statusOnlyStreamAfterComplete.body?.cancel();
+    await registry.disposeSession(statusOnlyChildId);
+
     const statusRunId = "run-" + randomUUID().slice(0, 8);
     const statusChildId = randomUUID();
     const statusChildPath = join(

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -22,7 +22,7 @@
  * project session dir as a child.
  */
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir, userInfo } from "node:os";
+import { homedir, tmpdir, userInfo } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
@@ -52,8 +52,16 @@ function piSubagentsTempRoot(): string {
   } catch {
     // Fall through to HOME-based scoping.
   }
-  const homedir = process.env.USERPROFILE ?? process.env.HOME;
-  if (homedir) return join(tmpdir(), `pi-subagents-home-${sanitizeTempScopeSegment(homedir)}`);
+  const envHomedir = process.env.USERPROFILE ?? process.env.HOME;
+  if (envHomedir)
+    return join(tmpdir(), `pi-subagents-home-${sanitizeTempScopeSegment(envHomedir)}`);
+  try {
+    const fallbackHomedir = homedir();
+    if (fallbackHomedir)
+      return join(tmpdir(), `pi-subagents-home-${sanitizeTempScopeSegment(fallbackHomedir)}`);
+  } catch {
+    // Fall through to shared last-resort scope.
+  }
   return join(tmpdir(), "pi-subagents-shared");
 }
 
@@ -114,8 +122,10 @@ interface TestLive {
     sessionFile?: string;
     messages: unknown[];
     sessionManager: { appendMessage: (msg: unknown) => string };
+    _emit?: (event: unknown) => void;
   };
   sessionId: string;
+  clients: Set<{ id: string; send: (event: unknown) => void; close: () => void }>;
 }
 interface TestDiscovered {
   sessionId: string;
@@ -459,6 +469,68 @@ async function main(): Promise<void> {
       statusCompletedChild?.isExternalLive !== true,
       `isExternalLive=${statusCompletedChild?.isExternalLive}`,
     );
+
+    const parentSseEvents: unknown[] = [];
+    const parentSseClient = {
+      id: "test-parent-sse",
+      send: (event: unknown) => parentSseEvents.push(event),
+      close: () => undefined,
+    };
+    parent.clients.add(parentSseClient);
+    const toolResultRunId = "run-" + randomUUID().slice(0, 8);
+    const toolResultChildId = randomUUID();
+    const toolResultChildPath = join(
+      projectSessionDir,
+      parent.sessionId,
+      toolResultRunId,
+      `${toolResultChildId}.jsonl`,
+    );
+    await writeChildSessionFile(toolResultChildPath, toolResultChildId, project.path);
+    parent.session._emit?.({
+      type: "tool_result",
+      toolName: "subagent",
+      toolCallId: "call-subagent-async",
+      input: {},
+      content: [{ type: "text", text: "Async started" }],
+      isError: false,
+      details: {
+        mode: "single",
+        runId: toolResultRunId,
+        asyncId: toolResultRunId,
+        asyncDir: join(piSubagentsAsyncRunsDir(), toolResultRunId),
+        results: [],
+      },
+    });
+    const toolResultStatusDir = join(piSubagentsAsyncRunsDir(), toolResultRunId);
+    await mkdir(toolResultStatusDir, { recursive: true });
+    await writeFile(
+      join(toolResultStatusDir, "status.json"),
+      `${JSON.stringify({
+        runId: toolResultRunId,
+        sessionId: parent.sessionId,
+        state: "complete",
+        summary: "tool_result parent delivery done",
+        sessionFile: toolResultChildPath,
+        steps: [{ agent: "worker", status: "completed", sessionFile: toolResultChildPath }],
+      })}\n`,
+    );
+    const parentGotSseNotify = await waitFor(() =>
+      parentSseEvents.some((event) => {
+        if (typeof event !== "object" || event === null) return false;
+        const e = event as {
+          type?: unknown;
+          message?: { customType?: unknown; content?: unknown };
+        };
+        return (
+          e.type === "message_end" &&
+          e.message?.customType === "subagent-notify" &&
+          typeof e.message.content === "string" &&
+          e.message.content.includes("tool_result parent delivery done")
+        );
+      }),
+    );
+    assert("async tool_result terminal status is delivered to parent SSE chat", parentGotSseNotify);
+    parent.clients.delete(parentSseClient);
     await rm(resultsDir, { recursive: true, force: true });
     await rm(piSubagentsAsyncRunsDir(), { recursive: true, force: true });
 

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -92,12 +92,15 @@ interface TestUnifiedSession {
   sessionId: string;
   parentSessionId?: string;
   runId?: string;
+  isExternalLive?: boolean;
 }
 interface TestRegistry {
   createSession: (projectId: string, workspacePath: string) => Promise<TestLive>;
   disposeSession: (id: string) => Promise<boolean>;
   disposeAllSessions: () => Promise<void>;
   resumeSession: (id: string, projectId: string, workspacePath: string) => Promise<TestLive>;
+  resumeSessionById: (id: string) => Promise<TestLive>;
+  markActiveSubagentParent: (parentSessionId: string, ttlMs?: number) => void;
   discoverSessionsOnDisk: (projectId: string, workspacePath: string) => Promise<TestDiscovered[]>;
   listSessionsForProject: (
     projectId: string,
@@ -151,6 +154,14 @@ async function main(): Promise<void> {
   const orchestrationStore = (await import(
     resolve(repoRoot, "packages/server/dist/orchestration/store.js")
   )) as unknown as TestOrchestrationStore;
+  const buildModule = (await import(resolve(repoRoot, "packages/server/dist/index.js"))) as {
+    buildServer: () => Promise<{
+      listen: (opts: { port: number; host: string }) => Promise<string>;
+      close: () => Promise<void>;
+    }>;
+  };
+  const fastify = await buildModule.buildServer();
+  const listenAddr = await fastify.listen({ port: 0, host: "127.0.0.1" });
 
   // Register the project so findSessionLocation can locate children.
   const project = await pm.createProject("test-subagent-project", workspacePath);
@@ -251,7 +262,60 @@ async function main(): Promise<void> {
       `loc=${JSON.stringify(loc)}`,
     );
 
-    // 5. resumeSession opens the child as a LiveSession (registry hit).
+    // 5. Externally-active child safety: opening a child while the
+    //    pi-subagents-owned process is still writing it must NOT
+    //    create a pi-forge AgentSession for the same JSONL. The stream
+    //    route blocks live SSE resume with 409, while /messages offers
+    //    a read-only snapshot for the chat view.
+    registry.markActiveSubagentParent(parent.sessionId, 60_000);
+    const activeList = await registry.listSessionsForProject(project.id, project.path);
+    const activeChild = activeList.find((s) => s.sessionId === childB);
+    assert(
+      "externally active child is marked isExternalLive in unified list",
+      activeChild?.isExternalLive === true,
+      `isExternalLive=${activeChild?.isExternalLive}`,
+    );
+    let blockedResume = false;
+    try {
+      await registry.resumeSessionById(childB);
+    } catch (err) {
+      blockedResume = err instanceof Error && err.name === "ExternallyActiveSubagentChildError";
+    }
+    assert("resumeSessionById blocks externally active child", blockedResume);
+    assert(
+      "blocked externally active child was not inserted into live registry",
+      registry.getSession(childB) === undefined,
+    );
+    const streamBlocked = await fetch(`${listenAddr}/api/v1/sessions/${childB}/stream`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    assert(
+      "stream route returns 409 for externally active child",
+      streamBlocked.status === 409,
+      `status=${streamBlocked.status}`,
+    );
+    const streamBody = (await streamBlocked.json()) as { error?: string };
+    assert(
+      "stream 409 explains external subagent ownership",
+      streamBody.error === "subagent_child_externally_active",
+      `body=${JSON.stringify(streamBody)}`,
+    );
+    const messagesSnapshot = await fetch(`${listenAddr}/api/v1/sessions/${childB}/messages`);
+    assert(
+      "messages route returns read-only snapshot for externally active child",
+      messagesSnapshot.status === 200,
+      `status=${messagesSnapshot.status}`,
+    );
+    const messagesBody = (await messagesSnapshot.json()) as { messages?: unknown };
+    assert("read-only snapshot has messages array", Array.isArray(messagesBody.messages));
+    assert(
+      "read-only snapshot did not live-resume the child",
+      registry.getSession(childB) === undefined,
+    );
+
+    // 6. resumeSession opens the child as a LiveSession (registry hit)
+    //    once called directly for a child that is not under test for
+    //    external ownership.
     const resumed = await registry.resumeSession(childA, project.id, project.path);
     assert(
       "resumeSession returns a LiveSession for the child",
@@ -259,7 +323,7 @@ async function main(): Promise<void> {
       `got ${resumed.sessionId}`,
     );
 
-    // 6. REALISTIC pi-subagents layout: the plugin's
+    // 7. REALISTIC pi-subagents layout: the plugin's
     // `getSubagentSessionRoot` names the child dir using the parent
     // FILE's full basename (timestamp + id), not the bare parent id.
     // The discovery has to map basename → parent's actual sessionId
@@ -295,7 +359,7 @@ async function main(): Promise<void> {
       `got parentSessionId=${realisticChildEntry?.parentSessionId} expected=${realisticParentId}`,
     );
 
-    // 7a. DEEP layout (parallel/chain mode):
+    // 8a. DEEP layout (parallel/chain mode):
     //     <basename>/<runId>/run-N/session.jsonl. Three dir levels
     //     under the parent — observed in the wild on real
     //     pi-subagents installs. Discovery has to walk past the runId
@@ -333,7 +397,7 @@ async function main(): Promise<void> {
       `got runId=${deepChildEntry?.runId}`,
     );
 
-    // 7b. FLAT layout (no runId subdir): some pi-subagents run modes
+    // 8b. FLAT layout (no runId subdir): some pi-subagents run modes
     // write children directly under <parentBasename>/, not under
     // <parentBasename>/<runId>/. Discovery must surface these too.
     const flatParentId = "flat-parent-" + randomUUID().slice(0, 6);
@@ -356,7 +420,7 @@ async function main(): Promise<void> {
       `parentSessionId=${flatChildEntry?.parentSessionId} runId=${flatChildEntry?.runId}`,
     );
 
-    // 8. Cascade-delete: deleting a parent session also wipes its
+    // 9. Cascade-delete: deleting a parent session also wipes its
     // pi-subagents sibling directory and any nested children, so the
     // sidebar doesn't accumulate orphan child sessions whose parent
     // is gone. We use the deep-layout fixture because it exercises
@@ -393,6 +457,7 @@ async function main(): Promise<void> {
     );
   } finally {
     await registry.disposeAllSessions();
+    await fastify.close();
     // Clean every temp dir we created. Safe to ignore failures —
     // mkdtemp dirs are isolated per test run.
     await rm(workspacePath, { recursive: true, force: true }).catch(() => undefined);

--- a/tests/test-subagent-parser.ts
+++ b/tests/test-subagent-parser.ts
@@ -14,7 +14,10 @@
  * https://github.com/nicobailon/pi-subagents — see also the integration
  * report captured in `notes/MOBILE.md` for the full schema.
  */
-import { parseSubagentDetails } from "../packages/client/src/lib/subagent-parser";
+import {
+  parseSubagentDetails,
+  parseSubagentNotify,
+} from "../packages/client/src/lib/subagent-parser";
 
 let failures = 0;
 
@@ -240,6 +243,54 @@ assertEqual(
     mode: "single",
     results: [{ agent: "x", task: "t", exitCode: 0, sessionFile: "/var/tmp/run/something.json" }],
   },
+);
+
+// --- Async notification custom messages -----------------------------
+
+assertEqual(
+  "subagent-notify content parses completion + session file",
+  parseSubagentNotify(
+    [
+      "Background task completed: **reviewer** (1/2)",
+      "",
+      "Looks good.",
+      "Second line.",
+      "",
+      "Session file: /tmp/pi-subagents/run/session.jsonl",
+    ].join("\n"),
+  ),
+  {
+    agent: "reviewer",
+    status: "completed",
+    taskInfo: "(1/2)",
+    resultPreview: "Looks good.\nSecond line.",
+    sessionLabel: "session file",
+    sessionValue: "/tmp/pi-subagents/run/session.jsonl",
+  },
+);
+
+assertEqual(
+  "subagent-notify structured details win over content",
+  parseSubagentNotify("unparseable", {
+    agent: "writer",
+    status: "paused",
+    resultPreview: "Paused after interrupt.",
+    sessionLabel: "session file",
+    sessionValue: "/tmp/paused/session.jsonl",
+  }),
+  {
+    agent: "writer",
+    status: "paused",
+    resultPreview: "Paused after interrupt.",
+    sessionLabel: "session file",
+    sessionValue: "/tmp/paused/session.jsonl",
+  },
+);
+
+assertEqual(
+  "malformed subagent-notify content returns undefined",
+  parseSubagentNotify("hello"),
+  undefined,
 );
 
 // --- Final tally -----------------------------------------------------


### PR DESCRIPTION
## Summary

`pi-subagents` async/background completions were being persisted as SDK custom messages (`role: "custom", customType: "subagent-notify"`), but pi-forge only rendered known chat/tool roles and fell back to an "unknown message" block. Child sessions also appeared stale/inactive because the first session-list refresh could race child JSONL creation and because externally running subagent children are not live in pi-forge's in-memory `AgentSession` registry.

This PR keeps the integration as a pi-forge bridge/UI fix: it recognizes the plugin's async notification shape, retries child discovery around subagent lifecycle events, adds a separate external-live hint for active child JSONLs, and makes "Open" buttons refetch before giving up on a freshly-created child session.

## Usage

No new operator-facing usage. Existing `pi-subagents` async/background runs now surface in the chat automatically, and their notification cards expose the child session "Open" button when a session file is provided.

## What changed (9 files)

- `packages/server/src/session-registry.ts` — added delayed/idempotent `session_list_changed` nudges for `subagent` start/end/async-complete events, plus external child liveness tracking based on active parent runs and recent child JSONL mtime.
- `packages/server/src/routes/sessions.ts` — exposes optional `isExternalLive` on unified session rows without changing `isLive` registry semantics.
- `packages/client/src/components/ChatView.tsx` — renders `subagent-notify` custom messages as rich background-result cards, reuses subagent Open navigation, and refetches all sessions before failing an Open-by-sessionFile action.
- `packages/client/src/components/SessionList.tsx` — shows the green live dot for either true live registry sessions or externally active subagent children.
- `packages/client/src/lib/subagent-parser.ts` — parses both `subagent` tool-result details and async notification custom-message content/details.
- `packages/client/src/store/session-store.ts` — reads tool args from the SDK's `args` field as well as the older `input` field for active-tool summaries.
- `packages/client/src/lib/api-client/index.ts`, `packages/client/src/lib/api-client/types.ts` — accept optional `isExternalLive` from the sessions API.
- `tests/test-subagent-parser.ts` — adds deterministic coverage for async notification parsing.

## Test plan

- [x] `npm run build`
- [x] `scripts/run-tests.sh --only session,sse,subagent-discovery,subagent-parser`
- [x] `npm run check`
- [ ] CI green before merge
