### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-06-04
+
+### Added
+
+- **Optional agent tool sandbox.** Container and deployed pi-forge instances can
+  opt in to running model/user tool surfaces as a restricted UID/GID while the
+  server keeps the privileges needed to manage pi-forge state. The sandbox adds
+  path policy checks for model file tools, runs shell-like surfaces with scrubbed
+  environments, disables pi-subagents while sandboxed, and documents Docker,
+  Kubernetes, OpenShift, and mount-permission setup.
+- **Git remote insecure TLS persistence.** The Git pane can explicitly mark a
+  remote as ignoring SSL/TLS verification, and clone-time insecure TLS choices
+  are persisted as repository-local, URL-scoped git config for future
+  fetch/pull/push operations.
+- **Tool input/output copy affordances.** Chat tool call inputs and outputs now
+  expose compact copy buttons without changing the existing native details
+  marker style.
+
+### Changed
+
+- **Chat and session pane polish.** Chat auto-scroll now stops following more
+  conservatively when the user scrolls upward, project session rows have subtle
+  separators, and double-click rename selects the displayed session label.
+
+### Fixed
+
+- **MCP tool calls recover from stale server sessions.** When an MCP server
+  restarts and rejects the cached session id with a session-not-found JSON-RPC
+  error, pi-forge reconnects the MCP transport once and retries the tool call.
+
 ## [1.3.7] — 2026-06-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.3.7",
+      "version": "1.4.0",
       "workspaces": [
         "packages/*"
       ],
@@ -16968,7 +16968,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.3.7",
+      "version": "1.4.0",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17014,7 +17014,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.3.7",
+      "version": "1.4.0",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.78.0",
         "@earendil-works/pi-ai": "0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts pi-forge v1.4.0 from the current `main` branch after the v1.3.7 release. Release notes were generated from the merged changes since `v1.3.7`, including the agent tool sandbox, git remote insecure TLS persistence, MCP stale-session recovery, and UI polish for chat/session interactions.

## Usage

No runtime behavior changes are introduced by this release commit itself. After this PR merges, tag the merged main commit:

```bash
git checkout main
git pull --ff-only origin main
git tag v1.4.0
git push origin v1.4.0
```

The release workflow should then build/publish the release artifacts from the tag.

## What changed (5 files)

- `CHANGELOG.md` — moved Unreleased notes into `## [1.4.0] — 2026-06-04` with Added/Changed/Fixed entries.
- `package.json` — bumped root package version to `1.4.0` via `scripts/bump-version.sh`.
- `packages/server/package.json` — bumped server package version to `1.4.0` via `scripts/bump-version.sh`.
- `packages/client/package.json` — bumped client package version to `1.4.0` via `scripts/bump-version.sh`.
- `package-lock.json` — refreshed lockfile versions via the bump script's package-lock-only install.

## Test plan

- [x] `scripts/bump-version.sh 1.4.0`
- [x] `npm run format:check`
- [ ] CI green before merge
