### PR TITLE
feat: refine chat and session pane interactions

### DIFF
--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1784,9 +1784,12 @@ function ToolCallEntry({
       </div>
 
       {argsText.length > 0 && (
-        <details className="border-t border-neutral-800/60">
-          <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
-            <span>Input</span>
+        <details className="group/details border-t border-neutral-800/60">
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
+            <span className="flex items-center gap-1">
+              <DetailsChevron />
+              Input
+            </span>
             <CopyButton getText={() => argsText} title={`Copy ${name} input`} compact />
           </summary>
           <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">
@@ -1796,19 +1799,24 @@ function ToolCallEntry({
       )}
 
       {result !== undefined && (
-        <details className="border-t border-neutral-800/60">
-          <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
-            <span>
-              Output
-              {editStats !== undefined && (
-                <span className="ml-2 font-mono text-[10px]">
-                  <span className="text-emerald-400 light:text-emerald-700">+{editStats.adds}</span>{" "}
-                  <span className="text-red-400 light:text-red-700">-{editStats.dels}</span>
-                </span>
-              )}
-              {editFn !== undefined && (
-                <span className="ml-2 font-mono text-[10px] text-neutral-500">{editFn}</span>
-              )}
+        <details className="group/details border-t border-neutral-800/60">
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
+            <span className="flex items-center gap-1">
+              <DetailsChevron />
+              <span>
+                Output
+                {editStats !== undefined && (
+                  <span className="ml-2 font-mono text-[10px]">
+                    <span className="text-emerald-400 light:text-emerald-700">
+                      +{editStats.adds}
+                    </span>{" "}
+                    <span className="text-red-400 light:text-red-700">-{editStats.dels}</span>
+                  </span>
+                )}
+                {editFn !== undefined && (
+                  <span className="ml-2 font-mono text-[10px] text-neutral-500">{editFn}</span>
+                )}
+              </span>
             </span>
             <CopyButton
               getText={() => editDiff ?? (outputText.length > 0 ? outputText : "(empty)")}
@@ -2307,6 +2315,15 @@ function BashExecution({ message }: { message: AgentMessageLike }) {
  * back to a synthetic textarea when the async clipboard API isn't
  * available (older Safari, insecure HTTP origins).
  */
+function DetailsChevron() {
+  return (
+    <span className="inline-flex h-3 w-3 shrink-0 items-center justify-center text-neutral-600">
+      <ChevronRight size={11} className="group-open/details:hidden" />
+      <ChevronDown size={11} className="hidden group-open/details:block" />
+    </span>
+  );
+}
+
 function CopyButton({
   getText,
   title,

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -2357,12 +2357,14 @@ function CopyButton({
         onClick();
       }}
       className={`inline-flex items-center justify-center rounded text-neutral-500 hover:bg-neutral-700/40 hover:text-neutral-300 ${
-        compact ? "h-5 w-5 shrink-0 p-0" : "min-h-11 min-w-11 px-1.5 py-0.5 md:min-h-0 md:min-w-0"
+        compact
+          ? "h-3.5 w-3.5 shrink-0 p-0"
+          : "min-h-11 min-w-11 px-1.5 py-0.5 md:min-h-0 md:min-w-0"
       }`}
       title={title}
       aria-label={title}
     >
-      {copied ? <Check size={14} /> : <Copy size={14} />}
+      {copied ? <Check size={compact ? 11 : 14} /> : <Copy size={compact ? 11 : 14} />}
     </button>
   );
 }

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1784,13 +1784,12 @@ function ToolCallEntry({
       </div>
 
       {argsText.length > 0 && (
-        <details className="group/details border-t border-neutral-800/60">
-          <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
-            <span className="flex items-center gap-1">
-              <DetailsChevron />
-              Input
+        <details className="border-t border-neutral-800/60">
+          <summary className="cursor-pointer px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
+            Input
+            <span className="float-right ml-2">
+              <CopyButton getText={() => argsText} title={`Copy ${name} input`} compact />
             </span>
-            <CopyButton getText={() => argsText} title={`Copy ${name} input`} compact />
           </summary>
           <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">
             {argsText}
@@ -1799,30 +1798,25 @@ function ToolCallEntry({
       )}
 
       {result !== undefined && (
-        <details className="group/details border-t border-neutral-800/60">
-          <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
-            <span className="flex items-center gap-1">
-              <DetailsChevron />
-              <span>
-                Output
-                {editStats !== undefined && (
-                  <span className="ml-2 font-mono text-[10px]">
-                    <span className="text-emerald-400 light:text-emerald-700">
-                      +{editStats.adds}
-                    </span>{" "}
-                    <span className="text-red-400 light:text-red-700">-{editStats.dels}</span>
-                  </span>
-                )}
-                {editFn !== undefined && (
-                  <span className="ml-2 font-mono text-[10px] text-neutral-500">{editFn}</span>
-                )}
+        <details className="border-t border-neutral-800/60">
+          <summary className="cursor-pointer px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
+            Output
+            {editStats !== undefined && (
+              <span className="ml-2 font-mono text-[10px]">
+                <span className="text-emerald-400 light:text-emerald-700">+{editStats.adds}</span>{" "}
+                <span className="text-red-400 light:text-red-700">-{editStats.dels}</span>
               </span>
+            )}
+            {editFn !== undefined && (
+              <span className="ml-2 font-mono text-[10px] text-neutral-500">{editFn}</span>
+            )}
+            <span className="float-right ml-2">
+              <CopyButton
+                getText={() => editDiff ?? (outputText.length > 0 ? outputText : "(empty)")}
+                title={`Copy ${name} output`}
+                compact
+              />
             </span>
-            <CopyButton
-              getText={() => editDiff ?? (outputText.length > 0 ? outputText : "(empty)")}
-              title={`Copy ${name} output`}
-              compact
-            />
           </summary>
           {editDiff !== undefined && editStats !== undefined ? (
             <div className="px-3 pb-2">
@@ -2315,15 +2309,6 @@ function BashExecution({ message }: { message: AgentMessageLike }) {
  * back to a synthetic textarea when the async clipboard API isn't
  * available (older Safari, insecure HTTP origins).
  */
-function DetailsChevron() {
-  return (
-    <span className="inline-flex h-3 w-3 shrink-0 items-center justify-center text-neutral-600">
-      <ChevronRight size={11} className="group-open/details:hidden" />
-      <ChevronDown size={11} className="hidden group-open/details:block" />
-    </span>
-  );
-}
-
 function CopyButton({
   getText,
   title,

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -206,20 +206,30 @@ export function ChatView({ sessionId }: Props) {
   // the check would always say "user scrolled away" during streaming and
   // auto-scroll would never fire. Reading the ref reflects the user's
   // last actual scroll position before the content grew.
-  const NEAR_BOTTOM_PX = 96;
+  const NEAR_BOTTOM_PX = 24;
   const isFollowingBottomRef = useRef(true);
+  const lastScrollTopRef = useRef(0);
 
   const onScroll = (): void => {
     const el = scrollRef.current;
     if (el === null) return;
     const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    isFollowingBottomRef.current = distance <= NEAR_BOTTOM_PX;
+    const scrolledUp = el.scrollTop < lastScrollTopRef.current - 1;
+    // Be conservative: any explicit upward scroll means "stop following"
+    // until the user intentionally returns to the very bottom. The old
+    // 96px cushion re-engaged while users were still reading near the tail,
+    // making streaming output feel like it was yanking the viewport around.
+    isFollowingBottomRef.current = !scrolledUp && distance <= NEAR_BOTTOM_PX;
+    lastScrollTopRef.current = el.scrollTop;
   };
 
   useEffect(() => {
     const el = scrollRef.current;
     if (el === null) return;
-    if (isFollowingBottomRef.current) el.scrollTop = el.scrollHeight;
+    if (isFollowingBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+      lastScrollTopRef.current = el.scrollTop;
+    }
   }, [messages, streamingText, isStreaming]);
 
   // Force scroll-to-bottom + re-engage follow mode whenever a NEW
@@ -233,7 +243,10 @@ export function ChatView({ sessionId }: Props) {
     const userCount = messages.reduce((n, m) => (m.role === "user" ? n + 1 : n), 0);
     if (userCount > lastUserMessageCountRef.current) {
       const el = scrollRef.current;
-      if (el !== null) el.scrollTop = el.scrollHeight;
+      if (el !== null) {
+        el.scrollTop = el.scrollHeight;
+        lastScrollTopRef.current = el.scrollTop;
+      }
       isFollowingBottomRef.current = true;
     }
     lastUserMessageCountRef.current = userCount;
@@ -712,24 +725,27 @@ function ChatEditDiff({
           <span className="ml-2 text-emerald-400 light:text-emerald-700">+{adds}</span>
           <span className="ml-1 text-red-400 light:text-red-700">−{dels}</span>
         </span>
-        <button
-          onClick={(e) => {
-            // The summary's default click toggles the <details>; stop
-            // propagation so flipping the view doesn't also collapse
-            // the diff the user just opened.
-            e.preventDefault();
-            e.stopPropagation();
-            setViewType(viewType === "split" ? "unified" : "split");
-          }}
-          className="rounded p-0.5 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
-          title={
-            viewType === "split"
-              ? "Switch chat diffs to unified view"
-              : "Switch chat diffs to side-by-side view"
-          }
-        >
-          {viewType === "split" ? <Rows2 size={11} /> : <Columns2 size={11} />}
-        </button>
+        <span className="flex shrink-0 items-center gap-1">
+          <CopyButton getText={() => diff} title="Copy edit output" />
+          <button
+            onClick={(e) => {
+              // The summary's default click toggles the <details>; stop
+              // propagation so flipping the view doesn't also collapse
+              // the diff the user just opened.
+              e.preventDefault();
+              e.stopPropagation();
+              setViewType(viewType === "split" ? "unified" : "split");
+            }}
+            className="rounded p-0.5 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
+            title={
+              viewType === "split"
+                ? "Switch chat diffs to unified view"
+                : "Switch chat diffs to side-by-side view"
+            }
+          >
+            {viewType === "split" ? <Rows2 size={11} /> : <Columns2 size={11} />}
+          </button>
+        </span>
       </summary>
       <DiffBlock diff={diff} viewType={viewType} />
     </details>
@@ -1769,8 +1785,9 @@ function ToolCallEntry({
 
       {argsText.length > 0 && (
         <details className="border-t border-neutral-800/60">
-          <summary className="cursor-pointer px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
-            Input
+          <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
+            <span>Input</span>
+            <CopyButton getText={() => argsText} title={`Copy ${name} input`} />
           </summary>
           <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">
             {argsText}
@@ -1780,17 +1797,23 @@ function ToolCallEntry({
 
       {result !== undefined && (
         <details className="border-t border-neutral-800/60">
-          <summary className="cursor-pointer px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
-            Output
-            {editStats !== undefined && (
-              <span className="ml-2 font-mono text-[10px]">
-                <span className="text-emerald-400 light:text-emerald-700">+{editStats.adds}</span>{" "}
-                <span className="text-red-400 light:text-red-700">-{editStats.dels}</span>
-              </span>
-            )}
-            {editFn !== undefined && (
-              <span className="ml-2 font-mono text-[10px] text-neutral-500">{editFn}</span>
-            )}
+          <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
+            <span>
+              Output
+              {editStats !== undefined && (
+                <span className="ml-2 font-mono text-[10px]">
+                  <span className="text-emerald-400 light:text-emerald-700">+{editStats.adds}</span>{" "}
+                  <span className="text-red-400 light:text-red-700">-{editStats.dels}</span>
+                </span>
+              )}
+              {editFn !== undefined && (
+                <span className="ml-2 font-mono text-[10px] text-neutral-500">{editFn}</span>
+              )}
+            </span>
+            <CopyButton
+              getText={() => editDiff ?? (outputText.length > 0 ? outputText : "(empty)")}
+              title={`Copy ${name} output`}
+            />
           </summary>
           {editDiff !== undefined && editStats !== undefined ? (
             <div className="px-3 pb-2">
@@ -1837,9 +1860,12 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
     const fn = extractFilename(message);
     return (
       <details className="rounded border border-neutral-800 bg-neutral-950 text-xs">
-        <summary className="cursor-pointer px-3 py-2 text-neutral-300">
-          <span className="text-neutral-500">read{fn !== undefined ? " " : ""}</span>
-          {fn !== undefined && <span className="font-mono">{fn}</span>}
+        <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-neutral-300">
+          <span>
+            <span className="text-neutral-500">read{fn !== undefined ? " " : ""}</span>
+            {fn !== undefined && <span className="font-mono">{fn}</span>}
+          </span>
+          <CopyButton getText={() => text} title="Copy read output" />
         </summary>
         <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">{text}</pre>
       </details>
@@ -1852,9 +1878,12 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
       <div
         className={`rounded border ${isError ? "border-red-700/40" : "border-neutral-800"} bg-neutral-950 text-xs`}
       >
-        <div className="px-3 py-2 text-neutral-400">
-          <span className="text-neutral-500">bash{cmd !== undefined ? " → " : " output"}</span>
-          {cmd !== undefined && <span className="font-mono">{cmd}</span>}
+        <div className="flex items-center justify-between gap-2 px-3 py-2 text-neutral-400">
+          <span className="min-w-0 truncate">
+            <span className="text-neutral-500">bash{cmd !== undefined ? " → " : " output"}</span>
+            {cmd !== undefined && <span className="font-mono">{cmd}</span>}
+          </span>
+          <CopyButton getText={() => text} title="Copy bash output" />
         </div>
         <pre className="max-h-64 overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-300">
           {text}
@@ -1867,10 +1896,13 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
     const fn = extractFilename(message);
     return (
       <details className="rounded border border-neutral-800 bg-neutral-950 text-xs">
-        <summary className="cursor-pointer px-3 py-2 text-neutral-300">
-          <span className="text-neutral-500">write{fn !== undefined ? " " : ""}</span>
-          {fn !== undefined && <span className="font-mono">{fn}</span>}
-          <span className="ml-2 text-neutral-500">({text.split("\n").length} lines)</span>
+        <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-neutral-300">
+          <span>
+            <span className="text-neutral-500">write{fn !== undefined ? " " : ""}</span>
+            {fn !== undefined && <span className="font-mono">{fn}</span>}
+            <span className="ml-2 text-neutral-500">({text.split("\n").length} lines)</span>
+          </span>
+          <CopyButton getText={() => text} title="Copy write output" />
         </summary>
         <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">{text}</pre>
       </details>
@@ -1890,9 +1922,12 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
     <details
       className={`rounded border ${isError ? "border-red-700/40 light:border-red-300" : "border-neutral-800"} bg-neutral-950 text-xs`}
     >
-      <summary className="cursor-pointer px-3 py-2 text-neutral-300">
-        <span className="text-neutral-500">{toolName}</span>
-        {isError && <span className="ml-2 text-red-400 light:text-red-700">error</span>}
+      <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-neutral-300">
+        <span>
+          <span className="text-neutral-500">{toolName}</span>
+          {isError && <span className="ml-2 text-red-400 light:text-red-700">error</span>}
+        </span>
+        <CopyButton getText={() => text} title={`Copy ${toolName} output`} />
       </summary>
       <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">{text}</pre>
     </details>
@@ -2101,8 +2136,9 @@ function SubagentResultCard({
           surface here as Output content rather than disappearing. */}
       {argsText.length > 0 && (
         <details className="border-t border-sky-900/30">
-          <summary className="cursor-pointer px-2.5 py-1 text-[11px] text-neutral-500 hover:text-neutral-300">
-            Input
+          <summary className="flex cursor-pointer items-center justify-between gap-2 px-2.5 py-1 text-[11px] text-neutral-500 hover:text-neutral-300">
+            <span>Input</span>
+            <CopyButton getText={() => argsText} title="Copy subagent input" />
           </summary>
           <pre className="overflow-auto px-2.5 pb-2 font-mono text-[11px] text-neutral-400">
             {argsText}
@@ -2117,8 +2153,9 @@ function SubagentResultCard({
           open={isError}
           className="border-t border-sky-900/30"
         >
-          <summary className="cursor-pointer px-2.5 py-1 text-[11px] text-neutral-500 hover:text-neutral-300">
-            Output
+          <summary className="flex cursor-pointer items-center justify-between gap-2 px-2.5 py-1 text-[11px] text-neutral-500 hover:text-neutral-300">
+            <span>Output</span>
+            <CopyButton getText={() => outputText} title="Copy subagent output" />
           </summary>
           <pre className="overflow-auto px-2.5 pb-2 font-mono text-[11px] text-neutral-300 whitespace-pre-wrap">
             {outputText}
@@ -2305,7 +2342,11 @@ function CopyButton({ getText, title }: { getText: () => string; title: string }
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onClick();
+      }}
       className="inline-flex min-h-11 min-w-11 items-center justify-center rounded px-1.5 py-0.5 text-neutral-500 hover:bg-neutral-700/40 hover:text-neutral-300 md:min-h-0 md:min-w-0"
       title={title}
       aria-label={title}

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -726,7 +726,7 @@ function ChatEditDiff({
           <span className="ml-1 text-red-400 light:text-red-700">−{dels}</span>
         </span>
         <span className="flex shrink-0 items-center gap-1">
-          <CopyButton getText={() => diff} title="Copy edit output" />
+          <CopyButton getText={() => diff} title="Copy edit output" compact />
           <button
             onClick={(e) => {
               // The summary's default click toggles the <details>; stop
@@ -1787,7 +1787,7 @@ function ToolCallEntry({
         <details className="border-t border-neutral-800/60">
           <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-1.5 text-[11px] text-neutral-500 hover:text-neutral-300">
             <span>Input</span>
-            <CopyButton getText={() => argsText} title={`Copy ${name} input`} />
+            <CopyButton getText={() => argsText} title={`Copy ${name} input`} compact />
           </summary>
           <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">
             {argsText}
@@ -1813,6 +1813,7 @@ function ToolCallEntry({
             <CopyButton
               getText={() => editDiff ?? (outputText.length > 0 ? outputText : "(empty)")}
               title={`Copy ${name} output`}
+              compact
             />
           </summary>
           {editDiff !== undefined && editStats !== undefined ? (
@@ -1865,7 +1866,7 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
             <span className="text-neutral-500">read{fn !== undefined ? " " : ""}</span>
             {fn !== undefined && <span className="font-mono">{fn}</span>}
           </span>
-          <CopyButton getText={() => text} title="Copy read output" />
+          <CopyButton getText={() => text} title="Copy read output" compact />
         </summary>
         <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">{text}</pre>
       </details>
@@ -1883,7 +1884,7 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
             <span className="text-neutral-500">bash{cmd !== undefined ? " → " : " output"}</span>
             {cmd !== undefined && <span className="font-mono">{cmd}</span>}
           </span>
-          <CopyButton getText={() => text} title="Copy bash output" />
+          <CopyButton getText={() => text} title="Copy bash output" compact />
         </div>
         <pre className="max-h-64 overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-300">
           {text}
@@ -1902,7 +1903,7 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
             {fn !== undefined && <span className="font-mono">{fn}</span>}
             <span className="ml-2 text-neutral-500">({text.split("\n").length} lines)</span>
           </span>
-          <CopyButton getText={() => text} title="Copy write output" />
+          <CopyButton getText={() => text} title="Copy write output" compact />
         </summary>
         <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">{text}</pre>
       </details>
@@ -1927,7 +1928,7 @@ function ToolResult({ message }: { message: AgentMessageLike }) {
           <span className="text-neutral-500">{toolName}</span>
           {isError && <span className="ml-2 text-red-400 light:text-red-700">error</span>}
         </span>
-        <CopyButton getText={() => text} title={`Copy ${toolName} output`} />
+        <CopyButton getText={() => text} title={`Copy ${toolName} output`} compact />
       </summary>
       <pre className="overflow-auto px-3 pb-2 font-mono text-[11px] text-neutral-400">{text}</pre>
     </details>
@@ -2138,7 +2139,7 @@ function SubagentResultCard({
         <details className="border-t border-sky-900/30">
           <summary className="flex cursor-pointer items-center justify-between gap-2 px-2.5 py-1 text-[11px] text-neutral-500 hover:text-neutral-300">
             <span>Input</span>
-            <CopyButton getText={() => argsText} title="Copy subagent input" />
+            <CopyButton getText={() => argsText} title="Copy subagent input" compact />
           </summary>
           <pre className="overflow-auto px-2.5 pb-2 font-mono text-[11px] text-neutral-400">
             {argsText}
@@ -2155,7 +2156,7 @@ function SubagentResultCard({
         >
           <summary className="flex cursor-pointer items-center justify-between gap-2 px-2.5 py-1 text-[11px] text-neutral-500 hover:text-neutral-300">
             <span>Output</span>
-            <CopyButton getText={() => outputText} title="Copy subagent output" />
+            <CopyButton getText={() => outputText} title="Copy subagent output" compact />
           </summary>
           <pre className="overflow-auto px-2.5 pb-2 font-mono text-[11px] text-neutral-300 whitespace-pre-wrap">
             {outputText}
@@ -2306,7 +2307,15 @@ function BashExecution({ message }: { message: AgentMessageLike }) {
  * back to a synthetic textarea when the async clipboard API isn't
  * available (older Safari, insecure HTTP origins).
  */
-function CopyButton({ getText, title }: { getText: () => string; title: string }) {
+function CopyButton({
+  getText,
+  title,
+  compact = false,
+}: {
+  getText: () => string;
+  title: string;
+  compact?: boolean;
+}) {
   const [copied, setCopied] = useState(false);
   const onClick = (): void => {
     const text = getText();
@@ -2347,7 +2356,9 @@ function CopyButton({ getText, title }: { getText: () => string; title: string }
         e.stopPropagation();
         onClick();
       }}
-      className="inline-flex min-h-11 min-w-11 items-center justify-center rounded px-1.5 py-0.5 text-neutral-500 hover:bg-neutral-700/40 hover:text-neutral-300 md:min-h-0 md:min-w-0"
+      className={`inline-flex items-center justify-center rounded text-neutral-500 hover:bg-neutral-700/40 hover:text-neutral-300 ${
+        compact ? "h-5 w-5 shrink-0 p-0" : "min-h-11 min-w-11 px-1.5 py-0.5 md:min-h-0 md:min-w-0"
+      }`}
       title={title}
       aria-label={title}
     >

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -453,7 +453,7 @@ function SessionRow(props: SessionRowProps) {
             }
             onSelect(s.sessionId);
           }}
-          onDoubleClick={() => onStartRename(s.sessionId, s.name ?? "")}
+          onDoubleClick={() => onStartRename(s.sessionId, label)}
           className="flex-1 truncate text-left"
           title={`${s.sessionId} — double-click to rename, Cmd/Ctrl+click to select for bulk delete`}
         >

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -436,6 +436,7 @@ function SessionRow(props: SessionRowProps) {
         <input
           autoFocus
           value={renameDraft}
+          onFocus={(e) => e.currentTarget.select()}
           onChange={(e) => onChangeRename(e.target.value)}
           onKeyDown={(e) => onRenameKeyDown(e, s.sessionId)}
           onBlur={() => onCommitRename(s.sessionId)}

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -409,12 +409,12 @@ function SessionRow(props: SessionRowProps) {
       // by 2 px. Blue, not emerald, to disambiguate from any future
       // success / drop affordances on these rows.
       style={depth > 0 ? { marginLeft: `${Math.min(depth, 3) * 8}px` } : undefined}
-      className={`group flex items-center gap-1 rounded border-l-2 px-2 py-0.5 text-xs ${
+      className={`group flex items-center gap-1 rounded border-l-2 border-t border-t-neutral-800/40 px-2 py-0.5 text-xs light:border-t-neutral-200 ${
         isSelected
-          ? "border-blue-400 bg-blue-500/15 text-neutral-100 hover:bg-blue-500/25"
+          ? "border-l-blue-400 bg-blue-500/15 text-neutral-100 hover:bg-blue-500/25"
           : isActive
-            ? "border-transparent bg-neutral-800 text-neutral-100"
-            : "border-transparent text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
+            ? "border-l-transparent bg-neutral-800 text-neutral-100"
+            : "border-l-transparent text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
       }`}
     >
       {/* Chevron column. Only parents with children get an interactive


### PR DESCRIPTION
## Summary

Auto-scroll in the chat view could pull users back to the bottom too aggressively while they were trying to read earlier output. This PR tightens the follow-bottom threshold and disables follow mode as soon as the user scrolls upward. It also adds copy controls for tool call inputs/outputs and visually separates sessions inside project groups with thin dividers.

## Usage

No configuration required. In the browser UI:

- Scroll upward in a chat transcript; new output should not force the viewport back to the bottom until you return there.
- Use the copy buttons on tool input/output sections to copy raw content.
- Project session rows in the session pane are separated by thin dividing lines.

## What changed (2 files)

- `packages/client/src/components/ChatView.tsx` — softened auto-scroll behavior and added copy affordances for tool call inputs/outputs.
- `packages/client/src/components/SessionList.tsx` — added thin dividers between session rows within a project while preserving selected styling.

## Test plan

- [x] `npx prettier --check packages/client/src/components/ChatView.tsx packages/client/src/components/SessionList.tsx`
- [ ] Manual: verify chat scroll behavior, tool input/output copy buttons, and project session dividers in the browser.
- [ ] CI green before merge
