### PR TITLE
fix: recover stale MCP sessions

### DIFF
--- a/packages/server/src/mcp/manager.ts
+++ b/packages/server/src/mcp/manager.ts
@@ -79,6 +79,8 @@ interface PoolEntry {
   /** Pre-built ToolDefinitions, rebuilt every reconnect so the closure
    *  captures the latest client instance. */
   bridged: ToolDefinition[];
+  /** In-flight reconnect shared by concurrent stale-session recoveries. */
+  reconnecting?: Promise<boolean>;
 }
 
 function entryKey(scope: Scope, name: string): string {
@@ -472,6 +474,7 @@ async function connectEntry(entry: PoolEntry): Promise<void> {
         description: t.description,
         inputSchema: t.inputSchema,
         getClient: () => pool.get(entryKey(entry.scope, entry.name))?.client,
+        recoverStaleSession: () => recoverStaleSession(entry.scope, entry.name),
       }),
     );
     entry.state = "connected";
@@ -482,6 +485,22 @@ async function connectEntry(entry: PoolEntry): Promise<void> {
     entry.bridged = [];
     entry.state = "error";
     entry.lastError = err instanceof Error ? err.message : String(err);
+  }
+}
+
+async function recoverStaleSession(scope: Scope, name: string): Promise<boolean> {
+  const entry = pool.get(entryKey(scope, name));
+  if (entry === undefined || entry.config.enabled === false) return false;
+  if (entry.reconnecting !== undefined) return await entry.reconnecting;
+  entry.reconnecting = (async () => {
+    await disconnectEntry(entry);
+    await connectEntry(entry);
+    return entry.state === "connected" && entry.client !== undefined;
+  })();
+  try {
+    return await entry.reconnecting;
+  } finally {
+    if (entry.reconnecting !== undefined) delete entry.reconnecting;
   }
 }
 

--- a/packages/server/src/mcp/tool-bridge.ts
+++ b/packages/server/src/mcp/tool-bridge.ts
@@ -31,6 +31,9 @@ export function bridgeMcpTool(opts: {
    *  on every call so a reconnect (new client instance) is picked up
    *  without the bridged ToolDefinition being rebuilt. */
   getClient: () => Client | undefined;
+  /** Reconnects the owning MCP server after the remote rejects the
+   *  cached session id. Returns true when a fresh client is available. */
+  recoverStaleSession?: () => Promise<boolean>;
 }): ToolDefinition {
   const prefixedName = `${opts.serverName}__${opts.toolName}`;
   const description =
@@ -50,22 +53,47 @@ export function bridgeMcpTool(opts: {
         );
       }
       try {
-        const res = await client.callTool(
-          {
-            name: opts.toolName,
-            arguments: (params as Record<string, unknown>) ?? {},
-          },
-          undefined,
-          signal !== undefined ? { signal } : undefined,
-        );
+        const res = await callMcpTool(client, opts.toolName, params, signal);
         return mcpResultToAgentResult(res);
       } catch (err) {
-        return errorResult(
-          `MCP tool '${prefixedName}' threw: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        if (
+          !isAbortError(err) &&
+          isStaleMcpSessionError(err) &&
+          opts.recoverStaleSession !== undefined
+        ) {
+          const recovered = await opts.recoverStaleSession().catch(() => false);
+          const retryClient = opts.getClient();
+          if (recovered && retryClient !== undefined) {
+            try {
+              const retryRes = await callMcpTool(retryClient, opts.toolName, params, signal);
+              return mcpResultToAgentResult(retryRes);
+            } catch (retryErr) {
+              return errorResult(
+                `MCP tool '${prefixedName}' threw after reconnect: ${errorMessage(retryErr)}`,
+              );
+            }
+          }
+        }
+        return errorResult(`MCP tool '${prefixedName}' threw: ${errorMessage(err)}`);
       }
     },
   } satisfies ToolDefinition;
+}
+
+async function callMcpTool(
+  client: Client,
+  toolName: string,
+  params: unknown,
+  signal: AbortSignal | undefined,
+): Promise<unknown> {
+  return await client.callTool(
+    {
+      name: toolName,
+      arguments: (params as Record<string, unknown>) ?? {},
+    },
+    undefined,
+    signal !== undefined ? { signal } : undefined,
+  );
 }
 
 function errorResult(message: string): AgentToolResult<unknown> {
@@ -73,6 +101,27 @@ function errorResult(message: string): AgentToolResult<unknown> {
     content: [{ type: "text", text: message }],
     details: undefined,
   };
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
+}
+
+function isStaleMcpSessionError(err: unknown): boolean {
+  const maybe = err as {
+    code?: unknown;
+    message?: unknown;
+    error?: { code?: unknown; message?: unknown };
+  };
+  const code = maybe.code ?? maybe.error?.code;
+  const message = String(maybe.message ?? maybe.error?.message ?? err).toLowerCase();
+  const hasStaleMessage =
+    message.includes("session not found") || message.includes("sesstion not found");
+  return hasStaleMessage && (code === undefined || code === -32600 || message.includes("-32600"));
 }
 
 interface McpContentBlock {

--- a/tests/test-mcp.ts
+++ b/tests/test-mcp.ts
@@ -7,6 +7,7 @@
  * against it and exercises:
  *   - global config load → connect → list tools
  *   - bridged ToolDefinition execute → MCP server tool ran
+ *   - stale MCP session id after server restart → reconnect + retry succeeds
  *   - per-server `enabled: false` → skipped, no tools contributed
  *   - master `disabled: true` → no tools at all (master toggle)
  *   - probe() → forced reconnect → status flips back to connected
@@ -44,6 +45,8 @@ interface FixtureServer {
   url: string;
   /** Counts tool invocations since spawn — handy for probe assertions. */
   callCount: () => number;
+  /** Simulates an MCP server restart that drops known session ids while keeping the URL stable. */
+  dropSessions: () => Promise<void>;
   close: () => Promise<void>;
 }
 
@@ -63,31 +66,35 @@ interface FixtureServer {
  */
 async function spawnFixtureServer(opts?: { toolPrefix?: string }): Promise<FixtureServer> {
   const prefix = opts?.toolPrefix ?? "";
-  const mcp = new McpServer({ name: "fixture", version: "0.0.1" });
 
   let calls = 0;
-  mcp.registerTool(
-    `${prefix}echo`,
-    {
-      description: "Echoes the input string.",
-      inputSchema: { text: z.string() },
-    },
-    ({ text }) => {
-      calls += 1;
-      return { content: [{ type: "text", text }] };
-    },
-  );
-  mcp.registerTool(
-    `${prefix}add`,
-    {
-      description: "Adds two numbers.",
-      inputSchema: { a: z.number(), b: z.number() },
-    },
-    ({ a, b }) => {
-      calls += 1;
-      return { content: [{ type: "text", text: String(a + b) }] };
-    },
-  );
+  const createMcp = (): McpServer => {
+    const server = new McpServer({ name: "fixture", version: "0.0.1" });
+    server.registerTool(
+      `${prefix}echo`,
+      {
+        description: "Echoes the input string.",
+        inputSchema: { text: z.string() },
+      },
+      ({ text }) => {
+        calls += 1;
+        return { content: [{ type: "text", text }] };
+      },
+    );
+    server.registerTool(
+      `${prefix}add`,
+      {
+        description: "Adds two numbers.",
+        inputSchema: { a: z.number(), b: z.number() },
+      },
+      ({ a, b }) => {
+        calls += 1;
+        return { content: [{ type: "text", text: String(a + b) }] };
+      },
+    );
+    return server;
+  };
+  let mcp = createMcp();
 
   // SSEServerTransport is per-connection. Track sessions by id so
   // POST /messages can route to the right transport (and so a
@@ -111,8 +118,15 @@ async function spawnFixtureServer(opts?: { toolPrefix?: string }): Promise<Fixtu
           const sessionId = url.searchParams.get("sessionId") ?? "";
           const transport = sessions.get(sessionId);
           if (transport === undefined) {
-            res.statusCode = 404;
-            res.end("session not found");
+            res.statusCode = 400;
+            res.setHeader("content-type", "application/json");
+            res.end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: null,
+                error: { code: -32600, message: "Sesstion not found" },
+              }),
+            );
             return;
           }
           await transport.handlePostMessage(req, res);
@@ -141,6 +155,13 @@ async function spawnFixtureServer(opts?: { toolPrefix?: string }): Promise<Fixtu
   return {
     url,
     callCount: () => calls,
+    dropSessions: async () => {
+      const oldSessions = Array.from(sessions.values());
+      sessions.clear();
+      await Promise.allSettled(oldSessions.map((t) => t.close()));
+      await mcp.close().catch(() => undefined);
+      mcp = createMcp();
+    },
     close: async () => {
       for (const t of sessions.values()) {
         await t.close().catch(() => undefined);
@@ -262,6 +283,33 @@ async function main(): Promise<void> {
         "echo execute: result text matches input",
         text === "hello-from-bridge",
         `got=${String(text)}`,
+      );
+
+      // ---- Case C2: stale MCP session id after server restart recovers ----
+      await fixture.dropSessions();
+      const staleCallsBefore = fixture.callCount();
+      const recoveredResult = await echo.execute(
+        "tcid-stale",
+        { text: "hello-after-restart" },
+        undefined,
+        undefined,
+        {} as Parameters<typeof echo.execute>[4],
+      );
+      const recoveredText =
+        recoveredResult.content[0]?.type === "text" ? recoveredResult.content[0].text : undefined;
+      assert(
+        "stale session: reconnect retried the call",
+        fixture.callCount() === staleCallsBefore + 1,
+        `before=${staleCallsBefore} after=${fixture.callCount()}`,
+      );
+      assert(
+        "stale session: recovered result text matches input",
+        recoveredText === "hello-after-restart",
+        `got=${String(recoveredText)}`,
+      );
+      assert(
+        "stale session: status remains connected",
+        manager.getStatus()[0]?.state === "connected",
       );
     }
 


### PR DESCRIPTION
## Summary

MCP tool calls could break after an MCP server restart because pi-forge retained a stale MCP session id. A later tool call could fail with:

```json
{"code": -32600, "message": "Sesstion not found"}
```

This PR detects stale-session MCP errors, coordinates a per-server reconnect, and retries the failed tool call once with a fresh client/transport.

## Usage

No user-facing configuration required. Existing MCP tools should recover automatically when a server restarts and the next call reports a stale session.

## What changed (3 files)

- `packages/server/src/mcp/manager.ts` — added per-server reconnect coordination and reconnect helper behavior.
- `packages/server/src/mcp/tool-bridge.ts` — detects stale MCP session errors, reconnects once, and retries the tool call transparently.
- `tests/test-mcp.ts` — added regression coverage for server restart/session-drop recovery.

## Test plan

- [x] `scripts/run-tests.sh --only mcp`
- [ ] CI green before merge
