### PR TITLE
chore(release): v1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.3.7] — 2026-06-03
+
 ### Added
 
 - **LDAP login integration.** pi-forge can authenticate users against LDAP while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+### Added
+
+- **LDAP login integration.** pi-forge can authenticate users against LDAP while
+  keeping the local `admin` account reserved for pi-forge admin auth, with
+  improved TLS, bind, and diagnostics configuration.
+- **Process and worker lifecycle status cards.** Process exits and orchestration
+  worker updates now render as dedicated custom lifecycle notifications instead
+  of plain chat messages, with trigger-turn behavior based on event severity.
+
+### Changed
+
+- **Orchestrator mode is enabled by default.** The orchestration feature now
+  starts enabled unless explicitly disabled via configuration, and related docs
+  and health/config surfaces reflect the new default.
+- **Compaction summaries are easier to collapse near the bottom of chat.** The
+  expanded summary opens upward without pulling the transcript away from the
+  bottom and includes collapse controls at both ends.
+
+### Fixed
+
+- **MCP polling and truncation warnings are more reliable.** MCP status polling
+  handles disabled/error states more cleanly, and truncation warnings are surfaced
+  without noisy transport failures.
+- **Codex transport failures no longer create UI noise.** Codex transport errors
+  are logged without surfacing spurious browser-facing failure states.
+- **Orchestration retry noise is filtered.** Transient worker retry events no
+  longer wake supervisors unnecessarily.
+- **External pi-subagents state is authoritative.** Active pi-subagents child
+  sessions open read-only with auto-refresh, completion notifications dedupe
+  across restarts, parent turns restart for terminal completions, and active
+  external children are no longer resumed or disposed as pi-forge live sessions.
+
 ## [1.3.6] — 2026-05-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "workspaces": [
         "packages/*"
       ],
@@ -16968,7 +16968,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17014,7 +17014,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.78.0",
         "@earendil-works/pi-ai": "0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the v1.3.7 release from current `main`. This adds release notes for the merged MCP, orchestration, LDAP, pi-subagents, lifecycle-notification, and compaction/orchestrator-default work, then uses the repository bump script to roll package versions and the changelog release heading.

## Usage

No runtime usage change in this PR itself. After merge, tag the merged `main` commit:

```bash
git checkout main
git pull --ff-only
git tag v1.3.7
git push origin v1.3.7
```

The release workflow will build the image and GitHub release from the tag.

## What changed

- `CHANGELOG.md` — added v1.3.7 release notes and rolled `## [Unreleased]` to `## [1.3.7] — 2026-06-03` via `scripts/bump-version.sh`.
- `package.json` — bumped root package version to `1.3.7`.
- `packages/server/package.json` — bumped server package version to `1.3.7`.
- `packages/client/package.json` — bumped client package version to `1.3.7`.
- `package-lock.json` — refreshed lockfile metadata for the new version.

## Test plan

- [x] `scripts/bump-version.sh 1.3.7`
- [x] `npm run format:check`
- [ ] CI green before merge
