### PR TITLE
fix(git): clarify auth-required remote failures

### DIFF
--- a/packages/server/src/git-runner.ts
+++ b/packages/server/src/git-runner.ts
@@ -39,14 +39,24 @@ export class GitNotInstalledError extends Error {
   }
 }
 
+export type GitCommandErrorCode = "git_failed" | "git_auth_required";
+
 export class GitCommandError extends Error {
   readonly exitCode: number | null;
+  /** Stable route error code for user-actionable git failures. */
+  readonly errorCode: GitCommandErrorCode;
   /** Sanitized first line of stderr — safe to surface to the user. */
   readonly userMessage: string;
-  constructor(exitCode: number | null, userMessage: string, fullMessage: string) {
+  constructor(
+    exitCode: number | null,
+    userMessage: string,
+    fullMessage: string,
+    errorCode: GitCommandErrorCode = "git_failed",
+  ) {
     super(fullMessage);
     this.name = "GitCommandError";
     this.exitCode = exitCode;
+    this.errorCode = errorCode;
     this.userMessage = userMessage;
   }
 }
@@ -191,9 +201,15 @@ async function runGit(cwd: string, args: string[]): Promise<RunResult> {
     };
     if (e.code === "ENOENT") throw new GitNotInstalledError();
     const stderr = (e.stderr ?? "").toString();
-    const userMessage = sanitizeStderr(stderr, cwd);
+    const authRequired = isGitAuthRequired(stderr);
+    const userMessage = authRequired ? gitAuthRequiredMessage() : sanitizeStderr(stderr, cwd);
     const exitCode = typeof e.code === "number" ? e.code : null;
-    throw new GitCommandError(exitCode, userMessage, stderr || (e.message ?? "git failed"));
+    throw new GitCommandError(
+      exitCode,
+      userMessage,
+      stderr || (e.message ?? "git failed"),
+      authRequired ? "git_auth_required" : "git_failed",
+    );
   }
 }
 
@@ -264,9 +280,28 @@ function sanitizeStderr(stderr: string, cwd?: string): string {
   if (cwd !== undefined && cwd.length > 0) {
     firstLine = firstLine.split(cwd).join("<project>");
   }
+  firstLine = redactCredentialUrls(firstLine);
   // Drop common "fatal: " / "error: " prefixes that confuse users.
   const stripped = firstLine.replace(/^(fatal|error|warning):\s*/i, "");
   return stripped.length > 200 ? stripped.slice(0, 197) + "…" : stripped;
+}
+
+function redactCredentialUrls(message: string): string {
+  return message.replace(/(https?:\/\/)([^\s/@:]+)(?::[^\s/@]*)?@/gi, "$1<credentials>@");
+}
+
+function isGitAuthRequired(stderr: string): boolean {
+  return /authentication failed|could not read (username|password).*terminal prompts disabled|terminal prompts disabled|permission denied \(publickey\)|permission denied .*publickey|authentication required|authorization failed|repository not found/i.test(
+    stderr,
+  );
+}
+
+function gitAuthRequiredMessage(): string {
+  return (
+    "Git authentication required. Configure this remote's credentials in the integrated " +
+    "terminal or system Git credential helper, then retry. pi-forge does not collect or store " +
+    "Git passwords or tokens."
+  );
 }
 
 /**

--- a/packages/server/src/routes/git.ts
+++ b/packages/server/src/routes/git.ts
@@ -197,9 +197,10 @@ function mapError(reply: FastifyReply, err: unknown): FastifyReply {
     // Git "rejected" / "non-fast-forward" / commit hook failures /
     // missing upstream are user-actionable, not server bugs. 400
     // with a sanitized message lets the client surface the hint
-    // verbatim. Network / auth failures during push are reported the
-    // same way — we don't try to enumerate every git failure mode.
-    return reply.code(400).send({ error: "git_failed", message: err.userMessage });
+    // verbatim. Auth failures get a stable error code so the UI can
+    // distinguish "configure credentials" from ordinary git failures
+    // without ever collecting or returning raw secrets.
+    return reply.code(400).send({ error: err.errorCode, message: err.userMessage });
   }
   reply.log.error({ err }, "unmapped git-runner error");
   return reply.code(500).send({ error: "internal_error" });
@@ -1159,8 +1160,8 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
           "plain `git push` against the configured upstream. `setUpstream: " +
           "true` adds `--set-upstream` so the remote/branch is recorded as " +
           "the tracking ref (required on first push of a new local branch). " +
-          "Returns 400 with git's stderr message on failure (no upstream set, " +
-          "auth refused, rejected non-fast-forward, etc.).",
+          "Returns 400 with a sanitized git failure message. Auth failures use " +
+          "error=git_auth_required with guidance to configure credentials outside pi-forge.",
         tags: ["git"],
         body: {
           type: "object",

--- a/tests/test-git.ts
+++ b/tests/test-git.ts
@@ -11,6 +11,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
 import { mkdir, mkdtemp, rm, writeFile as fsWrite } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
@@ -93,6 +94,24 @@ async function jsend(
 
 async function git(cwd: string, args: string[]): Promise<void> {
   await execFileAsync("git", args, { cwd });
+}
+
+async function startAuthRequiredGitServer(): Promise<{ server: HttpServer; url: string }> {
+  const server = createHttpServer((_req, res) => {
+    res.writeHead(401, { "WWW-Authenticate": 'Basic realm="pi-forge-test"' });
+    res.end("authentication required");
+  });
+  await new Promise<void>((resolveFn, rejectFn) => {
+    server.once("error", rejectFn);
+    server.listen(0, "127.0.0.1", () => resolveFn());
+  });
+  const addr = server.address();
+  if (addr === null || typeof addr === "string") throw new Error("missing auth server port");
+  return { server, url: `http://127.0.0.1:${addr.port}/private.git` };
+}
+
+async function closeHttpServer(server: HttpServer): Promise<void> {
+  await new Promise<void>((resolveFn) => server.close(() => resolveFn()));
 }
 
 async function main(): Promise<void> {
@@ -506,6 +525,37 @@ async function main(): Promise<void> {
         typeof body.message === "string" && body.message.length > 0,
         `message: ${body.message ?? "(none)"}`,
       );
+    }
+
+    // ---- auth-required remote → stable, actionable error code/message ----
+    {
+      const { server: authServer, url } = await startAuthRequiredGitServer();
+      try {
+        await git(projectPath, ["remote", "add", "auth-http", url]);
+        const r = await jsend(
+          "POST",
+          `${base}/api/v1/git/fetch`,
+          { projectId: gitProjectId, remote: "auth-http" },
+          auth,
+        );
+        assert("fetch requiring auth → 400", r.status === 400);
+        const body = r.body as { error: string; message?: string };
+        assert("auth failure error code", body.error === "git_auth_required");
+        assert(
+          "auth failure message gives credential guidance",
+          typeof body.message === "string" &&
+            body.message.includes("Configure this remote's credentials") &&
+            body.message.includes("does not collect or store"),
+          `message: ${body.message ?? "(none)"}`,
+        );
+        assert(
+          "auth failure does not echo remote URL",
+          typeof body.message === "string" && !body.message.includes(url),
+          `message: ${body.message ?? "(none)"}`,
+        );
+      } finally {
+        await closeHttpServer(authServer);
+      }
     }
 
     // ---- push round-trip: set up a local bare repo as origin ----


### PR DESCRIPTION
## Summary

When pi-forge runs `git fetch`, `git pull`, or `git push` from the Git panel and the remote needs credentials, the server intentionally disables interactive Git prompts with `GIT_TERMINAL_PROMPT=0` / `GIT_ASKPASS=true` so the request does not hang. That means the browser cannot complete Git auth inline today; users must configure credentials via the integrated/system terminal or a Git credential helper.

This PR makes that behavior explicit and actionable. Auth/access failures are now classified as `git_auth_required` and return a sanitized guidance message instead of an ambiguous generic Git failure. pi-forge still does not collect, store, log, or echo Git passwords/tokens.

Example failure modes covered include:

```text
fatal: Authentication failed for 'https://...'
fatal: could not read Username for 'https://...': terminal prompts disabled
Permission denied (publickey).
```

## Usage

No new setup is required. If a remote requires authentication, users should configure credentials outside the Git panel, for example:

```bash
# In the integrated terminal or system terminal
git credential-manager configure   # where available
# or configure SSH keys / git credential helper / PAT-backed HTTPS auth

git fetch origin
```

Then retry Fetch/Pull/Push in pi-forge. The API response for auth-required failures is now:

```json
{
  "error": "git_auth_required",
  "message": "Git authentication required. Configure this remote's credentials in the integrated terminal or system Git credential helper, then retry. pi-forge does not collect or store Git passwords or tokens."
}
```

## What changed (3 files)

- `packages/server/src/git-runner.ts` — adds a stable `GitCommandErrorCode`, detects common credential-required Git stderr patterns, returns a fixed auth guidance message, and redacts credentials embedded in HTTP(S) URLs before surfacing generic Git errors.
- `packages/server/src/routes/git.ts` — maps `GitCommandError.errorCode` through the Git routes and documents that auth failures use `git_auth_required`.
- `tests/test-git.ts` — adds an auth-required HTTP remote fixture and assertions that `/git/fetch` returns `git_auth_required`, includes credential guidance, and does not echo the remote URL.

## Test plan

- [x] `npx prettier --check packages/server/src/git-runner.ts packages/server/src/routes/git.ts tests/test-git.ts`
- [x] `git diff --check`
- [x] Direct `npx tsx` smoke test against `packages/server/src/git-runner.ts` with a local HTTP 401 remote, verifying `GitCommandError.errorCode === "git_auth_required"`
- [ ] `npm run build` / `npx tsx tests/test-git.ts` — blocked locally by pre-existing install/type issues unrelated to this change: missing `vite/client`, missing declarations for `jsonwebtoken` and `ws`, and an existing implicit-any in `packages/server/src/routes/terminal.ts`.
- [ ] CI green before merge

## Risks

- Git hosts sometimes return `Repository not found` for private repos without valid credentials. This PR treats that as auth/access guidance, which is more actionable for private-remotes but may be slightly less precise for genuinely deleted repositories.
- A browser-based credential prompt/modal is intentionally not implemented in v1.4.1 because that would require new secret-handling/storage decisions. This PR preserves the current terminal/credential-helper model and makes it clear to users.
