### PR TITLE
fix(orchestration): filter noisy worker retry events

### DIFF
--- a/packages/server/src/orchestration/event-bridge.ts
+++ b/packages/server/src/orchestration/event-bridge.ts
@@ -4,11 +4,11 @@
  * Four event sources feed the inbox (mirroring the webhooks bridge):
  *
  *   AgentSession events (per-session subscribe in session-registry):
- *     - `agent_end`        → inbox `worker.ended`
- *     - `auto_retry_end` (success=false) → inbox `worker.auto_retry_failed`
+ *     - `agent_start`      → record open turn state only
+ *     - `agent_end`        → inbox `worker.ended` (with final error info)
  *
  *   ask-user-question registry (forge-native):
- *     - `ask_user_question` → inbox `worker.ask_user`
+ *     - `ask_user_question` → inbox `worker.ask_user` + awaiting_question state
  *
  *   processManager (forge-native):
  *     - `process_alert` is intentionally not bridged to the supervisor inbox
@@ -26,6 +26,7 @@ import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-
 import type { ProcessAlertReason, ProcessInfo } from "../processes/types.js";
 import type { Question } from "../ask-user-question/types.js";
 import { bridgeWorkerEvent } from "./inbox.js";
+import { getWorkerRecord, updateWorkerLifecycle } from "./store.js";
 
 interface LastAssistantSummary {
   stopReason?: string;
@@ -70,42 +71,51 @@ function extractAssistantText(content: unknown): string | undefined {
 
 /**
  * Called from `session-registry.makeSubscribeHandler` for every
- * AgentSessionEvent on every live session. Filters for the two SDK
- * events that map to inbox items; everything else is ignored.
+ * AgentSessionEvent on every live session. Only authoritative
+ * lifecycle signals wake the supervisor: agent_end (final turn
+ * outcome) and explicit blocked state from ask_user_question (below).
+ * Retry events are deliberately ignored here; if retries ultimately
+ * fail, the SDK reports the terminal outcome on agent_end or the
+ * explicit stop/delete path reports no agent_end was observed.
  */
 export async function bridgeWorkerAgentEvent(
   meta: { sessionId: string; session: AgentSession },
   event: AgentSessionEvent,
 ): Promise<void> {
-  const e = event as unknown as {
-    type: string;
-    message?: { stopReason?: string; errorMessage?: string };
-    success?: boolean;
-    finalError?: string;
-    attempt?: number;
-    maxAttempts?: number;
-  };
-  if (e.type === "agent_end") {
-    const messages = meta.session.messages;
-    const lastAssistant = findLastAssistant(messages);
-    const errorMessage =
-      (meta.session as unknown as { errorMessage?: string }).errorMessage ??
-      lastAssistant?.errorMessage;
-    await bridgeWorkerEvent(meta.sessionId, "worker.ended", {
-      stopReason: lastAssistant?.stopReason ?? null,
-      errorMessage: errorMessage ?? null,
-      assistantTextPreview: lastAssistant?.text ?? null,
+  const e = event as unknown as { type: string };
+  const now = new Date().toISOString();
+  if (e.type === "agent_start") {
+    await updateWorkerLifecycle(meta.sessionId, {
+      state: "running",
+      turnOpen: true,
+      lastStateAt: now,
+      lastAgentStartAt: now,
+      stopReason: null,
+      errorMessage: null,
     });
     return;
   }
-  if (e.type === "auto_retry_end" && e.success === false) {
-    await bridgeWorkerEvent(meta.sessionId, "worker.auto_retry_failed", {
-      attempt: e.attempt ?? null,
-      maxAttempts: e.maxAttempts ?? null,
-      finalError: e.finalError ?? null,
-    });
-    return;
-  }
+  if (e.type !== "agent_end") return;
+
+  const messages = meta.session.messages;
+  const lastAssistant = findLastAssistant(messages);
+  const errorMessage =
+    (meta.session as unknown as { errorMessage?: string }).errorMessage ??
+    lastAssistant?.errorMessage;
+  const hasError = typeof errorMessage === "string" && errorMessage.length > 0;
+  await updateWorkerLifecycle(meta.sessionId, {
+    state: hasError ? "errored" : "ended",
+    turnOpen: false,
+    lastStateAt: now,
+    lastAgentEndAt: now,
+    stopReason: lastAssistant?.stopReason ?? null,
+    errorMessage: errorMessage ?? null,
+  });
+  await bridgeWorkerEvent(meta.sessionId, "worker.ended", {
+    stopReason: lastAssistant?.stopReason ?? null,
+    errorMessage: errorMessage ?? null,
+    assistantTextPreview: lastAssistant?.text ?? null,
+  });
 }
 
 export async function bridgeWorkerAskUserQuestion(
@@ -113,6 +123,10 @@ export async function bridgeWorkerAskUserQuestion(
   questions: readonly Question[],
   requestId: string,
 ): Promise<void> {
+  await updateWorkerLifecycle(sessionId, {
+    state: "awaiting_question",
+    lastStateAt: new Date().toISOString(),
+  });
   await bridgeWorkerEvent(sessionId, "worker.ask_user", {
     requestId,
     questionCount: questions.length,
@@ -151,10 +165,37 @@ export async function bridgeWorkerProcessAlert(
   });
 }
 
+export async function bridgeWorkerExecutionStopped(
+  sessionId: string,
+  meta: { wasLive: boolean; reason: "deleted" | "killed" | "disposed" | "aborted" },
+): Promise<void> {
+  const rec = await getWorkerRecord(sessionId);
+  if (rec?.turnOpen !== true) return;
+  await updateWorkerLifecycle(sessionId, {
+    state: "stopped",
+    turnOpen: false,
+    lastStateAt: new Date().toISOString(),
+    stopReason: meta.reason,
+  });
+  await bridgeWorkerEvent(sessionId, "worker.execution_stopped_without_agent_end", {
+    reason: meta.reason,
+    wasLive: meta.wasLive,
+    lastAgentStartAt: rec.lastAgentStartAt ?? null,
+  });
+}
+
 export async function bridgeWorkerDeleted(
   sessionId: string,
-  meta: { wasLive: boolean },
+  meta: { wasLive: boolean; reason?: "deleted" | "killed" | "disposed" | "aborted" },
 ): Promise<void> {
+  const reason = meta.reason ?? "deleted";
+  await bridgeWorkerExecutionStopped(sessionId, { wasLive: meta.wasLive, reason });
+  await updateWorkerLifecycle(sessionId, {
+    state: "deleted",
+    turnOpen: false,
+    lastStateAt: new Date().toISOString(),
+    stopReason: reason,
+  });
   await bridgeWorkerEvent(sessionId, "worker.deleted", {
     wasLive: meta.wasLive,
   });

--- a/packages/server/src/orchestration/init.ts
+++ b/packages/server/src/orchestration/init.ts
@@ -2,7 +2,7 @@
  * Boot-time wiring of the orchestration event bridge to the
  * forge-native singleton event channels (ask-user-question, processes).
  *
- * Per-AgentSession events (agent_end, auto_retry_end) are dispatched
+ * Per-AgentSession events (agent_start, agent_end) are dispatched
  * from inside `session-registry.makeSubscribeHandler` — those need
  * the LiveSession context at construction time. session-registry
  * also calls `notifySupervisorIdle` on supervisor agent_end and

--- a/packages/server/src/orchestration/store.ts
+++ b/packages/server/src/orchestration/store.ts
@@ -30,6 +30,7 @@ import {
   ORCHESTRATION_VERSION,
   type OrchestrationStore,
   type SupervisorRecord,
+  type WorkerLifecycleState,
   type WorkerRecord,
 } from "./types.js";
 
@@ -72,6 +73,20 @@ function isSupervisorRecord(v: unknown): v is SupervisorRecord {
   );
 }
 
+const WORKER_LIFECYCLE_STATES = new Set<WorkerLifecycleState>([
+  "idle",
+  "running",
+  "ended",
+  "errored",
+  "stopped",
+  "deleted",
+  "awaiting_question",
+]);
+
+function isWorkerLifecycleState(v: unknown): v is WorkerLifecycleState {
+  return typeof v === "string" && WORKER_LIFECYCLE_STATES.has(v as WorkerLifecycleState);
+}
+
 function isWorkerRecord(v: unknown): v is WorkerRecord {
   if (typeof v !== "object" || v === null) return false;
   const r = v as Record<string, unknown>;
@@ -80,6 +95,14 @@ function isWorkerRecord(v: unknown): v is WorkerRecord {
     const sf = r.spawnedFrom as Record<string, unknown>;
     if (typeof sf.sessionId !== "string") return false;
     if (sf.mode !== "fresh" && sf.mode !== "summary") return false;
+  }
+  if (r.state !== undefined && !isWorkerLifecycleState(r.state)) return false;
+  if (r.turnOpen !== undefined && typeof r.turnOpen !== "boolean") return false;
+  for (const key of ["lastStateAt", "lastAgentStartAt", "lastAgentEndAt"] as const) {
+    if (r[key] !== undefined && typeof r[key] !== "string") return false;
+  }
+  for (const key of ["stopReason", "errorMessage"] as const) {
+    if (r[key] !== undefined && r[key] !== null && typeof r[key] !== "string") return false;
   }
   return true;
 }
@@ -205,9 +228,13 @@ export async function registerWorker(opts: {
       );
     }
     sup.workerIds.push(opts.workerId);
+    const now = new Date().toISOString();
     const wrec: WorkerRecord = {
       supervisorId: opts.supervisorId,
-      spawnedAt: new Date().toISOString(),
+      spawnedAt: now,
+      state: "idle",
+      turnOpen: false,
+      lastStateAt: now,
     };
     if (opts.spawnedFrom !== undefined) wrec.spawnedFrom = opts.spawnedFrom;
     s.workers[opts.workerId] = wrec;
@@ -264,6 +291,31 @@ export async function getWorkerIds(supervisorId: string): Promise<string[]> {
 export async function getWorkerRecord(workerId: string): Promise<WorkerRecord | undefined> {
   const s = await readStoreFile();
   return s.workers[workerId];
+}
+
+export async function updateWorkerLifecycle(
+  workerId: string,
+  patch: Partial<
+    Pick<
+      WorkerRecord,
+      | "state"
+      | "turnOpen"
+      | "lastStateAt"
+      | "lastAgentStartAt"
+      | "lastAgentEndAt"
+      | "stopReason"
+      | "errorMessage"
+    >
+  >,
+): Promise<WorkerRecord | undefined> {
+  return withStoreLock(async () => {
+    const s = await readStoreFile();
+    const rec = s.workers[workerId];
+    if (rec === undefined) return undefined;
+    Object.assign(rec, patch);
+    await writeStoreFile(s);
+    return { ...rec };
+  });
 }
 
 // ---- orchestrator-inbox.json (queue) ----

--- a/packages/server/src/orchestration/tools.ts
+++ b/packages/server/src/orchestration/tools.ts
@@ -225,11 +225,16 @@ function summarizeInboxData(type: string, data: Record<string, unknown>): string
     const count = typeof data.questionCount === "number" ? data.questionCount : 1;
     return `${count} question(s)${header !== "" ? `, first: "${header}"` : ""}${text !== "" ? ` (${truncate(text, 120)})` : ""}`;
   }
+  if (type === "worker.execution_stopped_without_agent_end") {
+    const reason = typeof data.reason === "string" ? data.reason : "stopped";
+    const lastStart = typeof data.lastAgentStartAt === "string" ? data.lastAgentStartAt : "";
+    return `${reason} while turn was open${lastStart !== "" ? ` (started ${lastStart})` : ""}`;
+  }
   if (type === "worker.auto_retry_failed") {
     const attempt = typeof data.attempt === "number" ? data.attempt : "?";
     const maxA = typeof data.maxAttempts === "number" ? data.maxAttempts : "?";
     const finalErr = typeof data.finalError === "string" ? data.finalError : "";
-    return `attempts=${attempt}/${maxA}${finalErr !== "" ? ` err="${truncate(finalErr, 120)}"` : ""}`;
+    return `legacy retry failure attempts=${attempt}/${maxA}${finalErr !== "" ? ` err="${truncate(finalErr, 120)}"` : ""}`;
   }
   if (type === "worker.process_alert") {
     const reason = typeof data.reason === "string" ? data.reason : "unknown";
@@ -494,7 +499,16 @@ function createListWorkers(supervisorId: string): ToolDefinition {
     async execute() {
       interface WorkerRow {
         workerId: string;
-        state: "cold" | "idle" | "streaming";
+        state:
+          | "cold"
+          | "idle"
+          | "streaming"
+          | "running"
+          | "ended"
+          | "errored"
+          | "stopped"
+          | "deleted"
+          | "awaiting_question";
         isLive: boolean;
         isStreaming: boolean;
         messageCount: number | null;
@@ -502,33 +516,46 @@ function createListWorkers(supervisorId: string): ToolDefinition {
         name: string | null;
       }
       const ids = await getWorkerIds(supervisorId);
-      const workers: WorkerRow[] = ids.map((workerId) => {
-        const live = getSession(workerId);
-        if (live === undefined) {
+      const workers: WorkerRow[] = await Promise.all(
+        ids.map(async (workerId) => {
+          const rec = await getWorkerRecord(workerId);
+          const live = getSession(workerId);
+          if (live === undefined) {
+            return {
+              workerId,
+              state: rec?.state ?? "cold",
+              isLive: false,
+              isStreaming: false,
+              messageCount: null,
+              lastActivityAt: rec?.lastStateAt ?? null,
+              name: null,
+            };
+          }
           return {
             workerId,
-            state: "cold",
-            isLive: false,
-            isStreaming: false,
-            messageCount: null,
-            lastActivityAt: null,
-            name: null,
+            state:
+              rec?.state === "running" ||
+              rec?.state === "awaiting_question" ||
+              rec?.state === "errored" ||
+              rec?.state === "stopped" ||
+              rec?.state === "deleted"
+                ? rec.state
+                : live.session.isStreaming
+                  ? "streaming"
+                  : (rec?.state ?? "idle"),
+            isLive: true,
+            isStreaming: live.session.isStreaming,
+            messageCount: live.session.messages.length,
+            lastActivityAt: live.lastActivityAt.toISOString(),
+            name: live.session.sessionName ?? null,
           };
-        }
-        return {
-          workerId,
-          state: live.session.isStreaming ? "streaming" : "idle",
-          isLive: true,
-          isStreaming: live.session.isStreaming,
-          messageCount: live.session.messages.length,
-          lastActivityAt: live.lastActivityAt.toISOString(),
-          name: live.session.sessionName ?? null,
-        };
-      });
+        }),
+      );
       const summary =
         `${workers.length} worker(s) registered. ` +
-        `${workers.filter((w) => w.state === "streaming").length} streaming, ` +
-        `${workers.filter((w) => w.state === "idle").length} idle, ` +
+        `${workers.filter((w) => w.state === "running" || w.state === "streaming").length} running, ` +
+        `${workers.filter((w) => w.state === "idle" || w.state === "ended").length} idle/ended, ` +
+        `${workers.filter((w) => w.state === "awaiting_question").length} awaiting question, ` +
         `${workers.filter((w) => w.state === "cold").length} cold.`;
       const rows = workers.map((w) => {
         const label = w.name ?? "(unnamed)";

--- a/packages/server/src/orchestration/types.ts
+++ b/packages/server/src/orchestration/types.ts
@@ -27,6 +27,10 @@ export const ORCHESTRATION_VERSION = 1 as const;
 export const INBOX_EVENT_TYPES = [
   "worker.ended",
   "worker.ask_user",
+  "worker.execution_stopped_without_agent_end",
+  // Legacy inbox history can contain this from older builds. New
+  // retry failures are intentionally not enqueued; final agent_end
+  // or explicit stop-without-agent_end carries the authoritative outcome.
   "worker.auto_retry_failed",
   "worker.process_alert",
   "worker.deleted",
@@ -63,6 +67,15 @@ export interface SupervisorRecord {
   workerIds: string[];
 }
 
+export type WorkerLifecycleState =
+  | "idle"
+  | "running"
+  | "ended"
+  | "errored"
+  | "stopped"
+  | "deleted"
+  | "awaiting_question";
+
 export interface WorkerRecord {
   supervisorId: string;
   spawnedAt: string;
@@ -72,6 +85,19 @@ export interface WorkerRecord {
     sessionId: string;
     mode: "fresh" | "summary";
   };
+  /**
+   * Last authoritative lifecycle state observed for this worker.
+   * Updated only from explicit signals (agent_start/agent_end,
+   * ask_user_question, delete/kill/dispose), never timeouts.
+   */
+  state?: WorkerLifecycleState;
+  /** True after agent_start until agent_end or an explicit stop/delete. */
+  turnOpen?: boolean;
+  lastStateAt?: string;
+  lastAgentStartAt?: string;
+  lastAgentEndAt?: string;
+  stopReason?: string | null;
+  errorMessage?: string | null;
 }
 
 /**

--- a/packages/server/src/orchestration/worker-lifecycle.ts
+++ b/packages/server/src/orchestration/worker-lifecycle.ts
@@ -66,7 +66,7 @@ export async function killWorkerAndArchive(args: {
   }
 
   // Fire before unregistering so the bridge can still resolve the supervisor.
-  await bridgeWorkerDeleted(args.workerId, { wasLive }).catch(() => undefined);
+  await bridgeWorkerDeleted(args.workerId, { wasLive, reason: "killed" }).catch(() => undefined);
   await unregisterWorker(args.workerId);
   notifySupervisorSessionListChanged({
     supervisorId: args.supervisorId,

--- a/packages/server/src/routes/control.ts
+++ b/packages/server/src/routes/control.ts
@@ -13,6 +13,7 @@ import {
 } from "../config-manager.js";
 import { config } from "../config.js";
 import { expandFileReferences } from "../file-references.js";
+import { bridgeWorkerExecutionStopped } from "../orchestration/event-bridge.js";
 import { errorSchema, liveSummaryBody, liveSummarySchema } from "./_schemas.js";
 
 /**
@@ -193,6 +194,7 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
       const live = getSession(req.params.id);
       if (live === undefined) return notFound(reply);
       await live.session.abort();
+      await bridgeWorkerExecutionStopped(req.params.id, { wasLive: true, reason: "aborted" });
       return reply.code(204).send();
     },
   );

--- a/packages/server/src/routes/orchestration.ts
+++ b/packages/server/src/routes/orchestration.ts
@@ -104,7 +104,20 @@ const workerSummarySchema = {
     isLive: { type: "boolean" },
     isStreaming: { type: "boolean" },
     name: { type: "string" },
-    state: { type: "string", enum: ["streaming", "idle", "cold"] },
+    state: {
+      type: "string",
+      enum: [
+        "streaming",
+        "idle",
+        "cold",
+        "running",
+        "ended",
+        "errored",
+        "stopped",
+        "deleted",
+        "awaiting_question",
+      ],
+    },
     lastActivityAt: { type: "string" },
     messageCount: { type: "integer", minimum: 0 },
     projectId: { type: "string" },
@@ -364,13 +377,23 @@ export const orchestrationRoutes: FastifyPluginAsync = async (fastify) => {
           }
           if (live !== undefined) {
             base.isStreaming = live.session.isStreaming;
-            base.state = live.session.isStreaming ? "streaming" : "idle";
+            base.state =
+              rec?.state === "running" ||
+              rec?.state === "awaiting_question" ||
+              rec?.state === "errored" ||
+              rec?.state === "stopped" ||
+              rec?.state === "deleted"
+                ? rec.state
+                : live.session.isStreaming
+                  ? "streaming"
+                  : (rec?.state ?? "idle");
             base.name = live.session.sessionName ?? undefined;
             base.messageCount = live.session.messages.length;
             base.lastActivityAt = live.lastActivityAt.toISOString();
             base.projectId = live.projectId;
           } else {
-            base.state = "cold";
+            base.state = rec?.state ?? "cold";
+            if (rec?.lastStateAt !== undefined) base.lastActivityAt = rec.lastStateAt;
             const projectId = await findProjectIdForSession(workerId);
             if (projectId !== undefined) base.projectId = projectId;
           }

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -70,9 +70,15 @@ interface OrchestrationStoreModule {
     supervisorId: string,
     opts?: { markDelivered?: boolean },
   ) => Promise<{ id: string; type: string; delivered: boolean }[]>;
-  readAllInbox: (
-    supervisorId: string,
-  ) => Promise<{ id: string; type: string; delivered: boolean }[]>;
+  readAllInbox: (supervisorId: string) => Promise<
+    {
+      id: string;
+      type: string;
+      delivered: boolean;
+      data: Record<string, unknown>;
+      workerId: string;
+    }[]
+  >;
   pendingInboxCount: (supervisorId: string) => Promise<number>;
   clearInbox: (supervisorId: string) => Promise<void>;
   OrchestrationError: new (code: string, message: string) => Error & { code: string };
@@ -812,6 +818,10 @@ async function main(): Promise<void> {
       "utf8",
     );
     await store.registerWorker({ supervisorId: realSid, workerId: realWorkerId });
+    await eventBridge.bridgeWorkerAgentEvent(
+      { sessionId: realWorkerId, session: { messages: [] } },
+      { type: "agent_start" },
+    );
     const preKillNestedList = await jsend(
       onSrv.base,
       "GET",
@@ -849,6 +859,17 @@ async function main(): Promise<void> {
         (killRes.body as { wasLive?: boolean; archiveStatus?: string }).archiveStatus ===
           "archived",
       JSON.stringify(killRes.body),
+    );
+    const killInboxItems = await store.readAllInbox(realSid);
+    const killStopItem = killInboxItems.find(
+      (item) =>
+        item.workerId === realWorkerId &&
+        item.type === "worker.execution_stopped_without_agent_end",
+    );
+    assert(
+      "kill worker records stopped-without-agent_end reason=killed",
+      killStopItem?.data.reason === "killed",
+      JSON.stringify(killInboxItems),
     );
     const afterKillList = await jsend(
       onSrv.base,

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -48,6 +48,15 @@ interface OrchestrationStoreModule {
   isWorker: (sessionId: string) => Promise<boolean>;
   getSupervisorIdForWorker: (workerId: string) => Promise<string | undefined>;
   getWorkerIds: (supervisorId: string) => Promise<string[]>;
+  getWorkerRecord: (workerId: string) => Promise<
+    | {
+        state?: string;
+        turnOpen?: boolean;
+        lastAgentStartAt?: string;
+        errorMessage?: string | null;
+      }
+    | undefined
+  >;
   enqueueInboxItem: (
     supervisorId: string,
     item: {
@@ -60,8 +69,10 @@ interface OrchestrationStoreModule {
   readPendingInbox: (
     supervisorId: string,
     opts?: { markDelivered?: boolean },
-  ) => Promise<{ id: string; delivered: boolean }[]>;
-  readAllInbox: (supervisorId: string) => Promise<{ id: string; delivered: boolean }[]>;
+  ) => Promise<{ id: string; type: string; delivered: boolean }[]>;
+  readAllInbox: (
+    supervisorId: string,
+  ) => Promise<{ id: string; type: string; delivered: boolean }[]>;
   pendingInboxCount: (supervisorId: string) => Promise<number>;
   clearInbox: (supervisorId: string) => Promise<void>;
   OrchestrationError: new (code: string, message: string) => Error & { code: string };
@@ -90,6 +101,19 @@ interface EventBridgeModule {
     reason: "success" | "failure" | "killed",
   ) => Promise<void>;
   shouldBridgeWorkerProcessAlert: (reason: "success" | "failure" | "killed") => boolean;
+  bridgeWorkerAgentEvent: (
+    meta: { sessionId: string; session: { messages: unknown[]; errorMessage?: string } },
+    event: { type: string; [key: string]: unknown },
+  ) => Promise<void>;
+  bridgeWorkerAskUserQuestion: (
+    sessionId: string,
+    questions: { header: string; question: string }[],
+    requestId: string,
+  ) => Promise<void>;
+  bridgeWorkerDeleted: (
+    sessionId: string,
+    meta: { wasLive: boolean; reason?: "deleted" | "killed" | "disposed" | "aborted" },
+  ) => Promise<void>;
 }
 
 interface ToolResult {
@@ -365,6 +389,92 @@ async function main(): Promise<void> {
     "worker process failure/kill alerts do not enqueue inbox items",
     cnt2 === 0,
     `got ${cnt2}`,
+  );
+
+  // Authoritative lifecycle bridge: retry noise is ignored, final
+  // agent_end is delivered, ask_user_question wakes, and explicit
+  // delete/kill while a turn is open emits a stopped-without-agent_end item.
+  await store.registerWorker({ supervisorId: "sup-1", workerId: "w-state" });
+  const fakeSession = {
+    messages: [
+      {
+        role: "assistant",
+        stopReason: "end_turn",
+        content: [{ type: "text", text: "Done with the worker task." }],
+      },
+    ],
+  };
+  await eventBridge.bridgeWorkerAgentEvent(
+    { sessionId: "w-state", session: fakeSession },
+    { type: "agent_start" },
+  );
+  const runningRec = await store.getWorkerRecord("w-state");
+  assert(
+    "agent_start records running open turn",
+    runningRec?.state === "running" && runningRec.turnOpen === true,
+    JSON.stringify(runningRec),
+  );
+  await eventBridge.bridgeWorkerAgentEvent(
+    { sessionId: "w-state", session: fakeSession },
+    { type: "auto_retry_end", success: false, finalError: "temporary provider failure" },
+  );
+  assert(
+    "transient retry failure does not enqueue inbox item",
+    (await store.pendingInboxCount("sup-1")) === 0,
+    `got ${await store.pendingInboxCount("sup-1")}`,
+  );
+  await eventBridge.bridgeWorkerAgentEvent(
+    { sessionId: "w-state", session: fakeSession },
+    { type: "agent_end" },
+  );
+  let lifecycleItems = await store.readPendingInbox("sup-1");
+  assert(
+    "final agent_end enqueues worker.ended",
+    lifecycleItems.length === 1 && lifecycleItems[0]?.type === "worker.ended",
+    JSON.stringify(lifecycleItems),
+  );
+  const endedRec = await store.getWorkerRecord("w-state");
+  assert(
+    "agent_end closes turn state",
+    endedRec?.turnOpen === false && endedRec.state === "ended",
+    JSON.stringify(endedRec),
+  );
+  await store.clearInbox("sup-1");
+
+  await eventBridge.bridgeWorkerAskUserQuestion(
+    "w-state",
+    [{ header: "Decision", question: "Which branch should I use?" }],
+    "rq-state",
+  );
+  lifecycleItems = await store.readPendingInbox("sup-1");
+  assert(
+    "pending question enqueues worker.ask_user",
+    lifecycleItems.length === 1 && lifecycleItems[0]?.type === "worker.ask_user",
+    JSON.stringify(lifecycleItems),
+  );
+  assert(
+    "pending question records awaiting_question state",
+    (await store.getWorkerRecord("w-state"))?.state === "awaiting_question",
+  );
+  await store.clearInbox("sup-1");
+
+  await eventBridge.bridgeWorkerAgentEvent(
+    { sessionId: "w-state", session: fakeSession },
+    { type: "agent_start" },
+  );
+  await eventBridge.bridgeWorkerDeleted("w-state", { wasLive: true, reason: "killed" });
+  lifecycleItems = await store.readPendingInbox("sup-1");
+  assert(
+    "explicit stop without agent_end enqueues authoritative stop item",
+    lifecycleItems.length === 2 &&
+      lifecycleItems[0]?.type === "worker.execution_stopped_without_agent_end" &&
+      lifecycleItems[1]?.type === "worker.deleted",
+    JSON.stringify(lifecycleItems),
+  );
+  assert(
+    "explicit stop clears open turn and records deleted state",
+    (await store.getWorkerRecord("w-state"))?.turnOpen === false &&
+      (await store.getWorkerRecord("w-state"))?.state === "deleted",
   );
 
   // Clear inbox


### PR DESCRIPTION
## Summary

Orchestration workers were waking supervisors for retry-path failures that are not authoritative terminal state. This made the supervisor inbox noisy: a single failed retry or intermediate retry event could prompt the orchestrator even though the worker was still running and might later complete normally.

This PR makes worker event delivery state-driven instead of timeout-driven. Workers now record explicit lifecycle signals (`agent_start`, `agent_end`, `ask_user_question`, abort/delete/kill) and only enqueue/wake the supervisor for authoritative outcomes: final `agent_end`, pending question decisions, and explicit execution stops while a turn was still open.

## Usage

No operator-facing setup changes. Existing orchestration usage remains the same:

```text
orchestrate_spawn_worker → worker runs → supervisor reads orchestrate_read_inbox
```

The behavioral change is automatic: retry noise stays in the worker transcript/logs, while the supervisor inbox receives terminal or decision-required events.

## What changed (8 files)

- `packages/server/src/orchestration/types.ts` — adds persisted worker lifecycle state (`idle`, `running`, `ended`, `errored`, `stopped`, `deleted`, `awaiting_question`) plus `turnOpen`; adds `worker.execution_stopped_without_agent_end` while retaining legacy `worker.auto_retry_failed` history parsing.
- `packages/server/src/orchestration/store.ts` — initializes and validates lifecycle fields and adds `updateWorkerLifecycle()` for locked state updates.
- `packages/server/src/orchestration/event-bridge.ts` — records `agent_start`/`agent_end`, ignores retry events for inbox purposes, records pending questions, and emits `worker.execution_stopped_without_agent_end` when an explicit abort/delete/kill happens with an open turn.
- `packages/server/src/routes/control.ts` — reports worker aborts through the explicit stopped-without-agent-end path when applicable.
- `packages/server/src/orchestration/tools.ts` and `packages/server/src/routes/orchestration.ts` — surface the lifecycle state in worker list/tool output and summarize the new authoritative stop event.
- `packages/server/src/orchestration/init.ts` — updates bridge comments to match the new authoritative event model.
- `tests/test-orchestration.ts` — adds regressions for ignored retry failures, delivered final `agent_end`, pending questions, and explicit stop without `agent_end`.

## Test plan

- [x] `npm run build`
- [x] `scripts/run-tests.sh --only orchestration,session,sse`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only orchestration`
- [ ] CI green before merge
