### PR TITLE
fix: integrate authoritative pi-subagents async state

### DIFF
--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -229,6 +229,13 @@ const DOUBLE_ESC_WINDOW_MS = 600;
 
 export function ChatInput({ sessionId }: Props) {
   const isStreaming = useSessionStore((s) => s.streamingBySession[sessionId] ?? false);
+  const isReadOnlyExternal = useSessionStore((s) =>
+    Object.values(s.byProject).some((sessions) =>
+      sessions.some(
+        (session) => session.sessionId === sessionId && session.isExternalLive === true,
+      ),
+    ),
+  );
   // Minimal-mode deploys disable the chat-input bash exec (`!` /
   // `!!`) — locked-down installs can't justify giving end users a
   // direct shell. The agent's own `bash` tool is unaffected; the
@@ -1173,6 +1180,10 @@ export function ChatInput({ sessionId }: Props) {
     // Allow empty text only when there's at least one attachment —
     // sending "look at this" with an image but no caption is a
     // common path. Server still rejects entirely-empty prompts.
+    if (isReadOnlyExternal) {
+      setAttachmentError("This pi-subagents child is running externally and is read-only.");
+      return;
+    }
     if ((value.length === 0 && attachments.length === 0) || submitting) return;
     // Record EVERY submission (slash command, bash exec, prompt,
     // steer) in the per-session input history so up-arrow recall
@@ -1862,7 +1873,7 @@ export function ChatInput({ sessionId }: Props) {
             <div className="relative" ref={attachMenuRef}>
               <button
                 onClick={() => setAttachMenuOpen((o) => !o)}
-                disabled={submitting || isStreaming}
+                disabled={submitting || isStreaming || isReadOnlyExternal}
                 aria-label="Attach"
                 aria-expanded={attachMenuOpen}
                 className="inline-flex min-h-11 min-w-11 items-center justify-center self-stretch rounded-md border border-neutral-700 bg-neutral-900 px-2 text-neutral-300 hover:border-neutral-500 hover:text-neutral-100 disabled:cursor-not-allowed disabled:opacity-50"
@@ -1902,7 +1913,7 @@ export function ChatInput({ sessionId }: Props) {
           ) : (
             <button
               onClick={() => fileInputRef.current?.click()}
-              disabled={submitting || isStreaming}
+              disabled={submitting || isStreaming || isReadOnlyExternal}
               aria-label="Attach files"
               className="inline-flex items-center justify-center self-stretch rounded-md border border-neutral-700 bg-neutral-900 px-2 text-neutral-300 hover:border-neutral-500 hover:text-neutral-100 disabled:cursor-not-allowed disabled:opacity-50"
               title={
@@ -2022,19 +2033,21 @@ export function ChatInput({ sessionId }: Props) {
                 }, 0);
               }}
               placeholder={
-                isAutoRetrying
-                  ? "Auto-retry in progress — your message will be queued and sent after the retry completes…"
-                  : isStreaming
-                    ? isMobile
-                      ? "Steer the agent…"
-                      : "Steer the agent (Enter to send, Shift+Enter for newline)…"
-                    : isMobile
-                      ? minimalUi
-                        ? "Ask pi — `/` runs commands, `@path` references files…"
-                        : "Ask pi — `/` runs commands, `!` runs bash, `@path` references files…"
-                      : minimalUi
-                        ? "Ask pi (Enter to send, Shift+Enter for newline) — `/` runs commands, `@path` references files…"
-                        : "Ask pi (Enter to send, Shift+Enter for newline) — `/` runs commands, `!` runs bash, `@path` references files…"
+                isReadOnlyExternal
+                  ? "Read-only while this pi-subagents child is running externally…"
+                  : isAutoRetrying
+                    ? "Auto-retry in progress — your message will be queued and sent after the retry completes…"
+                    : isStreaming
+                      ? isMobile
+                        ? "Steer the agent…"
+                        : "Steer the agent (Enter to send, Shift+Enter for newline)…"
+                      : isMobile
+                        ? minimalUi
+                          ? "Ask pi — `/` runs commands, `@path` references files…"
+                          : "Ask pi — `/` runs commands, `!` runs bash, `@path` references files…"
+                        : minimalUi
+                          ? "Ask pi (Enter to send, Shift+Enter for newline) — `/` runs commands, `@path` references files…"
+                          : "Ask pi (Enter to send, Shift+Enter for newline) — `/` runs commands, `!` runs bash, `@path` references files…"
               }
               title={
                 isAutoRetrying
@@ -2049,6 +2062,7 @@ export function ChatInput({ sessionId }: Props) {
               // desktop so the inline style only applies the
               // user-dragged value.
               rows={isMobile ? 2 : 3}
+              disabled={isReadOnlyExternal}
               style={
                 isMobile && autoHeight !== undefined
                   ? { height: `${autoHeight}px`, maxHeight: "30vh" }
@@ -2056,7 +2070,7 @@ export function ChatInput({ sessionId }: Props) {
                     ? { height: `${textareaHeight}px` }
                     : undefined
               }
-              className={`block w-full resize-none rounded-md border bg-neutral-900 px-3 py-2 text-sm text-neutral-100 outline-none ${
+              className={`block w-full resize-none rounded-md border bg-neutral-900 px-3 py-2 text-sm text-neutral-100 outline-none disabled:cursor-not-allowed disabled:opacity-60 ${
                 // Match attach + send button min-height on mobile so
                 // every child of the row renders at the same baseline
                 // height. Without this the textarea collapses to its
@@ -2106,7 +2120,11 @@ export function ChatInput({ sessionId }: Props) {
           <div className="flex flex-col-reverse gap-1 self-stretch md:flex-row md:items-end md:self-auto">
             <button
               onClick={() => void submit()}
-              disabled={(text.trim().length === 0 && attachments.length === 0) || submitting}
+              disabled={
+                (text.trim().length === 0 && attachments.length === 0) ||
+                submitting ||
+                isReadOnlyExternal
+              }
               className="flex-1 rounded-md bg-neutral-100 px-4 text-sm font-medium text-neutral-900 disabled:cursor-not-allowed disabled:opacity-50 md:flex-none md:py-2"
               title={
                 isStreaming

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1113,6 +1113,10 @@ function Message({
     return <BashExecution message={message} />;
   }
 
+  if (message.role === "custom" && message.customType === "subagent-notify") {
+    return <SubagentNotify message={message} />;
+  }
+
   // Fallback: stringify so we can see what we missed.
   return (
     <details className="rounded-lg border border-neutral-800 bg-neutral-900/40 px-3 py-2 text-xs text-neutral-400">
@@ -2070,6 +2074,18 @@ function SubagentResultRow({
           Open
         </button>
       )}
+    </div>
+  );
+}
+
+function SubagentNotify({ message }: { message: AgentMessageLike }) {
+  const text = extractText(message).trim() || "Background subagent update";
+  return (
+    <div className="rounded-lg border border-amber-700/40 bg-amber-950/30 px-4 py-3 text-sm text-amber-100 light:border-amber-300 light:bg-amber-50 light:text-amber-900">
+      <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-amber-300 light:text-amber-700">
+        subagent background update
+      </div>
+      <ChatMarkdown text={text} />
     </div>
   );
 }

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -2080,13 +2080,23 @@ function SubagentResultRow({
 
 function SubagentNotify({ message }: { message: AgentMessageLike }) {
   const text = extractText(message).trim() || "Background subagent update";
+  const firstLine = text.split(/\r?\n/, 1)[0]?.trim();
+  const summary =
+    firstLine && firstLine.length > 0
+      ? firstLine.replace(/\*\*/g, "")
+      : "Background subagent update";
   return (
-    <div className="rounded-lg border border-amber-700/40 bg-amber-950/30 px-4 py-3 text-sm text-amber-100 light:border-amber-300 light:bg-amber-50 light:text-amber-900">
-      <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-amber-300 light:text-amber-700">
-        subagent background update
+    <details className="rounded border border-amber-700/40 bg-amber-950/30 text-xs text-amber-100 light:border-amber-300 light:bg-amber-50 light:text-amber-900">
+      <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-amber-200 light:text-amber-800">
+        <span className="flex min-w-0 items-baseline gap-2">
+          <span className="text-amber-400 light:text-amber-700">subagent</span>
+          <span className="truncate text-[11px]">{summary}</span>
+        </span>
+      </summary>
+      <div className="border-t border-amber-900/30 px-3 py-2 text-sm light:border-amber-200">
+        <ChatMarkdown text={text} />
       </div>
-      <ChatMarkdown text={text} />
-    </div>
+    </details>
   );
 }
 

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -457,6 +457,14 @@ function SessionRow(props: SessionRowProps) {
           title={`${s.sessionId} — double-click to rename, Cmd/Ctrl+click to select for bulk delete`}
         >
           {s.isLive && <span className="mr-1 text-emerald-500 light:text-emerald-700">●</span>}
+          {s.isExternalLive === true && (
+            <span
+              className="mr-1 text-amber-400 light:text-amber-700"
+              title={`pi-subagents external ${s.externalState ?? "running"}`}
+            >
+              ●
+            </span>
+          )}
           {depth > 0 && (
             <span
               className="mr-1 text-purple-400 light:text-purple-700"

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -267,6 +267,16 @@ function vUnifiedSession(value: unknown, status: number): UnifiedSession {
   if (typeof value.name === "string") out.name = value.name;
   if (typeof value.parentSessionId === "string") out.parentSessionId = value.parentSessionId;
   if (typeof value.runId === "string") out.runId = value.runId;
+  if (typeof value.isExternalLive === "boolean") out.isExternalLive = value.isExternalLive;
+  if (
+    value.externalState === "queued" ||
+    value.externalState === "running" ||
+    value.externalState === "complete" ||
+    value.externalState === "failed" ||
+    value.externalState === "paused"
+  ) {
+    out.externalState = value.externalState;
+  }
   if (typeof value.path === "string") out.path = value.path;
   return out;
 }

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -299,6 +299,10 @@ export interface UnifiedSession {
   parentSessionId?: string;
   /** pi-subagents run id when this is a child session. */
   runId?: string;
+  /** True when pi-subagents status.json says this child is queued/running externally. */
+  isExternalLive?: boolean;
+  /** Authoritative pi-subagents async status state when known. */
+  externalState?: "queued" | "running" | "complete" | "failed" | "paused";
   /**
    * Absolute disk path to the session JSONL. Set for disk-discovered
    * sessions; undefined for live-only sessions that haven't flushed

--- a/packages/client/src/lib/sse-client.ts
+++ b/packages/client/src/lib/sse-client.ts
@@ -18,8 +18,8 @@ import { clearStoredToken, getStoredToken } from "./auth-client";
  *     suppresses reconnect.
  *
  * Reconnect policy:
- *   - 401 / 404 are treated as terminal (auth gone, session deleted) — do
- *     not retry; reject immediately.
+ *   - 401 / 404 / 409 are treated as terminal (auth gone, session deleted,
+ *     or externally active read-only subagent) — do not retry; reject immediately.
  *   - Any other non-2xx, network-level error, or post-200 stream EOF
  *     triggers a backoff (1s → 2s → 4s → 8s → 16s, capped at 30s).
  *     `onReconnect` is invoked between attempts so the UI can show a
@@ -45,7 +45,7 @@ export interface StreamSSEOptions<T> {
   maxReconnects?: number;
 }
 
-const TERMINAL_STATUS = new Set([401, 404]);
+const TERMINAL_STATUS = new Set([401, 404, 409]);
 const MAX_BACKOFF_MS = 30_000;
 
 function backoffDelay(attempt: number): number {
@@ -103,7 +103,14 @@ async function runOneAttempt<T extends { type: string }>(
   }
 
   if (!res.ok || res.body === null) {
-    throw new ApiError(res.status, "stream_open_failed");
+    let code = "stream_open_failed";
+    try {
+      const body = (await res.clone().json()) as { error?: unknown };
+      if (typeof body.error === "string") code = body.error;
+    } catch {
+      // Non-JSON error body: keep generic stream_open_failed.
+    }
+    throw new ApiError(res.status, code);
   }
 
   const reader = res.body.pipeThrough(new TextDecoderStream()).getReader();

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -164,11 +164,16 @@ function revokeOptimisticBlobUrls(messages: readonly AgentMessageLike[]): void {
  * Revokes blob URLs in the soon-to-be-discarded messages so optimistic
  * image attachments that never got refetched don't leak.
  */
-function findProjectIdForSession(state: SessionState, sessionId: string): string | undefined {
-  for (const [pid, list] of Object.entries(state.byProject)) {
-    if (list.some((u) => u.sessionId === sessionId)) return pid;
+function findSessionInState(state: SessionState, sessionId: string): UnifiedSession | undefined {
+  for (const list of Object.values(state.byProject)) {
+    const match = list.find((u) => u.sessionId === sessionId);
+    if (match !== undefined) return match;
   }
   return undefined;
+}
+
+function findProjectIdForSession(state: SessionState, sessionId: string): string | undefined {
+  return findSessionInState(state, sessionId)?.projectId;
 }
 
 function removeSessionFromState(current: SessionState, sessionId: string): Partial<SessionState> {
@@ -504,6 +509,31 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   },
 
   openStream: (sessionId) => {
+    const row = findSessionInState(get(), sessionId);
+    if (row?.isExternalLive === true) {
+      void api
+        .getMessages(sessionId)
+        .then(({ messages }) => {
+          set((s) => ({
+            messagesBySession: { ...s.messagesBySession, [sessionId]: messages },
+            streamingBySession: { ...s.streamingBySession, [sessionId]: false },
+            bannerBySession: {
+              ...s.bannerBySession,
+              [sessionId]: `Read-only: pi-subagents child is ${row.externalState ?? "running"} externally`,
+            },
+          }));
+        })
+        .catch((err: unknown) => {
+          const code = err instanceof ApiError ? err.code : (err as Error).message;
+          set((s) => ({
+            bannerBySession: {
+              ...s.bannerBySession,
+              [sessionId]: `read-only snapshot failed: ${code}`,
+            },
+          }));
+        });
+      return;
+    }
     const existing = controllers.get(sessionId);
     if (existing !== undefined) return; // already open
     const ctrl = new AbortController();

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -176,6 +176,10 @@ function findProjectIdForSession(state: SessionState, sessionId: string): string
   return findSessionInState(state, sessionId)?.projectId;
 }
 
+function readOnlyExternalBanner(state?: string): string {
+  return `Read-only: pi-subagents child is ${state ?? "running"} externally`;
+}
+
 function removeSessionFromState(current: SessionState, sessionId: string): Partial<SessionState> {
   const stale = current.messagesBySession[sessionId];
   if (stale !== undefined) revokeOptimisticBlobUrls(stale);
@@ -510,7 +514,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 
   openStream: (sessionId) => {
     const row = findSessionInState(get(), sessionId);
-    if (row?.isExternalLive === true) {
+    const loadReadOnly = (state?: string): void => {
       void api
         .getMessages(sessionId)
         .then(({ messages }) => {
@@ -519,7 +523,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
             streamingBySession: { ...s.streamingBySession, [sessionId]: false },
             bannerBySession: {
               ...s.bannerBySession,
-              [sessionId]: `Read-only: pi-subagents child is ${row.externalState ?? "running"} externally`,
+              [sessionId]: readOnlyExternalBanner(state),
             },
           }));
         })
@@ -532,7 +536,14 @@ export const useSessionStore = create<SessionState>((set, get) => ({
             },
           }));
         });
-      return;
+    };
+    if (row?.isExternalLive === true) {
+      set((s) => ({
+        bannerBySession: {
+          ...s.bannerBySession,
+          [sessionId]: readOnlyExternalBanner(row.externalState),
+        },
+      }));
     }
     const existing = controllers.get(sessionId);
     if (existing !== undefined) return; // already open
@@ -582,6 +593,18 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       // experience of a same-tab delete. Without this the deleted
       // session lingered in the list with a stale "stream error"
       // banner until the user manually refreshed.
+      if (
+        err instanceof ApiError &&
+        err.status === 409 &&
+        err.code === "external_subagent_active"
+      ) {
+        onTerminate();
+        loadReadOnly("running");
+        void Promise.all(
+          Object.keys(get().byProject).map((projectId) => get().loadSessionsForProject(projectId)),
+        );
+        return;
+      }
       if (err instanceof ApiError && err.status === 404) {
         set((s) => removeSessionFromState(s, sessionId));
         if (get().activeSessionId === undefined) {
@@ -775,7 +798,15 @@ function applyEvent(
         ...s.streamingBySession,
         [sessionId]: event.isStreaming ?? false,
       },
-      bannerBySession: { ...s.bannerBySession, [sessionId]: undefined },
+      bannerBySession: {
+        ...s.bannerBySession,
+        [sessionId]:
+          event.readOnly === true || event.isExternalLive === true
+            ? readOnlyExternalBanner(
+                typeof event.externalState === "string" ? event.externalState : undefined,
+              )
+            : undefined,
+      },
       activeToolBySession: { ...s.activeToolBySession, [sessionId]: undefined },
     }));
     return;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -33,6 +33,7 @@ import { searchRoutes } from "./routes/search.js";
 import { terminalRoutes } from "./routes/terminal.js";
 import { disposeAll as disposeAllMcp, loadGlobal as loadGlobalMcp } from "./mcp/manager.js";
 import { initAskUserQuestionFanout, initProcessesFanout, initTodoFanout } from "./sse-bridge.js";
+import { startExternalSubagentsWatcher } from "./subagents-external.js";
 import { webhookRoutes } from "./routes/webhooks.js";
 import { initAskUserQuestionWebhookBridge, initProcessesWebhookBridge } from "./webhooks/init.js";
 import { orchestrationRoutes } from "./routes/orchestration.js";
@@ -500,6 +501,7 @@ export async function buildServer(): Promise<FastifyInstance> {
   initAskUserQuestionFanout();
   initTodoFanout();
   initProcessesFanout();
+  startExternalSubagentsWatcher();
 
   // Webhook bridges for the same forge-native event channels. Each
   // subscribes alongside the SSE fanout so webhooks see the same

--- a/packages/server/src/routes/_schemas.ts
+++ b/packages/server/src/routes/_schemas.ts
@@ -64,6 +64,8 @@ export const liveSummarySchema = {
     // disk-only entries (no live session, no active model).
     modelProvider: { type: "string" },
     modelId: { type: "string" },
+    isExternalLive: { type: "boolean" },
+    externalState: { type: "string", enum: ["queued", "running", "complete", "failed", "paused"] },
   },
 } as const;
 
@@ -92,6 +94,8 @@ export function liveSummaryBody(args: {
   // bare optional field. Body skips the emit when undefined either way.
   modelProvider?: string | undefined;
   modelId?: string | undefined;
+  isExternalLive?: boolean;
+  externalState?: "queued" | "running" | "complete" | "failed" | "paused";
 }): Record<string, unknown> {
   const out: Record<string, unknown> = {
     sessionId: args.sessionId,
@@ -107,5 +111,7 @@ export function liveSummaryBody(args: {
   if (args.thinkingLevel !== undefined) out.thinkingLevel = args.thinkingLevel;
   if (args.modelProvider !== undefined) out.modelProvider = args.modelProvider;
   if (args.modelId !== undefined) out.modelId = args.modelId;
+  if (args.isExternalLive !== undefined) out.isExternalLive = args.isExternalLive;
+  if (args.externalState !== undefined) out.externalState = args.externalState;
   return out;
 }

--- a/packages/server/src/routes/control.ts
+++ b/packages/server/src/routes/control.ts
@@ -1,9 +1,12 @@
 import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import {
   EntryNotFoundError,
+  findSessionLocation,
   forkSession,
   getSession,
+  listSessionsForProject,
   SessionNotFoundError,
+  type LiveSession,
 } from "../session-registry.js";
 import {
   liveModelRegistry,
@@ -15,6 +18,7 @@ import { config } from "../config.js";
 import { expandFileReferences } from "../file-references.js";
 import { bridgeWorkerExecutionStopped } from "../orchestration/event-bridge.js";
 import { errorSchema, liveSummaryBody, liveSummarySchema } from "./_schemas.js";
+import { getExternalSubagentStatusForSession } from "../subagents-external.js";
 
 /**
  * Wrap a Promise in a timeout. The SDK's compact / navigateTree calls
@@ -54,6 +58,34 @@ const NAVIGATE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes (with summarize)
 
 function notFound(reply: FastifyReply): FastifyReply {
   return reply.code(404).send({ error: "session_not_found" });
+}
+
+async function requireLiveOrRejectExternal(
+  sessionId: string,
+  reply: FastifyReply,
+): Promise<LiveSession | undefined> {
+  const live = getSession(sessionId);
+  if (live !== undefined) return live;
+  const loc = await findSessionLocation(sessionId);
+  if (loc !== undefined) {
+    const match = (await listSessionsForProject(loc.projectId, loc.workspacePath)).find(
+      (s) => s.sessionId === sessionId,
+    );
+    const external = await getExternalSubagentStatusForSession({
+      runId: match?.runId,
+      path: match?.path,
+    });
+    if (external?.isExternalLive === true) {
+      reply.code(409).send({
+        error: "external_subagent_active",
+        message:
+          "This pi-subagents child is still running externally and is read-only in pi-forge.",
+      });
+      return undefined;
+    }
+  }
+  notFound(reply);
+  return undefined;
 }
 
 /**
@@ -149,8 +181,8 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const live = getSession(req.params.id);
-      if (live === undefined) return notFound(reply);
+      const live = await requireLiveOrRejectExternal(req.params.id, reply);
+      if (live === undefined) return reply;
       const mode = req.body.mode ?? "steer";
       // Same `@<path>` expansion as the prompt route — steer/followUp
       // text is conversationally identical to a fresh prompt; the user
@@ -191,8 +223,8 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const live = getSession(req.params.id);
-      if (live === undefined) return notFound(reply);
+      const live = await requireLiveOrRejectExternal(req.params.id, reply);
+      if (live === undefined) return reply;
       await live.session.abort();
       await bridgeWorkerExecutionStopped(req.params.id, { wasLive: true, reason: "aborted" });
       return reply.code(204).send();
@@ -315,8 +347,8 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const live = getSession(req.params.id);
-      if (live === undefined) return notFound(reply);
+      const live = await requireLiveOrRejectExternal(req.params.id, reply);
+      if (live === undefined) return reply;
       const opts: Parameters<typeof live.session.navigateTree>[1] = {};
       if (req.body.summarize !== undefined) opts.summarize = req.body.summarize;
       if (req.body.customInstructions !== undefined)
@@ -383,8 +415,8 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const live = getSession(req.params.id);
-      if (live === undefined) return notFound(reply);
+      const live = await requireLiveOrRejectExternal(req.params.id, reply);
+      if (live === undefined) return reply;
       try {
         const result = await withTimeout(
           live.session.compact(req.body.customInstructions),
@@ -452,8 +484,8 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const live = getSession(req.params.id);
-      if (live === undefined) return notFound(reply);
+      const live = await requireLiveOrRejectExternal(req.params.id, reply);
+      if (live === undefined) return reply;
       // Look up the model in the SDK's ModelRegistry — it merges built-in
       // providers (Anthropic, OpenAI, Google, etc.) with anything defined in
       // models.json. The previous version called pi-ai's static `getModel`,
@@ -637,8 +669,8 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const live = getSession(req.params.id);
-      if (live === undefined) return notFound(reply);
+      const live = await requireLiveOrRejectExternal(req.params.id, reply);
+      if (live === undefined) return reply;
       type SetThinkingResult =
         | { ok: true; level: string }
         | { ok: false; status: number; body: { error: string; message?: string } };

--- a/packages/server/src/routes/control.ts
+++ b/packages/server/src/routes/control.ts
@@ -1,10 +1,12 @@
 import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import {
   EntryNotFoundError,
+  ExternalSubagentActiveError,
   findSessionLocation,
   forkSession,
   getSession,
   listSessionsForProject,
+  rejectOrDisposeExternallyActiveSession,
   SessionNotFoundError,
   type LiveSession,
 } from "../session-registry.js";
@@ -65,7 +67,22 @@ async function requireLiveOrRejectExternal(
   reply: FastifyReply,
 ): Promise<LiveSession | undefined> {
   const live = getSession(sessionId);
-  if (live !== undefined) return live;
+  if (live !== undefined) {
+    try {
+      await rejectOrDisposeExternallyActiveSession(sessionId, live.projectId, live.workspacePath);
+      return live;
+    } catch (err) {
+      if (err instanceof ExternalSubagentActiveError) {
+        reply.code(409).send({
+          error: "external_subagent_active",
+          message:
+            "This pi-subagents child is still running externally and is read-only in pi-forge.",
+        });
+        return undefined;
+      }
+      throw err;
+    }
+  }
   const loc = await findSessionLocation(sessionId);
   if (loc !== undefined) {
     const match = (await listSessionsForProject(loc.projectId, loc.workspacePath)).find(

--- a/packages/server/src/routes/prompt.ts
+++ b/packages/server/src/routes/prompt.ts
@@ -3,8 +3,14 @@ import { ConversionError, convertAttachment, pickConverter } from "../attachment
 import { config } from "../config.js";
 import { formatErrorChain } from "../diagnostics.js";
 import { expandFileReferences, languageHintForPath } from "../file-references.js";
-import { getSession, type LiveSession } from "../session-registry.js";
+import {
+  findSessionLocation,
+  getSession,
+  listSessionsForProject,
+  type LiveSession,
+} from "../session-registry.js";
 import { errorSchema } from "./_schemas.js";
+import { getExternalSubagentStatusForSession } from "../subagents-external.js";
 
 /**
  * Prompt route. Per CLAUDE.md "Pi SDK Key Facts": session.prompt() is async
@@ -295,6 +301,25 @@ async function preflight(
 ): Promise<LiveSession | undefined> {
   const live = getSession((req.params as { id: string }).id);
   if (live === undefined) {
+    const sessionId = (req.params as { id: string }).id;
+    const loc = await findSessionLocation(sessionId);
+    if (loc !== undefined) {
+      const match = (await listSessionsForProject(loc.projectId, loc.workspacePath)).find(
+        (s) => s.sessionId === sessionId,
+      );
+      const external = await getExternalSubagentStatusForSession({
+        runId: match?.runId,
+        path: match?.path,
+      });
+      if (external?.isExternalLive === true) {
+        await reply.code(409).send({
+          error: "external_subagent_active",
+          message:
+            "This pi-subagents child is still running externally and is read-only in pi-forge.",
+        });
+        return undefined;
+      }
+    }
     await reply
       .code(404)
       .send({ error: "session_not_found", message: "no live session with that id" });

--- a/packages/server/src/routes/prompt.ts
+++ b/packages/server/src/routes/prompt.ts
@@ -4,9 +4,11 @@ import { config } from "../config.js";
 import { formatErrorChain } from "../diagnostics.js";
 import { expandFileReferences, languageHintForPath } from "../file-references.js";
 import {
+  ExternalSubagentActiveError,
   findSessionLocation,
   getSession,
   listSessionsForProject,
+  rejectOrDisposeExternallyActiveSession,
   type LiveSession,
 } from "../session-registry.js";
 import { errorSchema } from "./_schemas.js";
@@ -299,9 +301,24 @@ async function preflight(
   req: FastifyRequest,
   reply: FastifyReply,
 ): Promise<LiveSession | undefined> {
-  const live = getSession((req.params as { id: string }).id);
+  const sessionId = (req.params as { id: string }).id;
+  const live = getSession(sessionId);
+  if (live !== undefined) {
+    try {
+      await rejectOrDisposeExternallyActiveSession(sessionId, live.projectId, live.workspacePath);
+    } catch (err) {
+      if (err instanceof ExternalSubagentActiveError) {
+        await reply.code(409).send({
+          error: "external_subagent_active",
+          message:
+            "This pi-subagents child is still running externally and is read-only in pi-forge.",
+        });
+        return undefined;
+      }
+      throw err;
+    }
+  }
   if (live === undefined) {
-    const sessionId = (req.params as { id: string }).id;
     const loc = await findSessionLocation(sessionId);
     if (loc !== undefined) {
       const match = (await listSessionsForProject(loc.projectId, loc.workspacePath)).find(

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -20,6 +20,10 @@ import {
 import { errorSchema, liveSummaryBody, liveSummarySchema } from "./_schemas.js";
 import { buildTurnDiff } from "../turn-diff-builder.js";
 import { buildCompactionHistory } from "../compaction-history.js";
+import {
+  getExternalSubagentStatusForSession,
+  readSessionMessagesFromDisk,
+} from "../subagents-external.js";
 
 const unifiedSchema = {
   type: "object",
@@ -51,6 +55,8 @@ const unifiedSchema = {
     parentSessionId: { type: "string" },
     /** pi-subagents run id when this is a child session. */
     runId: { type: "string" },
+    isExternalLive: { type: "boolean" },
+    externalState: { type: "string", enum: ["queued", "running", "complete", "failed", "paused"] },
     /**
      * Absolute disk path to the session JSONL — used by the
      * SubagentResultCard to resolve a result's `sessionFile` reference
@@ -79,6 +85,8 @@ function unifiedFromUnified(u: UnifiedSession): Record<string, unknown> {
   if (u.parentSessionId !== undefined) out.parentSessionId = u.parentSessionId;
   if (u.runId !== undefined) out.runId = u.runId;
   if (u.path !== undefined) out.path = u.path;
+  if (u.isExternalLive !== undefined) out.isExternalLive = u.isExternalLive;
+  if (u.externalState !== undefined) out.externalState = u.externalState;
   return out;
 }
 
@@ -258,7 +266,11 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       const list = await listSessionsForProject(loc.projectId, loc.workspacePath);
       const match = list.find((s) => s.sessionId === req.params.id);
       if (match === undefined) return notFound(reply);
-      return liveSummaryBody({
+      const external = await getExternalSubagentStatusForSession({
+        runId: match.runId,
+        path: match.path,
+      });
+      const bodyArgs: Parameters<typeof liveSummaryBody>[0] = {
         sessionId: match.sessionId,
         projectId: match.projectId,
         workspacePath: match.workspacePath,
@@ -268,7 +280,12 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
         messageCount: match.messageCount,
         isStreaming: false,
         isLive: false,
-      });
+      };
+      if (external !== undefined) {
+        bodyArgs.isExternalLive = external.isExternalLive;
+        bodyArgs.externalState = external.state;
+      }
+      return liveSummaryBody(bodyArgs);
     },
   );
 
@@ -304,8 +321,18 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const live = getSession(req.params.id);
-      if (live === undefined) return notFound(reply);
-      return { messages: live.session.messages };
+      if (live !== undefined) return { messages: live.session.messages };
+      const loc = await findSessionLocation(req.params.id);
+      if (loc === undefined) return notFound(reply);
+      const list = await listSessionsForProject(loc.projectId, loc.workspacePath);
+      const match = list.find((s) => s.sessionId === req.params.id);
+      if (match?.path === undefined) return notFound(reply);
+      const external = await getExternalSubagentStatusForSession({
+        runId: match.runId,
+        path: match.path,
+      });
+      if (external?.isExternalLive !== true) return notFound(reply);
+      return { messages: readSessionMessagesFromDisk(match.path, loc.workspacePath) };
     },
   );
 

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -4,10 +4,12 @@ import {
   createSession,
   deleteColdSession,
   disposeSession,
+  ExternalSubagentActiveError,
   findProjectIdForSession,
   findSessionLocation,
   getSession,
   listSessionsForProject,
+  rejectOrDisposeExternallyActiveSession,
   resumeSessionById,
   type UnifiedSession,
 } from "../session-registry.js";
@@ -120,6 +122,25 @@ function previewOfMessageContent(content: unknown): string | undefined {
 
 function notFound(reply: FastifyReply): FastifyReply {
   return reply.code(404).send({ error: "session_not_found" });
+}
+
+async function rejectExternalIfNeeded(
+  sessionId: string,
+  projectId: string,
+  workspacePath: string,
+  reply: FastifyReply,
+): Promise<boolean> {
+  try {
+    await rejectOrDisposeExternallyActiveSession(sessionId, projectId, workspacePath);
+    return false;
+  } catch (err) {
+    if (!(err instanceof ExternalSubagentActiveError)) throw err;
+    reply.code(409).send({
+      error: "external_subagent_active",
+      message: "This pi-subagents child is still running externally and is read-only in pi-forge.",
+    });
+    return true;
+  }
 }
 
 export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
@@ -246,6 +267,40 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     async (req, reply) => {
       const live = getSession(req.params.id);
       if (live !== undefined) {
+        try {
+          await rejectOrDisposeExternallyActiveSession(
+            req.params.id,
+            live.projectId,
+            live.workspacePath,
+          );
+        } catch (err) {
+          if (!(err instanceof ExternalSubagentActiveError)) throw err;
+          const loc = await findSessionLocation(req.params.id);
+          if (loc === undefined) return notFound(reply);
+          const list = await listSessionsForProject(loc.projectId, loc.workspacePath);
+          const match = list.find((s) => s.sessionId === req.params.id);
+          if (match === undefined) return notFound(reply);
+          const external = await getExternalSubagentStatusForSession({
+            runId: match.runId,
+            path: match.path,
+          });
+          const bodyArgs: Parameters<typeof liveSummaryBody>[0] = {
+            sessionId: match.sessionId,
+            projectId: match.projectId,
+            workspacePath: match.workspacePath,
+            createdAt: match.createdAt,
+            lastActivityAt: match.lastActivityAt,
+            name: match.name,
+            messageCount: match.messageCount,
+            isStreaming: false,
+            isLive: false,
+          };
+          if (external !== undefined) {
+            bodyArgs.isExternalLive = external.isExternalLive;
+            bodyArgs.externalState = external.state;
+          }
+          return liveSummaryBody(bodyArgs);
+        }
         return liveSummaryBody({
           sessionId: live.sessionId,
           projectId: live.projectId,
@@ -321,7 +376,18 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const live = getSession(req.params.id);
-      if (live !== undefined) return { messages: live.session.messages };
+      if (live !== undefined) {
+        try {
+          await rejectOrDisposeExternallyActiveSession(
+            req.params.id,
+            live.projectId,
+            live.workspacePath,
+          );
+          return { messages: live.session.messages };
+        } catch (err) {
+          if (!(err instanceof ExternalSubagentActiveError)) throw err;
+        }
+      }
       const loc = await findSessionLocation(req.params.id);
       if (loc === undefined) return notFound(reply);
       const list = await listSessionsForProject(loc.projectId, loc.workspacePath);
@@ -400,6 +466,9 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     async (req, reply) => {
       const live = getSession(req.params.id);
       if (live === undefined) return notFound(reply);
+      if (await rejectExternalIfNeeded(req.params.id, live.projectId, live.workspacePath, reply)) {
+        return reply;
+      }
       return { compactions: buildCompactionHistory(live.session) };
     },
   );
@@ -450,6 +519,9 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     async (req, reply) => {
       const live = getSession(req.params.id);
       if (live === undefined) return notFound(reply);
+      if (await rejectExternalIfNeeded(req.params.id, live.projectId, live.workspacePath, reply)) {
+        return reply;
+      }
       const entries = await buildTurnDiff(
         live.session,
         live.workspacePath,
@@ -513,6 +585,13 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       let live = getSession(req.params.id);
+      if (live !== undefined) {
+        if (
+          await rejectExternalIfNeeded(req.params.id, live.projectId, live.workspacePath, reply)
+        ) {
+          return reply;
+        }
+      }
       if (live === undefined) {
         try {
           live = await resumeSessionById(req.params.id);
@@ -658,6 +737,13 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       let live = getSession(req.params.id);
+      if (live !== undefined) {
+        if (
+          await rejectExternalIfNeeded(req.params.id, live.projectId, live.workspacePath, reply)
+        ) {
+          return reply;
+        }
+      }
       if (live === undefined) {
         try {
           live = await resumeSessionById(req.params.id);
@@ -781,6 +867,9 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     async (req, reply) => {
       const live = getSession(req.params.id);
       if (live === undefined) return notFound(reply);
+      if (await rejectExternalIfNeeded(req.params.id, live.projectId, live.workspacePath, reply)) {
+        return reply;
+      }
       live.session.setSessionName(req.body.name);
       return liveSummaryBody({
         sessionId: live.sessionId,

--- a/packages/server/src/routes/stream.ts
+++ b/packages/server/src/routes/stream.ts
@@ -3,6 +3,7 @@ import {
   resumeSessionById,
   SessionNotFoundError,
   SessionTombstonedError,
+  ExternalSubagentActiveError,
 } from "../session-registry.js";
 import { createSSEClient } from "../sse-bridge.js";
 import { errorSchema } from "./_schemas.js";
@@ -59,6 +60,9 @@ export const streamRoutes: FastifyPluginAsync = async (fastify) => {
       } catch (err) {
         if (err instanceof SessionNotFoundError) {
           return reply.code(404).send({ error: "session_not_found" });
+        }
+        if (err instanceof ExternalSubagentActiveError) {
+          return reply.code(409).send({ error: "external_subagent_active" });
         }
         if (err instanceof SessionTombstonedError) {
           // The session was disposed within the tombstone window

--- a/packages/server/src/routes/stream.ts
+++ b/packages/server/src/routes/stream.ts
@@ -1,11 +1,18 @@
-import type { FastifyPluginAsync } from "fastify";
+import { watch, type FSWatcher } from "node:fs";
+import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import {
+  findSessionLocation,
+  listSessionsForProject,
   resumeSessionById,
   SessionNotFoundError,
   SessionTombstonedError,
   ExternalSubagentActiveError,
 } from "../session-registry.js";
-import { createSSEClient } from "../sse-bridge.js";
+import { createSSEClient, serializeSSE } from "../sse-bridge.js";
+import {
+  getExternalSubagentStatusForSession,
+  readSessionMessagesFromDisk,
+} from "../subagents-external.js";
 import { errorSchema } from "./_schemas.js";
 
 /**
@@ -15,6 +22,75 @@ import { errorSchema } from "./_schemas.js";
  * only when no project on disk owns the id; 500 with a stable code when
  * the resume itself fails (corrupt JSONL, SDK error).
  */
+async function createReadOnlyExternalSubagentSSE(
+  reply: FastifyReply,
+  sessionId: string,
+): Promise<boolean> {
+  const loc = await findSessionLocation(sessionId);
+  if (loc === undefined) return false;
+  const sessions = await listSessionsForProject(loc.projectId, loc.workspacePath);
+  const match = sessions.find((s) => s.sessionId === sessionId);
+  if (match?.path === undefined) return false;
+  const sessionPath = match.path;
+  const external = await getExternalSubagentStatusForSession({
+    runId: match.runId,
+    path: sessionPath,
+  });
+  if (external?.isExternalLive !== true) return false;
+
+  reply.hijack();
+  const raw = reply.raw;
+  let watcher: FSWatcher | undefined;
+  let closed = false;
+
+  const close = (): void => {
+    if (closed) return;
+    closed = true;
+    watcher?.close();
+    watcher = undefined;
+    try {
+      raw.end();
+    } catch {
+      // ignore
+    }
+  };
+  const sendSnapshot = (): void => {
+    if (closed) return;
+    try {
+      raw.write(
+        serializeSSE({
+          type: "snapshot",
+          sessionId,
+          projectId: loc.projectId,
+          messages: readSessionMessagesFromDisk(sessionPath, loc.workspacePath),
+          isStreaming: false,
+          readOnly: true,
+          isExternalLive: true,
+          externalState: external.state,
+        }),
+      );
+    } catch {
+      close();
+    }
+  };
+
+  raw.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+    "X-Accel-Buffering": "no",
+  });
+  sendSnapshot();
+  try {
+    watcher = watch(sessionPath, sendSnapshot);
+    watcher.unref?.();
+  } catch {
+    // A one-shot read-only snapshot is still better than resuming the child.
+  }
+  raw.on("close", close);
+  return true;
+}
+
 export const streamRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Params: { id: string } }>(
     "/sessions/:id/stream",
@@ -62,6 +138,7 @@ export const streamRoutes: FastifyPluginAsync = async (fastify) => {
           return reply.code(404).send({ error: "session_not_found" });
         }
         if (err instanceof ExternalSubagentActiveError) {
+          if (await createReadOnlyExternalSubagentSSE(reply, req.params.id)) return reply;
           return reply.code(409).send({ error: "external_subagent_active" });
         }
         if (err instanceof SessionTombstonedError) {

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -806,11 +806,62 @@ function getForkLock(sessionId: string): Lock {
  * Concurrent calls for the same sessionId share a single in-flight
  * AgentSession creation — see resumeInflight.
  */
+async function externallyActiveDiscoveredSession(
+  sessionId: string,
+  projectId: string,
+  workspacePath: string,
+): Promise<DiscoveredSession | undefined> {
+  const discovered = await discoverSessionsOnDisk(projectId, workspacePath);
+  const match = discovered.find((s) => s.sessionId === sessionId);
+  if (match === undefined) return undefined;
+  const external = await getExternalSubagentStatusForSession({
+    runId: match.runId,
+    path: match.path,
+  });
+  return external?.isExternalLive === true ? match : undefined;
+}
+
+function detachExternallyActiveLiveSession(sessionId: string): void {
+  const live = registry.get(sessionId);
+  if (live === undefined) return;
+
+  // Do NOT call disposeSession(), AgentSession.abort(), AgentSession.dispose(),
+  // or processManager.disposeSession() here. If pi-subagents is already running
+  // this child externally, pi-forge must stop managing its in-memory view without
+  // sending any lifecycle signal that could abort/kill the external execution.
+  try {
+    live.unsubscribe();
+  } catch {
+    // ignore
+  }
+  for (const client of live.clients) {
+    try {
+      client.close();
+    } catch {
+      // ignore
+    }
+  }
+  live.clients.clear();
+  registry.delete(sessionId);
+}
+
+export async function rejectOrDisposeExternallyActiveSession(
+  sessionId: string,
+  projectId: string,
+  workspacePath: string,
+): Promise<void> {
+  const match = await externallyActiveDiscoveredSession(sessionId, projectId, workspacePath);
+  if (match === undefined) return;
+  detachExternallyActiveLiveSession(sessionId);
+  throw new ExternalSubagentActiveError(sessionId);
+}
+
 export async function resumeSession(
   sessionId: string,
   projectId: string,
   workspacePath: string,
 ): Promise<LiveSession> {
+  await rejectOrDisposeExternallyActiveSession(sessionId, projectId, workspacePath);
   const existing = registry.get(sessionId);
   if (existing) return existing;
 
@@ -823,6 +874,7 @@ export async function resumeSession(
   return resumeInflight(sessionId, async () => {
     // Re-check after lock acquisition: another resume may have raced
     // ahead and populated the registry while we were queued.
+    await rejectOrDisposeExternallyActiveSession(sessionId, projectId, workspacePath);
     const raced = registry.get(sessionId);
     if (raced) return raced;
 
@@ -1481,10 +1533,11 @@ export async function findSessionLocation(
  * receive projectId in the URL (the stream route specifically).
  */
 export async function resumeSessionById(sessionId: string): Promise<LiveSession> {
-  const existing = registry.get(sessionId);
-  if (existing) return existing;
   const loc = await findSessionLocation(sessionId);
   if (loc === undefined) throw new SessionNotFoundError(sessionId);
+  await rejectOrDisposeExternallyActiveSession(sessionId, loc.projectId, loc.workspacePath);
+  const existing = registry.get(sessionId);
+  if (existing) return existing;
   return resumeSession(sessionId, loc.projectId, loc.workspacePath);
 }
 

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -37,6 +37,7 @@ import { createOrchestrationTools } from "./orchestration/tools.js";
 import { bridgeWorkerAgentEvent } from "./orchestration/event-bridge.js";
 import { notifySupervisorDisposed, notifySupervisorIdle } from "./orchestration/inbox.js";
 import { archiveSessionFiles } from "./session-archive.js";
+import { getExternalSubagentStatusForSession } from "./subagents-external.js";
 
 /**
  * Minimal SSE client contract used by the registry to fan out events.
@@ -101,6 +102,10 @@ export interface DiscoveredSession {
   parentSessionId?: string;
   /** The pi-subagents run id (the directory between parent and child). */
   runId?: string;
+  /** True when pi-subagents authoritative status says this child is queued/running externally. */
+  isExternalLive?: boolean;
+  /** Authoritative pi-subagents async status state when known. */
+  externalState?: "queued" | "running" | "complete" | "failed" | "paused";
 }
 
 /**
@@ -127,6 +132,10 @@ export interface UnifiedSession {
   parentSessionId?: string;
   /** pi-subagents run id when this is a child session. */
   runId?: string;
+  /** True when pi-subagents authoritative status says this child is queued/running externally. */
+  isExternalLive?: boolean;
+  /** Authoritative pi-subagents async status state when known. */
+  externalState?: "queued" | "running" | "complete" | "failed" | "paused";
   /**
    * Absolute path to the session JSONL on disk. Surfaced so the
    * client can resolve a `sessionFile` reference (e.g. from a
@@ -155,6 +164,13 @@ export class EntryNotFoundError extends Error {
   constructor(id: string) {
     super(`entry not found: ${id}`);
     this.name = "EntryNotFoundError";
+  }
+}
+
+export class ExternalSubagentActiveError extends Error {
+  constructor(id: string) {
+    super(`external subagent is active: ${id}`);
+    this.name = "ExternalSubagentActiveError";
   }
 }
 
@@ -845,6 +861,14 @@ export async function resumeSession(
       }) + "\n",
     );
 
+    const external = await getExternalSubagentStatusForSession({
+      runId: match.runId,
+      path: match.path,
+    });
+    if (external?.isExternalLive === true) {
+      throw new ExternalSubagentActiveError(sessionId);
+    }
+
     // For child sessions, hand SessionManager.open the *child's* run
     // dir as the sessionDir so any subsequent file operations the SDK
     // performs land alongside the existing JSONL rather than in the
@@ -1342,6 +1366,11 @@ export async function listSessionsForProject(
       merged.firstMessage = d.firstMessage;
       if (d.parentSessionId !== undefined) merged.parentSessionId = d.parentSessionId;
       if (d.runId !== undefined) merged.runId = d.runId;
+      const external = await getExternalSubagentStatusForSession({ runId: d.runId, path: d.path });
+      if (external !== undefined) {
+        merged.externalState = external.state;
+        merged.isExternalLive = external.isExternalLive;
+      }
       merged.path = d.path;
       continue;
     }
@@ -1359,6 +1388,11 @@ export async function listSessionsForProject(
     };
     if (d.parentSessionId !== undefined) u.parentSessionId = d.parentSessionId;
     if (d.runId !== undefined) u.runId = d.runId;
+    const external = await getExternalSubagentStatusForSession({ runId: d.runId, path: d.path });
+    if (external !== undefined) {
+      u.externalState = external.state;
+      u.isExternalLive = external.isExternalLive;
+    }
     liveById.set(d.sessionId, u);
   }
 

--- a/packages/server/src/subagents-external.ts
+++ b/packages/server/src/subagents-external.ts
@@ -1,0 +1,264 @@
+import { existsSync, watch, type FSWatcher } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import * as os from "node:os";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { getSession } from "./session-registry.js";
+
+export type ExternalSubagentState = "queued" | "running" | "complete" | "failed" | "paused";
+
+export interface ExternalSubagentStatus {
+  runId: string;
+  rootRunId: string;
+  state: ExternalSubagentState;
+  isExternalLive: boolean;
+  statusPath: string;
+  resultPath?: string;
+  parentSessionId?: string;
+  sessionFile?: string;
+}
+
+interface AsyncStatusFile {
+  runId?: string;
+  sessionId?: string;
+  state?: ExternalSubagentState;
+  sessionFile?: string;
+  steps?: { sessionFile?: string; status?: string }[];
+}
+
+interface AsyncResultFile {
+  id?: string;
+  runId?: string;
+  agent?: string;
+  success?: boolean;
+  summary?: string;
+  state?: string;
+  sessionId?: string;
+  sessionFile?: string;
+  results?: {
+    agent?: string;
+    output?: string;
+    success?: boolean;
+    error?: string;
+    sessionFile?: string;
+  }[];
+}
+
+function sanitizeTempScopeSegment(value: string): string {
+  const sanitized = value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized || "unknown";
+}
+
+function resolveTempScopeId(): string {
+  if (typeof process.getuid === "function") return `uid-${process.getuid()}`;
+  for (const key of ["USERNAME", "USER", "LOGNAME"] as const) {
+    const value = process.env[key];
+    if (value) return `user-${sanitizeTempScopeSegment(value)}`;
+  }
+  try {
+    const username = os.userInfo().username;
+    if (username) return `user-${sanitizeTempScopeSegment(username)}`;
+  } catch {
+    // fall through
+  }
+  const homedir = process.env.USERPROFILE ?? process.env.HOME ?? os.homedir();
+  if (homedir) return `home-${sanitizeTempScopeSegment(homedir)}`;
+  return "shared";
+}
+
+export const SUBAGENTS_TEMP_ROOT = join(os.tmpdir(), `pi-subagents-${resolveTempScopeId()}`);
+export const SUBAGENTS_RESULTS_DIR = join(SUBAGENTS_TEMP_ROOT, "async-subagent-results");
+export const SUBAGENTS_ASYNC_DIR = join(SUBAGENTS_TEMP_ROOT, "async-subagent-runs");
+
+const TERMINAL_STATES = new Set<ExternalSubagentState>(["complete", "failed", "paused"]);
+const ACTIVE_STATES = new Set<ExternalSubagentState>(["queued", "running"]);
+const deliveredCompletionKeys = new Set<string>();
+let watcherStarted = false;
+let asyncWatcher: FSWatcher | undefined;
+let resultsWatcher: FSWatcher | undefined;
+let scanTimer: NodeJS.Timeout | undefined;
+
+function rootRunId(runId: string | undefined): string | undefined {
+  return runId?.split(/[\\/]/, 1)[0];
+}
+
+function isExternalState(value: unknown): value is ExternalSubagentState {
+  return (
+    value === "queued" ||
+    value === "running" ||
+    value === "complete" ||
+    value === "failed" ||
+    value === "paused"
+  );
+}
+
+async function readJson<T>(path: string): Promise<T | undefined> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readStatusByRoot(root: string): Promise<ExternalSubagentStatus | undefined> {
+  const statusPath = join(SUBAGENTS_ASYNC_DIR, root, "status.json");
+  const status = await readJson<AsyncStatusFile>(statusPath);
+  if (!isExternalState(status?.state)) return undefined;
+  const resultPath = join(SUBAGENTS_RESULTS_DIR, `${root}.json`);
+  const out: ExternalSubagentStatus = {
+    runId: status.runId ?? root,
+    rootRunId: root,
+    state: status.state,
+    isExternalLive: ACTIVE_STATES.has(status.state),
+    statusPath,
+  };
+  if (existsSync(resultPath)) out.resultPath = resultPath;
+  if (typeof status.sessionId === "string") out.parentSessionId = status.sessionId;
+  if (typeof status.sessionFile === "string") out.sessionFile = status.sessionFile;
+  return out;
+}
+
+function statusMatchesSession(
+  status: ExternalSubagentStatus,
+  sessionPath: string | undefined,
+): boolean {
+  if (sessionPath === undefined) return true;
+  if (status.sessionFile === sessionPath) return true;
+  return true;
+}
+
+export async function getExternalSubagentStatusForRun(
+  runId: string | undefined,
+): Promise<ExternalSubagentStatus | undefined> {
+  const root = rootRunId(runId);
+  if (root === undefined || root.length === 0) return undefined;
+  return readStatusByRoot(root);
+}
+
+export async function getExternalSubagentStatusForSession(info: {
+  runId?: string | undefined;
+  path?: string | undefined;
+}): Promise<ExternalSubagentStatus | undefined> {
+  const status = await getExternalSubagentStatusForRun(info.runId);
+  if (status === undefined) return undefined;
+  if (!statusMatchesSession(status, info.path)) return undefined;
+  return status;
+}
+
+export async function isExternallyActiveSubagentSession(info: {
+  runId?: string | undefined;
+  path?: string | undefined;
+}): Promise<boolean> {
+  const status = await getExternalSubagentStatusForSession(info);
+  return status?.isExternalLive === true;
+}
+
+export function readSessionMessagesFromDisk(
+  sessionPath: string,
+  workspacePath: string,
+): AgentMessage[] {
+  const manager = SessionManager.open(sessionPath, undefined, workspacePath);
+  return manager.buildSessionContext().messages;
+}
+
+function formatCompletionContent(
+  result: AsyncResultFile | undefined,
+  status: ExternalSubagentStatus,
+): string {
+  const state =
+    result?.state === "paused" || status.state === "paused"
+      ? "paused"
+      : result?.success === false || status.state === "failed"
+        ? "failed"
+        : "completed";
+  const agent = result?.agent ?? result?.results?.[0]?.agent ?? "subagent";
+  const summary =
+    result?.summary ??
+    result?.results?.[0]?.output ??
+    result?.results?.[0]?.error ??
+    `(background run ${status.rootRunId} ${state})`;
+  const sessionFile =
+    result?.sessionFile ??
+    result?.results?.find((r) => typeof r.sessionFile === "string")?.sessionFile ??
+    status.sessionFile;
+  return [
+    `Background task ${state}: **${agent}**`,
+    "",
+    summary.trim() || "(no output)",
+    sessionFile ? "" : undefined,
+    sessionFile ? `Session file: ${sessionFile}` : undefined,
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
+}
+
+export async function deliverExternalSubagentCompletionForRun(root: string): Promise<void> {
+  const status = await readStatusByRoot(root);
+  if (status === undefined || !TERMINAL_STATES.has(status.state)) return;
+  const resultPath = join(SUBAGENTS_RESULTS_DIR, `${root}.json`);
+  const result = await readJson<AsyncResultFile>(resultPath);
+  const parentId = result?.sessionId ?? status.parentSessionId;
+  if (parentId === undefined) return;
+  const live = getSession(parentId);
+  if (live === undefined) return;
+  const key = `${parentId}:${root}:${status.state}`;
+  if (deliveredCompletionKeys.has(key)) return;
+  deliveredCompletionKeys.add(key);
+  const content = formatCompletionContent(result, status);
+  await live.session.sendCustomMessage(
+    { customType: "subagent-notify", content, display: true },
+    { triggerTurn: false },
+  );
+  for (const c of live.clients) {
+    c.send({
+      type: "session_list_changed",
+      sessionId: parentId,
+      projectId: live.projectId,
+      reason: "subagent_async_complete",
+    });
+  }
+}
+
+async function scanTerminalCompletions(): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(SUBAGENTS_ASYNC_DIR);
+  } catch {
+    return;
+  }
+  await Promise.all(entries.map((root) => deliverExternalSubagentCompletionForRun(root)));
+}
+
+export function startExternalSubagentsWatcher(): void {
+  if (watcherStarted) return;
+  watcherStarted = true;
+  void scanTerminalCompletions();
+  scanTimer = setInterval(() => void scanTerminalCompletions(), 3000);
+  scanTimer.unref?.();
+  try {
+    asyncWatcher = watch(SUBAGENTS_ASYNC_DIR, () => void scanTerminalCompletions());
+    asyncWatcher.unref?.();
+  } catch {
+    // Directory may not exist until pi-subagents first runs. Explicit checks in routes still work.
+  }
+  try {
+    resultsWatcher = watch(SUBAGENTS_RESULTS_DIR, () => void scanTerminalCompletions());
+    resultsWatcher.unref?.();
+  } catch {
+    // Result files are optional and may be consumed by pi-subagents itself.
+  }
+}
+
+export function stopExternalSubagentsWatcher(): void {
+  asyncWatcher?.close();
+  resultsWatcher?.close();
+  if (scanTimer !== undefined) clearInterval(scanTimer);
+  asyncWatcher = undefined;
+  resultsWatcher = undefined;
+  scanTimer = undefined;
+  watcherStarted = false;
+}

--- a/packages/server/src/subagents-external.ts
+++ b/packages/server/src/subagents-external.ts
@@ -77,6 +77,7 @@ export const SUBAGENTS_ASYNC_DIR = join(SUBAGENTS_TEMP_ROOT, "async-subagent-run
 const TERMINAL_STATES = new Set<ExternalSubagentState>(["complete", "failed", "paused"]);
 const ACTIVE_STATES = new Set<ExternalSubagentState>(["queued", "running"]);
 const deliveredCompletionKeys = new Set<string>();
+const deliveredSessionListKeys = new Set<string>();
 let watcherStarted = false;
 let asyncWatcher: FSWatcher | undefined;
 let resultsWatcher: FSWatcher | undefined;
@@ -127,8 +128,49 @@ function statusMatchesSession(
   sessionPath: string | undefined,
 ): boolean {
   if (sessionPath === undefined) return true;
-  if (status.sessionFile === sessionPath) return true;
-  return true;
+  return status.sessionFile === sessionPath;
+}
+
+async function readStatusRoots(): Promise<string[]> {
+  try {
+    return await readdir(SUBAGENTS_ASYNC_DIR);
+  } catch {
+    return [];
+  }
+}
+
+function statusFileSessionPaths(status: AsyncStatusFile): string[] {
+  const paths: string[] = [];
+  if (typeof status.sessionFile === "string") paths.push(status.sessionFile);
+  for (const step of status.steps ?? []) {
+    if (typeof step.sessionFile === "string") paths.push(step.sessionFile);
+  }
+  return paths;
+}
+
+async function readStatusByRootForSessionPath(
+  root: string,
+  sessionPath: string,
+): Promise<ExternalSubagentStatus | undefined> {
+  const statusPath = join(SUBAGENTS_ASYNC_DIR, root, "status.json");
+  const raw = await readJson<AsyncStatusFile>(statusPath);
+  if (!isExternalState(raw?.state)) return undefined;
+  if (!statusFileSessionPaths(raw).includes(sessionPath)) return undefined;
+  const base = await readStatusByRoot(root);
+  if (base === undefined) return undefined;
+  return { ...base, sessionFile: sessionPath };
+}
+
+async function findExternalSubagentStatusForSessionPath(
+  sessionPath: string | undefined,
+): Promise<ExternalSubagentStatus | undefined> {
+  if (sessionPath === undefined) return undefined;
+  const roots = await readStatusRoots();
+  for (const root of roots) {
+    const status = await readStatusByRootForSessionPath(root, sessionPath);
+    if (status !== undefined) return status;
+  }
+  return undefined;
 }
 
 export async function getExternalSubagentStatusForRun(
@@ -144,9 +186,14 @@ export async function getExternalSubagentStatusForSession(info: {
   path?: string | undefined;
 }): Promise<ExternalSubagentStatus | undefined> {
   const status = await getExternalSubagentStatusForRun(info.runId);
-  if (status === undefined) return undefined;
-  if (!statusMatchesSession(status, info.path)) return undefined;
-  return status;
+  if (status !== undefined && statusMatchesSession(status, info.path)) return status;
+
+  // pi-subagents async status run ids are not always the same as the nested
+  // session directory segments that pi-forge discovers in the sidebar. In
+  // current pi-subagents, status.json can identify the child by exact
+  // `steps[].sessionFile` instead. That path match is the authoritative signal
+  // for protecting an externally running child.
+  return findExternalSubagentStatusForSessionPath(info.path);
 }
 
 export async function isExternallyActiveSubagentSession(info: {
@@ -196,22 +243,69 @@ function formatCompletionContent(
     .join("\n");
 }
 
+async function sessionIdFromSessionReference(ref: string | undefined): Promise<string | undefined> {
+  if (ref === undefined) return undefined;
+  if (getSession(ref) !== undefined) return ref;
+  try {
+    const firstLine = (await readFile(ref, "utf8")).split(/\r?\n/, 1)[0];
+    if (firstLine === undefined) return undefined;
+    const header = JSON.parse(firstLine) as { type?: unknown; id?: unknown };
+    return header.type === "session" && typeof header.id === "string" ? header.id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasDeliveredCompletionMessage(
+  messages: readonly AgentMessage[],
+  root: string,
+  state: ExternalSubagentState,
+  content: string,
+): boolean {
+  return messages.some((message) => {
+    if (message.role !== "custom" || message.customType !== "subagent-notify") return false;
+    const details = message.details as
+      | { source?: unknown; runId?: unknown; state?: unknown }
+      | undefined;
+    if (details?.source === "pi-subagents" && details.runId === root && details.state === state) {
+      return true;
+    }
+
+    // Backward-compatible durable dedupe for notifications written before we
+    // started persisting run metadata in details. This also covers SDK versions
+    // that might omit details from rebuilt custom-message state. The formatted
+    // completion includes the child session file when available, so exact
+    // content matching is stable enough to prevent restart replays without
+    // suppressing unrelated runs.
+    return message.content === content;
+  });
+}
+
 export async function deliverExternalSubagentCompletionForRun(root: string): Promise<void> {
   const status = await readStatusByRoot(root);
   if (status === undefined || !TERMINAL_STATES.has(status.state)) return;
   const resultPath = join(SUBAGENTS_RESULTS_DIR, `${root}.json`);
   const result = await readJson<AsyncResultFile>(resultPath);
-  const parentId = result?.sessionId ?? status.parentSessionId;
+  const parentId = await sessionIdFromSessionReference(result?.sessionId ?? status.parentSessionId);
   if (parentId === undefined) return;
   const live = getSession(parentId);
   if (live === undefined) return;
   const key = `${parentId}:${root}:${status.state}`;
   if (deliveredCompletionKeys.has(key)) return;
-  deliveredCompletionKeys.add(key);
   const content = formatCompletionContent(result, status);
+  if (hasDeliveredCompletionMessage(live.session.messages, root, status.state, content)) {
+    deliveredCompletionKeys.add(key);
+    return;
+  }
+  deliveredCompletionKeys.add(key);
   await live.session.sendCustomMessage(
-    { customType: "subagent-notify", content, display: true },
-    { triggerTurn: false },
+    {
+      customType: "subagent-notify",
+      content,
+      display: true,
+      details: { source: "pi-subagents", runId: root, state: status.state },
+    },
+    { triggerTurn: true },
   );
   for (const c of live.clients) {
     c.send({
@@ -223,30 +317,57 @@ export async function deliverExternalSubagentCompletionForRun(root: string): Pro
   }
 }
 
-async function scanTerminalCompletions(): Promise<void> {
+async function deliverExternalSubagentSessionListChange(root: string): Promise<void> {
+  const status = await readStatusByRoot(root);
+  if (status === undefined) return;
+  const parentId = await sessionIdFromSessionReference(status.parentSessionId);
+  if (parentId === undefined) return;
+  const live = getSession(parentId);
+  if (live === undefined) return;
+  const key = `${parentId}:${root}:${status.state}`;
+  if (TERMINAL_STATES.has(status.state)) {
+    if (deliveredSessionListKeys.has(key)) return;
+    deliveredSessionListKeys.add(key);
+  }
+  for (const c of live.clients) {
+    c.send({
+      type: "session_list_changed",
+      sessionId: parentId,
+      projectId: live.projectId,
+      reason: `subagent_async_${status.state}`,
+    });
+  }
+}
+
+async function scanSubagentRuns(): Promise<void> {
   let entries: string[];
   try {
     entries = await readdir(SUBAGENTS_ASYNC_DIR);
   } catch {
     return;
   }
-  await Promise.all(entries.map((root) => deliverExternalSubagentCompletionForRun(root)));
+  await Promise.all(
+    entries.map(async (root) => {
+      await deliverExternalSubagentSessionListChange(root);
+      await deliverExternalSubagentCompletionForRun(root);
+    }),
+  );
 }
 
 export function startExternalSubagentsWatcher(): void {
   if (watcherStarted) return;
   watcherStarted = true;
-  void scanTerminalCompletions();
-  scanTimer = setInterval(() => void scanTerminalCompletions(), 3000);
+  void scanSubagentRuns();
+  scanTimer = setInterval(() => void scanSubagentRuns(), 3000);
   scanTimer.unref?.();
   try {
-    asyncWatcher = watch(SUBAGENTS_ASYNC_DIR, () => void scanTerminalCompletions());
+    asyncWatcher = watch(SUBAGENTS_ASYNC_DIR, () => void scanSubagentRuns());
     asyncWatcher.unref?.();
   } catch {
     // Directory may not exist until pi-subagents first runs. Explicit checks in routes still work.
   }
   try {
-    resultsWatcher = watch(SUBAGENTS_RESULTS_DIR, () => void scanTerminalCompletions());
+    resultsWatcher = watch(SUBAGENTS_RESULTS_DIR, () => void scanSubagentRuns());
     resultsWatcher.unref?.();
   } catch {
     // Result files are optional and may be consumed by pi-subagents itself.

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -102,6 +102,7 @@ interface TestRegistry {
   disposeSession: (id: string) => Promise<boolean>;
   disposeAllSessions: () => Promise<void>;
   resumeSession: (id: string, projectId: string, workspacePath: string) => Promise<TestLive>;
+  resumeSessionById: (id: string) => Promise<TestLive>;
   discoverSessionsOnDisk: (projectId: string, workspacePath: string) => Promise<TestDiscovered[]>;
   listSessionsForProject: (
     projectId: string,
@@ -349,6 +350,43 @@ async function main(): Promise<void> {
       "resumeSession returns a LiveSession for the child",
       resumed.sessionId === childA,
       `got ${resumed.sessionId}`,
+    );
+
+    await writeFile(
+      join(subagentsExternal.SUBAGENTS_ASYNC_DIR, runId, "status.json"),
+      JSON.stringify({
+        runId,
+        sessionId: parent.sessionId,
+        state: "running",
+        sessionFile: childAPath,
+      }),
+      "utf8",
+    );
+    try {
+      await registry.resumeSessionById(childA);
+      assert(
+        "resumeSessionById rejects and removes existing live child when status becomes running",
+        false,
+        "resume unexpectedly succeeded",
+      );
+    } catch (err) {
+      assert(
+        "resumeSessionById rejects and removes existing live child when status becomes running",
+        err instanceof Error &&
+          err.name === "ExternalSubagentActiveError" &&
+          registry.getSession(childA) === undefined,
+        `err=${err instanceof Error ? err.name : String(err)} live=${registry.getSession(childA) !== undefined}`,
+      );
+    }
+    await writeFile(
+      join(subagentsExternal.SUBAGENTS_ASYNC_DIR, runId, "status.json"),
+      JSON.stringify({
+        runId,
+        sessionId: parent.sessionId,
+        state: "complete",
+        sessionFile: childAPath,
+      }),
+      "utf8",
     );
 
     // 7. REALISTIC pi-subagents layout: the plugin's

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -78,6 +78,7 @@ interface TestLive {
   session: {
     sessionId: string;
     sessionFile?: string;
+    messages?: unknown[];
     sessionManager: { appendMessage: (msg: unknown) => string };
   };
   sessionId: string;
@@ -92,6 +93,9 @@ interface TestUnifiedSession {
   sessionId: string;
   parentSessionId?: string;
   runId?: string;
+  isLive?: boolean;
+  isExternalLive?: boolean;
+  externalState?: "queued" | "running" | "complete" | "failed" | "paused";
 }
 interface TestRegistry {
   createSession: (projectId: string, workspacePath: string) => Promise<TestLive>;
@@ -151,6 +155,13 @@ async function main(): Promise<void> {
   const orchestrationStore = (await import(
     resolve(repoRoot, "packages/server/dist/orchestration/store.js")
   )) as unknown as TestOrchestrationStore;
+  const subagentsExternal = (await import(
+    resolve(repoRoot, "packages/server/dist/subagents-external.js")
+  )) as {
+    SUBAGENTS_ASYNC_DIR: string;
+    SUBAGENTS_RESULTS_DIR: string;
+    deliverExternalSubagentCompletionForRun: (runId: string) => Promise<void>;
+  };
 
   // Register the project so findSessionLocation can locate children.
   const project = await pm.createProject("test-subagent-project", workspacePath);
@@ -251,7 +262,88 @@ async function main(): Promise<void> {
       `loc=${JSON.stringify(loc)}`,
     );
 
-    // 5. resumeSession opens the child as a LiveSession (registry hit).
+    // 5. Authoritative pi-subagents status.json marks queued/running children as
+    // externally live without polluting the pi-forge live registry.
+    await mkdir(join(subagentsExternal.SUBAGENTS_ASYNC_DIR, runId), { recursive: true });
+    await writeFile(
+      join(subagentsExternal.SUBAGENTS_ASYNC_DIR, runId, "status.json"),
+      JSON.stringify({
+        runId,
+        sessionId: parent.sessionId,
+        state: "running",
+        sessionFile: childAPath,
+      }),
+      "utf8",
+    );
+    const activeList = await registry.listSessionsForProject(project.id, project.path);
+    const activeChild = activeList.find((s) => s.sessionId === childA);
+    assert(
+      "running pi-subagents child isExternalLive=true but isLive=false",
+      activeChild?.isExternalLive === true &&
+        activeChild?.isLive === false &&
+        activeChild.externalState === "running",
+      `row=${JSON.stringify(activeChild)}`,
+    );
+    try {
+      await registry.resumeSession(childA, project.id, project.path);
+      assert(
+        "resumeSession rejects externally running child",
+        false,
+        "resume unexpectedly succeeded",
+      );
+    } catch (err) {
+      assert(
+        "resumeSession rejects externally running child",
+        err instanceof Error && err.name === "ExternalSubagentActiveError",
+        `err=${err instanceof Error ? err.name : String(err)}`,
+      );
+    }
+    await writeFile(
+      join(subagentsExternal.SUBAGENTS_ASYNC_DIR, runId, "status.json"),
+      JSON.stringify({
+        runId,
+        sessionId: parent.sessionId,
+        state: "complete",
+        sessionFile: childAPath,
+      }),
+      "utf8",
+    );
+    await mkdir(subagentsExternal.SUBAGENTS_RESULTS_DIR, { recursive: true });
+    await writeFile(
+      join(subagentsExternal.SUBAGENTS_RESULTS_DIR, `${runId}.json`),
+      JSON.stringify({
+        runId,
+        sessionId: parent.sessionId,
+        agent: "reviewer",
+        success: true,
+        summary: "done",
+        sessionFile: childAPath,
+      }),
+      "utf8",
+    );
+    await subagentsExternal.deliverExternalSubagentCompletionForRun(runId);
+    const notifyMessage = parent.session.messages?.find(
+      (m) =>
+        typeof m === "object" &&
+        m !== null &&
+        (m as { customType?: unknown }).customType === "subagent-notify",
+    ) as { content?: unknown } | undefined;
+    assert(
+      "explicit async completion path appends renderable subagent-notify to parent",
+      typeof notifyMessage?.content === "string" &&
+        notifyMessage.content.includes("Background task completed"),
+      `message=${JSON.stringify(notifyMessage)}`,
+    );
+
+    const completeList = await registry.listSessionsForProject(project.id, project.path);
+    const completeChild = completeList.find((s) => s.sessionId === childA);
+    assert(
+      "terminal pi-subagents status clears isExternalLive",
+      completeChild?.isExternalLive === false && completeChild.externalState === "complete",
+      `row=${JSON.stringify(completeChild)}`,
+    );
+
+    // 6. resumeSession opens the completed child as a LiveSession (registry hit).
     const resumed = await registry.resumeSession(childA, project.id, project.path);
     assert(
       "resumeSession returns a LiveSession for the child",
@@ -259,7 +351,7 @@ async function main(): Promise<void> {
       `got ${resumed.sessionId}`,
     );
 
-    // 6. REALISTIC pi-subagents layout: the plugin's
+    // 7. REALISTIC pi-subagents layout: the plugin's
     // `getSubagentSessionRoot` names the child dir using the parent
     // FILE's full basename (timestamp + id), not the bare parent id.
     // The discovery has to map basename → parent's actual sessionId
@@ -295,7 +387,7 @@ async function main(): Promise<void> {
       `got parentSessionId=${realisticChildEntry?.parentSessionId} expected=${realisticParentId}`,
     );
 
-    // 7a. DEEP layout (parallel/chain mode):
+    // 8a. DEEP layout (parallel/chain mode):
     //     <basename>/<runId>/run-N/session.jsonl. Three dir levels
     //     under the parent — observed in the wild on real
     //     pi-subagents installs. Discovery has to walk past the runId
@@ -333,7 +425,7 @@ async function main(): Promise<void> {
       `got runId=${deepChildEntry?.runId}`,
     );
 
-    // 7b. FLAT layout (no runId subdir): some pi-subagents run modes
+    // 8b. FLAT layout (no runId subdir): some pi-subagents run modes
     // write children directly under <parentBasename>/, not under
     // <parentBasename>/<runId>/. Discovery must surface these too.
     const flatParentId = "flat-parent-" + randomUUID().slice(0, 6);
@@ -356,7 +448,7 @@ async function main(): Promise<void> {
       `parentSessionId=${flatChildEntry?.parentSessionId} runId=${flatChildEntry?.runId}`,
     );
 
-    // 8. Cascade-delete: deleting a parent session also wipes its
+    // 9. Cascade-delete: deleting a parent session also wipes its
     // pi-subagents sibling directory and any nested children, so the
     // sidebar doesn't accumulate orphan child sessions whose parent
     // is gone. We use the deep-layout fixture because it exercises


### PR DESCRIPTION
## Summary

pi-forge previously treated pi-subagents child sessions as either ordinary cold sessions or pi-forge live sessions. That meant opening a child that was still running externally could lazy-resume it into a new `AgentSession`, and async completion notifications were not reliably visible in the open parent chat.

This PR adds a small authoritative pi-subagents integration based on the plugin's own async artifacts (`async-subagent-runs/<runId>/status.json` and `async-subagent-results/<runId>.json`) instead of parent JSONL mtime/size or elapsed-time inference.

## Usage

No operator action required. When pi-subagents writes `status.json` with `queued` or `running`, pi-forge marks the child as externally live/read-only. When status becomes `complete`, `failed`, or `paused` (or a result file exists), pi-forge clears that external-live state and can open the child normally.

## What changed

- `packages/server/src/subagents-external.ts` — new helper for pi-subagents temp dirs, authoritative status/result reads, completion fanout, and read-only disk snapshots.
- `packages/server/src/session-registry.ts` and routes — list sessions with `isExternalLive`/`externalState`; guard resume/lazy-resume paths; return read-only messages for active external children; reject live/mutating routes with `409 external_subagent_active`.
- `packages/client/src/store/session-store.ts`, `SessionList.tsx`, `ChatView.tsx` — avoid opening SSE for active external children, show read-only banner/status, and render `customType: subagent-notify` cleanly.
- `tests/test-subagent-discovery.ts` — regression coverage for active vs live state, resume rejection, terminal-state clearing, and explicit async completion notification.

## Test plan

- [x] `npm run build`
- [x] `scripts/run-tests.sh --only session,sse,subagent-discovery,subagent-parser`
- [x] `npm run check`
- [ ] CI green before merge
