### PR TITLE
fix: avoid setuid caps in regular compose

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -24,10 +24,11 @@ PUID=1000
 PGID=1000
 
 # ---- Agent tool identity sandbox ----
-# Disabled by default. When enabled, the pi-forge server runs as root
-# and model/user shell surfaces (agent bash, process tool, terminal,
-# quick-action commands, !/!! exec) run as the restricted `pi-tools`
-# UID/GID. Compose grants only SETUID/SETGID for this switch.
+# Disabled by default. Regular compose starts the server as `pi` directly
+# and drops all Linux capabilities. When enabling sandbox mode, use the
+# docker-compose.sandbox.yml overlay so the pi-forge server runs as root
+# with only SETUID/SETGID and model/user shell surfaces run as the
+# restricted `pi-tools` UID/GID.
 AGENT_TOOL_SANDBOX_ENABLED=false
 AGENT_TOOL_UID=1001
 AGENT_TOOL_GID=1001

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -176,15 +176,14 @@ COPY --from=builder --chown=pi:pi /app/packages/client/dist ./packages/client/di
 # the server runs as `pi`, and pi-owned config/data dirs are writable by it.
 # Sandbox deployments must explicitly permission their mounts; see
 # docs/agent-tool-sandbox.md.
-RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local \
+RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm \
  && chown -R pi-tools:pi-tools /workspace \
  && chown root:root /home/pi \
  && chown root:pi-tools /home/pi/.pi \
- && chown -R pi:pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local \
+ && chown -R pi:pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm \
  && chmod 0775 /workspace \
- && chmod 0755 /home/pi \
- && chmod 0750 /home/pi/.pi \
- && chmod 0700 /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local
+ && chmod 0755 /home/pi /home/pi/.pi \
+ && chmod 0700 /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm
 
 RUN cat >/usr/local/bin/pi-forge-entrypoint <<'EOF'
 #!/bin/sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -194,12 +194,21 @@ case "$(printf '%s' "${AGENT_TOOL_SANDBOX_ENABLED:-false}" | tr '[:upper:]' '[:l
     # Sandbox mode: keep the server as root so it can setuid/setgid
     # model/user tool children to AGENT_TOOL_UID:GID. Mount ownership is
     # an operator contract; see docs/agent-tool-sandbox.md.
+    if [ "$(id -u)" != "0" ]; then
+      echo "AGENT_TOOL_SANDBOX_ENABLED=true requires the container to run as root" >&2
+      exit 1
+    fi
     exec "$@"
     ;;
   *)
-    # Legacy/default mode: run the server as pi, matching historical
-    # container behavior and pi-owned image defaults.
-    exec gosu pi "$@"
+    # Legacy/default mode: run as whichever non-root user the runtime
+    # selected. Compose starts as pi directly so regular mode does not
+    # need SETUID/SETGID capabilities; the root fallback preserves
+    # compatibility for `docker run` invocations without --user.
+    if [ "$(id -u)" = "0" ]; then
+      exec gosu pi "$@"
+    fi
+    exec "$@"
     ;;
 esac
 EOF

--- a/docker/docker-compose.sandbox.yml
+++ b/docker/docker-compose.sandbox.yml
@@ -1,0 +1,18 @@
+# Optional sandbox overlay.
+#
+# Use with the base compose file when AGENT_TOOL_SANDBOX_ENABLED=true:
+#   docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
+#
+# The base compose file starts as the pi user and drops all capabilities so
+# regular mode does not need SETUID/SETGID. Sandbox mode must start the server
+# as root and add back only SETUID/SETGID so pi-forge can spawn model/user tool
+# children as AGENT_TOOL_UID:AGENT_TOOL_GID.
+
+services:
+  pi-forge:
+    user: "0:0"
+    environment:
+      AGENT_TOOL_SANDBOX_ENABLED: ${AGENT_TOOL_SANDBOX_ENABLED:-true}
+    cap_add:
+      - SETUID
+      - SETGID

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,10 @@ services:
     image: pi-forge:latest
     container_name: ${CONTAINER_NAME:-pi-forge}
     restart: unless-stopped
+    # Regular/default mode runs the server as pi directly. This avoids
+    # requiring SETUID/SETGID capabilities just to have the entrypoint
+    # switch away from root. Sandbox mode uses docker-compose.sandbox.yml.
+    user: "${PUID:-1000}:${PGID:-1000}"
     ports:
       # Loopback only by default — drop the `127.0.0.1:` prefix to expose
       # to the LAN (and set UI_PASSWORD or API_KEY first; see SECURITY.md).
@@ -31,41 +35,41 @@ services:
       - ${FORGE_DATA_HOST_PATH:-~/.pi-forge-docker}:/home/pi/.pi-forge
     environment:
       # Container-internal paths — fixed.
-      - WORKSPACE_PATH=/workspace
-      - PI_CONFIG_DIR=/home/pi/.pi/agent
-      - FORGE_DATA_DIR=/home/pi/.pi-forge
-      - PORT=3000
+      WORKSPACE_PATH: /workspace
+      PI_CONFIG_DIR: /home/pi/.pi/agent
+      FORGE_DATA_DIR: /home/pi/.pi-forge
+      PORT: "3000"
       # Auth — read from .env. Both empty = auth disabled.
-      - UI_PASSWORD=${UI_PASSWORD:-}
-      - REQUIRE_PASSWORD_CHANGE=${REQUIRE_PASSWORD_CHANGE:-false}
-      - JWT_SECRET=${JWT_SECRET:-}
-      - API_KEY=${API_KEY:-}
+      UI_PASSWORD: ${UI_PASSWORD:-}
+      REQUIRE_PASSWORD_CHANGE: ${REQUIRE_PASSWORD_CHANGE:-false}
+      JWT_SECRET: ${JWT_SECRET:-}
+      API_KEY: ${API_KEY:-}
       # Logging + reverse-proxy hint.
-      - LOG_LEVEL=${LOG_LEVEL:-info}
-      - TRUST_PROXY=${TRUST_PROXY:-false}
-      - CORS_ORIGIN=${CORS_ORIGIN:-}
-      - MINIMAL_UI=${MINIMAL_UI:-false}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      TRUST_PROXY: ${TRUST_PROXY:-false}
+      CORS_ORIGIN: ${CORS_ORIGIN:-}
+      MINIMAL_UI: ${MINIMAL_UI:-false}
       # Session orchestration — enabled by default. Hard-disabled under
       # MINIMAL_UI; set ORCHESTRATION_DISABLED=true to remove the surface.
       # ORCHESTRATION_ENABLED=false remains a compatibility disable switch.
       # See docs/orchestration.md.
-      - ORCHESTRATION_DISABLED=${ORCHESTRATION_DISABLED:-false}
-      - ORCHESTRATION_ENABLED=${ORCHESTRATION_ENABLED:-}
-      - ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR=${ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR:-8}
-      # Identity sandbox — disabled by default. When true, the root
-      # server drops model/user shell surfaces to pi-tools via SETUID/SETGID.
-      - AGENT_TOOL_SANDBOX_ENABLED=${AGENT_TOOL_SANDBOX_ENABLED:-false}
-      - AGENT_TOOL_UID=${AGENT_TOOL_UID:-1001}
-      - AGENT_TOOL_GID=${AGENT_TOOL_GID:-1001}
-    # Hardening (mirrors the k8s manifests). Not read-only because the
-    # agent's bash tool needs to write to /home/pi/.npm, /tmp, etc.
+      ORCHESTRATION_DISABLED: ${ORCHESTRATION_DISABLED:-false}
+      ORCHESTRATION_ENABLED: ${ORCHESTRATION_ENABLED:-}
+      ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR: ${ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR:-8}
+      # Identity sandbox — disabled by default. Use
+      # docker-compose.sandbox.yml when enabling it so the server runs
+      # as root with only the SETUID/SETGID capabilities needed to drop
+      # model/user shell surfaces to pi-tools.
+      AGENT_TOOL_SANDBOX_ENABLED: ${AGENT_TOOL_SANDBOX_ENABLED:-false}
+      AGENT_TOOL_UID: ${AGENT_TOOL_UID:-1001}
+      AGENT_TOOL_GID: ${AGENT_TOOL_GID:-1001}
+    # Hardening. Not read-only because the agent's bash tool needs to
+    # write to /home/pi/.npm, /tmp, etc. Regular mode does not need any
+    # Linux capabilities because the container starts as pi directly.
     security_opt:
       - no-new-privileges:true
     cap_drop:
       - ALL
-    cap_add:
-      - SETUID
-      - SETGID
     pids_limit: 512
     mem_limit: 2g
     cpus: "1.0"

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -1,9 +1,10 @@
 # Agent tool identity sandbox
 
-`AGENT_TOOL_SANDBOX_ENABLED=false` by default. In the Docker image, the default
-entrypoint drops the server to the legacy `pi` user. When sandbox mode is
-enabled, pi-forge keeps the HTTP server running as root and runs model/user
-tool surfaces as a restricted UID/GID (`pi-tools` in the Docker image).
+`AGENT_TOOL_SANDBOX_ENABLED=false` by default. In the Docker Compose setup,
+regular mode starts the server as the legacy `pi` user directly and drops all
+Linux capabilities. When sandbox mode is enabled with the sandbox compose
+overlay, pi-forge keeps the HTTP server running as root and runs model/user tool
+surfaces as a restricted UID/GID (`pi-tools` in the Docker image).
 
 This is an operator-controlled hardening mode. It is useful only when the
 container or pod mounts are permissioned carefully. Leave it disabled for
@@ -88,7 +89,7 @@ the container or pod**.
 
 | Path | Required sandbox posture |
 |---|---|
-| `/workspace` | Writable by `AGENT_TOOL_UID:GID`. Secrets in the workspace are readable by the agent. |
+| `/workspace` | Writable by `AGENT_TOOL_UID` and traversable/readable by the root server without `DAC_OVERRIDE`. Recommended: `AGENT_TOOL_UID:0` with group rwX (`1001:0` in the Docker examples). Secrets in the workspace are readable by the agent. |
 | `/home/pi/.pi` | Traversable by `AGENT_TOOL_UID:GID` so package skills and non-secret resources can be loaded. Recommended: `root:pi-tools` `0750`. |
 | `/home/pi/.pi/agent` | Traversable/readable by `AGENT_TOOL_UID:GID` for non-secret resources. Recommended: `root:pi-tools` `0750`. |
 | `/home/pi/.pi/agent/auth.json` | Not readable by `AGENT_TOOL_UID:GID`. Recommended: `root:root` `0600`. Also blocked by file-tool policy. |
@@ -122,13 +123,16 @@ volumes:
 ```
 
 Native Linux bind mounts normally preserve host numeric ownership in the
-container. With default sandbox IDs (`1001:1001`), run these commands on the
-**host** before starting the container:
+container. With default sandbox tool IDs (`1001:1001`; workspace group `0` for
+the root server), run these commands on the **host** before starting the
+container:
 
 ```bash
-# Workspace: writable by pi-tools.
+# Workspace: writable by pi-tools and accessible to the root server.
+# Group 0 matters because sandbox containers drop DAC_OVERRIDE, so root
+# cannot bypass mode bits on host bind mounts.
 sudo mkdir -p ./workspace
-sudo chown -R 1001:1001 ./workspace
+sudo chown -R 1001:0 ./workspace
 sudo chmod -R u+rwX,g+rwX,o-rwx ./workspace
 
 # Forge data: server-only.
@@ -160,24 +164,20 @@ AGENT_TOOL_UID=1001
 AGENT_TOOL_GID=1001
 ```
 
-Compose capabilities for native Linux should be:
-
-```yaml
-cap_drop:
-  - ALL
-cap_add:
-  - SETUID
-  - SETGID
-security_opt:
-  - no-new-privileges:true
-```
-
-Then rebuild/recreate:
+Start sandbox mode with the sandbox compose overlay. The base compose file runs
+regular mode as `pi` with no Linux capabilities; the overlay switches the server
+container to root and adds back only `SETUID` / `SETGID` for sandbox child
+processes:
 
 ```bash
 cd docker
-docker compose down
-docker compose up -d --build
+docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
+```
+
+To stop it later, pass the same file set:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.sandbox.yml down
 ```
 
 ## Docker Compose: OrbStack / Docker Desktop / macOS
@@ -224,17 +224,14 @@ volumes:
 
 ### Compose capability changes
 
-Start with the native capability set:
+Start with the sandbox compose overlay:
 
-```yaml
-cap_drop:
-  - ALL
-cap_add:
-  - SETUID
-  - SETGID
-security_opt:
-  - no-new-privileges:true
+```bash
+docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
 ```
+
+The base compose file already drops all capabilities. The sandbox overlay adds
+back `SETUID` / `SETGID` and runs the server container as root.
 
 If OrbStack/Docker Desktop shows `.pi-forge` as `1000:1000 0700` inside the
 pi-forge container even after the helper volume init chowns it to `root:root`,
@@ -257,7 +254,7 @@ This example assumes the named volumes are `docker_pi-config` and
 
 ```bash
 cd docker
-docker compose down
+docker compose -f docker-compose.yml -f docker-compose.sandbox.yml down
 
 # Optional: seed the named pi config volume from the host before locking it down.
 docker run --rm \
@@ -306,18 +303,19 @@ AGENT_TOOL_UID=1001
 AGENT_TOOL_GID=1001
 ```
 
-Start pi-forge:
+Start pi-forge with the sandbox overlay:
 
 ```bash
-docker compose up -d --build
+docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
 ```
 
 Verify the actual mounts and ownership inside pi-forge:
 
 ```bash
-docker compose run --rm pi-forge sh -lc '
+docker compose -f docker-compose.yml -f docker-compose.sandbox.yml run --rm pi-forge sh -lc '
 id
 stat -c "%u:%g %a %n" /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
+# Expected /workspace owner/group is 1001:0 with owner+group rwX bits.
 touch /home/pi/.pi-forge/probe && rm /home/pi/.pi-forge/probe
 '
 ```
@@ -327,6 +325,7 @@ Then verify from the app terminal (which runs as `pi-tools`):
 ```bash
 id
 stat -c "%u:%g %a %n" /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
+# Expected /workspace owner/group is 1001:0 with owner+group rwX bits.
 cat /home/pi/.pi-forge/jwt-secret
 cat /home/pi/.pi/agent/auth.json
 ```
@@ -384,9 +383,11 @@ initContainers:
       - |
         set -eux
 
-        # Workspace: writable by pi-tools.
+        # Workspace: writable by pi-tools and accessible to the root server.
+        # Group 0 matters because sandbox containers drop DAC_OVERRIDE, so root
+        # cannot bypass mode bits on PVCs.
         mkdir -p /workspace
-        chown -R 1001:1001 /workspace
+        chown -R 1001:0 /workspace
         chmod -R u+rwX,g+rwX,o-rwx /workspace
 
         # Forge data: server-only.

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -140,18 +140,32 @@ sudo mkdir -p ~/.pi-forge-docker
 sudo chown -R root:root ~/.pi-forge-docker
 sudo chmod -R u+rwX,go-rwx ~/.pi-forge-docker
 
-# Pi config: pi-tools can traverse/read non-secret resources.
+# Pi config parent: traversable by pi-tools so non-secret resources can load.
 # The image-owned /home/pi/.pi parent is already traversable by pi-tools when
 # only ~/.pi/agent is mounted. If you mount the whole ~/.pi directory, set the
 # parent permissions too.
 sudo chown root:1001 ~/.pi
 sudo chmod 0750 ~/.pi
-sudo chown -R root:1001 ~/.pi/agent
+sudo chown root:1001 ~/.pi/agent
 sudo chmod 0750 ~/.pi/agent
-sudo find ~/.pi/agent -type d -exec chmod 0750 {} +
-sudo find ~/.pi/agent -type f -exec chmod 0640 {} +
 
-# Pi config secrets: server-only.
+# Existing non-secret Pi resources: readable/traversable by pi-tools.
+# This is required for previously installed skills/packages that may still be
+# 1000:1000 from regular mode. Keep execute bits where they already exist.
+for path in \
+  ~/.pi/agent/skills \
+  ~/.pi/agent/npm \
+  ~/.pi/agent/git \
+  ~/.pi/agent/extensions \
+  ~/.pi/agent/prompts \
+  ~/.pi/agent/themes; do
+  [ -e "$path" ] || continue
+  sudo chown -R root:1001 "$path"
+  sudo chmod -R u+rwX,g+rX,o-rwx "$path"
+done
+
+# Pi config secrets/settings: server-only. Re-run this after broad permission
+# changes so pi-tools cannot read provider auth, model config, or settings.
 sudo chown root:root ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/settings.json 2>/dev/null || true
 sudo chmod 0600 ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/settings.json 2>/dev/null || true
 ```
@@ -276,12 +290,14 @@ find /home/pi/.pi-forge -type d -exec chmod 0700 {} +
 find /home/pi/.pi-forge -type f -exec chmod 0600 {} +
 
 # Pi config: pi-tools can traverse/read non-secret resources.
+# This includes existing skills, managed npm/git packages, extensions,
+# prompts, and themes copied into the named volume.
 chown -R root:1001 /home/pi/.pi/agent
+chmod -R u+rwX,g+rX,o-rwx /home/pi/.pi/agent
 chmod 0750 /home/pi/.pi/agent
-find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
-find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
 
-# Pi config secrets: server-only.
+# Pi config secrets/settings: server-only. Re-run this after broad permission
+# changes so pi-tools cannot read provider auth, model config, or settings.
 chown root:root \
   /home/pi/.pi/agent/auth.json \
   /home/pi/.pi/agent/models.json \
@@ -397,16 +413,33 @@ initContainers:
         find /home/pi/.pi-forge -type d -exec chmod 0700 {} +
         find /home/pi/.pi-forge -type f -exec chmod 0600 {} +
 
-        # Pi config: pi-tools can traverse/read non-secret resources.
+        # Pi config parent: traversable by pi-tools so non-secret resources
+        # can load.
         mkdir -p /home/pi/.pi/agent
         chown 0:1001 /home/pi/.pi
         chmod 0750 /home/pi/.pi
-        chown -R 0:1001 /home/pi/.pi/agent
+        chown 0:1001 /home/pi/.pi/agent
         chmod 0750 /home/pi/.pi/agent
-        find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
-        find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
 
-        # Pi config secrets: server-only.
+        # Existing non-secret Pi resources: readable/traversable by pi-tools.
+        # This is required for previously installed skills/packages that may
+        # still be 1000:1000 from regular mode. Keep execute bits where they
+        # already exist.
+        for path in \
+          /home/pi/.pi/agent/skills \
+          /home/pi/.pi/agent/npm \
+          /home/pi/.pi/agent/git \
+          /home/pi/.pi/agent/extensions \
+          /home/pi/.pi/agent/prompts \
+          /home/pi/.pi/agent/themes; do
+          [ -e "$path" ] || continue
+          chown -R 0:1001 "$path"
+          chmod -R u+rwX,g+rX,o-rwx "$path"
+        done
+
+        # Pi config secrets/settings: server-only. Re-run this after resource
+        # permission changes so pi-tools cannot read provider auth, model
+        # config, or settings.
         chown 0:0 \
           /home/pi/.pi/agent/auth.json \
           /home/pi/.pi/agent/models.json \
@@ -494,6 +527,53 @@ When sandbox mode is enabled, pi-forge rejects:
 
 Use a literal environment value or an external secret broker instead. Tool
 children receive a scrubbed env and do not inherit the LDAP bind password.
+
+## Access model quick reference
+
+Default Docker image identities:
+
+| Surface | Regular mode (`AGENT_TOOL_SANDBOX_ENABLED=false`) | Sandbox mode (`AGENT_TOOL_SANDBOX_ENABLED=true`) |
+|---|---|---|
+| pi-forge HTTP server and session registry | `pi` (`1000:1000` by default) | `root` (`0:0`) |
+| Model file tools (`read`, `write`, `grep`, `find`, `ls`, `edit`) | SDK defaults as the server identity | Server identity plus pi-forge path policy |
+| Agent `bash`, process tool commands, terminal, quick actions, chat exec | `pi` (`1000:1000` by default) | `pi-tools` (`1001:1001` by default) |
+
+Use this matrix when debugging `EACCES`. `rwx` means the identity should be able
+to create/update entries there; `r-x` means traversal/read only; `denied` means
+normal Unix mode bits should block the identity; `policy denied` means sandboxed
+model file tools reject the path even if the server process could read it.
+
+| Path | `pi` regular server/tools | `root` sandbox server | `pi-tools` sandbox shell tools | Sandbox model file tools |
+|---|---|---|---|---|
+| `/home/pi` | `r-x`; home parent is not general scratch space | `rwx` | `r-x` | usually not used directly |
+| `/home/pi/.npm` | `rwx`; npm logs/cache | `rwx` | denied unless explicitly permissioned | outside allowed roots |
+| `/home/pi/.local` | `rwx`; user installs and Python user base | `rwx` | denied unless explicitly permissioned | outside allowed roots |
+| `/home/pi/.pi` | `r-x`; parent for Pi config | `rwx` | deployment-dependent traversal only | parent traversal only |
+| `/home/pi/.pi/agent` (`PI_CONFIG_DIR`) | `rwx` for regular config writes | `rwx` | ideally denied by mode bits, except deliberate non-secret resources | allowed for non-secret files only |
+| `auth.json`, `models.json`, `settings.json` | `rw` | `rw` | denied by mode bits | policy denied |
+| `/home/pi/.pi-forge` (`FORGE_DATA_DIR`) | `rwx` | `rwx` | denied by mode bits | policy denied |
+| `/workspace` (`WORKSPACE_PATH`) | mount-dependent; should be writable by `pi` in regular mode | mount-dependent; must be usable by the server for project/session setup | mount-dependent; should be writable by `pi-tools` in sandbox mode | allowed for the configured workspace root |
+| `/tmp` | `rwx` | `rwx` | `rwx` | outside allowed roots unless explicitly requested by a denied path |
+| `/app` | `r-x` app code | root can write but should treat as image-owned/read-only | `r-x` | outside allowed roots |
+
+Do not rely on the model file-tool policy to protect secrets from shell tools.
+Shell-like surfaces (`bash`, process commands, terminals, quick actions, and
+chat exec) run as an OS identity and are protected by ownership/mode bits and a
+scrubbed environment, not by the file-tool path policy.
+
+If sandbox sessions start but skills or package extensions are missing, inspect
+existing resource ownership. Previously installed trees often remain
+`1000:1000` from regular mode. The relevant non-secret trees are usually:
+
+- `${PI_CONFIG_DIR}/skills`
+- `${PI_CONFIG_DIR}/npm`
+- `${PI_CONFIG_DIR}/git`
+- `${PI_CONFIG_DIR}/extensions`
+- `${PI_CONFIG_DIR}/prompts`
+- `${PI_CONFIG_DIR}/themes`
+
+Those directories must be traversable/readable by `AGENT_TOOL_GID` while
+`${PI_CONFIG_DIR}/auth.json`, `models.json`, and `settings.json` stay `0600`.
 
 ## Suggested verification prompts
 

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -50,11 +50,14 @@ The image creates two users:
   `1001:1001`) is the restricted identity used when
   `AGENT_TOOL_SANDBOX_ENABLED=true`.
 
-By default (`AGENT_TOOL_SANDBOX_ENABLED=false`), the entrypoint drops
-the server to the legacy `pi` user. In sandbox mode, the server remains
-root. This is deliberate: the identity sandbox needs the server to call
-`setuid` / `setgid` for child tools while keeping server-owned config,
-forge data, and mounted secrets unreadable by `pi-tools`.
+By default (`AGENT_TOOL_SANDBOX_ENABLED=false`), compose starts the
+server as the legacy `pi` user directly and drops all Linux
+capabilities. The entrypoint only falls back to `gosu pi` for ad-hoc
+`docker run` invocations that still start as root. In sandbox mode,
+the server remains root. This is deliberate: the identity sandbox needs
+the server to call `setuid` / `setgid` for child tools while keeping
+server-owned config, forge data, and mounted secrets unreadable by
+`pi-tools`.
 
 Sandbox mode has a stricter volume permission contract than the default
 container. Read [`agent-tool-sandbox.md`](./agent-tool-sandbox.md)
@@ -227,9 +230,11 @@ SSE-buffering and WebSocket-upgrade settings live in
   as `pi-tools` and file tools / `@file` references are path-scoped.
   Keep secrets out of `/workspace`; workspace content is intentionally
   readable by the agent.
-- **Minimal capabilities.** Compose drops all capabilities and adds back
-  only `SETUID` / `SETGID`, which are required for the identity switch.
-  No privileged mode or host PID is needed.
+- **Minimal capabilities.** Regular compose starts as `pi`, drops all
+  capabilities, and does not need `SETUID` / `SETGID`. The optional
+  `docker-compose.sandbox.yml` overlay starts as root and adds back
+  only `SETUID` / `SETGID`, which are required for the sandbox identity
+  switch. No privileged mode or host PID is needed.
 - **Secret mounts.** Mount Pi config, forge data, LDAP/UI secret files,
   and cloud credentials so they are readable by the root server but not
   by `pi-tools` (for example mode `0600` root-owned files or `0700`

--- a/docs/site/docs/agent-tool-sandbox.html
+++ b/docs/site/docs/agent-tool-sandbox.html
@@ -212,18 +212,32 @@ sudo mkdir -p ~/.pi-forge-docker
 sudo chown -R root:root ~/.pi-forge-docker
 sudo chmod -R u+rwX,go-rwx ~/.pi-forge-docker
 
-# Pi config: pi-tools can traverse/read non-secret resources.
+# Pi config parent: traversable by pi-tools so non-secret resources can load.
 # The image-owned /home/pi/.pi parent is already traversable by pi-tools when
 # only ~/.pi/agent is mounted. If you mount the whole ~/.pi directory, set the
 # parent permissions too.
 sudo chown root:1001 ~/.pi
 sudo chmod 0750 ~/.pi
-sudo chown -R root:1001 ~/.pi/agent
+sudo chown root:1001 ~/.pi/agent
 sudo chmod 0750 ~/.pi/agent
-sudo find ~/.pi/agent -type d -exec chmod 0750 {} +
-sudo find ~/.pi/agent -type f -exec chmod 0640 {} +
 
-# Pi config secrets: server-only.
+# Existing non-secret Pi resources: readable/traversable by pi-tools.
+# This is required for previously installed skills/packages that may still be
+# 1000:1000 from regular mode. Keep execute bits where they already exist.
+for path in \
+  ~/.pi/agent/skills \
+  ~/.pi/agent/npm \
+  ~/.pi/agent/git \
+  ~/.pi/agent/extensions \
+  ~/.pi/agent/prompts \
+  ~/.pi/agent/themes; do
+  [ -e &quot;$path&quot; ] || continue
+  sudo chown -R root:1001 &quot;$path&quot;
+  sudo chmod -R u+rwX,g+rX,o-rwx &quot;$path&quot;
+done
+
+# Pi config secrets/settings: server-only. Re-run this after broad permission
+# changes so pi-tools cannot read provider auth, model config, or settings.
 sudo chown root:root ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/settings.json 2&gt;/dev/null || true
 sudo chmod 0600 ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/settings.json 2&gt;/dev/null || true
 </code></pre>
@@ -317,12 +331,14 @@ find /home/pi/.pi-forge -type d -exec chmod 0700 {} +
 find /home/pi/.pi-forge -type f -exec chmod 0600 {} +
 
 # Pi config: pi-tools can traverse/read non-secret resources.
+# This includes existing skills, managed npm/git packages, extensions,
+# prompts, and themes copied into the named volume.
 chown -R root:1001 /home/pi/.pi/agent
+chmod -R u+rwX,g+rX,o-rwx /home/pi/.pi/agent
 chmod 0750 /home/pi/.pi/agent
-find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
-find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
 
-# Pi config secrets: server-only.
+# Pi config secrets/settings: server-only. Re-run this after broad permission
+# changes so pi-tools cannot read provider auth, model config, or settings.
 chown root:root \
   /home/pi/.pi/agent/auth.json \
   /home/pi/.pi/agent/models.json \
@@ -412,16 +428,33 @@ volume names/mount paths:</p>
         find /home/pi/.pi-forge -type d -exec chmod 0700 {} +
         find /home/pi/.pi-forge -type f -exec chmod 0600 {} +
 
-        # Pi config: pi-tools can traverse/read non-secret resources.
+        # Pi config parent: traversable by pi-tools so non-secret resources
+        # can load.
         mkdir -p /home/pi/.pi/agent
         chown 0:1001 /home/pi/.pi
         chmod 0750 /home/pi/.pi
-        chown -R 0:1001 /home/pi/.pi/agent
+        chown 0:1001 /home/pi/.pi/agent
         chmod 0750 /home/pi/.pi/agent
-        find /home/pi/.pi/agent -type d -exec chmod 0750 {} +
-        find /home/pi/.pi/agent -type f -exec chmod 0640 {} +
 
-        # Pi config secrets: server-only.
+        # Existing non-secret Pi resources: readable/traversable by pi-tools.
+        # This is required for previously installed skills/packages that may
+        # still be 1000:1000 from regular mode. Keep execute bits where they
+        # already exist.
+        for path in \
+          /home/pi/.pi/agent/skills \
+          /home/pi/.pi/agent/npm \
+          /home/pi/.pi/agent/git \
+          /home/pi/.pi/agent/extensions \
+          /home/pi/.pi/agent/prompts \
+          /home/pi/.pi/agent/themes; do
+          [ -e &quot;$path&quot; ] || continue
+          chown -R 0:1001 &quot;$path&quot;
+          chmod -R u+rwX,g+rX,o-rwx &quot;$path&quot;
+        done
+
+        # Pi config secrets/settings: server-only. Re-run this after resource
+        # permission changes so pi-tools cannot read provider auth, model
+        # config, or settings.
         chown 0:0 \
           /home/pi/.pi/agent/auth.json \
           /home/pi/.pi/agent/models.json \
@@ -497,6 +530,134 @@ mount/UID policy.</p>
 </ul>
 <p>Use a literal environment value or an external secret broker instead. Tool
 children receive a scrubbed env and do not inherit the LDAP bind password.</p>
+<h2>Access model quick reference</h2>
+<p>Default Docker image identities:</p>
+<table>
+<thead>
+<tr>
+<th>Surface</th>
+<th>Regular mode (<code>AGENT_TOOL_SANDBOX_ENABLED=false</code>)</th>
+<th>Sandbox mode (<code>AGENT_TOOL_SANDBOX_ENABLED=true</code>)</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>pi-forge HTTP server and session registry</td>
+<td><code>pi</code> (<code>1000:1000</code> by default)</td>
+<td><code>root</code> (<code>0:0</code>)</td>
+</tr>
+<tr>
+<td>Model file tools (<code>read</code>, <code>write</code>, <code>grep</code>, <code>find</code>, <code>ls</code>, <code>edit</code>)</td>
+<td>SDK defaults as the server identity</td>
+<td>Server identity plus pi-forge path policy</td>
+</tr>
+<tr>
+<td>Agent <code>bash</code>, process tool commands, terminal, quick actions, chat exec</td>
+<td><code>pi</code> (<code>1000:1000</code> by default)</td>
+<td><code>pi-tools</code> (<code>1001:1001</code> by default)</td>
+</tr>
+</tbody></table>
+<p>Use this matrix when debugging <code>EACCES</code>. <code>rwx</code> means the identity should be able
+to create/update entries there; <code>r-x</code> means traversal/read only; <code>denied</code> means
+normal Unix mode bits should block the identity; <code>policy denied</code> means sandboxed
+model file tools reject the path even if the server process could read it.</p>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th><code>pi</code> regular server/tools</th>
+<th><code>root</code> sandbox server</th>
+<th><code>pi-tools</code> sandbox shell tools</th>
+<th>Sandbox model file tools</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>/home/pi</code></td>
+<td><code>r-x</code>; home parent is not general scratch space</td>
+<td><code>rwx</code></td>
+<td><code>r-x</code></td>
+<td>usually not used directly</td>
+</tr>
+<tr>
+<td><code>/home/pi/.npm</code></td>
+<td><code>rwx</code>; npm logs/cache</td>
+<td><code>rwx</code></td>
+<td>denied unless explicitly permissioned</td>
+<td>outside allowed roots</td>
+</tr>
+<tr>
+<td><code>/home/pi/.local</code></td>
+<td><code>rwx</code>; user installs and Python user base</td>
+<td><code>rwx</code></td>
+<td>denied unless explicitly permissioned</td>
+<td>outside allowed roots</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi</code></td>
+<td><code>r-x</code>; parent for Pi config</td>
+<td><code>rwx</code></td>
+<td>deployment-dependent traversal only</td>
+<td>parent traversal only</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi/agent</code> (<code>PI_CONFIG_DIR</code>)</td>
+<td><code>rwx</code> for regular config writes</td>
+<td><code>rwx</code></td>
+<td>ideally denied by mode bits, except deliberate non-secret resources</td>
+<td>allowed for non-secret files only</td>
+</tr>
+<tr>
+<td><code>auth.json</code>, <code>models.json</code>, <code>settings.json</code></td>
+<td><code>rw</code></td>
+<td><code>rw</code></td>
+<td>denied by mode bits</td>
+<td>policy denied</td>
+</tr>
+<tr>
+<td><code>/home/pi/.pi-forge</code> (<code>FORGE_DATA_DIR</code>)</td>
+<td><code>rwx</code></td>
+<td><code>rwx</code></td>
+<td>denied by mode bits</td>
+<td>policy denied</td>
+</tr>
+<tr>
+<td><code>/workspace</code> (<code>WORKSPACE_PATH</code>)</td>
+<td>mount-dependent; should be writable by <code>pi</code> in regular mode</td>
+<td>mount-dependent; must be usable by the server for project/session setup</td>
+<td>mount-dependent; should be writable by <code>pi-tools</code> in sandbox mode</td>
+<td>allowed for the configured workspace root</td>
+</tr>
+<tr>
+<td><code>/tmp</code></td>
+<td><code>rwx</code></td>
+<td><code>rwx</code></td>
+<td><code>rwx</code></td>
+<td>outside allowed roots unless explicitly requested by a denied path</td>
+</tr>
+<tr>
+<td><code>/app</code></td>
+<td><code>r-x</code> app code</td>
+<td>root can write but should treat as image-owned/read-only</td>
+<td><code>r-x</code></td>
+<td>outside allowed roots</td>
+</tr>
+</tbody></table>
+<p>Do not rely on the model file-tool policy to protect secrets from shell tools.
+Shell-like surfaces (<code>bash</code>, process commands, terminals, quick actions, and
+chat exec) run as an OS identity and are protected by ownership/mode bits and a
+scrubbed environment, not by the file-tool path policy.</p>
+<p>If sandbox sessions start but skills or package extensions are missing, inspect
+existing resource ownership. Previously installed trees often remain
+<code>1000:1000</code> from regular mode. The relevant non-secret trees are usually:</p>
+<ul>
+<li><code>${PI_CONFIG_DIR}/skills</code></li>
+<li><code>${PI_CONFIG_DIR}/npm</code></li>
+<li><code>${PI_CONFIG_DIR}/git</code></li>
+<li><code>${PI_CONFIG_DIR}/extensions</code></li>
+<li><code>${PI_CONFIG_DIR}/prompts</code></li>
+<li><code>${PI_CONFIG_DIR}/themes</code></li>
+</ul>
+<p>Those directories must be traversable/readable by <code>AGENT_TOOL_GID</code> while
+<code>${PI_CONFIG_DIR}/auth.json</code>, <code>models.json</code>, and <code>settings.json</code> stay <code>0600</code>.</p>
 <h2>Suggested verification prompts</h2>
 <p>Ask the model:</p>
 <pre><code class="language-txt">Use your file tools, not bash, to test sandbox file access.

--- a/docs/site/docs/agent-tool-sandbox.html
+++ b/docs/site/docs/agent-tool-sandbox.html
@@ -64,10 +64,11 @@
     <main class="docs-main">
       <h1>Agent Tool Sandbox</h1>
       <p class="docs-subtitle">Optional UID/GID split, path policy, mount permissions, and verification.</p>
-<p><code>AGENT_TOOL_SANDBOX_ENABLED=false</code> by default. In the Docker image, the default
-entrypoint drops the server to the legacy <code>pi</code> user. When sandbox mode is
-enabled, pi-forge keeps the HTTP server running as root and runs model/user
-tool surfaces as a restricted UID/GID (<code>pi-tools</code> in the Docker image).</p>
+<p><code>AGENT_TOOL_SANDBOX_ENABLED=false</code> by default. In the Docker Compose setup,
+regular mode starts the server as the legacy <code>pi</code> user directly and drops all
+Linux capabilities. When sandbox mode is enabled with the sandbox compose
+overlay, pi-forge keeps the HTTP server running as root and runs model/user tool
+surfaces as a restricted UID/GID (<code>pi-tools</code> in the Docker image).</p>
 <p>This is an operator-controlled hardening mode. It is useful only when the
 container or pod mounts are permissioned carefully. Leave it disabled for
 simple local installs or any deployment where the workspace, Pi config, forge
@@ -146,7 +147,7 @@ the container or pod</strong>.</p>
 </thead>
 <tbody><tr>
 <td><code>/workspace</code></td>
-<td>Writable by <code>AGENT_TOOL_UID:GID</code>. Secrets in the workspace are readable by the agent.</td>
+<td>Writable by <code>AGENT_TOOL_UID</code> and traversable/readable by the root server without <code>DAC_OVERRIDE</code>. Recommended: <code>AGENT_TOOL_UID:0</code> with group rwX (<code>1001:0</code> in the Docker examples). Secrets in the workspace are readable by the agent.</td>
 </tr>
 <tr>
 <td><code>/home/pi/.pi</code></td>
@@ -196,11 +197,14 @@ bind mounts from <code>docker/docker-compose.yml</code>:</p>
   - ${FORGE_DATA_HOST_PATH:-~/.pi-forge-docker}:/home/pi/.pi-forge
 </code></pre>
 <p>Native Linux bind mounts normally preserve host numeric ownership in the
-container. With default sandbox IDs (<code>1001:1001</code>), run these commands on the
-<strong>host</strong> before starting the container:</p>
-<pre><code class="language-bash"># Workspace: writable by pi-tools.
+container. With default sandbox tool IDs (<code>1001:1001</code>; workspace group <code>0</code> for
+the root server), run these commands on the <strong>host</strong> before starting the
+container:</p>
+<pre><code class="language-bash"># Workspace: writable by pi-tools and accessible to the root server.
+# Group 0 matters because sandbox containers drop DAC_OVERRIDE, so root
+# cannot bypass mode bits on host bind mounts.
 sudo mkdir -p ./workspace
-sudo chown -R 1001:1001 ./workspace
+sudo chown -R 1001:0 ./workspace
 sudo chmod -R u+rwX,g+rwX,o-rwx ./workspace
 
 # Forge data: server-only.
@@ -228,19 +232,15 @@ sudo chmod 0600 ~/.pi/agent/auth.json ~/.pi/agent/models.json ~/.pi/agent/settin
 AGENT_TOOL_UID=1001
 AGENT_TOOL_GID=1001
 </code></pre>
-<p>Compose capabilities for native Linux should be:</p>
-<pre><code class="language-yaml">cap_drop:
-  - ALL
-cap_add:
-  - SETUID
-  - SETGID
-security_opt:
-  - no-new-privileges:true
-</code></pre>
-<p>Then rebuild/recreate:</p>
+<p>Start sandbox mode with the sandbox compose overlay. The base compose file runs
+regular mode as <code>pi</code> with no Linux capabilities; the overlay switches the server
+container to root and adds back only <code>SETUID</code> / <code>SETGID</code> for sandbox child
+processes:</p>
 <pre><code class="language-bash">cd docker
-docker compose down
-docker compose up -d --build
+docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
+</code></pre>
+<p>To stop it later, pass the same file set:</p>
+<pre><code class="language-bash">docker compose -f docker-compose.yml -f docker-compose.sandbox.yml down
 </code></pre>
 <h2>Docker Compose: OrbStack / Docker Desktop / macOS</h2>
 <p>Use this section for OrbStack or Docker Desktop on macOS. Host file sharing can
@@ -276,15 +276,11 @@ volumes:
     name: docker_forge-data
 </code></pre>
 <h3>Compose capability changes</h3>
-<p>Start with the native capability set:</p>
-<pre><code class="language-yaml">cap_drop:
-  - ALL
-cap_add:
-  - SETUID
-  - SETGID
-security_opt:
-  - no-new-privileges:true
+<p>Start with the sandbox compose overlay:</p>
+<pre><code class="language-bash">docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
 </code></pre>
+<p>The base compose file already drops all capabilities. The sandbox overlay adds
+back <code>SETUID</code> / <code>SETGID</code> and runs the server container as root.</p>
 <p>If OrbStack/Docker Desktop shows <code>.pi-forge</code> as <code>1000:1000 0700</code> inside the
 pi-forge container even after the helper volume init chowns it to <code>root:root</code>,
 add <code>DAC_OVERRIDE</code> for local testing:</p>
@@ -299,7 +295,7 @@ can be permissioned normally.</p>
 <p>This example assumes the named volumes are <code>docker_pi-config</code> and
 <code>docker_forge-data</code>, and the sandbox UID/GID is <code>1001:1001</code>:</p>
 <pre><code class="language-bash">cd docker
-docker compose down
+docker compose -f docker-compose.yml -f docker-compose.sandbox.yml down
 
 # Optional: seed the named pi config volume from the host before locking it down.
 docker run --rm \
@@ -344,19 +340,21 @@ stat -c &quot;%u:%g %a %n&quot; /home/pi/.pi/agent /home/pi/.pi-forge
 AGENT_TOOL_UID=1001
 AGENT_TOOL_GID=1001
 </code></pre>
-<p>Start pi-forge:</p>
-<pre><code class="language-bash">docker compose up -d --build
+<p>Start pi-forge with the sandbox overlay:</p>
+<pre><code class="language-bash">docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
 </code></pre>
 <p>Verify the actual mounts and ownership inside pi-forge:</p>
-<pre><code class="language-bash">docker compose run --rm pi-forge sh -lc &#39;
+<pre><code class="language-bash">docker compose -f docker-compose.yml -f docker-compose.sandbox.yml run --rm pi-forge sh -lc &#39;
 id
 stat -c &quot;%u:%g %a %n&quot; /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
+# Expected /workspace owner/group is 1001:0 with owner+group rwX bits.
 touch /home/pi/.pi-forge/probe &amp;&amp; rm /home/pi/.pi-forge/probe
 &#39;
 </code></pre>
 <p>Then verify from the app terminal (which runs as <code>pi-tools</code>):</p>
 <pre><code class="language-bash">id
 stat -c &quot;%u:%g %a %n&quot; /workspace /home/pi/.pi /home/pi/.pi/agent /home/pi/.pi-forge
+# Expected /workspace owner/group is 1001:0 with owner+group rwX bits.
 cat /home/pi/.pi-forge/jwt-secret
 cat /home/pi/.pi/agent/auth.json
 </code></pre>
@@ -400,9 +398,11 @@ volume names/mount paths:</p>
       - |
         set -eux
 
-        # Workspace: writable by pi-tools.
+        # Workspace: writable by pi-tools and accessible to the root server.
+        # Group 0 matters because sandbox containers drop DAC_OVERRIDE, so root
+        # cannot bypass mode bits on PVCs.
         mkdir -p /workspace
-        chown -R 1001:1001 /workspace
+        chown -R 1001:0 /workspace
         chmod -R u+rwX,g+rwX,o-rwx /workspace
 
         # Forge data: server-only.

--- a/docs/site/docs/containers.html
+++ b/docs/site/docs/containers.html
@@ -129,11 +129,14 @@ preserves legacy path/env expectations.</li>
 <code>1001:1001</code>) is the restricted identity used when
 <code>AGENT_TOOL_SANDBOX_ENABLED=true</code>.</li>
 </ul>
-<p>By default (<code>AGENT_TOOL_SANDBOX_ENABLED=false</code>), the entrypoint drops
-the server to the legacy <code>pi</code> user. In sandbox mode, the server remains
-root. This is deliberate: the identity sandbox needs the server to call
-<code>setuid</code> / <code>setgid</code> for child tools while keeping server-owned config,
-forge data, and mounted secrets unreadable by <code>pi-tools</code>.</p>
+<p>By default (<code>AGENT_TOOL_SANDBOX_ENABLED=false</code>), compose starts the
+server as the legacy <code>pi</code> user directly and drops all Linux
+capabilities. The entrypoint only falls back to <code>gosu pi</code> for ad-hoc
+<code>docker run</code> invocations that still start as root. In sandbox mode,
+the server remains root. This is deliberate: the identity sandbox needs
+the server to call <code>setuid</code> / <code>setgid</code> for child tools while keeping
+server-owned config, forge data, and mounted secrets unreadable by
+<code>pi-tools</code>.</p>
 <p>Sandbox mode has a stricter volume permission contract than the default
 container. Read <a href="./agent-tool-sandbox.md"><code>agent-tool-sandbox.md</code></a>
 before enabling it; the short version is:</p>
@@ -319,9 +322,11 @@ When <code>AGENT_TOOL_SANDBOX_ENABLED=true</code>, the server runs as root and m
 as <code>pi-tools</code> and file tools / <code>@file</code> references are path-scoped.
 Keep secrets out of <code>/workspace</code>; workspace content is intentionally
 readable by the agent.</li>
-<li><strong>Minimal capabilities.</strong> Compose drops all capabilities and adds back
-only <code>SETUID</code> / <code>SETGID</code>, which are required for the identity switch.
-No privileged mode or host PID is needed.</li>
+<li><strong>Minimal capabilities.</strong> Regular compose starts as <code>pi</code>, drops all
+capabilities, and does not need <code>SETUID</code> / <code>SETGID</code>. The optional
+<code>docker-compose.sandbox.yml</code> overlay starts as root and adds back
+only <code>SETUID</code> / <code>SETGID</code>, which are required for the sandbox identity
+switch. No privileged mode or host PID is needed.</li>
 <li><strong>Secret mounts.</strong> Mount Pi config, forge data, LDAP/UI secret files,
 and cloud credentials so they are readable by the root server but not
 by <code>pi-tools</code> (for example mode <code>0600</code> root-owned files or <code>0700</code>


### PR DESCRIPTION
## Summary

Fixes the Docker/Compose sandbox rollout so regular mode no longer needs `SETUID` / `SETGID` capabilities just to start as the `pi` user.

In v1.4.0, the base compose file dropped all capabilities and then added back `SETUID` / `SETGID`; the entrypoint still started as root and used `gosu pi` in regular mode. If an operator removed those capabilities for non-sandbox hardening, startup failed with:

```txt
error: failed switch to "pi": operation not permitted
```

This PR makes base Compose start directly as `pi`, moves root + `SETUID` / `SETGID` into a sandbox-only overlay, and updates the sandbox guide to permission `/workspace` so both `pi-tools` and the root server can access it without `DAC_OVERRIDE`.

## Usage

Regular/default mode uses only the base compose file and requires no identity-switch capabilities:

```bash
cd docker
docker compose up -d
```

Sandbox mode explicitly includes the overlay:

```bash
cd docker
docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d
```

For sandbox workspace permissions, use group `0` so the root server can traverse/read/write without `DAC_OVERRIDE` while `pi-tools` owns workspace content:

```bash
chown -R 1001:0 /workspace
chmod -R u+rwX,g+rwX,o-rwx /workspace
```

## What changed

- `docker/docker-compose.yml` — starts regular mode as `${PUID}:${PGID}`, drops all capabilities, and uses mapping-style environment entries so overlays can override individual values.
- `docker/docker-compose.sandbox.yml` — new explicit overlay that switches the service to `user: "0:0"`, defaults `AGENT_TOOL_SANDBOX_ENABLED=true`, and adds back only `SETUID` / `SETGID`.
- `docker/Dockerfile` — entrypoint runs directly when already non-root, keeps `gosu pi` only as an ad-hoc root fallback, and errors clearly if sandbox mode is requested without UID 0.
- `docker/.env.example`, `docs/containers.md`, `docs/agent-tool-sandbox.md` — document regular vs sandbox compose commands and the corrected workspace permission posture.
- `docs/site/docs/*.html` — regenerated site docs for the container/sandbox guide updates.

## Test plan

- [x] `npm run build`
- [x] `npm run build:site`
- [x] `npm run check`
- [x] `git diff --check`
- [ ] Docker Compose config/runtime validation — Docker CLI is unavailable in this agent environment
- [ ] CI green before merge
