### PR TITLE
feat: support insecure TLS git remotes

### DIFF
--- a/packages/client/src/components/GitPanel.tsx
+++ b/packages/client/src/components/GitPanel.tsx
@@ -79,6 +79,7 @@ export function GitPanel() {
   const [showAddRemote, setShowAddRemote] = useState(false);
   const [newRemoteName, setNewRemoteName] = useState("");
   const [newRemoteUrl, setNewRemoteUrl] = useState("");
+  const [newRemoteInsecureTls, setNewRemoteInsecureTls] = useState(false);
   const [removeRemoteName, setRemoveRemoteName] = useState<string | undefined>(undefined);
 
   const reloadRemotes = async (): Promise<void> => {
@@ -99,10 +100,29 @@ export function GitPanel() {
     setRemoteBusy(name);
     setOpError(undefined);
     try {
-      await api.gitRemoteAdd(project.id, name, url, selectedWorktreePath);
+      const opts: { insecureTls: boolean; worktreePath?: string } = {
+        insecureTls: newRemoteInsecureTls,
+      };
+      if (selectedWorktreePath !== undefined) opts.worktreePath = selectedWorktreePath;
+      await api.gitRemoteAdd(project.id, name, url, opts);
       setShowAddRemote(false);
       setNewRemoteName("");
       setNewRemoteUrl("");
+      setNewRemoteInsecureTls(false);
+      await reloadRemotes();
+    } catch (err) {
+      setOpError(err instanceof ApiError ? err.message || err.code : (err as Error).message);
+    } finally {
+      setRemoteBusy(undefined);
+    }
+  };
+
+  const handleToggleRemoteTls = async (name: string, insecureTls: boolean): Promise<void> => {
+    if (project === undefined) return;
+    setRemoteBusy(name);
+    setOpError(undefined);
+    try {
+      await api.gitRemoteSetInsecureTls(project.id, name, insecureTls, selectedWorktreePath);
       await reloadRemotes();
     } catch (err) {
       setOpError(err instanceof ApiError ? err.message || err.code : (err as Error).message);
@@ -1043,9 +1063,8 @@ export function GitPanel() {
         </div>
 
         {/* Remotes section — same lazy-load pattern as Log + Branches.
-            Read-only for now; managing remotes (`git remote add/remove`)
-            is rare enough that the integrated terminal handles it
-            without a dedicated UI. */}
+            Supports add/remove plus the per-remote local TLS opt-in used by
+            internal Git hosts with private/self-signed certificates. */}
         <div className="border-t border-neutral-800/60">
           <button
             onClick={() => setShowRemotes((v) => !v)}
@@ -1082,6 +1101,14 @@ export function GitPanel() {
                                   fetch ≠ push
                                 </span>
                               )}
+                              {r.insecureTls && (
+                                <span
+                                  className="rounded bg-amber-900/40 px-1 py-0.5 text-[9px] uppercase tracking-wider text-amber-300 light:bg-amber-100 light:text-amber-800"
+                                  title="TLS certificate verification disabled for this remote URL in local git config"
+                                >
+                                  ignore tls
+                                </span>
+                              )}
                               <button
                                 onClick={() => setRemoveRemoteName(r.name)}
                                 disabled={busy}
@@ -1105,6 +1132,20 @@ export function GitPanel() {
                                 push → {r.pushUrl}
                               </span>
                             )}
+                            <label className="mt-0.5 flex items-start gap-1.5 text-[10px] text-neutral-500">
+                              <input
+                                type="checkbox"
+                                checked={r.insecureTls}
+                                onChange={(e) =>
+                                  void handleToggleRemoteTls(r.name, e.target.checked)
+                                }
+                                disabled={busy}
+                                className="mt-0.5 h-3 w-3"
+                              />
+                              <span>
+                                Ignore SSL/TLS verification for this remote (local repo config only)
+                              </span>
+                            </label>
                           </li>
                         );
                       })}
@@ -1114,6 +1155,7 @@ export function GitPanel() {
                     onClick={() => {
                       setNewRemoteName("");
                       setNewRemoteUrl("");
+                      setNewRemoteInsecureTls(false);
                       setShowAddRemote(true);
                     }}
                     className="mt-2 flex items-center gap-1 rounded px-1 py-0.5 text-[11px] text-neutral-400 hover:bg-neutral-900 hover:text-neutral-100"
@@ -1176,6 +1218,24 @@ export function GitPanel() {
               placeholder="git@github.com:user/repo.git"
               className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-1.5 font-mono text-sm text-neutral-100 outline-none focus:border-neutral-500"
             />
+          </label>
+          <label className="flex items-start gap-2 rounded border border-amber-900/40 bg-amber-950/30 px-2 py-1.5 text-xs light:border-amber-300 light:bg-amber-50">
+            <input
+              type="checkbox"
+              checked={newRemoteInsecureTls}
+              onChange={(e) => setNewRemoteInsecureTls(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="text-amber-200 light:text-amber-800">
+                Ignore SSL/TLS verification for this remote
+              </span>
+              <br />
+              <span className="text-[11px] text-amber-300/70 light:text-amber-700/80">
+                Persists only in this repository as URL-scoped git config. Use only for internal Git
+                hosts with a known self-signed/private-CA certificate.
+              </span>
+            </span>
           </label>
           <footer className="flex justify-end gap-2 pt-1">
             <button

--- a/packages/client/src/components/ProjectPicker.tsx
+++ b/packages/client/src/components/ProjectPicker.tsx
@@ -640,9 +640,10 @@ function CloneForm({
           </span>
           <br />
           <span className="text-[11px] text-amber-300/70 light:text-amber-700/80">
-            ⚠ Disables MITM protection for this clone. Use only for internal Git hosts with known
-            self-signed certs (corporate GHE, on-prem GitLab with a private CA). The server logs{" "}
-            <code>git-clone-insecure-tls</code> to stderr on every use.
+            ⚠ Disables MITM protection for this clone and persists a URL-scoped local git config
+            entry for future fetch/pull/push. Use only for internal Git hosts with known self-signed
+            certs/private CAs. The server logs <code>git-clone-insecure-tls</code> to stderr on
+            every use.
           </span>
         </span>
       </label>

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1327,11 +1327,12 @@ function vGitRemotes(value: unknown, status: number): GitRemotesResponse {
         !isObject(r) ||
         typeof r.name !== "string" ||
         typeof r.fetchUrl !== "string" ||
-        typeof r.pushUrl !== "string"
+        typeof r.pushUrl !== "string" ||
+        typeof r.insecureTls !== "boolean"
       ) {
         fail(status, "expected GitRemote");
       }
-      return { name: r.name, fetchUrl: r.fetchUrl, pushUrl: r.pushUrl };
+      return { name: r.name, fetchUrl: r.fetchUrl, pushUrl: r.pushUrl, insecureTls: r.insecureTls };
     }),
   };
 }
@@ -2695,7 +2696,12 @@ export const api = {
     request(`/api/v1/git/branches?${gitQuery(projectId, worktreePath)}`, vGitBranches),
   gitRemotes: (projectId: string, worktreePath?: string) =>
     request(`/api/v1/git/remotes?${gitQuery(projectId, worktreePath)}`, vGitRemotes),
-  gitRemoteAdd: (projectId: string, name: string, url: string, worktreePath?: string) =>
+  gitRemoteAdd: (
+    projectId: string,
+    name: string,
+    url: string,
+    opts?: { insecureTls?: boolean; worktreePath?: string },
+  ) =>
     request(
       "/api/v1/git/remote/add",
       (v, s) => {
@@ -2704,7 +2710,35 @@ export const api = {
       },
       {
         method: "POST",
-        body: { projectId, name, url, ...(worktreePath !== undefined ? { worktreePath } : {}) },
+        body: {
+          projectId,
+          name,
+          url,
+          ...(opts?.insecureTls === true ? { insecureTls: true } : {}),
+          ...(opts?.worktreePath !== undefined ? { worktreePath: opts.worktreePath } : {}),
+        },
+      },
+    ),
+  gitRemoteSetInsecureTls: (
+    projectId: string,
+    name: string,
+    insecureTls: boolean,
+    worktreePath?: string,
+  ) =>
+    request(
+      "/api/v1/git/remote/tls",
+      (v, s) => {
+        if (!isObject(v) || v.ok !== true) fail(s, "expected { ok: true }");
+        return { ok: true as const };
+      },
+      {
+        method: "POST",
+        body: {
+          projectId,
+          name,
+          insecureTls,
+          ...(worktreePath !== undefined ? { worktreePath } : {}),
+        },
       },
     ),
   gitRemoteRemove: (projectId: string, name: string, worktreePath?: string) =>

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -617,6 +617,7 @@ export interface GitRemote {
   name: string;
   fetchUrl: string;
   pushUrl: string;
+  insecureTls: boolean;
 }
 
 export interface GitRemotesResponse {

--- a/packages/server/src/git-clone.ts
+++ b/packages/server/src/git-clone.ts
@@ -359,6 +359,9 @@ export function cloneRepository(opts: CloneOptions): SpawnedClone {
           if (opts.token !== undefined) {
             await stripTokenFromOrigin(target, displayUrl).catch(() => undefined);
           }
+          if (opts.insecureTls === true) {
+            await persistInsecureTlsForOrigin(target, displayUrl).catch(() => undefined);
+          }
           finish({ type: "done", target });
           resolveOuter();
           return;
@@ -386,15 +389,29 @@ export function cloneRepository(opts: CloneOptions): SpawnedClone {
  * any failure is swallowed by the caller.
  */
 async function stripTokenFromOrigin(target: string, cleanUrl: string): Promise<void> {
+  await runGitQuiet(target, ["remote", "set-url", "origin", cleanUrl]);
+}
+
+/**
+ * Persist the clone-time TLS opt-in for future fetch/pull/push from the
+ * same repo without changing global git config. URL scoping keeps the
+ * relaxed verification tied to the cloned origin URL instead of every
+ * HTTPS remote on the machine.
+ */
+async function persistInsecureTlsForOrigin(target: string, cleanUrl: string): Promise<void> {
+  await runGitQuiet(target, ["config", "--local", `http.${cleanUrl}.sslVerify`, "false"]);
+}
+
+async function runGitQuiet(cwd: string, args: string[]): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const child = spawn("git", ["-C", target, "remote", "set-url", "origin", cleanUrl], {
+    const child = spawn("git", ["-C", cwd, ...args], {
       env: scrubbedEnv(),
       stdio: "ignore",
     });
     child.on("error", reject);
     child.on("close", (code) => {
       if (code === 0) resolve();
-      else reject(new Error(`set-url exited ${code}`));
+      else reject(new Error(`git ${args[0] ?? "command"} exited ${code}`));
     });
   });
 }

--- a/packages/server/src/git-runner.ts
+++ b/packages/server/src/git-runner.ts
@@ -518,6 +518,8 @@ export interface RemoteEntry {
    *  separately (e.g. read-only mirror + write-through fork). Surfaced
    *  alongside fetch so the UI can flag the divergence when present. */
   pushUrl: string;
+  /** True when this repo has local URL-scoped SSL verification disabled for the remote URL. */
+  insecureTls: boolean;
 }
 
 /**
@@ -552,7 +554,7 @@ export async function getRemotes(cwd: string): Promise<RemotesResult> {
     if (existing === undefined) {
       // Pre-fill the OTHER URL with the same value; if the second
       // line for this remote contradicts, we overwrite below.
-      map.set(name, { name, fetchUrl: url, pushUrl: url });
+      map.set(name, { name, fetchUrl: url, pushUrl: url, insecureTls: false });
     } else if (dir === "push") {
       existing.pushUrl = url;
     } else {
@@ -560,6 +562,11 @@ export async function getRemotes(cwd: string): Promise<RemotesResult> {
     }
   }
   const remotes = Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+  await Promise.all(
+    remotes.map(async (remote) => {
+      remote.insecureTls = await remoteHasInsecureTls(cwd, remote);
+    }),
+  );
   return { isGitRepo: true, remotes };
 }
 
@@ -571,8 +578,21 @@ export async function getRemotes(cwd: string): Promise<RemotesResult> {
  * metachars. Common shapes: `https://github.com/foo/bar.git`,
  * `git@github.com:foo/bar.git`, `file:///abs/path`.
  */
-export async function addRemote(cwd: string, name: string, url: string): Promise<void> {
+export async function addRemote(
+  cwd: string,
+  name: string,
+  url: string,
+  opts: { insecureTls?: boolean } = {},
+): Promise<void> {
   assertRemoteName(name);
+  assertRemoteUrl(url);
+  await runGit(cwd, ["remote", "add", name, url]);
+  if (opts.insecureTls === true) {
+    await setUrlInsecureTls(cwd, url, true);
+  }
+}
+
+function assertRemoteUrl(url: string): void {
   if (url.length === 0 || url.length > 1024) {
     throw new InvalidBranchNameError(`invalid remote URL`);
   }
@@ -582,7 +602,56 @@ export async function addRemote(cwd: string, name: string, url: string): Promise
   if (url.startsWith("-")) {
     throw new InvalidBranchNameError(`invalid remote URL`);
   }
-  await runGit(cwd, ["remote", "add", name, url]);
+}
+
+async function getRemoteUrls(cwd: string, name: string): Promise<string[]> {
+  assertRemoteName(name);
+  const urls = new Set<string>();
+  const fetchUrl = await runGit(cwd, ["remote", "get-url", name]);
+  const pushUrl = await runGit(cwd, ["remote", "get-url", "--push", name]).catch(() => undefined);
+  const fetch = fetchUrl.stdout.trim();
+  const push = pushUrl?.stdout.trim();
+  if (fetch.length > 0) urls.add(fetch);
+  if (push !== undefined && push.length > 0) urls.add(push);
+  return [...urls];
+}
+
+async function remoteHasInsecureTls(cwd: string, remote: RemoteEntry): Promise<boolean> {
+  const urls = new Set([remote.fetchUrl, remote.pushUrl].filter((url) => url.length > 0));
+  for (const url of urls) {
+    try {
+      const { stdout } = await runGit(cwd, [
+        "config",
+        "--local",
+        "--get-urlmatch",
+        "http.sslVerify",
+        url,
+      ]);
+      if (stdout.trim().toLowerCase() === "false") return true;
+    } catch {
+      // No local URL-specific match for this URL.
+    }
+  }
+  return false;
+}
+
+async function setUrlInsecureTls(cwd: string, url: string, enabled: boolean): Promise<void> {
+  assertRemoteUrl(url);
+  const key = `http.${url}.sslVerify`;
+  if (enabled) {
+    await runGit(cwd, ["config", "--local", key, "false"]);
+    return;
+  }
+  await runGit(cwd, ["config", "--local", "--unset-all", key]).catch(() => undefined);
+}
+
+export async function setRemoteInsecureTls(
+  cwd: string,
+  name: string,
+  enabled: boolean,
+): Promise<void> {
+  const urls = await getRemoteUrls(cwd, name);
+  await Promise.all(urls.map((url) => setUrlInsecureTls(cwd, url, enabled)));
 }
 
 /**

--- a/packages/server/src/routes/git.ts
+++ b/packages/server/src/routes/git.ts
@@ -12,6 +12,7 @@ import {
   getBranches,
   getRemotes,
   removeRemote,
+  setRemoteInsecureTls,
   getDiff,
   getFileDiff,
   getLog,
@@ -132,11 +133,12 @@ const remotesSchema = {
       type: "array",
       items: {
         type: "object",
-        required: ["name", "fetchUrl", "pushUrl"],
+        required: ["name", "fetchUrl", "pushUrl", "insecureTls"],
         properties: {
           name: { type: "string" },
           fetchUrl: { type: "string" },
           pushUrl: { type: "string" },
+          insecureTls: { type: "boolean" },
         },
       },
     },
@@ -554,7 +556,15 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
       withGitCwd(req.query.projectId, req.query.worktreePath, reply, (cwd) => getRemotes(cwd)),
   );
 
-  fastify.post<{ Body: { projectId: string; name: string; url: string; worktreePath?: string } }>(
+  fastify.post<{
+    Body: {
+      projectId: string;
+      name: string;
+      url: string;
+      insecureTls?: boolean;
+      worktreePath?: string;
+    };
+  }>(
     "/git/remote/add",
     {
       schema: {
@@ -562,7 +572,9 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
           "Add a git remote (`git remote add <name> <url>`). Name is " +
           "validated against the same character set as branch names. " +
           "URL accepts any string git itself accepts (https://, git@, " +
-          "file://, etc.). Duplicate name → 400 `git_failed`.",
+          "file://, etc.). Optional `insecureTls: true` persists a local, " +
+          "URL-scoped `http.<url>.sslVerify=false` setting for this repo. " +
+          "Duplicate name → 400 `git_failed`.",
         tags: ["git"],
         body: {
           type: "object",
@@ -572,6 +584,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
             projectId: { type: "string", minLength: 1 },
             name: { type: "string", minLength: 1 },
             url: { type: "string", minLength: 1, maxLength: 1024 },
+            insecureTls: { type: "boolean" },
             ...worktreeBodyProperty,
           },
         },
@@ -585,7 +598,46 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) =>
       withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
-        await addRemote(cwd, req.body.name, req.body.url);
+        await addRemote(cwd, req.body.name, req.body.url, {
+          insecureTls: req.body.insecureTls === true,
+        });
+        return { ok: true };
+      }),
+  );
+
+  fastify.post<{
+    Body: { projectId: string; name: string; insecureTls: boolean; worktreePath?: string };
+  }>(
+    "/git/remote/tls",
+    {
+      schema: {
+        description:
+          "Enable or disable TLS certificate verification for one remote in this repository. " +
+          "The setting is persisted in local git config as URL-scoped `http.<url>.sslVerify=false`; " +
+          "it does not change global git config or store credentials.",
+        tags: ["git"],
+        body: {
+          type: "object",
+          required: ["projectId", "name", "insecureTls"],
+          additionalProperties: false,
+          properties: {
+            projectId: { type: "string", minLength: 1 },
+            name: { type: "string", minLength: 1 },
+            insecureTls: { type: "boolean" },
+            ...worktreeBodyProperty,
+          },
+        },
+        response: {
+          200: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
+          400: errorSchema,
+          404: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) =>
+      withGitCwd(req.body.projectId, req.body.worktreePath, reply, async (cwd) => {
+        await setRemoteInsecureTls(cwd, req.body.name, req.body.insecureTls);
         return { ok: true };
       }),
   );

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -467,7 +467,9 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
           "the clone — necessary for internal Git hosts with self-signed " +
           "certs (corporate GHE, on-prem GitLab with a private CA, etc.). " +
           "Logs a `git-clone-insecure-tls` line to stderr on every use so " +
-          "the relaxed posture is visible in operator logs.",
+          "the relaxed posture is visible in operator logs, and persists a " +
+          "local URL-scoped `http.<origin>.sslVerify=false` setting in the " +
+          "cloned repo for future fetch/pull/push without changing global git config.",
         tags: ["projects"],
         body: {
           type: "object",

--- a/tests/test-clone.ts
+++ b/tests/test-clone.ts
@@ -82,25 +82,50 @@ async function waitFor(url: string, timeoutMs = 10_000): Promise<void> {
   throw new Error(`timeout waiting for ${url}`);
 }
 
+function gitEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    // Deterministic identity so commits succeed without the
+    // host user's git config.
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+  };
+}
+
 function runGit(cwd: string, args: string[]): Promise<void> {
   return new Promise((resolveFn, rejectFn) => {
     const child = spawn("git", args, {
       cwd,
       stdio: "ignore",
-      env: {
-        ...process.env,
-        // Deterministic identity so commits succeed without the
-        // host user's git config.
-        GIT_AUTHOR_NAME: "Test",
-        GIT_AUTHOR_EMAIL: "test@example.com",
-        GIT_COMMITTER_NAME: "Test",
-        GIT_COMMITTER_EMAIL: "test@example.com",
-      },
+      env: gitEnv(),
     });
     child.on("error", rejectFn);
     child.on("close", (code) => {
       if (code === 0) resolveFn();
       else rejectFn(new Error(`git ${args.join(" ")} exited ${code}`));
+    });
+  });
+}
+
+function gitOutput(cwd: string, args: string[]): Promise<string> {
+  return new Promise((resolveFn, rejectFn) => {
+    const child = spawn("git", args, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: gitEnv(),
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => (stdout += chunk));
+    child.stderr.on("data", (chunk: string) => (stderr += chunk));
+    child.on("error", rejectFn);
+    child.on("close", (code) => {
+      if (code === 0) resolveFn(stdout);
+      else rejectFn(new Error(`git ${args.join(" ")} exited ${code}: ${stderr}`));
     });
   });
 }
@@ -344,6 +369,26 @@ async function main(): Promise<void> {
       assert("cloned target contains README.md", readme.isFile());
       const dotGit = await stat(join(srv.workspacePath, "cloned-repo", ".git"));
       assert("cloned target contains .git directory", dotGit.isDirectory());
+
+      const insecure = await streamClone(srv.base, {
+        url: sourceUrl,
+        parentPath: srv.workspacePath,
+        folderName: "insecure-cloned-repo",
+        projectName: "Insecure Cloned Repo",
+        insecureTls: true,
+      });
+      assert("clone with insecureTls HTTP status 200", insecure.status === 200);
+      const persistedTls = await gitOutput(join(srv.workspacePath, "insecure-cloned-repo"), [
+        "config",
+        "--local",
+        "--get-urlmatch",
+        "http.sslVerify",
+        sourceUrl,
+      ]);
+      assert(
+        "clone insecureTls persists local URL-scoped sslVerify=false",
+        persistedTls.trim() === "false",
+      );
 
       // Second clone into the same folder fails fast with 409.
       const second = await streamClone(srv.base, {

--- a/tests/test-git.ts
+++ b/tests/test-git.ts
@@ -516,6 +516,49 @@ async function main(): Promise<void> {
     const upstreamPath = join(workspacePath, "upstream.git");
     await mkdir(upstreamPath, { recursive: true });
     await execFileAsync("git", ["init", "-q", "--bare", upstreamPath]);
+
+    // ---- remote TLS settings are local, URL-scoped git config ----
+    {
+      const corpUrl = "https://git.example.internal/acme/demo.git";
+      const add = await jsend(
+        "POST",
+        `${base}/api/v1/git/remote/add`,
+        { projectId: gitProjectId, name: "corp", url: corpUrl, insecureTls: true },
+        auth,
+      );
+      assert("remote/add with insecureTls → 200", add.status === 200);
+      const tlsValue = (
+        await execFileAsync(
+          "git",
+          ["config", "--local", "--get-urlmatch", "http.sslVerify", corpUrl],
+          { cwd: projectPath },
+        )
+      ).stdout.trim();
+      assert("remote TLS config persisted as sslVerify=false", tlsValue === "false");
+      const listed = await jget(
+        `${base}/api/v1/git/remotes?projectId=${encodeURIComponent(gitProjectId)}`,
+        auth,
+      );
+      const body = listed.body as { remotes: { name: string; insecureTls: boolean }[] };
+      assert(
+        "remotes list marks insecure TLS remote",
+        body.remotes.some((r) => r.name === "corp" && r.insecureTls),
+      );
+      const disable = await jsend(
+        "POST",
+        `${base}/api/v1/git/remote/tls`,
+        { projectId: gitProjectId, name: "corp", insecureTls: false },
+        auth,
+      );
+      assert("remote/tls disable → 200", disable.status === 200);
+      const disabled = await execFileAsync(
+        "git",
+        ["config", "--local", "--get-urlmatch", "http.sslVerify", corpUrl],
+        { cwd: projectPath },
+      ).catch((err: unknown) => err as { code?: number });
+      assert("remote TLS config unset on disable", "code" in disabled && disabled.code === 1);
+    }
+
     await git(projectPath, ["remote", "add", "origin", upstreamPath]);
     {
       const r = await jsend(


### PR DESCRIPTION
## Summary

Some repositories/remotes require bypassing SSL/TLS verification, but the git pane did not expose a way to persist that setting for future fetch/pull/push operations. This PR adds an explicit opt-in insecure TLS setting for remotes and clone flow persistence using repository-local, URL-scoped git config.

## Usage

In the git pane, use the remote TLS toggle or add a remote with “Ignore SSL/TLS verification” enabled. During clone, enabling insecure TLS persists the same repository-local setting after a successful clone.

The persisted setting is scoped to the repository and URL:

```bash
git config --local http.<remote-url>.sslVerify false
```

Security note: this is intentionally opt-in and local to the affected repository/remote; it does not change global git SSL verification.

## What changed (10 files)

- `packages/server/src/git-runner.ts` — reports remote `insecureTls`, persists URL-scoped local git config, and adds a remote TLS toggle helper.
- `packages/server/src/routes/git.ts` — adds `insecureTls` to remote APIs and introduces `POST /git/remote/tls`.
- `packages/server/src/git-clone.ts` — persists URL-scoped insecure TLS config after successful clone when requested.
- `packages/server/src/routes/projects.ts` — documents clone TLS persistence behavior in API schema.
- `packages/client/src/components/GitPanel.tsx` — adds add-remote checkbox, remote badge, and per-remote toggle.
- `packages/client/src/components/ProjectPicker.tsx` — updates clone warning copy for persisted insecure TLS behavior.
- `packages/client/src/lib/api-client/index.ts` and `packages/client/src/lib/api-client/types.ts` — updates client methods/types for remote TLS state.
- `tests/test-clone.ts` and `tests/test-git.ts` — add clone/remote TLS regression coverage.

## Test plan

- [x] `npx prettier --check packages/client/src/components/GitPanel.tsx packages/client/src/components/ProjectPicker.tsx packages/client/src/lib/api-client/index.ts packages/client/src/lib/api-client/types.ts packages/server/src/git-clone.ts packages/server/src/git-runner.ts packages/server/src/routes/git.ts packages/server/src/routes/projects.ts tests/test-clone.ts tests/test-git.ts`
- [x] `scripts/run-tests.sh --only git,clone`
- [ ] Manual: verify git pane add-remote checkbox, remote badge, and TLS toggle in the browser.
- [ ] CI green before merge
