### PR TITLE
feat: add optional agent tool sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ For source builds and a development setup see
   interrupt, and kill worker sessions in the same project. Worker
   events stream back into the supervisor's inbox; the supervisor's
   LLM wakes on activity and reacts.
+- **Optional tool sandbox** — opt-in deployment mode that runs agent/user
+  shell surfaces as a restricted UID/GID, scopes model file tools, and
+  keeps server-side config, forge data, and mounted secrets out of that
+  identity when mounts are permissioned for the split.
 - **Webhooks** — HTTPS POST deliveries on agent and session events
   (`agent_end`, `ask_user_question`, `process_alert`, `auto_retry_end`,
   `compaction_end`, `session_created`, `session_deleted`). Global or
@@ -147,6 +151,7 @@ The full feature grid (with categories and screenshots) is on the
 - [Docker image](./docs/containers.md) — image internals, volumes, env, troubleshooting
 - [Private-network deployment](./docs/deployment.md) — reverse proxy, auth, multi-deploy patterns
 - [Kubernetes / OpenShift](./kubernetes/DEPLOY.md) — manifests + walkthroughs
+- [Optional tool sandbox](./docs/agent-tool-sandbox.md) — UID/GID split, mount permissions, and verification prompts
 - [Security model](./SECURITY.md) — threat model + vulnerability reporting
 
 **Configure & extend**

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -23,6 +23,15 @@ HOST_PORT=3000
 PUID=1000
 PGID=1000
 
+# ---- Agent tool identity sandbox ----
+# Disabled by default. When enabled, the pi-forge server runs as root
+# and model/user shell surfaces (agent bash, process tool, terminal,
+# quick-action commands, !/!! exec) run as the restricted `pi-tools`
+# UID/GID. Compose grants only SETUID/SETGID for this switch.
+AGENT_TOOL_SANDBOX_ENABLED=false
+AGENT_TOOL_UID=1001
+AGENT_TOOL_GID=1001
+
 # ---- Volume sources ----
 # Where your project code lives on the host. Projects are subfolders.
 # Default is ../workspace (relative to the compose file). Use an

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,7 +139,7 @@ ARG PTOOLS_GID=1001
 #     present when `apt-get install gh` runs.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      tini git ripgrep bash curl ca-certificates less procps make g++ gnupg \
+      tini gosu git ripgrep bash curl ca-certificates less procps make g++ gnupg \
  && install -dm 0755 /etc/apt/keyrings \
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -170,18 +170,37 @@ COPY --from=builder --chown=pi:pi /app/packages/server/dist ./packages/server/di
 COPY --from=builder --chown=pi:pi /app/packages/client/package.json ./packages/client/package.json
 COPY --from=builder --chown=pi:pi /app/packages/client/dist ./packages/client/dist
 
-# Workspace + pi config + pi-forge data dirs are mounted at runtime;
-# create defaults with the intended split: `pi-tools` can read/write the
-# workspace, while pi config / forge data are readable by the root server
-# but not by the restricted tool identity.
+# Workspace + pi config + pi-forge data dirs are mounted at runtime.
+# Image-layer defaults preserve the historical non-sandbox posture:
+# the server runs as `pi`, and pi-owned config/data dirs are writable by it.
+# Sandbox deployments must explicitly permission their mounts; see
+# docs/agent-tool-sandbox.md.
 RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local \
  && chown -R pi-tools:pi-tools /workspace \
  && chown root:root /home/pi \
- && chown -R root:pi /home/pi/.pi /home/pi/.pi-forge \
- && chown -R pi:pi /home/pi/.local \
+ && chown -R pi:pi /home/pi/.pi /home/pi/.pi-forge /home/pi/.local \
  && chmod 0775 /workspace \
  && chmod 0755 /home/pi \
- && chmod 0750 /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local
+ && chmod 0700 /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local
+
+RUN cat >/usr/local/bin/pi-forge-entrypoint <<'EOF'
+#!/bin/sh
+set -eu
+case "$(printf '%s' "${AGENT_TOOL_SANDBOX_ENABLED:-false}" | tr '[:upper:]' '[:lower:]')" in
+  1|true|yes|on)
+    # Sandbox mode: keep the server as root so it can setuid/setgid
+    # model/user tool children to AGENT_TOOL_UID:GID. Mount ownership is
+    # an operator contract; see docs/agent-tool-sandbox.md.
+    exec "$@"
+    ;;
+  *)
+    # Legacy/default mode: run the server as pi, matching historical
+    # container behavior and pi-owned image defaults.
+    exec gosu pi "$@"
+    ;;
+esac
+EOF
+RUN chmod 0755 /usr/local/bin/pi-forge-entrypoint
 
 USER root
 
@@ -213,5 +232,5 @@ ENV NODE_ENV=production \
 
 EXPOSE 3000
 
-ENTRYPOINT ["/usr/bin/tini", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/pi-forge-entrypoint"]
 CMD ["node", "packages/server/dist/index.js"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,9 @@
 #
 #   builder  → install deps, compile server TS, build Vite client
 #   runtime  → node:22-bookworm-slim with Python 3.12 + pip, compiled
-#              output, and hoisted node_modules; runs as a non-root user.
+#              output, and hoisted node_modules. The server runs as root
+#              so the opt-in identity sandbox can drop tool processes to
+#              the restricted pi-tools UID/GID.
 #
 # Why bookworm-slim and not alpine: the Node native-module ecosystem
 # (node-pty, bcrypt, sharp, better-sqlite3, …) ships prebuilt binaries
@@ -87,14 +89,16 @@ FROM node-python-base AS runtime
 # shutdown of pi-forge's onClose hook). Without it, dropped SIGTERMs
 # leave SSE clients hanging on `docker compose down`.
 #
-# PUID/PGID build args let the user match the container's `pi` user to
-# their host UID/GID. Default 1000 is the common Linux interactive UID.
-# Without this, the system-allocated UID won't match the host owner of
-# the bind-mounted /workspace + ~/.pi-forge dirs, and the container
-# can't write to them. Override at build time:
+# PUID/PGID build args let the legacy `pi` user match the host owner of
+# mounted config/data directories. PTOOLS_UID/PTOOLS_GID create the
+# restricted `pi-tools` identity used by AGENT_TOOL_SANDBOX_ENABLED.
+# Override at build time when your host bind mounts require different
+# ownership:
 #   docker compose build --build-arg PUID=$(id -u) --build-arg PGID=$(id -g)
 ARG PUID=1000
 ARG PGID=1000
+ARG PTOOLS_UID=1001
+ARG PTOOLS_GID=1001
 
 # Some upstream base images have shipped a pre-baked `node` user/group
 # at UID/GID 1000 — the same default we want for `pi`. Drop it before
@@ -148,7 +152,9 @@ RUN apt-get update \
  && (userdel node 2>/dev/null || true) \
  && (groupdel node 2>/dev/null || true) \
  && groupadd -g $PGID pi \
- && useradd -m -u $PUID -g $PGID -s /bin/bash pi
+ && useradd -m -u $PUID -g $PGID -s /bin/bash pi \
+ && groupadd -g $PTOOLS_GID pi-tools \
+ && useradd -M -u $PTOOLS_UID -g $PTOOLS_GID -s /usr/sbin/nologin pi-tools
 
 WORKDIR /app
 
@@ -165,12 +171,17 @@ COPY --from=builder --chown=pi:pi /app/packages/client/package.json ./packages/c
 COPY --from=builder --chown=pi:pi /app/packages/client/dist ./packages/client/dist
 
 # Workspace + pi config + pi-forge data dirs are mounted at runtime;
-# create them so non-root `pi` can read them on first start even if the
-# host bind is currently empty.
+# create defaults with the intended split: `pi-tools` can read/write the
+# workspace, while pi config / forge data are readable by the root server
+# but not by the restricted tool identity.
 RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local \
- && chown -R pi:pi /workspace /home/pi/.pi /home/pi/.pi-forge /home/pi/.local
+ && chown -R pi-tools:pi-tools /workspace \
+ && chown -R root:pi /home/pi/.pi /home/pi/.pi-forge \
+ && chown -R pi:pi /home/pi/.local \
+ && chmod 0775 /workspace \
+ && chmod 0750 /home/pi /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local
 
-USER pi
+USER root
 
 # SHELL=/bin/bash so node-pty spawns bash for the integrated terminal
 # (pty-manager.ts uses `process.env.SHELL || '/bin/sh'`). TERM hint
@@ -187,6 +198,9 @@ USER pi
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
     PORT=3000 \
+    HOME=/home/pi \
+    USER=pi \
+    LOGNAME=pi \
     PATH=/home/pi/.local/bin:/app/node_modules/.bin:$PATH \
     WORKSPACE_PATH=/workspace \
     PI_CONFIG_DIR=/home/pi/.pi/agent \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -176,10 +176,12 @@ COPY --from=builder --chown=pi:pi /app/packages/client/dist ./packages/client/di
 # but not by the restricted tool identity.
 RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local \
  && chown -R pi-tools:pi-tools /workspace \
+ && chown root:root /home/pi \
  && chown -R root:pi /home/pi/.pi /home/pi/.pi-forge \
  && chown -R pi:pi /home/pi/.local \
  && chmod 0775 /workspace \
- && chmod 0750 /home/pi /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local
+ && chmod 0755 /home/pi \
+ && chmod 0750 /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -154,7 +154,8 @@ RUN apt-get update \
  && groupadd -g $PGID pi \
  && useradd -m -u $PUID -g $PGID -s /bin/bash pi \
  && groupadd -g $PTOOLS_GID pi-tools \
- && useradd -M -u $PTOOLS_UID -g $PTOOLS_GID -s /usr/sbin/nologin pi-tools
+ && useradd -M -u $PTOOLS_UID -g $PTOOLS_GID -s /usr/sbin/nologin pi-tools \
+ && usermod -aG pi-tools pi
 
 WORKDIR /app
 
@@ -178,10 +179,12 @@ COPY --from=builder --chown=pi:pi /app/packages/client/dist ./packages/client/di
 RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local \
  && chown -R pi-tools:pi-tools /workspace \
  && chown root:root /home/pi \
- && chown -R pi:pi /home/pi/.pi /home/pi/.pi-forge /home/pi/.local \
+ && chown root:pi-tools /home/pi/.pi \
+ && chown -R pi:pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local \
  && chmod 0775 /workspace \
  && chmod 0755 /home/pi \
- && chmod 0700 /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local
+ && chmod 0750 /home/pi/.pi \
+ && chmod 0700 /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local
 
 RUN cat >/usr/local/bin/pi-forge-entrypoint <<'EOF'
 #!/bin/sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,8 @@ services:
         # Override in .env to match `id -u` / `id -g` for writable bind mounts.
         PUID: ${PUID:-1000}
         PGID: ${PGID:-1000}
+        PTOOLS_UID: ${AGENT_TOOL_UID:-1001}
+        PTOOLS_GID: ${AGENT_TOOL_GID:-1001}
     image: pi-forge:latest
     container_name: ${CONTAINER_NAME:-pi-forge}
     restart: unless-stopped
@@ -50,12 +52,20 @@ services:
       - ORCHESTRATION_DISABLED=${ORCHESTRATION_DISABLED:-false}
       - ORCHESTRATION_ENABLED=${ORCHESTRATION_ENABLED:-}
       - ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR=${ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR:-8}
+      # Identity sandbox — disabled by default. When true, the root
+      # server drops model/user shell surfaces to pi-tools via SETUID/SETGID.
+      - AGENT_TOOL_SANDBOX_ENABLED=${AGENT_TOOL_SANDBOX_ENABLED:-false}
+      - AGENT_TOOL_UID=${AGENT_TOOL_UID:-1001}
+      - AGENT_TOOL_GID=${AGENT_TOOL_GID:-1001}
     # Hardening (mirrors the k8s manifests). Not read-only because the
     # agent's bash tool needs to write to /home/pi/.npm, /tmp, etc.
     security_opt:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    cap_add:
+      - SETUID
+      - SETGID
     pids_limit: 512
     mem_limit: 2g
     cpus: "1.0"

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -71,7 +71,9 @@ the workspace.
 
 Regular/non-sandbox mode keeps the historical simple contract: the server runs
 as `pi`, and mounted workspace/config/data paths should be writable by `pi`.
-Sandbox mode is different and requires the split below.
+Sandbox mode is different and requires the split below. The Docker image makes
+the image-owned parent `/home/pi/.pi` traversable by `pi-tools`; the mounted
+`/home/pi/.pi/agent` subtree still needs the permissions below.
 
 The permissions that matter are numeric UID/GID and mode bits **as seen inside
 the container or pod**.
@@ -103,7 +105,9 @@ volume ownership/modes.
 
 On native Linux bind mounts, host numeric ownership is normally what the
 container sees. With default Docker sandbox IDs (`1001:1001`), run this on the
-**host** before starting the container:
+**host** before starting the container. This works best on native Linux; for
+Docker Desktop / OrbStack / macOS, prefer the inside-container commands in the
+next section.
 
 ```bash
 # Workspace: writable by pi-tools.
@@ -117,8 +121,9 @@ sudo chown -R root:root ~/.pi-forge-docker
 sudo chmod -R u+rwX,go-rwx ~/.pi-forge-docker
 
 # Pi config: pi-tools can traverse/read non-secret resources.
-# IMPORTANT: include the parent ~/.pi directory, not only ~/.pi/agent,
-# otherwise pi-tools cannot traverse into the mounted agent dir.
+# If you bind-mount only ~/.pi/agent (the compose default), the image-owned
+# /home/pi/.pi parent is already traversable by pi-tools. If you bind-mount
+# the whole ~/.pi directory instead, set the parent permissions too:
 sudo chown root:1001 ~/.pi
 sudo chmod 0750 ~/.pi
 sudo chown -R root:1001 ~/.pi/agent
@@ -176,8 +181,12 @@ If the restricted terminal can read `.pi-forge`, the host bind mount cannot
 reliably test this isolation. Use Docker named volumes for sensitive mounts
 while testing on macOS/OrbStack.
 
-If host-side ownership changes are ignored or translated, apply the sandbox
-permissions from a root shell **inside the running container** instead:
+### Required when host ownership is translated: run inside the container
+
+If host-side ownership changes are ignored or translated (common with Docker
+Desktop / OrbStack / macOS), apply the sandbox permissions from a root shell
+**inside the running container** instead. These commands affect the container's
+view of the mounts, which is the view that matters for `pi-tools`:
 
 ```bash
 docker compose exec pi-forge sh -lc '

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -6,7 +6,9 @@ enabled, pi-forge keeps the HTTP server running as root and runs model/user
 tool surfaces as a restricted UID/GID (`pi-tools` in the Docker image).
 
 This is an operator-controlled hardening mode. It is useful only when the
-container or pod mounts are permissioned carefully.
+container or pod mounts are permissioned carefully. Leave it disabled for
+simple local installs or any deployment where the workspace, Pi config, forge
+data, and secret mounts cannot be owned/mode-bit split as described below.
 
 ## What changes when enabled
 
@@ -43,7 +45,7 @@ surfaces:
 
 - model file tools can read the configured workspace root (`WORKSPACE_PATH`), not only the active project subfolder
 - model file tools cannot read outside allowed roots
-- model file tools cannot read protected Pi config files:
+- model file tools cannot read protected Pi config files, even if `PI_CONFIG_DIR` is accidentally mounted inside `WORKSPACE_PATH`:
   - `${PI_CONFIG_DIR}/auth.json`
   - `${PI_CONFIG_DIR}/models.json`
   - `${PI_CONFIG_DIR}/settings.json`
@@ -67,7 +69,11 @@ This mode does **not** protect:
 
 The model and user shell surfaces are intentionally allowed to read and write
 the entire configured workspace root (`WORKSPACE_PATH`, `/workspace` in the
-Docker image), including sibling project folders.
+Docker image), including sibling project folders. Unlike model file tools,
+`bash`, process-tool commands, integrated terminals, quick actions, and chat
+exec commands are not path-policy scoped; after they drop to
+`AGENT_TOOL_UID:GID`, access to `PI_CONFIG_DIR`, `FORGE_DATA_DIR`, and any
+other path is controlled by Unix ownership and mode bits.
 
 ## Required mount permissions
 

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -41,6 +41,7 @@ When enabled:
 The sandbox is intended to protect server-side secrets from model/user tool
 surfaces:
 
+- model file tools can read the configured workspace root (`WORKSPACE_PATH`), not only the active project subfolder
 - model file tools cannot read outside allowed roots
 - model file tools cannot read protected Pi config files:
   - `${PI_CONFIG_DIR}/auth.json`
@@ -65,7 +66,8 @@ This mode does **not** protect:
 - anything readable by `AGENT_TOOL_UID:GID` at the filesystem layer
 
 The model and user shell surfaces are intentionally allowed to read and write
-the workspace.
+the entire configured workspace root (`WORKSPACE_PATH`, `/workspace` in the
+Docker image), including sibling project folders.
 
 ## Required mount permissions
 
@@ -463,6 +465,17 @@ subjects:
 Use the Kubernetes initContainer permission commands above, plus the OpenShift
 SCC binding. If you build a custom SCC, it needs UID 0 plus `SETUID`/`SETGID`;
 it does not need privileged mode.
+
+## pi-subagents package disabled in sandbox mode
+
+The `pi-subagents` package/extension is disabled while
+`AGENT_TOOL_SANDBOX_ENABLED=true`. The package shells out to the `pi` CLI and
+manages child sessions outside pi-forge's normal in-process tool override path,
+which makes its security boundary harder to reason about in this mode.
+
+Built-in pi-forge orchestration tools remain separate from `pi-subagents`; if
+you use them with sandbox mode, validate their worker behavior under your
+mount/UID policy.
 
 ## LDAP bind password files
 

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -1,0 +1,251 @@
+# Agent tool identity sandbox
+
+`AGENT_TOOL_SANDBOX_ENABLED=false` by default. In the Docker image, the default
+entrypoint drops the server to the legacy `pi` user. When sandbox mode is
+enabled, pi-forge keeps the HTTP server running as root and runs model/user
+tool surfaces as a restricted UID/GID (`pi-tools` in the Docker image).
+
+This is an operator-controlled hardening mode. It is useful only when the
+container or pod mounts are permissioned carefully.
+
+## What changes when enabled
+
+Set:
+
+```txt
+AGENT_TOOL_SANDBOX_ENABLED=true
+AGENT_TOOL_UID=<numeric uid>
+AGENT_TOOL_GID=<numeric gid>
+```
+
+In the Docker image defaults, `pi-tools` is:
+
+```txt
+AGENT_TOOL_UID=1001
+AGENT_TOOL_GID=1001
+```
+
+When enabled:
+
+- agent/model file tools are path-scoped
+- `@file` expansion is path-scoped
+- agent `bash` runs as `AGENT_TOOL_UID:GID`
+- process-tool commands run as `AGENT_TOOL_UID:GID`
+- integrated terminals run as `AGENT_TOOL_UID:GID`
+- quick-action command chips run as `AGENT_TOOL_UID:GID`
+- chat `!` / `!!` exec commands run as `AGENT_TOOL_UID:GID`
+- shell/process/terminal env is scrubbed
+
+## What is protected
+
+The sandbox is intended to protect server-side secrets from model/user tool
+surfaces:
+
+- model file tools cannot read outside allowed roots
+- model file tools cannot read protected Pi config files:
+  - `${PI_CONFIG_DIR}/auth.json`
+  - `${PI_CONFIG_DIR}/models.json`
+  - `${PI_CONFIG_DIR}/settings.json`
+- model file tools cannot read `${FORGE_DATA_DIR}`
+- model file tools reject `/proc`, `/etc`, `/run/secrets`, and
+  `/var/run/secrets`
+- model file tools reject traversal and symlink escapes
+- bash/process/terminal children do not inherit server/provider env secrets
+- with correct UID separation, `/proc/<server-pid>/environ` is not readable by
+  tool children
+
+## What is not protected
+
+This mode does **not** protect:
+
+- secrets placed in `/workspace`
+- a compromised pi-forge server process
+- host/container/pod misconfiguration
+- third-party extensions or tools that bypass pi-forge's policy hooks
+- anything readable by `AGENT_TOOL_UID:GID` at the filesystem layer
+
+The model and user shell surfaces are intentionally allowed to read and write
+the workspace.
+
+## Required mount permissions
+
+Regular/non-sandbox mode keeps the historical simple contract: the server runs
+as `pi`, and mounted workspace/config/data paths should be writable by `pi`.
+Sandbox mode is different and requires the split below.
+
+The permissions that matter are numeric UID/GID and mode bits **as seen inside
+the container or pod**.
+
+| Path | Required sandbox posture |
+|---|---|
+| `/workspace` | Writable by `AGENT_TOOL_UID:GID`. Secrets in the workspace are readable by the agent. |
+| `/home/pi/.pi` | Traversable by `AGENT_TOOL_UID:GID` so package skills and non-secret resources can be loaded. Recommended: `root:pi-tools` `0750`. |
+| `/home/pi/.pi/agent` | Traversable/readable by `AGENT_TOOL_UID:GID` for non-secret resources. Recommended: `root:pi-tools` `0750`. |
+| `/home/pi/.pi/agent/auth.json` | Not readable by `AGENT_TOOL_UID:GID`. Recommended: `root:root` `0600`. Also blocked by file-tool policy. |
+| `/home/pi/.pi/agent/models.json` | Not readable by `AGENT_TOOL_UID:GID`. Recommended: `root:root` `0600`. Also blocked by file-tool policy. |
+| `/home/pi/.pi/agent/settings.json` | Not readable by `AGENT_TOOL_UID:GID`. Recommended: `root:root` `0600`. Also blocked by file-tool policy. |
+| `/home/pi/.pi-forge` | Not readable by `AGENT_TOOL_UID:GID`. Recommended: `root:root` `0700`. |
+| mounted secret dirs/files | Not readable by `AGENT_TOOL_UID:GID`; prefer root-owned `0700` dirs and `0600` files. |
+
+Why `.pi` is partially readable: pi package skills and other non-secret pi
+resources may live under the Pi config/home tree. The sandbox blocks the known
+secret Pi config files by policy and filesystem mode, while leaving non-secret
+resources loadable.
+
+The Docker image's built-in directory ownership remains optimized for regular
+mode (`pi` owns `/home/pi/.pi` and `/home/pi/.pi-forge`). Enabling sandbox with
+bind mounts or persistent volumes is an explicit operator step: adjust the mount
+permissions to the table above before relying on filesystem isolation. Switching
+an existing deployment between regular and sandbox mode may require changing
+volume ownership/modes.
+
+## Native Linux example
+
+With default Docker sandbox IDs (`1001:1001`):
+
+```bash
+# Workspace: writable by pi-tools.
+sudo mkdir -p ./workspace
+sudo chown -R 1001:1001 ./workspace
+sudo chmod -R u+rwX,g+rwX,o-rwx ./workspace
+
+# Forge data: server-only.
+sudo mkdir -p ~/.pi-forge-docker
+sudo chown -R root:root ~/.pi-forge-docker
+sudo chmod -R u+rwX,go-rwx ~/.pi-forge-docker
+
+# Pi config: pi-tools can traverse/read non-secret resources.
+sudo chown -R root:1001 ~/.pi/agent
+sudo chmod 0750 ~/.pi ~/.pi/agent
+sudo find ~/.pi/agent -type d -exec chmod 0750 {} +
+sudo find ~/.pi/agent -type f -exec chmod 0640 {} +
+
+# Pi config secrets: server-only.
+sudo chown root:root ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/settings.json 2>/dev/null || true
+sudo chmod 0600 ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/settings.json 2>/dev/null || true
+```
+
+Then in `docker/.env`:
+
+```txt
+AGENT_TOOL_SANDBOX_ENABLED=true
+AGENT_TOOL_UID=1001
+AGENT_TOOL_GID=1001
+```
+
+Rebuild/recreate:
+
+```bash
+cd docker
+docker compose down
+docker compose up -d --build
+```
+
+## Docker Desktop / OrbStack / macOS note
+
+On macOS file-sharing layers, bind-mount ownership can be virtualized. A host
+path owned by your macOS user may appear as `pi`, `pi-tools`, or another mapped
+identity inside the container. In some cases, ownership may appear differently
+from a root shell and from the restricted app terminal.
+
+Always verify inside the running container:
+
+```bash
+docker compose exec pi-forge sh -lc '
+id
+id pi-tools
+stat -c "%u:%g %a %n" /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
+'
+```
+
+Then verify from the app terminal:
+
+```bash
+id
+stat -c "%u:%g %a %n" /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
+cat /home/pi/.pi-forge/jwt-secret
+```
+
+If the restricted terminal can read `.pi-forge`, the host bind mount cannot
+reliably test this isolation. Use Docker named volumes for sensitive mounts
+while testing on macOS/OrbStack.
+
+## Docker Compose requirements
+
+The server must be able to switch child identity. Compose therefore needs:
+
+```yaml
+cap_drop:
+  - ALL
+cap_add:
+  - SETUID
+  - SETGID
+security_opt:
+  - no-new-privileges:true
+```
+
+No privileged mode or host PID is required.
+
+## Kubernetes / OpenShift requirements
+
+Vanilla Kubernetes example:
+
+```yaml
+securityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+    add: ["SETUID", "SETGID"]
+```
+
+OpenShift `restricted-v2` random UID does not support this mode. Use `anyuid`
+for a simple deployment, or a custom SCC that allows:
+
+- UID 0 for the server container
+- `SETUID`
+- `SETGID`
+- no privileged mode
+
+Keep SCC RoleBindings in namespace/security bootstrap, not in the
+DeploymentConfig.
+
+## LDAP bind password files
+
+When sandbox mode is enabled, pi-forge rejects:
+
+- `LDAP_BIND_PASSWORD_FILE`
+- CLI `--ldap-bind-password @/path`
+- env-style `LDAP_BIND_PASSWORD=@/path`
+
+Use a literal environment value or an external secret broker instead. Tool
+children receive a scrubbed env and do not inherit the LDAP bind password.
+
+## Suggested verification prompts
+
+Ask the model:
+
+```txt
+Use your file tools, not bash, to test sandbox file access.
+Try to read /workspace/sandbox-test.txt, list /workspace, read
+/home/pi/.pi/agent/auth.json, /home/pi/.pi/agent/models.json,
+/home/pi/.pi/agent/settings.json, /home/pi/.pi-forge/jwt-secret,
+/proc/self/environ, /etc/passwd, and /run/secrets/anything.
+Report which succeeded and which failed.
+```
+
+Expected: workspace succeeds; protected config, forge data, `/proc`, `/etc`,
+and secret mounts are denied.
+
+Ask the model:
+
+```txt
+Use bash to run: id; env | sort; echo ok > /workspace/bash-sandbox-test.txt;
+cat /workspace/bash-sandbox-test.txt; cat /home/pi/.pi-forge/jwt-secret;
+cat /home/pi/.pi/agent/auth.json; cat /proc/1/environ.
+Report the output and explain what was protected.
+```
+
+Expected: `id` shows the restricted UID/GID, env is scrubbed, workspace write
+works, and server secrets fail with permission denied.

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -99,9 +99,11 @@ permissions to the table above before relying on filesystem isolation. Switching
 an existing deployment between regular and sandbox mode may require changing
 volume ownership/modes.
 
-## Native Linux example
+## Native Linux host example
 
-With default Docker sandbox IDs (`1001:1001`):
+On native Linux bind mounts, host numeric ownership is normally what the
+container sees. With default Docker sandbox IDs (`1001:1001`), run this on the
+**host** before starting the container:
 
 ```bash
 # Workspace: writable by pi-tools.
@@ -115,8 +117,11 @@ sudo chown -R root:root ~/.pi-forge-docker
 sudo chmod -R u+rwX,go-rwx ~/.pi-forge-docker
 
 # Pi config: pi-tools can traverse/read non-secret resources.
+# IMPORTANT: include the parent ~/.pi directory, not only ~/.pi/agent,
+# otherwise pi-tools cannot traverse into the mounted agent dir.
+sudo chown root:1001 ~/.pi
+sudo chmod 0750 ~/.pi
 sudo chown -R root:1001 ~/.pi/agent
-sudo chmod 0750 ~/.pi ~/.pi/agent
 sudo find ~/.pi/agent -type d -exec chmod 0750 {} +
 sudo find ~/.pi/agent -type f -exec chmod 0640 {} +
 
@@ -169,6 +174,34 @@ cat /home/pi/.pi-forge/jwt-secret
 If the restricted terminal can read `.pi-forge`, the host bind mount cannot
 reliably test this isolation. Use Docker named volumes for sensitive mounts
 while testing on macOS/OrbStack.
+
+If host-side ownership changes are ignored or translated, apply the sandbox
+permissions from a root shell **inside the running container** instead:
+
+```bash
+docker compose exec pi-forge sh -lc '
+# Workspace: writable by pi-tools.
+chown -R pi-tools:pi-tools /workspace
+chmod -R u+rwX,g+rwX,o-rwx /workspace
+
+# Forge data: server-only.
+chown -R root:root /home/pi/.pi-forge
+chmod -R u+rwX,go-rwx /home/pi/.pi-forge
+
+# Pi config: pi-tools can traverse/read non-secret resources.
+chown root:pi-tools /home/pi/.pi
+chmod 0750 /home/pi/.pi
+chown -R root:pi-tools /home/pi/.pi/agent
+find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
+find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
+
+# Pi config secrets: server-only.
+chown root:root /home/pi/.pi/agent/auth.json /home/pi/.pi/agent/models.json /home/pi/.pi/agent/settings.json 2>/dev/null || true
+chmod 0600 /home/pi/.pi/agent/auth.json /home/pi/.pi/agent/models.json /home/pi/.pi/agent/settings.json 2>/dev/null || true
+
+stat -c "%U:%G %u:%g %a %n" /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
+'
+```
 
 ## Docker Compose requirements
 

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -95,19 +95,27 @@ secret Pi config files by policy and filesystem mode, while leaving non-secret
 resources loadable.
 
 The Docker image's built-in directory ownership remains optimized for regular
-mode (`pi` owns `/home/pi/.pi` and `/home/pi/.pi-forge`). Enabling sandbox with
-bind mounts or persistent volumes is an explicit operator step: adjust the mount
-permissions to the table above before relying on filesystem isolation. Switching
-an existing deployment between regular and sandbox mode may require changing
-volume ownership/modes.
+mode (`pi` owns `/home/pi/.pi/agent` and `/home/pi/.pi-forge`). Enabling sandbox
+with bind mounts or persistent volumes is an explicit operator step: adjust the
+mount permissions to the table above before relying on filesystem isolation.
+Switching an existing deployment between regular and sandbox mode may require
+changing volume ownership/modes.
 
-## Native Linux host example
+## Docker Compose: native Linux bind mounts
 
-On native Linux bind mounts, host numeric ownership is normally what the
-container sees. With default Docker sandbox IDs (`1001:1001`), run this on the
-**host** before starting the container. This works best on native Linux; for
-Docker Desktop / OrbStack / macOS, prefer the inside-container commands in the
-next section.
+Use this section for regular Docker Engine on Linux. You can keep the default
+bind mounts from `docker/docker-compose.yml`:
+
+```yaml
+volumes:
+  - ${WORKSPACE_HOST_PATH:-../workspace}:/workspace
+  - ${PI_CONFIG_HOST_PATH:-~/.pi/agent}:/home/pi/.pi/agent
+  - ${FORGE_DATA_HOST_PATH:-~/.pi-forge-docker}:/home/pi/.pi-forge
+```
+
+Native Linux bind mounts normally preserve host numeric ownership in the
+container. With default sandbox IDs (`1001:1001`), run these commands on the
+**host** before starting the container:
 
 ```bash
 # Workspace: writable by pi-tools.
@@ -121,9 +129,9 @@ sudo chown -R root:root ~/.pi-forge-docker
 sudo chmod -R u+rwX,go-rwx ~/.pi-forge-docker
 
 # Pi config: pi-tools can traverse/read non-secret resources.
-# If you bind-mount only ~/.pi/agent (the compose default), the image-owned
-# /home/pi/.pi parent is already traversable by pi-tools. If you bind-mount
-# the whole ~/.pi directory instead, set the parent permissions too:
+# The image-owned /home/pi/.pi parent is already traversable by pi-tools when
+# only ~/.pi/agent is mounted. If you mount the whole ~/.pi directory, set the
+# parent permissions too.
 sudo chown root:1001 ~/.pi
 sudo chmod 0750 ~/.pi
 sudo chown -R root:1001 ~/.pi/agent
@@ -136,7 +144,7 @@ sudo chown root:root ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/s
 sudo chmod 0600 ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/settings.json 2>/dev/null || true
 ```
 
-Then in `docker/.env`:
+Set sandbox env in `docker/.env`:
 
 ```txt
 AGENT_TOOL_SANDBOX_ENABLED=true
@@ -144,7 +152,19 @@ AGENT_TOOL_UID=1001
 AGENT_TOOL_GID=1001
 ```
 
-Rebuild/recreate:
+Compose capabilities for native Linux should be:
+
+```yaml
+cap_drop:
+  - ALL
+cap_add:
+  - SETUID
+  - SETGID
+security_opt:
+  - no-new-privileges:true
+```
+
+Then rebuild/recreate:
 
 ```bash
 cd docker
@@ -152,16 +172,80 @@ docker compose down
 docker compose up -d --build
 ```
 
-## Docker one-shot volume init container
+## Docker Compose: OrbStack / Docker Desktop / macOS
 
-If pi-forge cannot start because a named volume has regular-mode ownership
-(for example `/home/pi/.pi-forge` is `1000:1000 0700` while sandbox mode keeps
-the server as root with limited capabilities), run a one-shot helper container
-before starting pi-forge.
+Use this section for OrbStack or Docker Desktop on macOS. Host file sharing can
+translate ownership differently depending on the container and the accessing
+UID, so host-side `chown` may not produce stable results inside pi-forge.
 
-This example assumes the compose file uses named volumes called
-`docker_pi-config` and `docker_forge-data` and the default sandbox UID/GID
-`1001:1001`:
+Recommended differences from native Linux:
+
+1. Keep `/workspace` as a host bind mount if you want to edit code from macOS.
+2. Use Docker named volumes for `/home/pi/.pi/agent` and `/home/pi/.pi-forge`.
+3. Initialize those named volumes with a one-shot helper container.
+4. Add `DAC_OVERRIDE` only for local OrbStack/Docker Desktop testing if the root
+   server cannot write the id-mapped `.pi-forge` volume.
+
+### Compose volume changes
+
+Change the service volumes from host binds for Pi config / forge data to named
+volumes:
+
+```yaml
+services:
+  pi-forge:
+    volumes:
+      - ${WORKSPACE_HOST_PATH:-../workspace}:/workspace
+      - pi-config:/home/pi/.pi/agent
+      - forge-data:/home/pi/.pi-forge
+
+volumes:
+  pi-config:
+  forge-data:
+```
+
+If you want stable names for helper commands:
+
+```yaml
+volumes:
+  pi-config:
+    name: docker_pi-config
+  forge-data:
+    name: docker_forge-data
+```
+
+### Compose capability changes
+
+Start with the native capability set:
+
+```yaml
+cap_drop:
+  - ALL
+cap_add:
+  - SETUID
+  - SETGID
+security_opt:
+  - no-new-privileges:true
+```
+
+If OrbStack/Docker Desktop shows `.pi-forge` as `1000:1000 0700` inside the
+pi-forge container even after the helper volume init chowns it to `root:root`,
+add `DAC_OVERRIDE` for local testing:
+
+```yaml
+cap_add:
+  - SETUID
+  - SETGID
+  - DAC_OVERRIDE # local OrbStack/Docker Desktop workaround only
+```
+
+Keep production/native-Linux deployments to `SETUID` and `SETGID` when mounts
+can be permissioned normally.
+
+### One-shot volume init commands
+
+This example assumes the named volumes are `docker_pi-config` and
+`docker_forge-data`, and the sandbox UID/GID is `1001:1001`:
 
 ```bash
 cd docker
@@ -173,7 +257,7 @@ docker run --rm \
   -v docker_pi-config:/home/pi/.pi/agent \
   debian:bookworm-slim sh -lc 'cp -a /src/. /home/pi/.pi/agent/'
 
-# Permission the volumes for sandbox mode.
+# Permission the named volumes for sandbox mode.
 docker run --rm \
   -v docker_pi-config:/home/pi/.pi/agent \
   -v docker_forge-data:/home/pi/.pi-forge \
@@ -204,113 +288,54 @@ chmod 0600 \
 
 stat -c "%u:%g %a %n" /home/pi/.pi/agent /home/pi/.pi-forge
 '
+```
 
+Set sandbox env in `docker/.env`:
+
+```txt
+AGENT_TOOL_SANDBOX_ENABLED=true
+AGENT_TOOL_UID=1001
+AGENT_TOOL_GID=1001
+```
+
+Start pi-forge:
+
+```bash
 docker compose up -d --build
 ```
 
-If you use different volume names, inspect them first:
+Verify the actual mounts and ownership inside pi-forge:
 
 ```bash
-docker compose config --volumes
-docker volume ls | grep -E 'pi-config|forge-data'
-```
-
-## Docker Desktop / OrbStack / macOS note
-
-On macOS file-sharing layers, bind-mount ownership can be virtualized. A host
-path owned by your macOS user may appear as `pi`, `pi-tools`, or another mapped
-identity inside the container. In some cases, ownership may appear differently
-from a root shell and from the restricted app terminal.
-
-Always verify inside the running container:
-
-```bash
-docker compose exec pi-forge sh -lc '
+docker compose run --rm pi-forge sh -lc '
 id
-id pi-tools
 stat -c "%u:%g %a %n" /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
+touch /home/pi/.pi-forge/probe && rm /home/pi/.pi-forge/probe
 '
 ```
 
-Then verify from the app terminal:
+Then verify from the app terminal (which runs as `pi-tools`):
 
 ```bash
 id
 stat -c "%u:%g %a %n" /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
 cat /home/pi/.pi-forge/jwt-secret
+cat /home/pi/.pi/agent/auth.json
 ```
 
-If the restricted terminal can read `.pi-forge`, the host bind mount cannot
-reliably test this isolation. Use Docker named volumes for sensitive mounts
-while testing on macOS/OrbStack.
+Expected: `id` shows `pi-tools`; workspace writes work; `.pi/agent` traversal
+works; `.pi-forge` and protected config files are permission denied.
 
-### Required when host ownership is translated: run inside the container
+## Kubernetes
 
-If host-side ownership changes are ignored or translated (common with Docker
-Desktop / OrbStack / macOS), apply the sandbox permissions from a root shell
-**inside the running container** instead. These commands affect the container's
-view of the mounts, which is the view that matters for `pi-tools`:
+Use this section for vanilla Kubernetes. You do **not** need Docker named
+volumes. Use PVCs and an initContainer to set the ownership/modes before the
+pi-forge app container starts.
 
-```bash
-docker compose exec pi-forge sh -lc '
-# Workspace: writable by pi-tools.
-chown -R pi-tools:pi-tools /workspace
-chmod -R u+rwX,g+rwX,o-rwx /workspace
+### App container security context
 
-# Forge data: server-only.
-chown -R root:root /home/pi/.pi-forge
-chmod -R u+rwX,go-rwx /home/pi/.pi-forge
-
-# Pi config: pi-tools can traverse/read non-secret resources.
-chown root:pi-tools /home/pi/.pi
-chmod 0750 /home/pi/.pi
-chown -R root:pi-tools /home/pi/.pi/agent
-chmod 0750 /home/pi/.pi/agent
-find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
-find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
-
-# Pi config secrets: server-only.
-chown root:root /home/pi/.pi/agent/auth.json /home/pi/.pi/agent/models.json /home/pi/.pi/agent/settings.json 2>/dev/null || true
-chmod 0600 /home/pi/.pi/agent/auth.json /home/pi/.pi/agent/models.json /home/pi/.pi/agent/settings.json 2>/dev/null || true
-
-stat -c "%U:%G %u:%g %a %n" /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
-'
-```
-
-## Docker Compose requirements
-
-The server must be able to switch child identity. Compose therefore needs:
-
-```yaml
-cap_drop:
-  - ALL
-cap_add:
-  - SETUID
-  - SETGID
-security_opt:
-  - no-new-privileges:true
-```
-
-No privileged mode or host PID is required.
-
-On OrbStack / Docker Desktop, id-mapped volumes may appear as `1000:1000 0700`
-inside the pi-forge image even after a helper container chowns them to
-`root:root`. If the root server cannot write `/home/pi/.pi-forge` in sandbox
-mode, add `DAC_OVERRIDE` for local testing:
-
-```yaml
-cap_add:
-  - SETUID
-  - SETGID
-  - DAC_OVERRIDE # local OrbStack/Docker Desktop workaround only
-```
-
-Keep production/native-Linux deployments to `SETUID` and `SETGID` when the
-mounts can be permissioned normally.
-
-## Kubernetes / OpenShift requirements
-
-Vanilla Kubernetes container security context example:
+The app container must start as UID 0 so the server can drop tool children to
+`AGENT_TOOL_UID:GID`:
 
 ```yaml
 securityContext:
@@ -320,11 +345,26 @@ securityContext:
   capabilities:
     drop: ["ALL"]
     add: ["SETUID", "SETGID"]
+  seccompProfile:
+    type: RuntimeDefault
 ```
 
-A Kubernetes initContainer should set the PVC permissions before the pi-forge
-container starts. This example assumes default IDs (`pi=1000`, `pi-tools=1001`)
-and the shipped volume names/mount paths:
+### Required env
+
+```yaml
+env:
+  - name: AGENT_TOOL_SANDBOX_ENABLED
+    value: "true"
+  - name: AGENT_TOOL_UID
+    value: "1001"
+  - name: AGENT_TOOL_GID
+    value: "1001"
+```
+
+### Init container
+
+This example assumes default IDs (`pi=1000`, `pi-tools=1001`) and the shipped
+volume names/mount paths:
 
 ```yaml
 initContainers:
@@ -389,6 +429,8 @@ Do not use `fsGroup` to make the sensitive volumes broadly group-readable; the
 sandbox relies on `.pi-forge` and protected Pi config files staying unreadable
 by `AGENT_TOOL_UID:GID`.
 
+## OpenShift
+
 OpenShift `restricted-v2` random UID does not support this mode. Use `anyuid`
 for a simple deployment, or a custom SCC that allows:
 
@@ -399,6 +441,28 @@ for a simple deployment, or a custom SCC that allows:
 
 Keep SCC RoleBindings in namespace/security bootstrap, not in the
 DeploymentConfig.
+
+Example RoleBinding for `anyuid`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pi-forge-anyuid
+  namespace: pi-forge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+  - kind: ServiceAccount
+    name: pi-forge
+    namespace: pi-forge
+```
+
+Use the Kubernetes initContainer permission commands above, plus the OpenShift
+SCC binding. If you build a custom SCC, it needs UID 0 plus `SETUID`/`SETGID`;
+it does not need privileged mode.
 
 ## LDAP bind password files
 

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -152,6 +152,69 @@ docker compose down
 docker compose up -d --build
 ```
 
+## Docker one-shot volume init container
+
+If pi-forge cannot start because a named volume has regular-mode ownership
+(for example `/home/pi/.pi-forge` is `1000:1000 0700` while sandbox mode keeps
+the server as root with limited capabilities), run a one-shot helper container
+before starting pi-forge.
+
+This example assumes the compose file uses named volumes called
+`docker_pi-config` and `docker_forge-data` and the default sandbox UID/GID
+`1001:1001`:
+
+```bash
+cd docker
+docker compose down
+
+# Optional: seed the named pi config volume from the host before locking it down.
+docker run --rm \
+  -v "$HOME/.pi/agent":/src:ro \
+  -v docker_pi-config:/home/pi/.pi/agent \
+  debian:bookworm-slim sh -lc 'cp -a /src/. /home/pi/.pi/agent/'
+
+# Permission the volumes for sandbox mode.
+docker run --rm \
+  -v docker_pi-config:/home/pi/.pi/agent \
+  -v docker_forge-data:/home/pi/.pi-forge \
+  debian:bookworm-slim sh -lc '
+set -eux
+
+# Forge data: server-only.
+chown -R root:root /home/pi/.pi-forge
+chmod 0700 /home/pi/.pi-forge
+find /home/pi/.pi-forge -type d -exec chmod 0700 {} +
+find /home/pi/.pi-forge -type f -exec chmod 0600 {} +
+
+# Pi config: pi-tools can traverse/read non-secret resources.
+chown -R root:1001 /home/pi/.pi/agent
+chmod 0750 /home/pi/.pi/agent
+find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
+find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
+
+# Pi config secrets: server-only.
+chown root:root \
+  /home/pi/.pi/agent/auth.json \
+  /home/pi/.pi/agent/models.json \
+  /home/pi/.pi/agent/settings.json 2>/dev/null || true
+chmod 0600 \
+  /home/pi/.pi/agent/auth.json \
+  /home/pi/.pi/agent/models.json \
+  /home/pi/.pi/agent/settings.json 2>/dev/null || true
+
+stat -c "%u:%g %a %n" /home/pi/.pi/agent /home/pi/.pi-forge
+'
+
+docker compose up -d --build
+```
+
+If you use different volume names, inspect them first:
+
+```bash
+docker compose config --volumes
+docker volume ls | grep -E 'pi-config|forge-data'
+```
+
 ## Docker Desktop / OrbStack / macOS note
 
 On macOS file-sharing layers, bind-mount ownership can be virtualized. A host
@@ -230,9 +293,24 @@ security_opt:
 
 No privileged mode or host PID is required.
 
+On OrbStack / Docker Desktop, id-mapped volumes may appear as `1000:1000 0700`
+inside the pi-forge image even after a helper container chowns them to
+`root:root`. If the root server cannot write `/home/pi/.pi-forge` in sandbox
+mode, add `DAC_OVERRIDE` for local testing:
+
+```yaml
+cap_add:
+  - SETUID
+  - SETGID
+  - DAC_OVERRIDE # local OrbStack/Docker Desktop workaround only
+```
+
+Keep production/native-Linux deployments to `SETUID` and `SETGID` when the
+mounts can be permissioned normally.
+
 ## Kubernetes / OpenShift requirements
 
-Vanilla Kubernetes example:
+Vanilla Kubernetes container security context example:
 
 ```yaml
 securityContext:
@@ -243,6 +321,73 @@ securityContext:
     drop: ["ALL"]
     add: ["SETUID", "SETGID"]
 ```
+
+A Kubernetes initContainer should set the PVC permissions before the pi-forge
+container starts. This example assumes default IDs (`pi=1000`, `pi-tools=1001`)
+and the shipped volume names/mount paths:
+
+```yaml
+initContainers:
+  - name: sandbox-volume-permissions
+    image: busybox:1.36
+    command:
+      - sh
+      - -lc
+      - |
+        set -eux
+
+        # Workspace: writable by pi-tools.
+        mkdir -p /workspace
+        chown -R 1001:1001 /workspace
+        chmod -R u+rwX,g+rwX,o-rwx /workspace
+
+        # Forge data: server-only.
+        mkdir -p /home/pi/.pi-forge
+        chown -R 0:0 /home/pi/.pi-forge
+        chmod 0700 /home/pi/.pi-forge
+        find /home/pi/.pi-forge -type d -exec chmod 0700 {} +
+        find /home/pi/.pi-forge -type f -exec chmod 0600 {} +
+
+        # Pi config: pi-tools can traverse/read non-secret resources.
+        mkdir -p /home/pi/.pi/agent
+        chown 0:1001 /home/pi/.pi
+        chmod 0750 /home/pi/.pi
+        chown -R 0:1001 /home/pi/.pi/agent
+        chmod 0750 /home/pi/.pi/agent
+        find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
+        find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
+
+        # Pi config secrets: server-only.
+        chown 0:0 \
+          /home/pi/.pi/agent/auth.json \
+          /home/pi/.pi/agent/models.json \
+          /home/pi/.pi/agent/settings.json 2>/dev/null || true
+        chmod 0600 \
+          /home/pi/.pi/agent/auth.json \
+          /home/pi/.pi/agent/models.json \
+          /home/pi/.pi/agent/settings.json 2>/dev/null || true
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+        add: ["CHOWN", "FOWNER"]
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+    volumeMounts:
+      - name: workspace
+        mountPath: /workspace
+      - name: pi-config
+        mountPath: /home/pi/.pi/agent
+      - name: pi-forge-data
+        mountPath: /home/pi/.pi-forge
+```
+
+Do not use `fsGroup` to make the sensitive volumes broadly group-readable; the
+sandbox relies on `.pi-forge` and protected Pi config files staying unreadable
+by `AGENT_TOOL_UID:GID`.
 
 OpenShift `restricted-v2` random UID does not support this mode. Use `anyuid`
 for a simple deployment, or a custom SCC that allows:

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -122,6 +122,7 @@ sudo chmod -R u+rwX,go-rwx ~/.pi-forge-docker
 sudo chown root:1001 ~/.pi
 sudo chmod 0750 ~/.pi
 sudo chown -R root:1001 ~/.pi/agent
+sudo chmod 0750 ~/.pi/agent
 sudo find ~/.pi/agent -type d -exec chmod 0750 {} +
 sudo find ~/.pi/agent -type f -exec chmod 0640 {} +
 
@@ -192,6 +193,7 @@ chmod -R u+rwX,go-rwx /home/pi/.pi-forge
 chown root:pi-tools /home/pi/.pi
 chmod 0750 /home/pi/.pi
 chown -R root:pi-tools /home/pi/.pi/agent
+chmod 0750 /home/pi/.pi/agent
 find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
 find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
 

--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -28,6 +28,11 @@ If both `UI_PASSWORD` and `API_KEY` are unset, auth is disabled entirely.
 Production deploys should set at least one. Setting both is common — browser
 users log in with the password, scripts use the API key.
 
+`AGENT_TOOL_SANDBOX_ENABLED` defaults false. When true, config startup requires
+numeric `AGENT_TOOL_UID` and `AGENT_TOOL_GID`, and LDAP bind-password file
+references are rejected. Keep sandbox env parsing in `config.ts` and the CLI
+surface in `cli.ts` together.
+
 ---
 
 ## Config Files

--- a/docs/agent/sessions.md
+++ b/docs/agent/sessions.md
@@ -42,6 +42,11 @@ These are facts about the pi SDK that are easy to get wrong:
   every `createAgentSession` call as `customTools`. See
   [`docs/mcp.md`](../mcp.md) for the user-facing surface; the doc-comment
   at the top of `mcp/manager.ts` is the integration contract.
+- When `AGENT_TOOL_SANDBOX_ENABLED=true`, `session-registry.ts` appends
+  pi-forge custom tool definitions that override the SDK built-in
+  read/grep/find/ls/edit/write/bash tools. Keep all create/resume/fork/tool-refresh
+  `createAgentSession()` paths using the same sandbox override helper so live and
+  cold sessions have identical tool behavior.
 
 ---
 

--- a/docs/agent/sessions.md
+++ b/docs/agent/sessions.md
@@ -46,7 +46,9 @@ These are facts about the pi SDK that are easy to get wrong:
   pi-forge custom tool definitions that override the SDK built-in
   read/grep/find/ls/edit/write/bash tools. Keep all create/resume/fork/tool-refresh
   `createAgentSession()` paths using the same sandbox override helper so live and
-  cold sessions have identical tool behavior.
+  cold sessions have identical tool behavior. Sandbox mode also filters
+  `pi-subagents` packages/extensions out of session settings/resource discovery;
+  do not re-enable that extension in sandbox mode without a separate security review.
 
 ---
 

--- a/docs/agent/terminal.md
+++ b/docs/agent/terminal.md
@@ -9,6 +9,9 @@ connected over a WebSocket (not SSE — terminals need bidirectional communicati
 
 - One PTY per terminal tab, spawned with `cwd` set to the project path
 - Default shell: `process.env.SHELL || '/bin/sh'`
+- When `AGENT_TOOL_SANDBOX_ENABLED=true`, `pty-manager.ts` passes `uid`/`gid`
+  to `node-pty.spawn()` so terminals run as the restricted tool identity with
+  the scrubbed terminal env, not as the root/server identity.
 - WebSocket endpoint: `ws://localhost:3000/api/v1/terminal?projectId=<id>&tabId=<optional>&token=<jwt-or-api-key>`
   - `projectId` is required; `tabId` is the stable client-side tab identifier used for reattach across reconnects; `token` is required when auth is enabled (browsers can't attach `Authorization` headers on WebSocket upgrades).
 - Fastify WebSocket support via `@fastify/websocket`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,9 +65,41 @@ in `cli.ts`). The most-touched ones:
 | `ORCHESTRATION_DISABLED` | `false` | Disable the chat-view `Orch` toggle and orchestration REST/tool surface. Orchestration is enabled by default; hard-disabled under `MINIMAL_UI` regardless. See [`orchestration.md`](./orchestration.md). |
 | `ORCHESTRATION_ENABLED` | `true` | Legacy compatibility switch. `false` disables orchestration; `true`/unset keep the default enabled behavior. Prefer `ORCHESTRATION_DISABLED=true` for new deployments. |
 | `ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR` | `8` | Per-supervisor live-worker cap. Bounded to `[1, 100]`. |
+| `AGENT_TOOL_SANDBOX_ENABLED` | `false` | Opt-in identity/path sandbox for model/user tool surfaces. When `true`, `AGENT_TOOL_UID` and `AGENT_TOOL_GID` are required. |
+| `AGENT_TOOL_UID` | (unset) | Numeric UID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled. |
+| `AGENT_TOOL_GID` | (unset) | Numeric GID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled. |
 
 Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
 are documented in [`deployment.md`](./deployment.md).
+
+### Agent tool identity sandbox
+
+`AGENT_TOOL_SANDBOX_ENABLED=false` by default. When enabled, pi-forge
+keeps the server process privileged enough to read server-owned config
+and secrets, but runs model/user shell surfaces as the configured
+restricted UID/GID: the agent `bash` tool, process tool, integrated
+terminal, quick-action command chips, and chat `!` / `!!` exec. Their
+environment is scrubbed with the same allowlist used by the terminal.
+
+Model file tools and `@file` expansion are path-scoped to the project
+workspace and non-secret files under `PI_CONFIG_DIR`. They reject
+protected Pi config files (`auth.json`, `models.json`, `settings.json`),
+`FORGE_DATA_DIR`, `/proc`, `/etc`, mounted secret paths such as
+`/run/secrets` and `/var/run/secrets`, home secret dirs such as `.ssh`,
+`.aws`, `.kube`, `.gnupg`, traversal escapes, and symlink escapes.
+
+Protected: server env secrets are not inherited by child shells,
+`/proc/<server-pid>/environ` is protected by UID separation when the
+container/cluster honors the UID split, and server-owned config/data
+files can be mode-owned away from the restricted UID. Not protected:
+secrets stored in the workspace, host/container misconfiguration,
+third-party extensions or tools that bypass pi-forge's overrides, or a
+server compromise (the server can still read server-accessible secrets).
+
+When this mode is enabled, LDAP bind password file references are
+rejected (`LDAP_BIND_PASSWORD_FILE` and CLI/env `@file` forms). Use a
+literal environment value or an external secret broker instead; child
+tool processes receive the scrubbed env and do not inherit it.
 
 ### LDAP browser login
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,27 +74,12 @@ are documented in [`deployment.md`](./deployment.md).
 
 ### Agent tool identity sandbox
 
-`AGENT_TOOL_SANDBOX_ENABLED=false` by default. When enabled, pi-forge
-keeps the server process privileged enough to read server-owned config
-and secrets, but runs model/user shell surfaces as the configured
-restricted UID/GID: the agent `bash` tool, process tool, integrated
-terminal, quick-action command chips, and chat `!` / `!!` exec. Their
-environment is scrubbed with the same allowlist used by the terminal.
-
-Model file tools and `@file` expansion are path-scoped to the project
-workspace and non-secret files under `PI_CONFIG_DIR`. They reject
-protected Pi config files (`auth.json`, `models.json`, `settings.json`),
-`FORGE_DATA_DIR`, `/proc`, `/etc`, mounted secret paths such as
-`/run/secrets` and `/var/run/secrets`, home secret dirs such as `.ssh`,
-`.aws`, `.kube`, `.gnupg`, traversal escapes, and symlink escapes.
-
-Protected: server env secrets are not inherited by child shells,
-`/proc/<server-pid>/environ` is protected by UID separation when the
-container/cluster honors the UID split, and server-owned config/data
-files can be mode-owned away from the restricted UID. Not protected:
-secrets stored in the workspace, host/container misconfiguration,
-third-party extensions or tools that bypass pi-forge's overrides, or a
-server compromise (the server can still read server-accessible secrets).
+The identity sandbox is off by default and has a strict mount-permission
+contract. Read [`agent-tool-sandbox.md`](./agent-tool-sandbox.md) before
+enabling it. In short: pi-forge runs the server as root, drops
+model/user shell surfaces to `AGENT_TOOL_UID:GID`, scopes model file
+access, and requires workspace / Pi config / forge data mounts to have
+specific ownership and mode bits.
 
 When this mode is enabled, LDAP bind password file references are
 rejected (`LDAP_BIND_PASSWORD_FILE` and CLI/env `@file` forms). Use a

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -22,7 +22,7 @@ runtime (Node + native bindings), and makes deploys reproducible.
 | `python-base` | `python:3.12-slim-bookworm` | Source for the Python 3.12 + pip runtime copied into the shared Node base |
 | `node-python-base` | `node:22-bookworm-slim` | Shared Debian slim base with Node.js 22 plus Python 3.12 + pip |
 | `builder` | `node-python-base` | Installs all deps including devDeps, compiles native bindings (`node-pty`), runs `npm run build` for both packages |
-| `runtime` | `node-python-base` | Production deps + built artifacts only. Adds `git`, `ripgrep`, `bash`, `curl`, `less`, `procps`, and the C++ toolchain needed for native-module rebuilds during in-container development. Runs as non-root `pi`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
+| `runtime` | `node-python-base` | Production deps + built artifacts only. Adds `git`, `ripgrep`, `bash`, `curl`, `less`, `procps`, and the C++ toolchain needed for native-module rebuilds during in-container development. Runs the server as root so the opt-in identity sandbox can drop model/user tool processes to `pi-tools`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
 
 Final image size varies by architecture and cache state. Debian-based
 (not Alpine) because the Node native-module ecosystem ships glibc
@@ -42,10 +42,20 @@ Installed at runtime:
 
 ### User and permissions
 
-The image creates a `pi` user (uid/gid configurable via `PUID` /
-`PGID` build args; default `1000:1000`). For bind mounts to be
-writable, the container `pi` user must match the host owner of the
-mounted directory. On Linux:
+The image creates two users:
+
+- `pi` (`PUID` / `PGID`, default `1000:1000`) owns the home layout and
+  preserves legacy path/env expectations.
+- `pi-tools` (`AGENT_TOOL_UID` / `AGENT_TOOL_GID` in compose, default
+  `1001:1001`) is the restricted identity used when
+  `AGENT_TOOL_SANDBOX_ENABLED=true`.
+
+The server runtime user is root. This is deliberate: the identity
+sandbox needs the server to call `setuid` / `setgid` for child tools
+while keeping server-owned config, forge data, and mounted secrets
+unreadable by `pi-tools`. For bind mounts to be writable by sandboxed
+commands, `/workspace` must be owned by or group-writable to
+`pi-tools`. On Linux:
 
 ```bash
 PUID=$(id -u) PGID=$(id -g) docker compose -f docker/docker-compose.yml up -d --build
@@ -115,6 +125,8 @@ in `docker/.env`:
 | `PI_CONFIG_DIR` | `/home/pi/.pi/agent` |
 | `FORGE_DATA_DIR` | `/home/pi/.pi-forge` |
 | `PYTHONUSERBASE` | `/home/pi/.local` |
+| `AGENT_TOOL_SANDBOX_ENABLED` | `false` by default; set `true` to run tool children as `pi-tools` |
+| `AGENT_TOOL_UID` / `AGENT_TOOL_GID` | `1001` / `1001` in compose defaults |
 
 Set `UI_PASSWORD` and / or `API_KEY` in `.env` for any non-loopback
 deploy — without them, auth is disabled.
@@ -200,11 +212,19 @@ SSE-buffering and WebSocket-upgrade settings live in
 
 ## Security inside the container
 
-- **Non-root.** Runs as `pi:pi`. `tini` forwards signals so
-  `docker stop` shuts down cleanly.
-- **No extra capabilities.** No privileged mode, host PID, or
-  `--cap-add` needed. If you find yourself adding any, you're working
-  around the threat model — open an issue first.
+- **Root server, restricted tools (opt-in).** The server runs as root;
+  when `AGENT_TOOL_SANDBOX_ENABLED=true`, model/user shell surfaces run
+  as `pi-tools` and file tools / `@file` references are path-scoped.
+  Keep secrets out of `/workspace`; workspace content is intentionally
+  readable by the agent.
+- **Minimal capabilities.** Compose drops all capabilities and adds back
+  only `SETUID` / `SETGID`, which are required for the identity switch.
+  No privileged mode or host PID is needed.
+- **Secret mounts.** Mount Pi config, forge data, LDAP/UI secret files,
+  and cloud credentials so they are readable by the root server but not
+  by `pi-tools` (for example mode `0600` root-owned files or `0700`
+  directories). The sandbox also blocks `/run/secrets` and
+  `/var/run/secrets` from model file tools.
 - **Read-only root filesystem (optional).** Add `read_only: true` to
   compose with `tmpfs` mounts for `/tmp` and `/home/pi/.npm` if you
   want a hardened deploy. Native modules + node_modules live in the

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -22,7 +22,7 @@ runtime (Node + native bindings), and makes deploys reproducible.
 | `python-base` | `python:3.12-slim-bookworm` | Source for the Python 3.12 + pip runtime copied into the shared Node base |
 | `node-python-base` | `node:22-bookworm-slim` | Shared Debian slim base with Node.js 22 plus Python 3.12 + pip |
 | `builder` | `node-python-base` | Installs all deps including devDeps, compiles native bindings (`node-pty`), runs `npm run build` for both packages |
-| `runtime` | `node-python-base` | Production deps + built artifacts only. Adds `git`, `ripgrep`, `bash`, `curl`, `less`, `procps`, and the C++ toolchain needed for native-module rebuilds during in-container development. Runs the server as root so the opt-in identity sandbox can drop model/user tool processes to `pi-tools`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
+| `runtime` | `node-python-base` | Production deps + built artifacts only. Adds `git`, `ripgrep`, `bash`, `curl`, `less`, `procps`, `gosu`, and the C++ toolchain needed for native-module rebuilds during in-container development. Default mode drops the server to `pi`; sandbox mode keeps the server as root so it can drop model/user tool processes to `pi-tools`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
 
 Final image size varies by architecture and cache state. Debian-based
 (not Alpine) because the Node native-module ecosystem ships glibc
@@ -50,18 +50,28 @@ The image creates two users:
   `1001:1001`) is the restricted identity used when
   `AGENT_TOOL_SANDBOX_ENABLED=true`.
 
-The server runtime user is root. This is deliberate: the identity
-sandbox needs the server to call `setuid` / `setgid` for child tools
-while keeping server-owned config, forge data, and mounted secrets
-unreadable by `pi-tools`. For bind mounts to be writable by sandboxed
-commands, `/workspace` must be owned by or group-writable to
-`pi-tools`. On Linux:
+By default (`AGENT_TOOL_SANDBOX_ENABLED=false`), the entrypoint drops
+the server to the legacy `pi` user. In sandbox mode, the server remains
+root. This is deliberate: the identity sandbox needs the server to call
+`setuid` / `setgid` for child tools while keeping server-owned config,
+forge data, and mounted secrets unreadable by `pi-tools`.
 
-```bash
-PUID=$(id -u) PGID=$(id -g) docker compose -f docker/docker-compose.yml up -d --build
-```
+Sandbox mode has a stricter volume permission contract than the default
+container. Read [`agent-tool-sandbox.md`](./agent-tool-sandbox.md)
+before enabling it; the short version is:
 
-On Docker Desktop for macOS, UID translation is automatic.
+- `/workspace` must be writable by `AGENT_TOOL_UID:GID`.
+- `/home/pi/.pi` and `/home/pi/.pi/agent` must be traversable/readable
+  by `AGENT_TOOL_UID:GID` for non-secret skills/resources.
+- `/home/pi/.pi/agent/auth.json`, `models.json`, and `settings.json`
+  must not be readable by `AGENT_TOOL_UID:GID`.
+- `/home/pi/.pi-forge` and mounted secret dirs/files must not be
+  readable by `AGENT_TOOL_UID:GID`.
+
+On Docker Desktop / OrbStack / macOS, bind-mount ownership can be
+virtualized; verify numeric ownership and mode bits inside the
+container and from an app terminal. Use named volumes for sensitive
+mounts if the host file-sharing layer makes ownership inconsistent.
 
 ## Volumes
 
@@ -212,8 +222,8 @@ SSE-buffering and WebSocket-upgrade settings live in
 
 ## Security inside the container
 
-- **Root server, restricted tools (opt-in).** The server runs as root;
-  when `AGENT_TOOL_SANDBOX_ENABLED=true`, model/user shell surfaces run
+- **Root server, restricted tools (opt-in).** By default the server runs as `pi`.
+  When `AGENT_TOOL_SANDBOX_ENABLED=true`, the server runs as root and model/user shell surfaces run
   as `pi-tools` and file tools / `@file` references are path-scoped.
   Keep secrets out of `/workspace`; workspace content is intentionally
   readable by the agent.

--- a/docs/site/docs/agent-tool-sandbox.html
+++ b/docs/site/docs/agent-tool-sandbox.html
@@ -1,0 +1,534 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agent Tool Sandbox — pi-forge</title>
+  <meta name="description" content="Optional UID/GID split, path policy, mount permissions, and verification.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%230d0d10'/><path d='M12 13 H20 M14 13 V21 M18 13 V21' stroke='%23e6e7eb' stroke-width='1.6' stroke-linecap='round' fill='none'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="../index.html" class="logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="#0d0d10"/>
+  <path d="M9 11 L6 16 L9 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M23 11 L26 16 L23 21" stroke="#10b981" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M12 13 H20 M14 13 V21 M18 13 V21" stroke="#e6e7eb" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+        pi-forge
+      </a>
+      <nav class="nav-links" id="navLinks">
+        <a href="../index.html#features">Features</a>
+        <a href="../index.html#quickstart">Quick Start</a>
+        <a href="architecture.html">Docs</a>
+        <a href="https://github.com/Devin-Marks/pi-forge" class="nav-cta">GitHub</a>
+      </nav>
+      <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle menu">&#9776;</button>
+    </div>
+  </header>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-section">
+        <h4>Documentation</h4>
+        <a href="architecture.html">Architecture</a>
+        <a href="configuration.html">Configuration</a>
+        <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html" class="active">Agent Tool Sandbox</a>
+        <a href="deployment.html">Deployment</a>
+        <a href="mobile.html">Mobile</a>
+        <a href="api.html">API Examples</a>
+        <a href="mcp.html">MCP Servers</a>
+        <a href="webhooks.html">Webhooks</a>
+        <a href="orchestration.html">Session Orchestration</a>
+        <a href="processes.html">Background Processes</a>
+        <a href="todo.html">Todo Tool</a>
+        <a href="ask-user-question.html">Ask User Question</a>
+        <a href="quick-actions.html">Quick Actions</a>
+        <a href="sse-events.html">SSE Events</a>
+      </div>
+      <div class="sidebar-section">
+        <h4>Project</h4>
+        <a href="https://github.com/Devin-Marks/pi-forge">GitHub</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/Devin-Marks/pi-forge/blob/main/SECURITY.md">Security</a>
+      </div>
+    </aside>
+
+    <main class="docs-main">
+      <h1>Agent Tool Sandbox</h1>
+      <p class="docs-subtitle">Optional UID/GID split, path policy, mount permissions, and verification.</p>
+<p><code>AGENT_TOOL_SANDBOX_ENABLED=false</code> by default. In the Docker image, the default
+entrypoint drops the server to the legacy <code>pi</code> user. When sandbox mode is
+enabled, pi-forge keeps the HTTP server running as root and runs model/user
+tool surfaces as a restricted UID/GID (<code>pi-tools</code> in the Docker image).</p>
+<p>This is an operator-controlled hardening mode. It is useful only when the
+container or pod mounts are permissioned carefully. Leave it disabled for
+simple local installs or any deployment where the workspace, Pi config, forge
+data, and secret mounts cannot be owned/mode-bit split as described below.</p>
+<h2>What changes when enabled</h2>
+<p>Set:</p>
+<pre><code class="language-txt">AGENT_TOOL_SANDBOX_ENABLED=true
+AGENT_TOOL_UID=&lt;numeric uid&gt;
+AGENT_TOOL_GID=&lt;numeric gid&gt;
+</code></pre>
+<p>In the Docker image defaults, <code>pi-tools</code> is:</p>
+<pre><code class="language-txt">AGENT_TOOL_UID=1001
+AGENT_TOOL_GID=1001
+</code></pre>
+<p>When enabled:</p>
+<ul>
+<li>agent/model file tools are path-scoped</li>
+<li><code>@file</code> expansion is path-scoped</li>
+<li>agent <code>bash</code> runs as <code>AGENT_TOOL_UID:GID</code></li>
+<li>process-tool commands run as <code>AGENT_TOOL_UID:GID</code></li>
+<li>integrated terminals run as <code>AGENT_TOOL_UID:GID</code></li>
+<li>quick-action command chips run as <code>AGENT_TOOL_UID:GID</code></li>
+<li>chat <code>!</code> / <code>!!</code> exec commands run as <code>AGENT_TOOL_UID:GID</code></li>
+<li>shell/process/terminal env is scrubbed</li>
+</ul>
+<h2>What is protected</h2>
+<p>The sandbox is intended to protect server-side secrets from model/user tool
+surfaces:</p>
+<ul>
+<li>model file tools can read the configured workspace root (<code>WORKSPACE_PATH</code>), not only the active project subfolder</li>
+<li>model file tools cannot read outside allowed roots</li>
+<li>model file tools cannot read protected Pi config files, even if <code>PI_CONFIG_DIR</code> is accidentally mounted inside <code>WORKSPACE_PATH</code>:<ul>
+<li><code>${PI_CONFIG_DIR}/auth.json</code></li>
+<li><code>${PI_CONFIG_DIR}/models.json</code></li>
+<li><code>${PI_CONFIG_DIR}/settings.json</code></li>
+</ul>
+</li>
+<li>model file tools cannot read <code>${FORGE_DATA_DIR}</code></li>
+<li>model file tools reject <code>/proc</code>, <code>/etc</code>, <code>/run/secrets</code>, and
+<code>/var/run/secrets</code></li>
+<li>model file tools reject traversal and symlink escapes</li>
+<li>bash/process/terminal children do not inherit server/provider env secrets</li>
+<li>with correct UID separation, <code>/proc/&lt;server-pid&gt;/environ</code> is not readable by
+tool children</li>
+</ul>
+<h2>What is not protected</h2>
+<p>This mode does <strong>not</strong> protect:</p>
+<ul>
+<li>secrets placed in <code>/workspace</code></li>
+<li>a compromised pi-forge server process</li>
+<li>host/container/pod misconfiguration</li>
+<li>third-party extensions or tools that bypass pi-forge&#39;s policy hooks</li>
+<li>anything readable by <code>AGENT_TOOL_UID:GID</code> at the filesystem layer</li>
+</ul>
+<p>The model and user shell surfaces are intentionally allowed to read and write
+the entire configured workspace root (<code>WORKSPACE_PATH</code>, <code>/workspace</code> in the
+Docker image), including sibling project folders. Unlike model file tools,
+<code>bash</code>, process-tool commands, integrated terminals, quick actions, and chat
+exec commands are not path-policy scoped; after they drop to
+<code>AGENT_TOOL_UID:GID</code>, access to <code>PI_CONFIG_DIR</code>, <code>FORGE_DATA_DIR</code>, and any
+other path is controlled by Unix ownership and mode bits.</p>
+<h2>Required mount permissions</h2>
+<p>Regular/non-sandbox mode keeps the historical simple contract: the server runs
+as <code>pi</code>, and mounted workspace/config/data paths should be writable by <code>pi</code>.
+Sandbox mode is different and requires the split below. The Docker image makes
+the image-owned parent <code>/home/pi/.pi</code> traversable by <code>pi-tools</code>; the mounted
+<code>/home/pi/.pi/agent</code> subtree still needs the permissions below.</p>
+<p>The permissions that matter are numeric UID/GID and mode bits <strong>as seen inside
+the container or pod</strong>.</p>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Required sandbox posture</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>/workspace</code></td>
+<td>Writable by <code>AGENT_TOOL_UID:GID</code>. Secrets in the workspace are readable by the agent.</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi</code></td>
+<td>Traversable by <code>AGENT_TOOL_UID:GID</code> so package skills and non-secret resources can be loaded. Recommended: <code>root:pi-tools</code> <code>0750</code>.</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi/agent</code></td>
+<td>Traversable/readable by <code>AGENT_TOOL_UID:GID</code> for non-secret resources. Recommended: <code>root:pi-tools</code> <code>0750</code>.</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi/agent/auth.json</code></td>
+<td>Not readable by <code>AGENT_TOOL_UID:GID</code>. Recommended: <code>root:root</code> <code>0600</code>. Also blocked by file-tool policy.</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi/agent/models.json</code></td>
+<td>Not readable by <code>AGENT_TOOL_UID:GID</code>. Recommended: <code>root:root</code> <code>0600</code>. Also blocked by file-tool policy.</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi/agent/settings.json</code></td>
+<td>Not readable by <code>AGENT_TOOL_UID:GID</code>. Recommended: <code>root:root</code> <code>0600</code>. Also blocked by file-tool policy.</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi-forge</code></td>
+<td>Not readable by <code>AGENT_TOOL_UID:GID</code>. Recommended: <code>root:root</code> <code>0700</code>.</td>
+</tr>
+<tr>
+<td>mounted secret dirs/files</td>
+<td>Not readable by <code>AGENT_TOOL_UID:GID</code>; prefer root-owned <code>0700</code> dirs and <code>0600</code> files.</td>
+</tr>
+</tbody></table>
+<p>Why <code>.pi</code> is partially readable: pi package skills and other non-secret pi
+resources may live under the Pi config/home tree. The sandbox blocks the known
+secret Pi config files by policy and filesystem mode, while leaving non-secret
+resources loadable.</p>
+<p>The Docker image&#39;s built-in directory ownership remains optimized for regular
+mode (<code>pi</code> owns <code>/home/pi/.pi/agent</code> and <code>/home/pi/.pi-forge</code>). Enabling sandbox
+with bind mounts or persistent volumes is an explicit operator step: adjust the
+mount permissions to the table above before relying on filesystem isolation.
+Switching an existing deployment between regular and sandbox mode may require
+changing volume ownership/modes.</p>
+<h2>Docker Compose: native Linux bind mounts</h2>
+<p>Use this section for regular Docker Engine on Linux. You can keep the default
+bind mounts from <code>docker/docker-compose.yml</code>:</p>
+<pre><code class="language-yaml">volumes:
+  - ${WORKSPACE_HOST_PATH:-../workspace}:/workspace
+  - ${PI_CONFIG_HOST_PATH:-~/.pi/agent}:/home/pi/.pi/agent
+  - ${FORGE_DATA_HOST_PATH:-~/.pi-forge-docker}:/home/pi/.pi-forge
+</code></pre>
+<p>Native Linux bind mounts normally preserve host numeric ownership in the
+container. With default sandbox IDs (<code>1001:1001</code>), run these commands on the
+<strong>host</strong> before starting the container:</p>
+<pre><code class="language-bash"># Workspace: writable by pi-tools.
+sudo mkdir -p ./workspace
+sudo chown -R 1001:1001 ./workspace
+sudo chmod -R u+rwX,g+rwX,o-rwx ./workspace
+
+# Forge data: server-only.
+sudo mkdir -p ~/.pi-forge-docker
+sudo chown -R root:root ~/.pi-forge-docker
+sudo chmod -R u+rwX,go-rwx ~/.pi-forge-docker
+
+# Pi config: pi-tools can traverse/read non-secret resources.
+# The image-owned /home/pi/.pi parent is already traversable by pi-tools when
+# only ~/.pi/agent is mounted. If you mount the whole ~/.pi directory, set the
+# parent permissions too.
+sudo chown root:1001 ~/.pi
+sudo chmod 0750 ~/.pi
+sudo chown -R root:1001 ~/.pi/agent
+sudo chmod 0750 ~/.pi/agent
+sudo find ~/.pi/agent -type d -exec chmod 0750 {} +
+sudo find ~/.pi/agent -type f -exec chmod 0640 {} +
+
+# Pi config secrets: server-only.
+sudo chown root:root ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/settings.json 2&gt;/dev/null || true
+sudo chmod 0600 ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/settings.json 2&gt;/dev/null || true
+</code></pre>
+<p>Set sandbox env in <code>docker/.env</code>:</p>
+<pre><code class="language-txt">AGENT_TOOL_SANDBOX_ENABLED=true
+AGENT_TOOL_UID=1001
+AGENT_TOOL_GID=1001
+</code></pre>
+<p>Compose capabilities for native Linux should be:</p>
+<pre><code class="language-yaml">cap_drop:
+  - ALL
+cap_add:
+  - SETUID
+  - SETGID
+security_opt:
+  - no-new-privileges:true
+</code></pre>
+<p>Then rebuild/recreate:</p>
+<pre><code class="language-bash">cd docker
+docker compose down
+docker compose up -d --build
+</code></pre>
+<h2>Docker Compose: OrbStack / Docker Desktop / macOS</h2>
+<p>Use this section for OrbStack or Docker Desktop on macOS. Host file sharing can
+translate ownership differently depending on the container and the accessing
+UID, so host-side <code>chown</code> may not produce stable results inside pi-forge.</p>
+<p>Recommended differences from native Linux:</p>
+<ol>
+<li>Keep <code>/workspace</code> as a host bind mount if you want to edit code from macOS.</li>
+<li>Use Docker named volumes for <code>/home/pi/.pi/agent</code> and <code>/home/pi/.pi-forge</code>.</li>
+<li>Initialize those named volumes with a one-shot helper container.</li>
+<li>Add <code>DAC_OVERRIDE</code> only for local OrbStack/Docker Desktop testing if the root
+server cannot write the id-mapped <code>.pi-forge</code> volume.</li>
+</ol>
+<h3>Compose volume changes</h3>
+<p>Change the service volumes from host binds for Pi config / forge data to named
+volumes:</p>
+<pre><code class="language-yaml">services:
+  pi-forge:
+    volumes:
+      - ${WORKSPACE_HOST_PATH:-../workspace}:/workspace
+      - pi-config:/home/pi/.pi/agent
+      - forge-data:/home/pi/.pi-forge
+
+volumes:
+  pi-config:
+  forge-data:
+</code></pre>
+<p>If you want stable names for helper commands:</p>
+<pre><code class="language-yaml">volumes:
+  pi-config:
+    name: docker_pi-config
+  forge-data:
+    name: docker_forge-data
+</code></pre>
+<h3>Compose capability changes</h3>
+<p>Start with the native capability set:</p>
+<pre><code class="language-yaml">cap_drop:
+  - ALL
+cap_add:
+  - SETUID
+  - SETGID
+security_opt:
+  - no-new-privileges:true
+</code></pre>
+<p>If OrbStack/Docker Desktop shows <code>.pi-forge</code> as <code>1000:1000 0700</code> inside the
+pi-forge container even after the helper volume init chowns it to <code>root:root</code>,
+add <code>DAC_OVERRIDE</code> for local testing:</p>
+<pre><code class="language-yaml">cap_add:
+  - SETUID
+  - SETGID
+  - DAC_OVERRIDE # local OrbStack/Docker Desktop workaround only
+</code></pre>
+<p>Keep production/native-Linux deployments to <code>SETUID</code> and <code>SETGID</code> when mounts
+can be permissioned normally.</p>
+<h3>One-shot volume init commands</h3>
+<p>This example assumes the named volumes are <code>docker_pi-config</code> and
+<code>docker_forge-data</code>, and the sandbox UID/GID is <code>1001:1001</code>:</p>
+<pre><code class="language-bash">cd docker
+docker compose down
+
+# Optional: seed the named pi config volume from the host before locking it down.
+docker run --rm \
+  -v &quot;$HOME/.pi/agent&quot;:/src:ro \
+  -v docker_pi-config:/home/pi/.pi/agent \
+  debian:bookworm-slim sh -lc &#39;cp -a /src/. /home/pi/.pi/agent/&#39;
+
+# Permission the named volumes for sandbox mode.
+docker run --rm \
+  -v docker_pi-config:/home/pi/.pi/agent \
+  -v docker_forge-data:/home/pi/.pi-forge \
+  debian:bookworm-slim sh -lc &#39;
+set -eux
+
+# Forge data: server-only.
+chown -R root:root /home/pi/.pi-forge
+chmod 0700 /home/pi/.pi-forge
+find /home/pi/.pi-forge -type d -exec chmod 0700 {} +
+find /home/pi/.pi-forge -type f -exec chmod 0600 {} +
+
+# Pi config: pi-tools can traverse/read non-secret resources.
+chown -R root:1001 /home/pi/.pi/agent
+chmod 0750 /home/pi/.pi/agent
+find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
+find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
+
+# Pi config secrets: server-only.
+chown root:root \
+  /home/pi/.pi/agent/auth.json \
+  /home/pi/.pi/agent/models.json \
+  /home/pi/.pi/agent/settings.json 2&gt;/dev/null || true
+chmod 0600 \
+  /home/pi/.pi/agent/auth.json \
+  /home/pi/.pi/agent/models.json \
+  /home/pi/.pi/agent/settings.json 2&gt;/dev/null || true
+
+stat -c &quot;%u:%g %a %n&quot; /home/pi/.pi/agent /home/pi/.pi-forge
+&#39;
+</code></pre>
+<p>Set sandbox env in <code>docker/.env</code>:</p>
+<pre><code class="language-txt">AGENT_TOOL_SANDBOX_ENABLED=true
+AGENT_TOOL_UID=1001
+AGENT_TOOL_GID=1001
+</code></pre>
+<p>Start pi-forge:</p>
+<pre><code class="language-bash">docker compose up -d --build
+</code></pre>
+<p>Verify the actual mounts and ownership inside pi-forge:</p>
+<pre><code class="language-bash">docker compose run --rm pi-forge sh -lc &#39;
+id
+stat -c &quot;%u:%g %a %n&quot; /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
+touch /home/pi/.pi-forge/probe &amp;&amp; rm /home/pi/.pi-forge/probe
+&#39;
+</code></pre>
+<p>Then verify from the app terminal (which runs as <code>pi-tools</code>):</p>
+<pre><code class="language-bash">id
+stat -c &quot;%u:%g %a %n&quot; /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
+cat /home/pi/.pi-forge/jwt-secret
+cat /home/pi/.pi/agent/auth.json
+</code></pre>
+<p>Expected: <code>id</code> shows <code>pi-tools</code>; workspace writes work; <code>.pi/agent</code> traversal
+works; <code>.pi-forge</code> and protected config files are permission denied.</p>
+<h2>Kubernetes</h2>
+<p>Use this section for vanilla Kubernetes. You do <strong>not</strong> need Docker named
+volumes. Use PVCs and an initContainer to set the ownership/modes before the
+pi-forge app container starts.</p>
+<h3>App container security context</h3>
+<p>The app container must start as UID 0 so the server can drop tool children to
+<code>AGENT_TOOL_UID:GID</code>:</p>
+<pre><code class="language-yaml">securityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [&quot;ALL&quot;]
+    add: [&quot;SETUID&quot;, &quot;SETGID&quot;]
+  seccompProfile:
+    type: RuntimeDefault
+</code></pre>
+<h3>Required env</h3>
+<pre><code class="language-yaml">env:
+  - name: AGENT_TOOL_SANDBOX_ENABLED
+    value: &quot;true&quot;
+  - name: AGENT_TOOL_UID
+    value: &quot;1001&quot;
+  - name: AGENT_TOOL_GID
+    value: &quot;1001&quot;
+</code></pre>
+<h3>Init container</h3>
+<p>This example assumes default IDs (<code>pi=1000</code>, <code>pi-tools=1001</code>) and the shipped
+volume names/mount paths:</p>
+<pre><code class="language-yaml">initContainers:
+  - name: sandbox-volume-permissions
+    image: busybox:1.36
+    command:
+      - sh
+      - -lc
+      - |
+        set -eux
+
+        # Workspace: writable by pi-tools.
+        mkdir -p /workspace
+        chown -R 1001:1001 /workspace
+        chmod -R u+rwX,g+rwX,o-rwx /workspace
+
+        # Forge data: server-only.
+        mkdir -p /home/pi/.pi-forge
+        chown -R 0:0 /home/pi/.pi-forge
+        chmod 0700 /home/pi/.pi-forge
+        find /home/pi/.pi-forge -type d -exec chmod 0700 {} +
+        find /home/pi/.pi-forge -type f -exec chmod 0600 {} +
+
+        # Pi config: pi-tools can traverse/read non-secret resources.
+        mkdir -p /home/pi/.pi/agent
+        chown 0:1001 /home/pi/.pi
+        chmod 0750 /home/pi/.pi
+        chown -R 0:1001 /home/pi/.pi/agent
+        chmod 0750 /home/pi/.pi/agent
+        find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
+        find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
+
+        # Pi config secrets: server-only.
+        chown 0:0 \
+          /home/pi/.pi/agent/auth.json \
+          /home/pi/.pi/agent/models.json \
+          /home/pi/.pi/agent/settings.json 2&gt;/dev/null || true
+        chmod 0600 \
+          /home/pi/.pi/agent/auth.json \
+          /home/pi/.pi/agent/models.json \
+          /home/pi/.pi/agent/settings.json 2&gt;/dev/null || true
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [&quot;ALL&quot;]
+        add: [&quot;CHOWN&quot;, &quot;FOWNER&quot;]
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+    volumeMounts:
+      - name: workspace
+        mountPath: /workspace
+      - name: pi-config
+        mountPath: /home/pi/.pi/agent
+      - name: pi-forge-data
+        mountPath: /home/pi/.pi-forge
+</code></pre>
+<p>Do not use <code>fsGroup</code> to make the sensitive volumes broadly group-readable; the
+sandbox relies on <code>.pi-forge</code> and protected Pi config files staying unreadable
+by <code>AGENT_TOOL_UID:GID</code>.</p>
+<h2>OpenShift</h2>
+<p>OpenShift <code>restricted-v2</code> random UID does not support this mode. Use <code>anyuid</code>
+for a simple deployment, or a custom SCC that allows:</p>
+<ul>
+<li>UID 0 for the server container</li>
+<li><code>SETUID</code></li>
+<li><code>SETGID</code></li>
+<li>no privileged mode</li>
+</ul>
+<p>Keep SCC RoleBindings in namespace/security bootstrap, not in the
+DeploymentConfig.</p>
+<p>Example RoleBinding for <code>anyuid</code>:</p>
+<pre><code class="language-yaml">apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pi-forge-anyuid
+  namespace: pi-forge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+  - kind: ServiceAccount
+    name: pi-forge
+    namespace: pi-forge
+</code></pre>
+<p>Use the Kubernetes initContainer permission commands above, plus the OpenShift
+SCC binding. If you build a custom SCC, it needs UID 0 plus <code>SETUID</code>/<code>SETGID</code>;
+it does not need privileged mode.</p>
+<h2>pi-subagents package disabled in sandbox mode</h2>
+<p>The <code>pi-subagents</code> package/extension is disabled while
+<code>AGENT_TOOL_SANDBOX_ENABLED=true</code>. The package shells out to the <code>pi</code> CLI and
+manages child sessions outside pi-forge&#39;s normal in-process tool override path,
+which makes its security boundary harder to reason about in this mode.</p>
+<p>Built-in pi-forge orchestration tools remain separate from <code>pi-subagents</code>; if
+you use them with sandbox mode, validate their worker behavior under your
+mount/UID policy.</p>
+<h2>LDAP bind password files</h2>
+<p>When sandbox mode is enabled, pi-forge rejects:</p>
+<ul>
+<li><code>LDAP_BIND_PASSWORD_FILE</code></li>
+<li>CLI <code>--ldap-bind-password @/path</code></li>
+<li>env-style <code>LDAP_BIND_PASSWORD=@/path</code></li>
+</ul>
+<p>Use a literal environment value or an external secret broker instead. Tool
+children receive a scrubbed env and do not inherit the LDAP bind password.</p>
+<h2>Suggested verification prompts</h2>
+<p>Ask the model:</p>
+<pre><code class="language-txt">Use your file tools, not bash, to test sandbox file access.
+Try to read /workspace/sandbox-test.txt, list /workspace, read
+/home/pi/.pi/agent/auth.json, /home/pi/.pi/agent/models.json,
+/home/pi/.pi/agent/settings.json, /home/pi/.pi-forge/jwt-secret,
+/proc/self/environ, /etc/passwd, and /run/secrets/anything.
+Report which succeeded and which failed.
+</code></pre>
+<p>Expected: workspace succeeds; protected config, forge data, <code>/proc</code>, <code>/etc</code>,
+and secret mounts are denied.</p>
+<p>Ask the model:</p>
+<pre><code class="language-txt">Use bash to run: id; env | sort; echo ok &gt; /workspace/bash-sandbox-test.txt;
+cat /workspace/bash-sandbox-test.txt; cat /home/pi/.pi-forge/jwt-secret;
+cat /home/pi/.pi/agent/auth.json; cat /proc/1/environ.
+Report the output and explain what was protected.
+</code></pre>
+<p>Expected: <code>id</code> shows the restricted UID/GID, env is scrubbed, workspace write
+works, and server secrets fail with permission denied.</p>
+
+    </main>
+  </div>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle sidebar">&#9776;</button>
+
+  <script>
+    document.getElementById('mobileToggle').addEventListener('click', () => {
+      document.getElementById('navLinks').classList.toggle('open');
+    });
+    document.getElementById('sidebarToggle').addEventListener('click', () => {
+      document.getElementById('docsSidebar').classList.toggle('open');
+    });
+  </script>
+</body>
+</html>

--- a/docs/site/docs/api.html
+++ b/docs/site/docs/api.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html" class="active">API Examples</a>

--- a/docs/site/docs/architecture.html
+++ b/docs/site/docs/architecture.html
@@ -40,6 +40,7 @@
         <a href="architecture.html" class="active">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>

--- a/docs/site/docs/ask-user-question.html
+++ b/docs/site/docs/ask-user-question.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>

--- a/docs/site/docs/configuration.html
+++ b/docs/site/docs/configuration.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html" class="active">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>
@@ -81,9 +82,11 @@ pi-forge --no-expose-docs --minimal-ui
 pi-forge --api-key @/run/secrets/api-key   # @&lt;path&gt; reads from file
 </code></pre>
 <ul>
-<li><strong>Sensitive flags</strong> (<code>--ui-password</code>, <code>--api-key</code>, <code>--jwt-secret</code>)
-accept <code>@&lt;path&gt;</code> to read from a file (keeps secrets out of shell
-history and <code>ps</code>).</li>
+<li><strong>Sensitive flags</strong> (<code>--ui-password</code>, <code>--api-key</code>, <code>--jwt-secret</code>,
+<code>--ldap-bind-password</code>) accept <code>@&lt;path&gt;</code> to read from a file (keeps
+secrets out of shell history and <code>ps</code>). Environment variables do not
+use <code>@</code> expansion; use the dedicated <code>*_FILE</code> env vars for mounted
+secret files.</li>
 <li><strong>Boolean flags</strong> accept <code>true|false|on|off|1|0|yes|no</code>. Bare
 <code>--flag</code> means <code>true</code>; <code>--no-flag</code> means <code>false</code>.</li>
 </ul>
@@ -129,7 +132,12 @@ in <code>cli.ts</code>). The most-touched ones:</p>
 <tr>
 <td><code>UI_PASSWORD</code></td>
 <td>(unset)</td>
-<td>Enables browser JWT auth. After the user changes it via the UI, a scrypt hash is persisted to <code>${FORGE_DATA_DIR}/password-hash</code> and the env value is ignored.</td>
+<td>Enables browser JWT auth. Literal env value only; it does not expand <code>@/path</code>. After the user changes it via the UI, a scrypt hash is persisted to <code>${FORGE_DATA_DIR}/password-hash</code> and the env value is ignored.</td>
+</tr>
+<tr>
+<td><code>UI_PASSWORD_FILE</code></td>
+<td>(unset)</td>
+<td>File containing the browser login password (for Kubernetes/OpenShift mounted Secrets). Takes precedence over <code>UI_PASSWORD</code>. Equivalent CLI: <code>--ui-password-file</code>; CLI <code>--ui-password @/path</code> is also supported.</td>
 </tr>
 <tr>
 <td><code>API_KEY</code></td>
@@ -139,7 +147,62 @@ in <code>cli.ts</code>). The most-touched ones:</p>
 <tr>
 <td><code>JWT_SECRET</code></td>
 <td>(auto-generated)</td>
-<td>HS256 signing key. Auto-generated and persisted to <code>${FORGE_DATA_DIR}/jwt-secret</code> (mode 0600) when <code>UI_PASSWORD</code> or <code>password-hash</code> is in play. Set explicitly (<code>openssl rand -hex 32</code>) to override; delete the file to rotate.</td>
+<td>HS256 signing key. Auto-generated and persisted to <code>${FORGE_DATA_DIR}/jwt-secret</code> (mode 0600) when <code>UI_PASSWORD</code>, LDAP auth, or <code>password-hash</code> is in play. Set explicitly (<code>openssl rand -hex 32</code>) to override; delete the file to rotate.</td>
+</tr>
+<tr>
+<td><code>LDAP_ENABLED</code></td>
+<td><code>false</code></td>
+<td>Enables LDAP username/password browser login. Requires the LDAP variables below.</td>
+</tr>
+<tr>
+<td><code>LDAP_URL</code></td>
+<td>(unset)</td>
+<td>LDAP server URL, e.g. <code>ldap://ldap.example.com:389</code> or <code>ldaps://ldap.example.com:636</code>.</td>
+</tr>
+<tr>
+<td><code>LDAP_BIND_DN</code></td>
+<td>(unset)</td>
+<td>Service-account bind DN used only to search for the user entry.</td>
+</tr>
+<tr>
+<td><code>LDAP_BIND_PASSWORD</code></td>
+<td>(unset)</td>
+<td>Service-account bind password. Literal env value only; it does not expand <code>@/path</code>. Prefer <code>LDAP_BIND_PASSWORD_FILE</code> or <code>--ldap-bind-password @/path</code> for secret mounts.</td>
+</tr>
+<tr>
+<td><code>LDAP_BIND_PASSWORD_FILE</code></td>
+<td>(unset)</td>
+<td>File containing the service-account password (for Kubernetes/OpenShift mounted Secrets). Takes precedence over <code>LDAP_BIND_PASSWORD</code>.</td>
+</tr>
+<tr>
+<td><code>LDAP_BASE_DN</code></td>
+<td>(unset)</td>
+<td>Base DN for user searches.</td>
+</tr>
+<tr>
+<td><code>LDAP_USER_FILTER</code></td>
+<td>`(</td>
+<td>(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))`</td>
+</tr>
+<tr>
+<td><code>LDAP_REQUIRED_GROUP_DN</code></td>
+<td>(unset)</td>
+<td>Optional required group DN. When set, the user&#39;s <code>memberOf</code> values must include it.</td>
+</tr>
+<tr>
+<td><code>LDAP_GROUP_ATTRIBUTE</code></td>
+<td><code>memberOf</code></td>
+<td>User attribute checked for group DNs. Change only for directories that expose group membership under a different attribute.</td>
+</tr>
+<tr>
+<td><code>LDAP_TIMEOUT_MS</code></td>
+<td><code>5000</code></td>
+<td>LDAP connect/operation timeout in milliseconds.</td>
+</tr>
+<tr>
+<td><code>LDAP_TLS_REJECT_UNAUTHORIZED</code></td>
+<td><code>true</code></td>
+<td>Reject untrusted TLS certificates for <code>ldaps://</code> connections. Set <code>false</code> only for local/self-signed testing.</td>
 </tr>
 <tr>
 <td><code>MINIMAL_UI</code></td>
@@ -166,9 +229,75 @@ in <code>cli.ts</code>). The most-touched ones:</p>
 <td><code>8</code></td>
 <td>Per-supervisor live-worker cap. Bounded to <code>[1, 100]</code>.</td>
 </tr>
+<tr>
+<td><code>AGENT_TOOL_SANDBOX_ENABLED</code></td>
+<td><code>false</code></td>
+<td>Opt-in identity/path sandbox for model/user tool surfaces. When <code>true</code>, <code>AGENT_TOOL_UID</code> and <code>AGENT_TOOL_GID</code> are required.</td>
+</tr>
+<tr>
+<td><code>AGENT_TOOL_UID</code></td>
+<td>(unset)</td>
+<td>Numeric UID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled.</td>
+</tr>
+<tr>
+<td><code>AGENT_TOOL_GID</code></td>
+<td>(unset)</td>
+<td>Numeric GID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled.</td>
+</tr>
 </tbody></table>
 <p>Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
 are documented in <a href="./deployment.md"><code>deployment.md</code></a>.</p>
+<h3>Agent tool identity sandbox</h3>
+<p>The identity sandbox is off by default and has a strict mount-permission
+contract. Read <a href="./agent-tool-sandbox.md"><code>agent-tool-sandbox.md</code></a> before
+enabling it. In short: pi-forge runs the server as root, drops
+model/user shell surfaces to <code>AGENT_TOOL_UID:GID</code>, scopes model file
+access, and requires workspace / Pi config / forge data mounts to have
+specific ownership and mode bits.</p>
+<p>When this mode is enabled, LDAP bind password file references are
+rejected (<code>LDAP_BIND_PASSWORD_FILE</code> and CLI/env <code>@file</code> forms). Use a
+literal environment value or an external secret broker instead; child
+tool processes receive the scrubbed env and do not inherit it.</p>
+<h3>LDAP browser login</h3>
+<p>LDAP is opt-in and off by default. When <code>LDAP_ENABLED=true</code>, pi-forge&#39;s
+login form asks for a username and password. Username <code>admin</code> (and
+password-only API calls) always use the local pi-forge admin password
+from <code>UI_PASSWORD</code>, <code>UI_PASSWORD_FILE</code>, or the persisted password hash;
+all other usernames use LDAP. The server binds with the
+configured service account, searches under <code>LDAP_BASE_DN</code> using
+<code>LDAP_USER_FILTER</code>, optionally checks the returned user&#39;s <code>memberOf</code>
+(or <code>LDAP_GROUP_ATTRIBUTE</code>) against <code>LDAP_REQUIRED_GROUP_DN</code>, and then
+binds as the returned user DN with the presented password. A successful
+LDAP bind issues the same pi-forge JWT used by local <code>UI_PASSWORD</code>
+login. API-key auth is unchanged, and protected routes still require a
+valid bearer JWT or API key.</p>
+<p>Minimal example:</p>
+<pre><code class="language-bash">LDAP_ENABLED=true
+LDAP_URL=ldaps://ldap.example.com:636
+LDAP_BIND_DN=&#39;cn=pi-forge,ou=svc,dc=example,dc=com&#39;
+LDAP_BIND_PASSWORD_FILE=/run/secrets/ldap-bind-password
+LDAP_BASE_DN=&#39;ou=people,dc=example,dc=com&#39;
+LDAP_REQUIRED_GROUP_DN=&#39;cn=pi-forge-users,ou=groups,dc=example,dc=com&#39;
+# Local/self-signed test only:
+# LDAP_TLS_REJECT_UNAUTHORIZED=false
+</code></pre>
+<p><code>LDAP_BIND_PASSWORD_FILE</code> is intended for Kubernetes/OpenShift mounted
+Secrets and takes precedence over <code>LDAP_BIND_PASSWORD</code>. <code>LDAP_BIND_PASSWORD</code>
+is always a literal password value; unlike CLI sensitive flags, env vars
+are not <code>@</code>-expanded. The password is read only in <code>config.ts</code>, never
+returned by any API, and redacted from request logs. Do not put
+service-account passwords in container images or command-line history;
+use a mounted secret file or the CLI <code>--ldap-bind-password @/path/to/file</code>
+form instead.</p>
+<p>If both LDAP and local <code>UI_PASSWORD</code> / <code>UI_PASSWORD_FILE</code> / stored-password
+auth are present, username <code>admin</code> and password-only login use the local
+pi-forge password. Other usernames use LDAP. The username <code>admin</code> is
+reserved for local pi-forge admin auth while LDAP is enabled; an LDAP
+account named <code>admin</code> cannot be used unless this policy changes later.
+This preserves existing single-tenant admin access while allowing LDAP
+to be enabled during migration. LDAP login attempts write sanitized
+<code>[ldap]</code> lines to the server logs with the URL, base DN, username, TLS
+validation mode, and failure category; passwords are not logged.</p>
 <h2>Pi SDK config files</h2>
 <p>The pi SDK owns three JSON files under <code>${PI_CONFIG_DIR}</code> (default
 <code>~/.pi/agent</code>). Pi-forge reads/writes them through the
@@ -279,9 +408,7 @@ schemas at session create).</p>
 <pre><code class="language-json">{
   &quot;defaultProvider&quot;: &quot;anthropic&quot;,
   &quot;defaultModel&quot;: &quot;claude-sonnet-4-5-20250929&quot;,
-  &quot;defaultThinkingLevel&quot;: &quot;medium&quot;,
-  &quot;steeringMode&quot;: &quot;all&quot;,
-  &quot;followUpMode&quot;: &quot;all&quot;
+  &quot;defaultThinkingLevel&quot;: &quot;medium&quot;
 }
 </code></pre>
 <table>
@@ -306,16 +433,6 @@ schemas at session create).</p>
 <td><code>defaultThinkingLevel</code></td>
 <td><code>minimal</code> / <code>low</code> / <code>medium</code> / <code>high</code> / <code>xhigh</code></td>
 <td>Reasoning-capable models only</td>
-</tr>
-<tr>
-<td><code>steeringMode</code></td>
-<td><code>all</code> / <code>one-at-a-time</code></td>
-<td>How the SDK delivers queued steering messages — flush-all vs wait-between</td>
-</tr>
-<tr>
-<td><code>followUpMode</code></td>
-<td><code>all</code> / <code>one-at-a-time</code></td>
-<td>Same, for follow-up (post-idle) delivery</td>
 </tr>
 </tbody></table>
 <p>Other SDK keys are accepted by <code>PUT /api/v1/config/settings</code> and persist

--- a/docs/site/docs/containers.html
+++ b/docs/site/docs/containers.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html" class="active">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>
@@ -84,35 +85,71 @@ runtime (Node + native bindings), and makes deploys reproducible.</p>
 </tr>
 </thead>
 <tbody><tr>
-<td><code>builder</code></td>
+<td><code>python-base</code></td>
+<td><code>python:3.12-slim-bookworm</code></td>
+<td>Source for the Python 3.12 + pip runtime copied into the shared Node base</td>
+</tr>
+<tr>
+<td><code>node-python-base</code></td>
 <td><code>node:22-bookworm-slim</code></td>
+<td>Shared Debian slim base with Node.js 22 plus Python 3.12 + pip</td>
+</tr>
+<tr>
+<td><code>builder</code></td>
+<td><code>node-python-base</code></td>
 <td>Installs all deps including devDeps, compiles native bindings (<code>node-pty</code>), runs <code>npm run build</code> for both packages</td>
 </tr>
 <tr>
 <td><code>runtime</code></td>
-<td><code>node:22-bookworm-slim</code></td>
-<td>Production deps + built artifacts only. Adds <code>git</code>, <code>ripgrep</code>, <code>bash</code>, <code>curl</code>, <code>less</code>, <code>procps</code>. Runs as non-root <code>pi</code>; <code>SHELL=/bin/bash</code> so xterm sessions land in bash, not dash</td>
+<td><code>node-python-base</code></td>
+<td>Production deps + built artifacts only. Adds <code>git</code>, <code>ripgrep</code>, <code>bash</code>, <code>curl</code>, <code>less</code>, <code>procps</code>, <code>gosu</code>, and the C++ toolchain needed for native-module rebuilds during in-container development. Default mode drops the server to <code>pi</code>; sandbox mode keeps the server as root so it can drop model/user tool processes to <code>pi-tools</code>; <code>SHELL=/bin/bash</code> so xterm sessions land in bash, not dash</td>
 </tr>
 </tbody></table>
-<p>Final image is ~330 MB. Debian-based (not Alpine) because the Node
-native-module ecosystem ships glibc prebuilds; on musl, those packages
-fall back to source builds.</p>
+<p>Final image size varies by architecture and cache state. Debian-based
+(not Alpine) because the Node native-module ecosystem ships glibc
+prebuilds; on musl, those packages fall back to source builds.</p>
 <p>Installed at runtime:</p>
 <ul>
 <li><strong>Node.js 22</strong></li>
+<li><strong>Python 3.12 + pip</strong> — callable as <code>python3</code>, <code>python</code>, or <code>py</code></li>
 <li><strong><code>tini</code></strong> — init for signal forwarding + zombie reaping</li>
 <li><strong><code>git</code></strong> — required by the agent&#39;s <code>bash</code> tool and the GitPanel routes</li>
 <li><strong><code>ripgrep</code></strong> — pi&#39;s <code>grep</code> tool delegates to <code>rg</code> when present;
 silently degrades to a Node walker without it</li>
+<li><strong><code>make</code>, <code>g++</code></strong> — keeps <code>npm install</code> / <code>npm rebuild</code> working
+inside the running container when native modules such as <code>node-pty</code>
+need to compile against the container&#39;s Node ABI</li>
 </ul>
 <h3>User and permissions</h3>
-<p>The image creates a <code>pi</code> user (uid/gid configurable via <code>PUID</code> /
-<code>PGID</code> build args; default <code>1000:1000</code>). For bind mounts to be
-writable, the container <code>pi</code> user must match the host owner of the
-mounted directory. On Linux:</p>
-<pre><code class="language-bash">PUID=$(id -u) PGID=$(id -g) docker compose -f docker/docker-compose.yml up -d --build
-</code></pre>
-<p>On Docker Desktop for macOS, UID translation is automatic.</p>
+<p>The image creates two users:</p>
+<ul>
+<li><code>pi</code> (<code>PUID</code> / <code>PGID</code>, default <code>1000:1000</code>) owns the home layout and
+preserves legacy path/env expectations.</li>
+<li><code>pi-tools</code> (<code>AGENT_TOOL_UID</code> / <code>AGENT_TOOL_GID</code> in compose, default
+<code>1001:1001</code>) is the restricted identity used when
+<code>AGENT_TOOL_SANDBOX_ENABLED=true</code>.</li>
+</ul>
+<p>By default (<code>AGENT_TOOL_SANDBOX_ENABLED=false</code>), the entrypoint drops
+the server to the legacy <code>pi</code> user. In sandbox mode, the server remains
+root. This is deliberate: the identity sandbox needs the server to call
+<code>setuid</code> / <code>setgid</code> for child tools while keeping server-owned config,
+forge data, and mounted secrets unreadable by <code>pi-tools</code>.</p>
+<p>Sandbox mode has a stricter volume permission contract than the default
+container. Read <a href="./agent-tool-sandbox.md"><code>agent-tool-sandbox.md</code></a>
+before enabling it; the short version is:</p>
+<ul>
+<li><code>/workspace</code> must be writable by <code>AGENT_TOOL_UID:GID</code>.</li>
+<li><code>/home/pi/.pi</code> and <code>/home/pi/.pi/agent</code> must be traversable/readable
+by <code>AGENT_TOOL_UID:GID</code> for non-secret skills/resources.</li>
+<li><code>/home/pi/.pi/agent/auth.json</code>, <code>models.json</code>, and <code>settings.json</code>
+must not be readable by <code>AGENT_TOOL_UID:GID</code>.</li>
+<li><code>/home/pi/.pi-forge</code> and mounted secret dirs/files must not be
+readable by <code>AGENT_TOOL_UID:GID</code>.</li>
+</ul>
+<p>On Docker Desktop / OrbStack / macOS, bind-mount ownership can be
+virtualized; verify numeric ownership and mode bits inside the
+container and from an app terminal. Use named volumes for sensitive
+mounts if the host file-sharing layer makes ownership inconsistent.</p>
 <h2>Volumes</h2>
 <p>Three bind-mounted volumes:</p>
 <table>
@@ -142,6 +179,30 @@ mounted directory. On Linux:</p>
 <p>Session JSONLs default to <code>${WORKSPACE_PATH}/.pi/sessions/</code> so they
 live on the workspace bind mount — backing up the workspace backs up
 conversation history. Override with <code>SESSION_DIR</code> to relocate.</p>
+<h3>Persistent Python packages outside this project</h3>
+<p>The image includes Python 3.12 and pip. Python is callable as <code>python3</code>,
+<code>python</code>, or <code>py</code>. The shipped compose file does not persist Python
+package installs by default. If you want package installs
+to survive image rebuilds/container replacement without storing them in
+the pi-forge checkout or workspace, mount an external host directory or
+named volume at <code>/home/pi/.local</code> from your own Docker Compose override
+or deployment wrapper:</p>
+<pre><code class="language-yaml">services:
+  pi-forge:
+    volumes:
+      - ~/.pi-forge-python:/home/pi/.local
+</code></pre>
+<p>Then install with:</p>
+<pre><code class="language-bash">python3 -m pip install --user &lt;package&gt;
+</code></pre>
+<p>The image sets <code>PYTHONUSERBASE=/home/pi/.local</code> and prepends
+<code>/home/pi/.local/bin</code> to <code>PATH</code>, so console scripts installed by pip are
+available automatically. On Linux, pre-create the host directory with the
+same owner as <code>PUID</code> / <code>PGID</code> if Docker would otherwise create it as
+root.</p>
+<p>For per-project isolation, create virtual environments inside
+<code>/workspace/&lt;project&gt;</code> instead; those persist because <code>/workspace</code> is a
+bind mount.</p>
 <h2>Environment variables</h2>
 <p>The full env-var reference lives in
 <a href="./configuration.md#environment-variables"><code>configuration.md</code></a>. The
@@ -173,6 +234,18 @@ in <code>docker/.env</code>:</p>
 <tr>
 <td><code>FORGE_DATA_DIR</code></td>
 <td><code>/home/pi/.pi-forge</code></td>
+</tr>
+<tr>
+<td><code>PYTHONUSERBASE</code></td>
+<td><code>/home/pi/.local</code></td>
+</tr>
+<tr>
+<td><code>AGENT_TOOL_SANDBOX_ENABLED</code></td>
+<td><code>false</code> by default; set <code>true</code> to run tool children as <code>pi-tools</code></td>
+</tr>
+<tr>
+<td><code>AGENT_TOOL_UID</code> / <code>AGENT_TOOL_GID</code></td>
+<td><code>1001</code> / <code>1001</code> in compose defaults</td>
 </tr>
 </tbody></table>
 <p>Set <code>UI_PASSWORD</code> and / or <code>API_KEY</code> in <code>.env</code> for any non-loopback
@@ -241,11 +314,19 @@ SSE-buffering and WebSocket-upgrade settings live in
 <a href="./deployment.md"><code>deployment.md</code></a>.</p>
 <h2>Security inside the container</h2>
 <ul>
-<li><strong>Non-root.</strong> Runs as <code>pi:pi</code>. <code>tini</code> forwards signals so
-<code>docker stop</code> shuts down cleanly.</li>
-<li><strong>No extra capabilities.</strong> No privileged mode, host PID, or
-<code>--cap-add</code> needed. If you find yourself adding any, you&#39;re working
-around the threat model — open an issue first.</li>
+<li><strong>Root server, restricted tools (opt-in).</strong> By default the server runs as <code>pi</code>.
+When <code>AGENT_TOOL_SANDBOX_ENABLED=true</code>, the server runs as root and model/user shell surfaces run
+as <code>pi-tools</code> and file tools / <code>@file</code> references are path-scoped.
+Keep secrets out of <code>/workspace</code>; workspace content is intentionally
+readable by the agent.</li>
+<li><strong>Minimal capabilities.</strong> Compose drops all capabilities and adds back
+only <code>SETUID</code> / <code>SETGID</code>, which are required for the identity switch.
+No privileged mode or host PID is needed.</li>
+<li><strong>Secret mounts.</strong> Mount Pi config, forge data, LDAP/UI secret files,
+and cloud credentials so they are readable by the root server but not
+by <code>pi-tools</code> (for example mode <code>0600</code> root-owned files or <code>0700</code>
+directories). The sandbox also blocks <code>/run/secrets</code> and
+<code>/var/run/secrets</code> from model file tools.</li>
 <li><strong>Read-only root filesystem (optional).</strong> Add <code>read_only: true</code> to
 compose with <code>tmpfs</code> mounts for <code>/tmp</code> and <code>/home/pi/.npm</code> if you
 want a hardened deploy. Native modules + node_modules live in the
@@ -272,9 +353,11 @@ container&#39;s defaults</li>
 </ul>
 <h3>Terminal fails to spawn (<code>posix_spawnp failed</code>)</h3>
 <p>The native <code>node-pty</code> binding doesn&#39;t match the runtime Node version.
-This is a host-only issue (the Docker image rebuilds the binding during
-its build stage). If you somehow hit it inside the container, your
-local image is stale — <code>docker compose up -d --build</code> (note <code>--build</code>).</p>
+Rebuild the image first: <code>docker compose up -d --build</code> (note <code>--build</code>).
+If you&#39;re using the running container as a development shell and running
+<code>npm install</code> against a bind-mounted checkout, the runtime image includes
+Python 3.12, <code>pip</code>, <code>make</code>, and <code>g++</code> so node-gyp can rebuild <code>node-pty</code>
+in place.</p>
 <h3>Health check failing on first start</h3>
 <p>The first request lazy-loads the project registry from disk, which on a
 slow filesystem (NFS, network bind mount) can take a few seconds. The

--- a/docs/site/docs/deployment.html
+++ b/docs/site/docs/deployment.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html" class="active">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>

--- a/docs/site/docs/mcp.html
+++ b/docs/site/docs/mcp.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>
@@ -357,6 +358,16 @@ Settings → MCP)</li>
 <li><strong>neutral</strong> — master toggle off</li>
 </ul>
 <p>Hidden when no servers are configured and in <code>MINIMAL_UI</code> mode.</p>
+<p>The header summary and any Settings → MCP project status list already opened by
+this browser tab refresh automatically on the shared MCP ticker. Unchanged status
+payloads keep their existing UI state to avoid unnecessary churn.</p>
+<h2>Tool result truncation</h2>
+<p>Very large text results from MCP tools are capped before they enter the agent
+context. When truncation happens, the returned text starts with a concise
+<code>MCP_RESULT_TRUNCATED</code> warning that includes the omitted size and tells the model
+to retry with a smaller scope, narrower filter, or pagination. The visible payload
+then keeps the start and end of the original result with a marker where the middle
+was omitted.</p>
 <h2>Troubleshooting</h2>
 <p><strong>Status stuck in <code>error</code></strong> — Settings → MCP, expand the row, read
 <code>lastError</code>. Common causes:</p>

--- a/docs/site/docs/mobile.html
+++ b/docs/site/docs/mobile.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html" class="active">Mobile</a>
         <a href="api.html">API Examples</a>

--- a/docs/site/docs/orchestration.html
+++ b/docs/site/docs/orchestration.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>
@@ -208,7 +209,7 @@ types:</p>
 </tr>
 <tr>
 <td><code>worker.process_alert</code></td>
-<td>A background process the worker spawned exited (success / failure / external kill)</td>
+<td>Not enqueued for worker process alerts; process success/failure/kill notifications stay in the worker session and do not wake the supervisor</td>
 </tr>
 <tr>
 <td><code>worker.deleted</code></td>
@@ -390,8 +391,8 @@ supervisor. v1 disallows this by design — depth is capped at 1.</p>
 agent events&quot; surface. Webhooks fan out OVER HTTPS to external
 systems; orchestration fans IN to a supervisor session.</li>
 <li><a href="./processes.md"><code>processes.md</code></a> — workers can spawn background
-processes the same way standalone sessions can; process alerts
-fed back into the supervisor&#39;s inbox as <code>worker.process_alert</code>.</li>
+processes the same way standalone sessions can; process alerts stay
+local to the worker session and do not wake the supervisor.</li>
 <li><a href="./ask-user-question.md"><code>ask-user-question.md</code></a> — when a worker
 calls this tool, the supervisor sees a <code>worker.ask_user</code> inbox
 item and can answer via <code>orchestrate_send_to_worker</code>.</li>

--- a/docs/site/docs/processes.html
+++ b/docs/site/docs/processes.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>

--- a/docs/site/docs/quick-actions.html
+++ b/docs/site/docs/quick-actions.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>

--- a/docs/site/docs/sse-events.html
+++ b/docs/site/docs/sse-events.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>

--- a/docs/site/docs/todo.html
+++ b/docs/site/docs/todo.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>

--- a/docs/site/docs/webhooks.html
+++ b/docs/site/docs/webhooks.html
@@ -40,6 +40,7 @@
         <a href="architecture.html">Architecture</a>
         <a href="configuration.html">Configuration</a>
         <a href="containers.html">Containers</a>
+        <a href="agent-tool-sandbox.html">Agent Tool Sandbox</a>
         <a href="deployment.html">Deployment</a>
         <a href="mobile.html">Mobile</a>
         <a href="api.html">API Examples</a>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -104,6 +104,11 @@
         <p>Default-available supervisor mode lets one session spawn, observe, and coordinate worker sessions in the same project. Worker events stream into the supervisor's inbox.</p>
       </div>
       <div class="feature-card">
+        <div class="feature-icon">&#128737;&#65039;</div>
+        <h3>Optional tool sandbox</h3>
+        <p>Opt-in hardening mode runs agent/user shell surfaces as a restricted UID/GID, scopes model file tools, and keeps server-side config and forge data out of that identity.</p>
+      </div>
+      <div class="feature-card">
         <div class="feature-icon">&#128268;</div>
         <h3>Webhooks</h3>
         <p>HTTPS POST deliveries on agent and session events. Global or per-project scope, HMAC-SHA256 signing, retry with exponential backoff, delivery history.</p>

--- a/kubernetes/DEPLOY.md
+++ b/kubernetes/DEPLOY.md
@@ -94,10 +94,10 @@ oc apply -f kubernetes/openshift/base.yaml
 # 3. DeploymentConfig
 oc apply -f kubernetes/openshift/deployment.yaml
 
-# 4. Allow the pod to run as UID 1000 (the image's `pi` user).
-#    OpenShift's default SCC assigns a random UID per namespace, which
-#    breaks the chown'd /workspace and /home/pi paths in the image.
-#    The `anyuid` SCC bypasses that for the project's ServiceAccount.
+# 4. Allow the pod to run as UID 0 when using the identity sandbox.
+#    OpenShift restricted-v2 assigns a random non-root UID and cannot
+#    support pi-forge's UID/GID-switching identity sandbox. Bind an SCC
+#    that allows UID 0 and SETUID/SETGID for the ServiceAccount.
 oc adm policy add-scc-to-user anyuid -z pi-forge -n pi-forge
 
 # 5. Verify
@@ -142,6 +142,49 @@ in [`docs/configuration.md`](../docs/configuration.md) and
   preferably, as a mounted Secret file with `LDAP_BIND_PASSWORD_FILE`
   pointing at the mount path. `LDAP_BIND_PASSWORD` itself is a literal
   env value; it does not expand `@/path`. See `docs/configuration.md#ldap-browser-login`.
+- **Agent tool identity sandbox.** `AGENT_TOOL_SANDBOX_ENABLED=false`
+  by default. To enable it on vanilla Kubernetes, the container security
+  context must run the server as root and permit only the identity-switch
+  capabilities:
+
+  ```yaml
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+      add: ["SETUID", "SETGID"]
+  ```
+
+  The workspace PVC must be writable by `AGENT_TOOL_UID:GID`; Pi config,
+  forge data, and mounted secrets should be root/server-readable but not
+  readable by that restricted UID. The sandbox path-scopes model file
+  tools and `@file` expansion, scrubs env for bash/process/terminal, and
+  runs those shells as the restricted identity. It does not protect
+  secrets placed in `/workspace` or third-party extensions that bypass
+  pi-forge's policy hooks.
+- **OpenShift SCC.** restricted-v2 random UID will not support identity
+  sandbox. Use `anyuid` for a simple deployment, or a custom SCC that
+  allows UID 0 plus `SETUID`/`SETGID`; privileged mode is not required.
+  Keep the SCC RoleBinding with namespace/security bootstrap, not inside
+  the `DeploymentConfig`. Declarative example:
+
+  ```yaml
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: pi-forge-anyuid
+    namespace: pi-forge
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:openshift:scc:anyuid
+  subjects:
+    - kind: ServiceAccount
+      name: pi-forge
+      namespace: pi-forge
+  ```
 - **Resource defaults** per pod: requests 512 Mi / 250 m CPU; limits
   2 Gi / 1 CPU. Memory is the typical ceiling for long agent
   contexts or compiling inside the integrated terminal.

--- a/kubernetes/kube/deployment.yaml
+++ b/kubernetes/kube/deployment.yaml
@@ -13,17 +13,12 @@ spec:
       labels:
         app: pi-forge
     spec:
-      # Pod-level security context — these apply to every container.
-      # `fsGroup` + `fsGroupChangePolicy: OnRootMismatch` lets the kubelet
-      # chown the volume mounts to GID 1000 on first attach, replacing
-      # the previous `chmod -R 777` init container (which was a wildly
-      # permissive mode that defeated the purpose of fsGroup).
+      # Pod-level security context. The server runs as root so the
+      # opt-in identity sandbox can drop model/user shell surfaces to
+      # AGENT_TOOL_UID/GID. No privileged mode is required.
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
+        runAsUser: 0
+        runAsGroup: 0
         seccompProfile:
           type: RuntimeDefault
       initContainers:
@@ -40,13 +35,13 @@ spec:
             [
               "sh",
               "-c",
-              "mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chown -R 1000:1000 /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chmod 700 /workspace /home/pi/.pi/agent /home/pi/.pi-forge || true",
+              "mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chown -R 1001:1001 /workspace && chown -R 0:0 /home/pi/.pi/agent /home/pi/.pi-forge && chmod 775 /workspace && chmod 700 /home/pi/.pi/agent /home/pi/.pi-forge || true",
             ]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              # CHOWN is required for `chown -R 1000:1000`. Without it
+              # CHOWN is required for volume ownership fixups. Without it
               # the init container fails on the chown step. We don't
               # need to run as root for this — the busybox shell does
               # the chown via its own UID.
@@ -79,8 +74,8 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+              add: ["SETUID", "SETGID"]
             readOnlyRootFilesystem: true
-            runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
           ports:
@@ -103,6 +98,12 @@ spec:
               value: "1000"
             - name: PGID
               value: "1000"
+            - name: AGENT_TOOL_SANDBOX_ENABLED
+              value: "false"
+            - name: AGENT_TOOL_UID
+              value: "1001"
+            - name: AGENT_TOOL_GID
+              value: "1001"
             - name: LOG_LEVEL
               value: info
             - name: TRUST_PROXY

--- a/kubernetes/kube/deployment.yaml
+++ b/kubernetes/kube/deployment.yaml
@@ -13,9 +13,9 @@ spec:
       labels:
         app: pi-forge
     spec:
-      # Pod-level security context. The server runs as root so the
-      # opt-in identity sandbox can drop model/user shell surfaces to
-      # AGENT_TOOL_UID/GID. No privileged mode is required.
+      # Pod-level security context. The container starts as root so the
+      # entrypoint can either drop the server to pi (default) or keep it
+      # root for the opt-in identity sandbox. No privileged mode is required.
       securityContext:
         runAsUser: 0
         runAsGroup: 0
@@ -35,7 +35,7 @@ spec:
             [
               "sh",
               "-c",
-              "mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chown -R 1001:1001 /workspace && chown -R 0:0 /home/pi/.pi/agent /home/pi/.pi-forge && chmod 775 /workspace && chmod 700 /home/pi/.pi/agent /home/pi/.pi-forge || true",
+              "mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chown -R 1000:1000 /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chmod 700 /workspace /home/pi/.pi/agent /home/pi/.pi-forge || true",
             ]
           securityContext:
             allowPrivilegeEscalation: false

--- a/kubernetes/openshift/deployment.yaml
+++ b/kubernetes/openshift/deployment.yaml
@@ -13,13 +13,12 @@ spec:
         app: pi-forge
     spec:
       serviceAccountName: pi-forge
-      # Pod-level security context. OpenShift's `restricted-v2` SCC will
-      # typically inject a UID for you, but specifying these here gives
-      # a stable, audit-friendly baseline that works on clusters with
-      # looser SCC defaults too. Verify your cluster's SCC binding
-      # accepts these (see kubernetes/DEPLOY.md).
+      # Pod-level security context. Identity sandbox requires an SCC
+      # that permits UID 0 plus SETUID/SETGID; restricted-v2 random UID
+      # cannot support this mode (see kubernetes/DEPLOY.md).
       securityContext:
-        runAsNonRoot: true
+        runAsUser: 0
+        runAsGroup: 0
         seccompProfile:
           type: RuntimeDefault
       initContainers:
@@ -32,7 +31,7 @@ spec:
             [
               "sh",
               "-c",
-              "mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chown -R 1000:1000 /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chmod 700 /workspace /home/pi/.pi/agent /home/pi/.pi-forge || true",
+              "mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chown -R 1001:1001 /workspace && chown -R 0:0 /home/pi/.pi/agent /home/pi/.pi-forge && chmod 775 /workspace && chmod 700 /home/pi/.pi/agent /home/pi/.pi-forge || true",
             ]
           securityContext:
             allowPrivilegeEscalation: false
@@ -62,8 +61,8 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+              add: ["SETUID", "SETGID"]
             readOnlyRootFilesystem: true
-            runAsNonRoot: true
           ports:
             - containerPort: 3000
               name: http
@@ -86,6 +85,12 @@ spec:
               value: "1000"
             - name: PGID
               value: "1000"
+            - name: AGENT_TOOL_SANDBOX_ENABLED
+              value: "false"
+            - name: AGENT_TOOL_UID
+              value: "1001"
+            - name: AGENT_TOOL_GID
+              value: "1001"
             - name: LOG_LEVEL
               value: info
             - name: TRUST_PROXY

--- a/kubernetes/openshift/deployment.yaml
+++ b/kubernetes/openshift/deployment.yaml
@@ -13,9 +13,10 @@ spec:
         app: pi-forge
     spec:
       serviceAccountName: pi-forge
-      # Pod-level security context. Identity sandbox requires an SCC
-      # that permits UID 0 plus SETUID/SETGID; restricted-v2 random UID
-      # cannot support this mode (see kubernetes/DEPLOY.md).
+      # Pod-level security context. The container starts as root so the
+      # entrypoint can either drop the server to pi (default) or keep it
+      # root for the opt-in identity sandbox. restricted-v2 random UID
+      # cannot support sandbox mode (see kubernetes/DEPLOY.md).
       securityContext:
         runAsUser: 0
         runAsGroup: 0
@@ -31,7 +32,7 @@ spec:
             [
               "sh",
               "-c",
-              "mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chown -R 1001:1001 /workspace && chown -R 0:0 /home/pi/.pi/agent /home/pi/.pi-forge && chmod 775 /workspace && chmod 700 /home/pi/.pi/agent /home/pi/.pi-forge || true",
+              "mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chown -R 1000:1000 /workspace /home/pi/.pi/agent /home/pi/.pi-forge && chmod 700 /workspace /home/pi/.pi/agent /home/pi/.pi-forge || true",
             ]
           securityContext:
             allowPrivilegeEscalation: false

--- a/packages/server/src/agent-bash-operations.ts
+++ b/packages/server/src/agent-bash-operations.ts
@@ -1,0 +1,46 @@
+import { spawn } from "node:child_process";
+import type { BashOperations } from "@earendil-works/pi-coding-agent";
+import { config } from "./config.js";
+import { scrubbedEnv } from "./pty-manager.js";
+
+export function sandboxSpawnIdentity(): { uid?: number; gid?: number } {
+  if (!config.agentToolSandbox.enabled) return {};
+  return { uid: config.agentToolSandbox.uid!, gid: config.agentToolSandbox.gid! };
+}
+
+export function createForgeBashOperations(workspacePath: string): BashOperations {
+  return {
+    exec: (command, _cwd, options) => {
+      return new Promise<{ exitCode: number | null }>((resolve, reject) => {
+        const proc = spawn("/bin/sh", ["-c", command], {
+          cwd: workspacePath,
+          env: scrubbedEnv(),
+          stdio: ["ignore", "pipe", "pipe"],
+          ...sandboxSpawnIdentity(),
+        });
+        const onAbort = (): void => {
+          try {
+            proc.kill("SIGTERM");
+          } catch {
+            // best-effort
+          }
+          setTimeout(() => {
+            try {
+              proc.kill("SIGKILL");
+            } catch {
+              // best-effort
+            }
+          }, 2000);
+        };
+        if (options.signal !== undefined) {
+          if (options.signal.aborted) onAbort();
+          else options.signal.addEventListener("abort", onAbort, { once: true });
+        }
+        proc.stdout?.on("data", (data: Buffer) => options.onData(data));
+        proc.stderr?.on("data", (data: Buffer) => options.onData(data));
+        proc.on("error", (err) => reject(err));
+        proc.on("close", (code) => resolve({ exitCode: code }));
+      });
+    },
+  };
+}

--- a/packages/server/src/agent-tool-overrides.ts
+++ b/packages/server/src/agent-tool-overrides.ts
@@ -1,0 +1,117 @@
+import { access, mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { glob } from "glob";
+import {
+  createBashToolDefinition,
+  createEditToolDefinition,
+  createFindToolDefinition,
+  createGrepToolDefinition,
+  createLsToolDefinition,
+  createReadToolDefinition,
+  createWriteToolDefinition,
+  type EditOperations,
+  type FindOperations,
+  type GrepOperations,
+  type LsOperations,
+  type ReadOperations,
+  type ToolDefinition,
+  type WriteOperations,
+} from "@earendil-works/pi-coding-agent";
+import { createForgeBashOperations } from "./agent-bash-operations.js";
+import { assertAgentToolPathAllowed, resolveAgentToolPath } from "./agent-tool-policy.js";
+
+function guard(workspacePath: string, absolutePath: string): string {
+  return resolveAgentToolPath(workspacePath, absolutePath);
+}
+
+export function createSandboxedToolDefinitions(workspacePath: string): ToolDefinition[] {
+  const readOps: ReadOperations = {
+    readFile: async (absolutePath) => readFile(guard(workspacePath, absolutePath)),
+    access: async (absolutePath) => access(guard(workspacePath, absolutePath)),
+    detectImageMimeType: async () => undefined,
+  };
+
+  const grepOps: GrepOperations = {
+    isDirectory: async (absolutePath) =>
+      (await stat(guard(workspacePath, absolutePath))).isDirectory(),
+    readFile: async (absolutePath) => readFile(guard(workspacePath, absolutePath), "utf8"),
+  };
+
+  const findOps: FindOperations = {
+    exists: async (absolutePath) => {
+      try {
+        await access(guard(workspacePath, absolutePath));
+        return true;
+      } catch (err) {
+        const e = err as NodeJS.ErrnoException;
+        if (e.code === "ENOENT") return false;
+        throw err;
+      }
+    },
+    glob: async (pattern, cwd, options) => {
+      const safeCwd = guard(workspacePath, cwd);
+      const results = await glob(pattern, {
+        cwd: safeCwd,
+        absolute: true,
+        nodir: false,
+        dot: true,
+        ignore: options.ignore,
+      });
+      const allowed: string[] = [];
+      for (const result of results) {
+        assertAgentToolPathAllowed(workspacePath, result);
+        allowed.push(result);
+        if (allowed.length >= options.limit) break;
+      }
+      return allowed;
+    },
+  };
+
+  const lsOps: LsOperations = {
+    exists: async (absolutePath) => {
+      try {
+        await access(guard(workspacePath, absolutePath));
+        return true;
+      } catch (err) {
+        const e = err as NodeJS.ErrnoException;
+        if (e.code === "ENOENT") return false;
+        throw err;
+      }
+    },
+    stat: async (absolutePath) => stat(guard(workspacePath, absolutePath)),
+    readdir: async (absolutePath) => readdir(guard(workspacePath, absolutePath)),
+  };
+
+  const editOps: EditOperations = {
+    readFile: async (absolutePath) => readFile(guard(workspacePath, absolutePath)),
+    writeFile: async (absolutePath, content) => {
+      await writeFile(guard(workspacePath, absolutePath), content);
+    },
+    access: async (absolutePath) => access(guard(workspacePath, absolutePath)),
+  };
+
+  const writeOps: WriteOperations = {
+    writeFile: async (absolutePath, content) => {
+      await writeFile(guard(workspacePath, absolutePath), content);
+    },
+    mkdir: async (dir) => {
+      await mkdir(guard(workspacePath, dir), { recursive: true });
+    },
+  };
+
+  return [
+    createReadToolDefinition(workspacePath, { operations: readOps }),
+    createGrepToolDefinition(workspacePath, { operations: grepOps }),
+    createFindToolDefinition(workspacePath, { operations: findOps }),
+    createLsToolDefinition(workspacePath, { operations: lsOps }),
+    createEditToolDefinition(workspacePath, { operations: editOps }),
+    createWriteToolDefinition(workspacePath, { operations: writeOps }),
+    createBashToolDefinition(workspacePath, {
+      operations: createForgeBashOperations(workspacePath),
+    }),
+  ] as unknown as ToolDefinition[];
+}
+
+export function resolveSandboxedAgentPath(workspacePath: string, requestedPath: string): string {
+  return guard(workspacePath, join(workspacePath, requestedPath));
+}

--- a/packages/server/src/agent-tool-policy.ts
+++ b/packages/server/src/agent-tool-policy.ts
@@ -1,0 +1,96 @@
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, resolve, sep, relative } from "node:path";
+import { config } from "./config.js";
+
+const PROTECTED_PI_CONFIG_FILES = new Set(["auth.json", "models.json", "settings.json"]);
+const HOME_SECRET_DIRS = new Set([".ssh", ".aws", ".kube", ".gnupg"]);
+const DENIED_PREFIXES = ["/proc", "/etc", "/run/secrets", "/var/run/secrets"];
+
+export class AgentToolPathDeniedError extends Error {
+  constructor(message: string) {
+    super(`agent_tool_path_denied: ${message}`);
+    this.name = "AgentToolPathDeniedError";
+  }
+}
+
+function pathWithin(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function realpathExistingOrParent(abs: string): string {
+  let cur = abs;
+  while (!existsSync(cur)) {
+    const parent = dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return realpathSync.native(cur);
+}
+
+function firstSegment(rel: string): string {
+  return rel.split(/[\\/]/)[0] ?? "";
+}
+
+function denyIfSensitiveAbsolute(abs: string, workspaceReal: string, piConfigReal: string): void {
+  for (const prefix of DENIED_PREFIXES) {
+    if (abs === prefix || abs.startsWith(`${prefix}/`)) {
+      throw new AgentToolPathDeniedError(`${abs} is not available to model tools`);
+    }
+  }
+  if (pathWithin(abs, config.forgeDataDir)) {
+    throw new AgentToolPathDeniedError(`${abs} is inside FORGE_DATA_DIR`);
+  }
+  const home = process.env.HOME;
+  if (home !== undefined && home !== "") {
+    const homeAbs = resolve(home);
+    if (pathWithin(abs, homeAbs)) {
+      const seg = firstSegment(relative(homeAbs, abs));
+      if (
+        HOME_SECRET_DIRS.has(seg) &&
+        !pathWithin(abs, workspaceReal) &&
+        !pathWithin(abs, piConfigReal)
+      ) {
+        throw new AgentToolPathDeniedError(`${abs} is inside a home secret directory`);
+      }
+    }
+  }
+}
+
+export function resolveAgentToolPath(workspacePath: string, requestedPath: string): string {
+  if (requestedPath.trim() === "") {
+    throw new AgentToolPathDeniedError("empty path is not allowed");
+  }
+  const workspaceReal = realpathExistingOrParent(resolve(workspacePath));
+  const piConfigReal = realpathExistingOrParent(resolve(config.piConfigDir));
+  const forgeDataReal = realpathExistingOrParent(resolve(config.forgeDataDir));
+  const baseResolved = isAbsolute(requestedPath)
+    ? resolve(requestedPath)
+    : resolve(workspacePath, requestedPath);
+  const resolvedReal = realpathExistingOrParent(baseResolved);
+
+  denyIfSensitiveAbsolute(baseResolved, workspaceReal, piConfigReal);
+  denyIfSensitiveAbsolute(resolvedReal, workspaceReal, piConfigReal);
+  if (pathWithin(baseResolved, forgeDataReal) || pathWithin(resolvedReal, forgeDataReal)) {
+    throw new AgentToolPathDeniedError(`${baseResolved} is inside FORGE_DATA_DIR`);
+  }
+
+  if (pathWithin(resolvedReal, workspaceReal)) return baseResolved;
+
+  if (pathWithin(resolvedReal, piConfigReal)) {
+    const rel = relative(piConfigReal, baseResolved).split(sep).join("/");
+    if (rel === "" || rel.startsWith("../")) {
+      throw new AgentToolPathDeniedError(`${baseResolved} is outside PI_CONFIG_DIR`);
+    }
+    if (!rel.includes("/") && PROTECTED_PI_CONFIG_FILES.has(rel)) {
+      throw new AgentToolPathDeniedError(`${rel} is protected pi config`);
+    }
+    return baseResolved;
+  }
+
+  throw new AgentToolPathDeniedError(`${baseResolved} is outside allowed roots`);
+}
+
+export function assertAgentToolPathAllowed(workspacePath: string, requestedPath: string): void {
+  resolveAgentToolPath(workspacePath, requestedPath);
+}

--- a/packages/server/src/agent-tool-policy.ts
+++ b/packages/server/src/agent-tool-policy.ts
@@ -32,6 +32,36 @@ function firstSegment(rel: string): string {
   return rel.split(/[\\/]/)[0] ?? "";
 }
 
+function piConfigRelativePath(
+  baseResolved: string,
+  resolvedReal: string,
+  piConfigReal: string,
+): string | undefined {
+  const candidate = pathWithin(baseResolved, piConfigReal) ? baseResolved : resolvedReal;
+  const rel = relative(piConfigReal, candidate).split(sep).join("/");
+  if (rel === "" || rel.startsWith("../")) return undefined;
+  return rel;
+}
+
+function assertPiConfigPathAllowed(
+  baseResolved: string,
+  resolvedReal: string,
+  piConfigReal: string,
+): boolean {
+  if (!pathWithin(baseResolved, piConfigReal) && !pathWithin(resolvedReal, piConfigReal)) {
+    return false;
+  }
+
+  for (const candidate of [baseResolved, resolvedReal]) {
+    if (!pathWithin(candidate, piConfigReal)) continue;
+    const rel = relative(piConfigReal, candidate).split(sep).join("/");
+    if (!rel.includes("/") && PROTECTED_PI_CONFIG_FILES.has(rel)) {
+      throw new AgentToolPathDeniedError(`${rel} is protected pi config`);
+    }
+  }
+  return true;
+}
+
 function denyIfSensitiveAbsolute(abs: string, workspaceReal: string, piConfigReal: string): void {
   for (const prefix of DENIED_PREFIXES) {
     if (abs === prefix || abs.startsWith(`${prefix}/`)) {
@@ -75,15 +105,14 @@ export function resolveAgentToolPath(workspacePath: string, requestedPath: strin
     throw new AgentToolPathDeniedError(`${baseResolved} is inside FORGE_DATA_DIR`);
   }
 
+  const isPiConfigPath = assertPiConfigPathAllowed(baseResolved, resolvedReal, piConfigReal);
+
   if (pathWithin(resolvedReal, workspaceReal)) return baseResolved;
 
-  if (pathWithin(resolvedReal, piConfigReal)) {
-    const rel = relative(piConfigReal, baseResolved).split(sep).join("/");
-    if (rel === "" || rel.startsWith("../")) {
+  if (isPiConfigPath) {
+    const rel = piConfigRelativePath(baseResolved, resolvedReal, piConfigReal);
+    if (rel === undefined) {
       throw new AgentToolPathDeniedError(`${baseResolved} is outside PI_CONFIG_DIR`);
-    }
-    if (!rel.includes("/") && PROTECTED_PI_CONFIG_FILES.has(rel)) {
-      throw new AgentToolPathDeniedError(`${rel} is protected pi config`);
     }
     return baseResolved;
   }

--- a/packages/server/src/agent-tool-policy.ts
+++ b/packages/server/src/agent-tool-policy.ts
@@ -61,7 +61,7 @@ export function resolveAgentToolPath(workspacePath: string, requestedPath: strin
   if (requestedPath.trim() === "") {
     throw new AgentToolPathDeniedError("empty path is not allowed");
   }
-  const workspaceReal = realpathExistingOrParent(resolve(workspacePath));
+  const workspaceReal = realpathExistingOrParent(resolve(config.workspacePath));
   const piConfigReal = realpathExistingOrParent(resolve(config.piConfigDir));
   const forgeDataReal = realpathExistingOrParent(resolve(config.forgeDataDir));
   const baseResolved = isAbsolute(requestedPath)

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -30,7 +30,7 @@ import { readFileSync } from "node:fs";
 import { parseArgs } from "node:util";
 
 type FlagType = "string" | "number" | "boolean" | "list";
-type FlagGroup = "network" | "paths" | "auth" | "rate-limits" | "features" | "terminal";
+type FlagGroup = "network" | "paths" | "auth" | "rate-limits" | "features" | "terminal" | "sandbox";
 
 interface FlagDef {
   name: string; // kebab-case CLI flag (without leading --)
@@ -331,6 +331,31 @@ const FLAGS: readonly FlagDef[] = [
     desc: "Append a secret-hygiene rule to the agent's system prompt",
     defaultText: "false",
   },
+  // sandbox
+  {
+    name: "agent-tool-sandbox-enabled",
+    env: "AGENT_TOOL_SANDBOX_ENABLED",
+    type: "boolean",
+    group: "sandbox",
+    desc: "Run model/user shell surfaces as restricted UID/GID with path-scoped file tools",
+    defaultText: "false",
+  },
+  {
+    name: "agent-tool-uid",
+    env: "AGENT_TOOL_UID",
+    type: "number",
+    group: "sandbox",
+    desc: "Numeric UID for sandboxed model/user shell processes",
+    defaultText: "(required when sandbox enabled)",
+  },
+  {
+    name: "agent-tool-gid",
+    env: "AGENT_TOOL_GID",
+    type: "number",
+    group: "sandbox",
+    desc: "Numeric GID for sandboxed model/user shell processes",
+    defaultText: "(required when sandbox enabled)",
+  },
   // rate limits
   {
     name: "rate-limit-login-max",
@@ -572,6 +597,26 @@ export function parseCliArgs(argv: string[]): ParseResult {
     );
   }
 
+  const sandboxRaw =
+    parsed.values["agent-tool-sandbox-enabled"] ?? process.env.AGENT_TOOL_SANDBOX_ENABLED;
+  const sandboxEnabled =
+    sandboxRaw !== undefined && BOOL_TRUE.has(String(sandboxRaw).toLowerCase());
+  const ldapBindPasswordRaw = parsed.values["ldap-bind-password"];
+  if (
+    sandboxEnabled &&
+    typeof ldapBindPasswordRaw === "string" &&
+    ldapBindPasswordRaw.startsWith("@")
+  ) {
+    result.errors.push(
+      "LDAP bind password file references are not allowed when AGENT_TOOL_SANDBOX_ENABLED=true. Use an environment variable value or external secret broker.",
+    );
+  }
+  if (sandboxEnabled && parsed.values["ldap-bind-password-file"] !== undefined) {
+    result.errors.push(
+      "LDAP bind password file references are not allowed when AGENT_TOOL_SANDBOX_ENABLED=true. Use an environment variable value or external secret broker.",
+    );
+  }
+
   for (const f of FLAGS) {
     const raw = parsed.values[f.name];
     if (raw === undefined) continue;
@@ -636,6 +681,7 @@ const GROUP_LABELS: Record<FlagGroup, string> = {
   paths: "Paths",
   auth: "Authentication",
   features: "Features",
+  sandbox: "Agent tool sandbox",
   "rate-limits": "Rate limits",
   terminal: "Terminal",
 };
@@ -654,7 +700,15 @@ export function buildHelpText(version: string): string {
   );
   out.push("");
 
-  const groups: FlagGroup[] = ["network", "paths", "auth", "features", "rate-limits", "terminal"];
+  const groups: FlagGroup[] = [
+    "network",
+    "paths",
+    "auth",
+    "features",
+    "sandbox",
+    "rate-limits",
+    "terminal",
+  ];
   for (const group of groups) {
     const flags = FLAGS.filter((f) => f.group === group);
     if (flags.length === 0) continue;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -13,7 +13,17 @@ function readInt(key: string, fallback: number): number {
   const v = readEnv(key);
   if (v === undefined) return fallback;
   const n = Number.parseInt(v, 10);
-  if (!Number.isFinite(n) || n < 0) {
+  if (!Number.isFinite(n) || n < 0 || String(n) !== v.trim()) {
+    throw new Error(`config: ${key} must be a non-negative integer (got ${v})`);
+  }
+  return n;
+}
+
+function readOptionalInt(key: string): number | undefined {
+  const v = readEnv(key);
+  if (v === undefined) return undefined;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n) || n < 0 || String(n) !== v.trim()) {
     throw new Error(`config: ${key} must be a non-negative integer (got ${v})`);
   }
   return n;
@@ -133,11 +143,28 @@ const UI_PASSWORD = UI_PASSWORD_FILE
 const API_KEY = readEnv("API_KEY");
 const CORS_ORIGIN = readEnv("CORS_ORIGIN");
 const PASSWORD_HASH_FILE = join(FORGE_DATA_DIR, "password-hash");
+const AGENT_TOOL_SANDBOX_ENABLED = readBool("AGENT_TOOL_SANDBOX_ENABLED", false);
+const AGENT_TOOL_UID = readOptionalInt("AGENT_TOOL_UID");
+const AGENT_TOOL_GID = readOptionalInt("AGENT_TOOL_GID");
+if (AGENT_TOOL_SANDBOX_ENABLED && (AGENT_TOOL_UID === undefined || AGENT_TOOL_GID === undefined)) {
+  throw new Error(
+    "config: AGENT_TOOL_SANDBOX_ENABLED=true requires numeric AGENT_TOOL_UID and AGENT_TOOL_GID",
+  );
+}
+const LDAP_FILE_REFERENCE_ERROR =
+  "LDAP bind password file references are not allowed when AGENT_TOOL_SANDBOX_ENABLED=true. Use an environment variable value or external secret broker.";
 const LDAP_ENABLED = readBool("LDAP_ENABLED", false);
 const LDAP_BIND_PASSWORD_FILE = readEnv("LDAP_BIND_PASSWORD_FILE");
+const LDAP_BIND_PASSWORD_ENV = readEnv("LDAP_BIND_PASSWORD");
+if (AGENT_TOOL_SANDBOX_ENABLED && LDAP_BIND_PASSWORD_FILE !== undefined) {
+  throw new Error(`config: ${LDAP_FILE_REFERENCE_ERROR}`);
+}
+if (AGENT_TOOL_SANDBOX_ENABLED && LDAP_BIND_PASSWORD_ENV?.startsWith("@")) {
+  throw new Error(`config: ${LDAP_FILE_REFERENCE_ERROR}`);
+}
 const LDAP_BIND_PASSWORD = LDAP_BIND_PASSWORD_FILE
   ? readSecretFile(LDAP_BIND_PASSWORD_FILE, "LDAP_BIND_PASSWORD_FILE")
-  : readEnv("LDAP_BIND_PASSWORD");
+  : LDAP_BIND_PASSWORD_ENV;
 
 /**
  * Load a JWT signing key from `${FORGE_DATA_DIR}/jwt-secret`, or
@@ -427,6 +454,11 @@ export const config = Object.freeze({
    * the same time they meet its caveats.
    */
   agentSecretHygieneRule: readBool("AGENT_SECRET_HYGIENE_RULE", false),
+  agentToolSandbox: Object.freeze({
+    enabled: AGENT_TOOL_SANDBOX_ENABLED,
+    uid: AGENT_TOOL_UID,
+    gid: AGENT_TOOL_GID,
+  }),
   /**
    * How long a detached PTY (its WebSocket closed but no replacement
    * attached yet) is held alive before being reaped. The 10-minute

--- a/packages/server/src/extensions-discovery.ts
+++ b/packages/server/src/extensions-discovery.ts
@@ -43,6 +43,10 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { config } from "./config.js";
 
+function isDisabledInSandboxPackageSource(source: string): boolean {
+  return config.agentToolSandbox.enabled && source.includes("pi-subagents");
+}
+
 export interface ExtensionToolInfo {
   /** Name as the agent sees it (what `pi.registerTool({ name })` set). */
   name: string;
@@ -110,6 +114,7 @@ export async function discoverExtensionResources(cwd: string): Promise<Extension
       if (!r.enabled) continue;
       const src = r.metadata.source;
       if (typeof src !== "string" || src.length === 0) continue;
+      if (isDisabledInSandboxPackageSource(src)) continue;
       extensionPathToPackage.set(r.path, src);
     }
     skillEntries = [];
@@ -124,6 +129,7 @@ export async function discoverExtensionResources(cwd: string): Promise<Extension
       if (r.metadata.origin !== "package") continue;
       const src = r.metadata.source;
       if (typeof src !== "string" || src.length === 0) continue;
+      if (isDisabledInSandboxPackageSource(src)) continue;
       skillEntries.push({ packageSource: src, skillPath: r.path });
     }
   } catch (err) {

--- a/packages/server/src/file-references.ts
+++ b/packages/server/src/file-references.ts
@@ -1,4 +1,6 @@
 import { extname, join } from "node:path";
+import { resolveAgentToolPath } from "./agent-tool-policy.js";
+import { config } from "./config.js";
 import { checkFileReference, readFile } from "./file-manager.js";
 
 /**
@@ -144,8 +146,12 @@ export async function expandFileReferences(text: string, workspacePath: string):
   const classifications: Classification[] = await Promise.all(
     matches.map(async (mm): Promise<Classification> => {
       try {
-        const abs = join(workspacePath, mm.path);
-        const check = await checkFileReference(abs, workspacePath);
+        const abs = config.agentToolSandbox.enabled
+          ? resolveAgentToolPath(workspacePath, mm.path)
+          : join(workspacePath, mm.path);
+        const check = config.agentToolSandbox.enabled
+          ? await checkFileReference(abs, abs)
+          : await checkFileReference(abs, workspacePath);
         if (check.kind === "directory") return { kind: "directory" };
         if (check.binary) return { kind: "error", reason: "binary file" };
         if (check.size > INLINE_THRESHOLD_BYTES) return { kind: "deferLarge" };
@@ -155,8 +161,8 @@ export async function expandFileReferences(text: string, workspacePath: string):
         if (e.name === "NotFoundError" || e.code === "ENOENT") {
           return { kind: "error", reason: "file not found" };
         }
-        if (e.name === "PathOutsideRootError") {
-          return { kind: "error", reason: "path is outside the project root" };
+        if (e.name === "PathOutsideRootError" || e.name === "AgentToolPathDeniedError") {
+          return { kind: "error", reason: "path is outside allowed roots" };
         }
         // NotAFileError now only fires for non-regular non-directory
         // entries (sockets, devices, etc.) — directories are handled
@@ -212,7 +218,10 @@ export async function expandFileReferences(text: string, workspacePath: string):
       // c.kind === "inlineCandidate"
       if (!inlineSet.has(i)) return { kind: "defer" };
       try {
-        const result = await readFile(c.abs, workspacePath);
+        const result = await readFile(
+          c.abs,
+          config.agentToolSandbox.enabled ? c.abs : workspacePath,
+        );
         if (result.binary) return { kind: "error", reason: "binary file" };
         const mm = matches[i];
         if (mm === undefined) return { kind: "defer" };

--- a/packages/server/src/processes/manager.ts
+++ b/packages/server/src/processes/manager.ts
@@ -2,6 +2,7 @@ import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child
 import { rm } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { join } from "node:path";
+import { sandboxSpawnIdentity } from "../agent-bash-operations.js";
 import { config } from "../config.js";
 import { scrubbedEnv } from "../pty-manager.js";
 import { LogChannel, processLogDir } from "./log-store.js";
@@ -106,6 +107,7 @@ class ProcessManagerRegistry {
       cwd,
       env: scrubbedEnv(),
       stdio: ["pipe", "pipe", "pipe"],
+      ...sandboxSpawnIdentity(),
       // Put each managed command in its own process group. The
       // tracked child is only the `/bin/sh -c` wrapper; npm scripts,
       // concurrently, Vite, test watchers, etc. commonly spawn

--- a/packages/server/src/processes/tool.ts
+++ b/packages/server/src/processes/tool.ts
@@ -273,10 +273,13 @@ function executeLogs(sessionId: string, p: ToolParams): ExecuteResult {
   }
   const files = processManager.logFiles(sessionId, p.id);
   if (files === undefined) return err("logs", `Process not found: ${p.id}`);
+  const sandboxNote = config.agentToolSandbox.enabled
+    ? "\n\nSandbox note: process log files live under server-private forge data and may not be readable by model file tools. Use process output for recent stdout/stderr from sandboxed sessions."
+    : "";
   return ok({
     action: "logs",
     success: true,
-    message: `Log files for ${p.id}:\n  stdout: ${files.stdoutFile}\n  stderr: ${files.stderrFile}\n\nUse the read tool to inspect them.`,
+    message: `Log files for ${p.id}:\n  stdout: ${files.stdoutFile}\n  stderr: ${files.stderrFile}\n\nUse the read tool to inspect them.${sandboxNote}`,
     logFiles: files,
   });
 }

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -115,12 +115,16 @@ export function spawnPty(opts: SpawnOptions): ManagedPty {
   const cols = opts.cols ?? 80;
   const rows = opts.rows ?? 24;
   const env = opts.env ?? process.env;
+  const identity = config.agentToolSandbox.enabled
+    ? { uid: config.agentToolSandbox.uid, gid: config.agentToolSandbox.gid }
+    : {};
   const proc = nodePty.spawn(shell, [], {
     name: "xterm-color",
     cols,
     rows,
     cwd: opts.cwd,
     env: filterEnv(env),
+    ...identity,
   });
   const ptyId = randomUUID();
   const managed: ManagedPty = {

--- a/packages/server/src/routes/exec.ts
+++ b/packages/server/src/routes/exec.ts
@@ -1,9 +1,8 @@
-import { spawn } from "node:child_process";
 import type { FastifyPluginAsync } from "fastify";
 import type { BashOperations } from "@earendil-works/pi-coding-agent";
 import { errorSchema } from "./_schemas.js";
 import { getSession } from "../session-registry.js";
-import { scrubbedEnv } from "../pty-manager.js";
+import { createForgeBashOperations } from "../agent-bash-operations.js";
 
 /**
  * One-shot user bash execution — the chat input's `!` / `!!` prefix.
@@ -46,56 +45,6 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 interface ExecBody {
   command: string;
   excludeFromContext?: boolean;
-}
-
-/**
- * Build a BashOperations that delegates to local spawn, but with our
- * scrubbed env. createLocalBashOperations from the SDK would inherit
- * `process.env` verbatim, leaking secrets the pi-forge process
- * carries (JWT_SECRET, API_KEY, etc.) — see
- * pty-manager.TERMINAL_ENV_ALLOWLIST for the full set of allowed
- * passthrough vars and rationale.
- */
-function forgeBashOperations(): BashOperations {
-  return {
-    exec: (command, cwd, options) => {
-      return new Promise<{ exitCode: number | null }>((resolve, reject) => {
-        const proc = spawn("/bin/sh", ["-c", command], {
-          cwd,
-          env: scrubbedEnv(),
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-        // Honor an external AbortSignal (the SDK ties this to its own
-        // _bashAbortController so abortBash() propagates).
-        const onAbort = (): void => {
-          try {
-            proc.kill("SIGTERM");
-          } catch {
-            // best-effort
-          }
-          // SIGKILL after grace if SIGTERM is ignored.
-          setTimeout(() => {
-            try {
-              proc.kill("SIGKILL");
-            } catch {
-              // best-effort
-            }
-          }, 2000);
-        };
-        if (options.signal !== undefined) {
-          if (options.signal.aborted) onAbort();
-          else options.signal.addEventListener("abort", onAbort, { once: true });
-        }
-        // Stream chunks back so the SDK's truncation-and-buffering
-        // logic gets to apply (executor caps total output, writes
-        // overflow to a temp file, etc.).
-        proc.stdout?.on("data", (data: Buffer) => options.onData(data));
-        proc.stderr?.on("data", (data: Buffer) => options.onData(data));
-        proc.on("error", (err) => reject(err));
-        proc.on("close", (code) => resolve({ exitCode: code }));
-      });
-    },
-  };
 }
 
 /**
@@ -193,7 +142,10 @@ export const execRoutes: FastifyPluginAsync = async (fastify) => {
       try {
         const result = await live.session.executeBash(command, undefined, {
           excludeFromContext,
-          operations: timeoutOperations(forgeBashOperations(), timeoutController.signal),
+          operations: timeoutOperations(
+            createForgeBashOperations(live.workspacePath),
+            timeoutController.signal,
+          ),
         });
         const durationMs = Date.now() - started;
         live.lastActivityAt = new Date();

--- a/packages/server/src/routes/quick-actions.ts
+++ b/packages/server/src/routes/quick-actions.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import type { FastifyPluginAsync, FastifyReply } from "fastify";
+import { sandboxSpawnIdentity } from "../agent-bash-operations.js";
 import { config } from "../config.js";
 import { getProject } from "../project-manager.js";
 import { scrubbedEnv } from "../pty-manager.js";
@@ -147,6 +148,7 @@ async function runCommand(
       cwd,
       env: scrubbedEnv(),
       stdio: ["ignore", "pipe", "pipe"],
+      ...sandboxSpawnIdentity(),
     });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -6,6 +6,7 @@ import {
   createAgentSession,
   SessionManager,
   SettingsManager,
+  type PackageSource,
   type SessionInfo,
 } from "@earendil-works/pi-coding-agent";
 import { buildForgeResourceLoader } from "./agent-resource-loader.js";
@@ -1930,6 +1931,26 @@ export async function disposeAllSessions(): Promise<void> {
  * patterns to the user skills dir and project patterns to the project
  * skills dir; injecting into one would only filter half the discovery.
  */
+function isPiSubagentsPackageSource(source: string): boolean {
+  return source.includes("pi-subagents");
+}
+
+function packageSourceValue(pkg: PackageSource): string {
+  return typeof pkg === "string" ? pkg : pkg.source;
+}
+
+function filterSandboxDisabledPackages(packages: PackageSource[] | undefined): PackageSource[] {
+  const current = packages ?? [];
+  if (!config.agentToolSandbox.enabled) return current;
+  return current.filter((pkg) => !isPiSubagentsPackageSource(packageSourceValue(pkg)));
+}
+
+function filterSandboxDisabledExtensions(extensions: string[] | undefined): string[] {
+  const current = extensions ?? [];
+  if (!config.agentToolSandbox.enabled) return current;
+  return current.filter((ext) => !isPiSubagentsPackageSource(ext));
+}
+
 async function buildSessionSettingsManager(
   workspacePath: string,
   projectId: string,
@@ -1939,7 +1960,9 @@ async function buildSessionSettingsManager(
     effectiveSkillsForProject(projectId),
     effectivePromptsForProject(projectId),
   ]);
-  if (skillPatterns.length === 0 && promptPatterns.length === 0) return sm;
+  const shouldPatch =
+    skillPatterns.length > 0 || promptPatterns.length > 0 || config.agentToolSandbox.enabled;
+  if (!shouldPatch) return sm;
   const origGlobal = sm.getGlobalSettings.bind(sm);
   const origProject = sm.getProjectSettings.bind(sm);
   const mergeSkills = (existing: string[] | undefined): string[] =>
@@ -1950,12 +1973,17 @@ async function buildSessionSettingsManager(
     promptPatterns.length === 0
       ? (existing ?? [])
       : Array.from(new Set([...(existing ?? []), ...promptPatterns]));
+  const applySandboxPackageFilters = <T extends ReturnType<typeof origGlobal>>(s: T): T => ({
+    ...s,
+    packages: filterSandboxDisabledPackages(s.packages),
+    extensions: filterSandboxDisabledExtensions(s.extensions),
+  });
   sm.getGlobalSettings = (): ReturnType<typeof origGlobal> => {
-    const s = origGlobal();
+    const s = applySandboxPackageFilters(origGlobal());
     return { ...s, skills: mergeSkills(s.skills), prompts: mergePrompts(s.prompts) };
   };
   sm.getProjectSettings = (): ReturnType<typeof origProject> => {
-    const s = origProject();
+    const s = applySandboxPackageFilters(origProject());
     return { ...s, skills: mergeSkills(s.skills), prompts: mergePrompts(s.prompts) };
   };
   return sm;

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -9,6 +9,7 @@ import {
   type SessionInfo,
 } from "@earendil-works/pi-coding-agent";
 import { buildForgeResourceLoader } from "./agent-resource-loader.js";
+import { createSandboxedToolDefinitions } from "./agent-tool-overrides.js";
 import { config } from "./config.js";
 import { makeDedupe, makeLock } from "./concurrency.js";
 import { effectivePromptsForProject, effectiveSkillsForProject } from "./config-manager.js";
@@ -617,6 +618,14 @@ async function resolveOrchestrationTools(sessionId: string): Promise<ToolDefinit
   return createOrchestrationTools(sessionId);
 }
 
+function applyAgentToolSandbox(
+  workspacePath: string,
+  customTools: readonly ToolDefinition[],
+): ToolDefinition[] {
+  if (!config.agentToolSandbox.enabled) return [...customTools];
+  return [...customTools, ...createSandboxedToolDefinitions(workspacePath)];
+}
+
 export async function createSession(
   projectId: string,
   workspacePath: string,
@@ -646,6 +655,7 @@ export async function createSession(
     processTool,
     ...orchestrationTools,
   ];
+  const effectiveCustomTools = applyAgentToolSandbox(workspacePath, customTools);
   const settingsManager = await buildSessionSettingsManager(workspacePath, projectId);
   const resourceLoader = await buildForgeResourceLoader(
     workspacePath,
@@ -659,8 +669,8 @@ export async function createSession(
     settingsManager,
     resourceLoader,
     agentDir: config.piConfigDir,
-    customTools,
-    tools: await buildToolsAllowlist(customTools, projectId, workspacePath),
+    customTools: effectiveCustomTools,
+    tools: await buildToolsAllowlist(effectiveCustomTools, projectId, workspacePath),
   });
 
   const now = new Date();
@@ -938,6 +948,7 @@ export async function resumeSession(
       processTool,
       ...orchestrationTools,
     ];
+    const effectiveCustomTools = applyAgentToolSandbox(workspacePath, customTools);
     // Resumed session — refresh the todo cache from the branch so
     // the UI panel sees the persisted state on first SSE connect,
     // not an empty list.
@@ -955,8 +966,8 @@ export async function resumeSession(
       settingsManager,
       resourceLoader,
       agentDir: config.piConfigDir,
-      customTools,
-      tools: await buildToolsAllowlist(customTools, projectId, workspacePath),
+      customTools: effectiveCustomTools,
+      tools: await buildToolsAllowlist(effectiveCustomTools, projectId, workspacePath),
     });
 
     const now = new Date();
@@ -1611,6 +1622,7 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
     processTool,
     ...orchestrationTools,
   ];
+  const effectiveCustomTools = applyAgentToolSandbox(source.workspacePath, customTools);
   // Forked session — replay the branch (which now belongs to the
   // fork) so the new session's todo cache reflects the inherited
   // state, not the parent's stale entry.
@@ -1628,8 +1640,8 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
     settingsManager,
     resourceLoader,
     agentDir: config.piConfigDir,
-    customTools,
-    tools: await buildToolsAllowlist(customTools, source.projectId, source.workspacePath),
+    customTools: effectiveCustomTools,
+    tools: await buildToolsAllowlist(effectiveCustomTools, source.projectId, source.workspacePath),
   });
 
   const now = new Date();
@@ -1705,6 +1717,10 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
         restoredProcessTool,
         ...restoredOrchestrationTools,
       ];
+      const restoredEffectiveCustomTools = applyAgentToolSandbox(
+        source.workspacePath,
+        restoredCustomTools,
+      );
       // Re-derive the original source's todo cache from the (now
       // un-mutated) source JSONL — the SDK's fork machinery left
       // the cache pointing at fork state.
@@ -1725,9 +1741,9 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
         settingsManager: restoredSettingsManager,
         resourceLoader: restoredResourceLoader,
         agentDir: config.piConfigDir,
-        customTools: restoredCustomTools,
+        customTools: restoredEffectiveCustomTools,
         tools: await buildToolsAllowlist(
-          restoredCustomTools,
+          restoredEffectiveCustomTools,
           source.projectId,
           source.workspacePath,
         ),
@@ -1839,6 +1855,7 @@ export async function rebuildAgentSessionForTools(
     processTool,
     ...orchestrationTools,
   ];
+  const effectiveCustomTools = applyAgentToolSandbox(live.workspacePath, customTools);
   const settingsManager = await buildSessionSettingsManager(live.workspacePath, live.projectId);
   const resourceLoader = await buildForgeResourceLoader(
     live.workspacePath,
@@ -1852,8 +1869,8 @@ export async function rebuildAgentSessionForTools(
     settingsManager,
     resourceLoader,
     agentDir: config.piConfigDir,
-    customTools,
-    tools: await buildToolsAllowlist(customTools, live.projectId, live.workspacePath),
+    customTools: effectiveCustomTools,
+    tools: await buildToolsAllowlist(effectiveCustomTools, live.projectId, live.workspacePath),
   });
   // Drop the old AgentSession only AFTER the new one is constructed
   // — if createAgentSession throws, we still have a working session.

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -62,6 +62,12 @@ const SOURCES = [
     subtitle: "What's inside the Docker image, how it's structured, and why.",
   },
   {
+    src: "docs/agent-tool-sandbox.md",
+    out: "agent-tool-sandbox.html",
+    title: "Agent Tool Sandbox",
+    subtitle: "Optional UID/GID split, path policy, mount permissions, and verification.",
+  },
+  {
     src: "docs/deployment.md",
     out: "deployment.html",
     title: "Deployment",
@@ -357,6 +363,11 @@ ${HEADER_NAV_LANDING}
         <div class="feature-icon">&#128104;&#8205;&#128104;&#8205;&#128103;</div>
         <h3>Session orchestration</h3>
         <p>Default-available supervisor mode lets one session spawn, observe, and coordinate worker sessions in the same project. Worker events stream into the supervisor's inbox.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">&#128737;&#65039;</div>
+        <h3>Optional tool sandbox</h3>
+        <p>Opt-in hardening mode runs agent/user shell surfaces as a restricted UID/GID, scopes model file tools, and keeps server-side config and forge data out of that identity.</p>
       </div>
       <div class="feature-card">
         <div class="feature-icon">&#128268;</div>

--- a/tests/test-agent-tool-sandbox.ts
+++ b/tests/test-agent-tool-sandbox.ts
@@ -27,7 +27,7 @@ const tmp = mkdtempSync(resolve(tmpdir(), "pi-agent-tool-sandbox-"));
 const workspace = resolve(tmp, "workspace");
 const project = resolve(workspace, "project-a");
 const shared = resolve(workspace, "shared");
-const piConfig = resolve(tmp, "pi-config");
+const piConfig = resolve(workspace, ".pi", "agent");
 const forgeData = resolve(tmp, "forge-data");
 const outside = resolve(tmp, "outside");
 mkdirSync(workspace, { recursive: true });

--- a/tests/test-agent-tool-sandbox.ts
+++ b/tests/test-agent-tool-sandbox.ts
@@ -1,0 +1,252 @@
+/**
+ * Agent tool identity sandbox tests.
+ *
+ * Unit-style coverage for startup config validation, path policy,
+ * sandboxed SDK tool overrides, and @file expansion scoping.
+ */
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const tmp = mkdtempSync(resolve(tmpdir(), "pi-agent-tool-sandbox-"));
+const workspace = resolve(tmp, "workspace");
+const piConfig = resolve(tmp, "pi-config");
+const forgeData = resolve(tmp, "forge-data");
+const outside = resolve(tmp, "outside");
+mkdirSync(workspace, { recursive: true });
+mkdirSync(piConfig, { recursive: true });
+mkdirSync(forgeData, { recursive: true });
+mkdirSync(outside, { recursive: true });
+writeFileSync(resolve(workspace, "hello.txt"), "hello workspace\n");
+writeFileSync(resolve(outside, "secret.txt"), "outside secret\n");
+writeFileSync(resolve(piConfig, "profile.json"), "profile ok\n");
+writeFileSync(resolve(piConfig, "auth.json"), "secret auth\n");
+writeFileSync(resolve(forgeData, "jwt-secret"), "secret jwt\n");
+symlinkSync(resolve(outside, "secret.txt"), resolve(workspace, "escape-link"));
+
+process.env.NODE_ENV = "test";
+process.env.HOME = tmp;
+process.env.WORKSPACE_PATH = workspace;
+process.env.PI_CONFIG_DIR = piConfig;
+process.env.FORGE_DATA_DIR = forgeData;
+process.env.AGENT_TOOL_SANDBOX_ENABLED = "true";
+process.env.AGENT_TOOL_UID = String(process.getuid?.() ?? 1000);
+process.env.AGENT_TOOL_GID = String(process.getgid?.() ?? 1000);
+process.env.SERVE_CLIENT = "false";
+
+try {
+  console.log("config validation");
+  {
+    const baseEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      NODE_ENV: "test",
+      HOME: tmp,
+      WORKSPACE_PATH: workspace,
+      PI_CONFIG_DIR: piConfig,
+      FORGE_DATA_DIR: forgeData,
+      AGENT_TOOL_SANDBOX_ENABLED: "true",
+    };
+    delete baseEnv.AGENT_TOOL_UID;
+    delete baseEnv.AGENT_TOOL_GID;
+    const missing = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `import ${JSON.stringify(resolve(repoRoot, "packages/server/dist/config.js"))}`,
+      ],
+      { env: baseEnv, encoding: "utf8" },
+    );
+    assert("enabled without UID/GID fails", missing.status !== 0, missing.stderr);
+
+    const ldapRaw = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `import ${JSON.stringify(resolve(repoRoot, "packages/server/dist/config.js"))}`,
+      ],
+      {
+        env: { ...baseEnv, AGENT_TOOL_UID: "1", AGENT_TOOL_GID: "1", LDAP_BIND_PASSWORD: "raw" },
+        encoding: "utf8",
+      },
+    );
+    assert("LDAP raw env accepted", ldapRaw.status === 0, ldapRaw.stderr);
+
+    const ldapFile = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `import ${JSON.stringify(resolve(repoRoot, "packages/server/dist/config.js"))}`,
+      ],
+      {
+        env: {
+          ...baseEnv,
+          AGENT_TOOL_UID: "1",
+          AGENT_TOOL_GID: "1",
+          LDAP_BIND_PASSWORD_FILE: resolve(outside, "secret.txt"),
+        },
+        encoding: "utf8",
+      },
+    );
+    assert("LDAP file refs rejected", ldapFile.status !== 0, ldapFile.stderr);
+  }
+
+  const { resolveAgentToolPath } = (await import(
+    resolve(repoRoot, "packages/server/dist/agent-tool-policy.js")
+  )) as { resolveAgentToolPath: (workspacePath: string, requestedPath: string) => string };
+  const { createSandboxedToolDefinitions } = (await import(
+    resolve(repoRoot, "packages/server/dist/agent-tool-overrides.js")
+  )) as { createSandboxedToolDefinitions: (workspacePath: string) => any[] };
+  const { expandFileReferences } = (await import(
+    resolve(repoRoot, "packages/server/dist/file-references.js")
+  )) as { expandFileReferences: (text: string, workspacePath: string) => Promise<string> };
+
+  function allowed(label: string, requested: string): void {
+    try {
+      resolveAgentToolPath(workspace, requested);
+      assert(label, true);
+    } catch (err) {
+      assert(label, false, (err as Error).message);
+    }
+  }
+  function denied(label: string, requested: string): void {
+    try {
+      resolveAgentToolPath(workspace, requested);
+      assert(label, false, "allowed unexpectedly");
+    } catch (err) {
+      assert(
+        label,
+        (err as Error).message.startsWith("agent_tool_path_denied"),
+        (err as Error).message,
+      );
+    }
+  }
+
+  console.log("\npath policy");
+  allowed("relative workspace allowed", "hello.txt");
+  allowed("absolute workspace allowed", resolve(workspace, "hello.txt"));
+  allowed("allowed pi config non-secret file allowed", resolve(piConfig, "profile.json"));
+  denied("auth.json rejected", resolve(piConfig, "auth.json"));
+  denied("models.json rejected", resolve(piConfig, "models.json"));
+  denied("settings.json rejected", resolve(piConfig, "settings.json"));
+  denied("outside absolute rejected", resolve(outside, "secret.txt"));
+  denied("../ escape rejected", "../outside/secret.txt");
+  denied("symlink escape rejected", "escape-link");
+  denied("/proc/self/environ rejected", "/proc/self/environ");
+  denied("FORGE_DATA_DIR rejected", resolve(forgeData, "jwt-secret"));
+
+  console.log("\ntool overrides");
+  const tools = new Map(createSandboxedToolDefinitions(workspace).map((tool) => [tool.name, tool]));
+  const read = tools.get("read")!;
+  const write = tools.get("write")!;
+  const ls = tools.get("ls")!;
+  const grep = tools.get("grep")!;
+  const find = tools.get("find")!;
+  const edit = tools.get("edit")!;
+  const okRead = await read.execute("t1", { path: "hello.txt" }, undefined, undefined, {});
+  assert("read in-workspace works", JSON.stringify(okRead).includes("hello workspace"));
+  await assertRejects("read outside rejected", () =>
+    read.execute("t2", { path: resolve(outside, "secret.txt") }, undefined, undefined, {}),
+  );
+  await write.execute("t3", { path: "new.txt", content: "new content" }, undefined, undefined, {});
+  const newRead = await read.execute("t4", { path: "new.txt" }, undefined, undefined, {});
+  assert("write in-workspace works", JSON.stringify(newRead).includes("new content"));
+  await assertRejects("write outside rejected", () =>
+    write.execute(
+      "t5",
+      { path: resolve(outside, "x.txt"), content: "x" },
+      undefined,
+      undefined,
+      {},
+    ),
+  );
+  await assertRejects("ls outside rejected", () =>
+    ls.execute("t6", { path: outside }, undefined, undefined, {}),
+  );
+  await assertRejects("grep outside rejected", () =>
+    grep.execute("t7", { pattern: "secret", path: outside }, undefined, undefined, {}),
+  );
+  await assertRejects("find outside rejected", () =>
+    find.execute("t8", { pattern: "*", path: outside }, undefined, undefined, {}),
+  );
+  await assertRejects("edit outside rejected", () =>
+    edit.execute(
+      "t9",
+      { path: resolve(outside, "secret.txt"), edits: [{ oldText: "outside", newText: "inside" }] },
+      undefined,
+      undefined,
+      {},
+    ),
+  );
+  const piRead = await read.execute(
+    "t10",
+    { path: resolve(piConfig, "profile.json") },
+    undefined,
+    undefined,
+    {},
+  );
+  assert("allowed pi config non-secret read works", JSON.stringify(piRead).includes("profile ok"));
+  await assertRejects("protected pi config file rejected", () =>
+    read.execute("t11", { path: resolve(piConfig, "auth.json") }, undefined, undefined, {}),
+  );
+
+  console.log("\n@file expansion");
+  const expandedWorkspace = await expandFileReferences("see @hello.txt", workspace);
+  assert("workspace expands", expandedWorkspace.includes("hello workspace"));
+  const expandedPi = await expandFileReferences(
+    `see @${resolve(piConfig, "profile.json")}`,
+    workspace,
+  );
+  assert("allowed pi config non-secret expands", expandedPi.includes("profile ok"));
+  const deniedAuth = await expandFileReferences(
+    `see @${resolve(piConfig, "auth.json")}`,
+    workspace,
+  );
+  assert("protected pi config rejected", deniedAuth.includes("not included"));
+  const deniedOutside = await expandFileReferences(
+    `see @${resolve(outside, "secret.txt")}`,
+    workspace,
+  );
+  assert("outside rejected", deniedOutside.includes("not included"));
+  const deniedSymlink = await expandFileReferences("see @escape-link", workspace);
+  assert("symlink escape rejected", deniedSymlink.includes("not included"));
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+async function assertRejects(label: string, fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn();
+    assert(label, false, "resolved unexpectedly");
+  } catch (err) {
+    const message = (err as Error).message;
+    assert(
+      label,
+      message.includes("agent_tool_path_denied") || message.includes("Path not found"),
+      message,
+    );
+  }
+}
+
+if (failures > 0) {
+  console.log(`\nFAILURES: ${failures}`);
+  process.exit(1);
+}
+console.log("\nagent-tool-sandbox tests passed");

--- a/tests/test-agent-tool-sandbox.ts
+++ b/tests/test-agent-tool-sandbox.ts
@@ -25,19 +25,24 @@ function assert(label: string, ok: boolean, detail?: string): void {
 
 const tmp = mkdtempSync(resolve(tmpdir(), "pi-agent-tool-sandbox-"));
 const workspace = resolve(tmp, "workspace");
+const project = resolve(workspace, "project-a");
+const shared = resolve(workspace, "shared");
 const piConfig = resolve(tmp, "pi-config");
 const forgeData = resolve(tmp, "forge-data");
 const outside = resolve(tmp, "outside");
 mkdirSync(workspace, { recursive: true });
+mkdirSync(project, { recursive: true });
+mkdirSync(shared, { recursive: true });
 mkdirSync(piConfig, { recursive: true });
 mkdirSync(forgeData, { recursive: true });
 mkdirSync(outside, { recursive: true });
-writeFileSync(resolve(workspace, "hello.txt"), "hello workspace\n");
+writeFileSync(resolve(project, "hello.txt"), "hello workspace\n");
+writeFileSync(resolve(shared, "shared.txt"), "hello shared workspace\n");
 writeFileSync(resolve(outside, "secret.txt"), "outside secret\n");
 writeFileSync(resolve(piConfig, "profile.json"), "profile ok\n");
 writeFileSync(resolve(piConfig, "auth.json"), "secret auth\n");
 writeFileSync(resolve(forgeData, "jwt-secret"), "secret jwt\n");
-symlinkSync(resolve(outside, "secret.txt"), resolve(workspace, "escape-link"));
+symlinkSync(resolve(outside, "secret.txt"), resolve(project, "escape-link"));
 
 process.env.NODE_ENV = "test";
 process.env.HOME = tmp;
@@ -120,7 +125,7 @@ try {
 
   function allowed(label: string, requested: string): void {
     try {
-      resolveAgentToolPath(workspace, requested);
+      resolveAgentToolPath(project, requested);
       assert(label, true);
     } catch (err) {
       assert(label, false, (err as Error).message);
@@ -128,7 +133,7 @@ try {
   }
   function denied(label: string, requested: string): void {
     try {
-      resolveAgentToolPath(workspace, requested);
+      resolveAgentToolPath(project, requested);
       assert(label, false, "allowed unexpectedly");
     } catch (err) {
       assert(
@@ -140,20 +145,21 @@ try {
   }
 
   console.log("\npath policy");
-  allowed("relative workspace allowed", "hello.txt");
-  allowed("absolute workspace allowed", resolve(workspace, "hello.txt"));
+  allowed("relative project path allowed", "hello.txt");
+  allowed("absolute project path allowed", resolve(project, "hello.txt"));
+  allowed("absolute sibling under WORKSPACE_PATH allowed", resolve(shared, "shared.txt"));
   allowed("allowed pi config non-secret file allowed", resolve(piConfig, "profile.json"));
   denied("auth.json rejected", resolve(piConfig, "auth.json"));
   denied("models.json rejected", resolve(piConfig, "models.json"));
   denied("settings.json rejected", resolve(piConfig, "settings.json"));
   denied("outside absolute rejected", resolve(outside, "secret.txt"));
-  denied("../ escape rejected", "../outside/secret.txt");
+  denied("../ escape rejected", "../../outside/secret.txt");
   denied("symlink escape rejected", "escape-link");
   denied("/proc/self/environ rejected", "/proc/self/environ");
   denied("FORGE_DATA_DIR rejected", resolve(forgeData, "jwt-secret"));
 
   console.log("\ntool overrides");
-  const tools = new Map(createSandboxedToolDefinitions(workspace).map((tool) => [tool.name, tool]));
+  const tools = new Map(createSandboxedToolDefinitions(project).map((tool) => [tool.name, tool]));
   const read = tools.get("read")!;
   const write = tools.get("write")!;
   const ls = tools.get("ls")!;
@@ -208,24 +214,21 @@ try {
   );
 
   console.log("\n@file expansion");
-  const expandedWorkspace = await expandFileReferences("see @hello.txt", workspace);
+  const expandedWorkspace = await expandFileReferences("see @hello.txt", project);
   assert("workspace expands", expandedWorkspace.includes("hello workspace"));
   const expandedPi = await expandFileReferences(
     `see @${resolve(piConfig, "profile.json")}`,
-    workspace,
+    project,
   );
   assert("allowed pi config non-secret expands", expandedPi.includes("profile ok"));
-  const deniedAuth = await expandFileReferences(
-    `see @${resolve(piConfig, "auth.json")}`,
-    workspace,
-  );
+  const deniedAuth = await expandFileReferences(`see @${resolve(piConfig, "auth.json")}`, project);
   assert("protected pi config rejected", deniedAuth.includes("not included"));
   const deniedOutside = await expandFileReferences(
     `see @${resolve(outside, "secret.txt")}`,
-    workspace,
+    project,
   );
   assert("outside rejected", deniedOutside.includes("not included"));
-  const deniedSymlink = await expandFileReferences("see @escape-link", workspace);
+  const deniedSymlink = await expandFileReferences("see @escape-link", project);
   assert("symlink escape rejected", deniedSymlink.includes("not included"));
 } finally {
   rmSync(tmp, { recursive: true, force: true });

--- a/tests/test-cli-flags.ts
+++ b/tests/test-cli-flags.ts
@@ -96,10 +96,12 @@ console.log("flag round-trip");
           argv.push(`--${def.name}`, "1234");
           expected.set(def.env, "1234");
           break;
-        case "boolean":
-          argv.push(`--${def.name}`, "true");
-          expected.set(def.env, "true");
+        case "boolean": {
+          const value = def.name === "agent-tool-sandbox-enabled" ? "false" : "true";
+          argv.push(`--${def.name}`, value);
+          expected.set(def.env, value);
           break;
+        }
         case "list":
           argv.push(`--${def.name}`, "a,b,c");
           expected.set(def.env, "a,b,c");
@@ -218,6 +220,36 @@ console.log("\n@file syntax");
       blank.errors.some((e) => e.includes("--api-key")),
       blank.errors.join("; "),
     );
+    const sandboxLdapFile = parseCliArgs([
+      "--agent-tool-sandbox-enabled",
+      "--agent-tool-uid",
+      "1234",
+      "--agent-tool-gid",
+      "1234",
+      "--ldap-bind-password",
+      `@${secretFile}`,
+    ]);
+    assert(
+      "--ldap-bind-password @file is rejected when sandbox enabled",
+      sandboxLdapFile.errors.some((e) => e.includes("LDAP bind password file references")),
+      sandboxLdapFile.errors.join("; "),
+    );
+
+    const sandboxLdapRaw = parseCliArgs([
+      "--agent-tool-sandbox-enabled",
+      "--agent-tool-uid",
+      "1234",
+      "--agent-tool-gid",
+      "1234",
+      "--ldap-bind-password",
+      "raw-secret",
+    ]);
+    assert(
+      "--ldap-bind-password raw value is accepted when sandbox enabled",
+      envFor(sandboxLdapRaw, "LDAP_BIND_PASSWORD") === "raw-secret" &&
+        sandboxLdapRaw.errors.length === 0,
+      sandboxLdapRaw.errors.join("; "),
+    );
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
@@ -239,7 +271,15 @@ console.log("\nhelp + version");
 
   const helpText = buildHelpText("9.9.9");
   assert("buildHelpText embeds the version", helpText.startsWith("pi-forge 9.9.9"));
-  const helpGroups = ["Network", "Paths", "Authentication", "Features", "Rate limits", "Terminal"];
+  const helpGroups = [
+    "Network",
+    "Paths",
+    "Authentication",
+    "Features",
+    "Agent tool sandbox",
+    "Rate limits",
+    "Terminal",
+  ];
   assert(
     "buildHelpText lists at least one flag from each group",
     helpGroups.every((g) => helpText.includes(`${g}:`)),


### PR DESCRIPTION
## Summary

Adds an opt-in agent tool identity sandbox for containerized/deployed pi-forge. The sandbox is disabled by default and preserves the existing non-sandbox Docker behavior where the server runs as `pi`. When enabled, the server keeps the privileges needed to manage pi-forge state while model/user tool surfaces run as a restricted UID/GID (`pi-tools` in the Docker image).

The change hardens model file tools with path policy checks, runs shell-like surfaces under the tool UID/GID with scrubbed environment variables, disables `pi-subagents` in sandbox mode, and documents Docker, OrbStack, Kubernetes, and OpenShift mount permission setup.

## Usage

Default behavior remains unchanged:

```bash
AGENT_TOOL_SANDBOX_ENABLED=false
```

Enable sandbox mode only when mounted paths can be permissioned for the UID/GID split:

```bash
AGENT_TOOL_SANDBOX_ENABLED=true
AGENT_TOOL_UID=1001
AGENT_TOOL_GID=1001
```

In the Docker image, non-sandbox startup drops to `pi`; sandbox startup keeps the server as root and runs agent/user tool children as `pi-tools`. Model file tools can access the configured `WORKSPACE_PATH` and allowed non-secret Pi config files, but deny forge data, protected Pi config files, common secret/system paths, traversal, and symlink escapes.

## What changed

- `packages/server/src/config.ts`, `packages/server/src/cli.ts` — added sandbox env/CLI config and validation, including LDAP bind password file-reference rejection while sandboxed.
- `packages/server/src/agent-tool-policy.ts`, `agent-tool-overrides.ts`, `agent-bash-operations.ts` — added sandbox path policy and SDK tool overrides for `read`, `grep`, `find`, `ls`, `edit`, `write`, and `bash`.
- `packages/server/src/session-registry.ts`, `agent-resource-loader.ts`, `extensions-discovery.ts` — wired sandboxed tool definitions into sessions and filtered `pi-subagents` package/extension resources in sandbox mode.
- `packages/server/src/processes/*`, `pty-manager.ts`, `routes/exec.ts`, `routes/quick-actions.ts`, `file-references.ts` — run process/terminal/exec/quick-action surfaces as the sandbox UID/GID, scrub env, and scope `@file` expansion.
- `docker/*`, `kubernetes/*` — updated image startup and deployment manifests for opt-in sandbox mode while preserving regular Docker behavior.
- `docs/agent-tool-sandbox.md`, `docs/containers.md`, `docs/configuration.md`, `kubernetes/DEPLOY.md`, generated `docs/site/*`, `README.md` — added operator docs, verification prompts, deployment-specific mount guidance, and website/readme feature coverage.
- `tests/test-agent-tool-sandbox.ts`, `tests/test-cli-flags.ts` — added focused coverage for config validation, path policy, tool overrides, file references, and CLI flags.

## Test plan

- [x] `npm run build`
- [x] `scripts/run-tests.sh --only agent-tool-sandbox,cli-flags`
- [x] `npm run check`
- [x] `npm run build:site`
- [x] `npx prettier --check README.md docs/agent-tool-sandbox.md scripts/build-site.mjs`
- [x] `git diff --check`
- [x] Manual Docker/OrbStack sandbox prompt validation by maintainer during development
- [ ] CI green before merge
