### PR TITLE
fix: refresh file pane after write tools

### DIFF
--- a/docs/agent/filesystem.md
+++ b/docs/agent/filesystem.md
@@ -11,8 +11,8 @@ Read this when changing file browser behavior, file-manager operations, path val
    `../../../etc/passwd` style traversal.
 3. Max file read size: 5MB. Larger files return a truncation notice.
 4. `getTree()` skips: `node_modules`, `.git`, `dist`, `build`, `__pycache__`,
-   `.next`, `.nuxt`, `coverage`, `.vite`, `.turbo`, `.cache`. Default max depth: 6 levels;
-   `/files/tree?maxDepth=` is clamped to 1–32 and truncated directories return `truncated: true`.
+   `.next`, `.nuxt`, `coverage`, `.vite`, `.turbo`, `.cache`. Recursion is capped at
+   max depth 32; `/files/tree?maxDepth=` is clamped to 1–32.
 5. Delete operations on non-empty directories are rejected — return a helpful error
    asking the user to delete contents first. Do not implement recursive force-delete.
 

--- a/docs/agent/filesystem.md
+++ b/docs/agent/filesystem.md
@@ -11,7 +11,8 @@ Read this when changing file browser behavior, file-manager operations, path val
    `../../../etc/passwd` style traversal.
 3. Max file read size: 5MB. Larger files return a truncation notice.
 4. `getTree()` skips: `node_modules`, `.git`, `dist`, `build`, `__pycache__`,
-   `.next`, `.nuxt`, `coverage`, `.vite`, `.turbo`, `.cache`. Max depth: 6 levels.
+   `.next`, `.nuxt`, `coverage`, `.vite`, `.turbo`, `.cache`. Default max depth: 6 levels;
+   `/files/tree?maxDepth=` is clamped to 1–32 and truncated directories return `truncated: true`.
 5. Delete operations on non-empty directories are rejected — return a helpful error
    asking the user to delete contents first. Do not implement recursive force-delete.
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -240,33 +240,23 @@ export function App() {
   const sessionProcesses = useProcessesStore((s) => selectProcesses(s, activeSessionId));
   const runningProcessCount = countRunning(sessionProcesses);
 
-  // Refresh the file tree on every agent_end the active project hears,
-  // since the agent commonly writes/edits files mid-turn. The session
-  // store bumps `agentEndCountBySession[id]` exactly once per agent_end,
-  // so this effect fires once per turn — no false positives from
-  // benign array-replacement refetches that would trip a length proxy.
-  const agentEndCount = useSessionStore((s) =>
-    activeSessionId !== undefined ? (s.agentEndCountBySession[activeSessionId] ?? 0) : 0,
-  );
-  const isStreaming = useSessionStore((s) =>
-    activeSessionId !== undefined ? (s.streamingBySession[activeSessionId] ?? false) : false,
+  // Refresh the file tree/editor tabs when the session store observes
+  // workspace mutations. `write` tool completions bump this immediately
+  // mid-turn; `agent_end` bumps it only for turns with no write calls so
+  // bash/MCP-side mutations still reconcile without double-loading after
+  // normal write-tool turns.
+  const fileRefreshCount = useSessionStore((s) =>
+    activeSessionId !== undefined ? (s.fileRefreshCountBySession[activeSessionId] ?? 0) : 0,
   );
   const loadFileTree = useFileStore((s) => s.loadTree);
   const restoreTabs = useFileStore((s) => s.restoreTabs);
   const refreshOpenFiles = useFileStore((s) => s.refreshOpenFiles);
-  // After every agent turn, reconcile the file browser tree AND the
-  // open editor tabs against on-disk state. Decoupled from
-  // tool-result inspection: this fires once per `agent_end` and
-  // catches every kind of change — built-in edit/write tools, MCP
-  // tools, terminal commands the agent shelled out to, git ops, etc.
-  // Refresh helper handles per-tab reconciliation (silent reload
-  // for clean buffers, externally-changed banner for dirty ones).
   useEffect(() => {
-    if (active === undefined || isStreaming) return;
+    if (active === undefined || fileRefreshCount === 0) return;
     void loadFileTree(active.id);
     void refreshOpenFiles(active.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active?.id, isStreaming, agentEndCount]);
+  }, [active?.id, fileRefreshCount]);
 
   // Re-open the editor tabs persisted for this project. No-op if any
   // tabs are already open, so a project hot-switch doesn't fight a

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -195,6 +195,10 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
   delete nextActiveTool[sessionId];
   const nextAgentEndCount = { ...current.agentEndCountBySession };
   delete nextAgentEndCount[sessionId];
+  const nextFileRefreshCount = { ...current.fileRefreshCountBySession };
+  delete nextFileRefreshCount[sessionId];
+  const nextTurnWriteCount = { ...current.turnWriteCountBySession };
+  delete nextTurnWriteCount[sessionId];
   const nextQueued = { ...current.queuedBySession };
   delete nextQueued[sessionId];
   const byProject: Record<string, UnifiedSession[]> = {};
@@ -208,6 +212,8 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
     streamingTextBySession: nextStreamingText,
     activeToolBySession: nextActiveTool,
     agentEndCountBySession: nextAgentEndCount,
+    fileRefreshCountBySession: nextFileRefreshCount,
+    turnWriteCountBySession: nextTurnWriteCount,
     queuedBySession: nextQueued,
     byProject,
     activeSessionId: current.activeSessionId === sessionId ? undefined : current.activeSessionId,
@@ -266,6 +272,16 @@ interface SessionState {
    * too. Cheap to compare; no allocations.
    */
   agentEndCountBySession: Record<string, number>;
+  /**
+   * Per-session monotonic counter for refreshing file browser/editor
+   * state. Incremented immediately when a `write` tool finishes so the
+   * file pane reflects agent-created files mid-turn. If a turn has no
+   * write calls, `agent_end` increments this counter as a catch-all for
+   * other possible workspace mutations (bash, MCP tools, etc.).
+   */
+  fileRefreshCountBySession: Record<string, number>;
+  /** Number of write tool completions observed in the current turn. */
+  turnWriteCountBySession: Record<string, number>;
   /**
    * Per-session monotonic counter incremented on every
    * `compaction_end` event. Mirrors `agentEndCountBySession` for
@@ -359,6 +375,8 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   streamingTextBySession: {},
   activeToolBySession: {},
   agentEndCountBySession: {},
+  fileRefreshCountBySession: {},
+  turnWriteCountBySession: {},
   compactionEndCountBySession: {},
   queuedBySession: {},
   pendingScrollByMessageIndex: {},
@@ -823,6 +841,7 @@ function applyEvent(
       streamingBySession: { ...s.streamingBySession, [sessionId]: true },
       streamingTextBySession: { ...s.streamingTextBySession, [sessionId]: "" },
       bannerBySession: { ...s.bannerBySession, [sessionId]: undefined },
+      turnWriteCountBySession: { ...s.turnWriteCountBySession, [sessionId]: 0 },
     }));
     return;
   }
@@ -872,6 +891,13 @@ function applyEvent(
               ...s.agentEndCountBySession,
               [sessionId]: (s.agentEndCountBySession[sessionId] ?? 0) + 1,
             },
+            fileRefreshCountBySession:
+              (s.turnWriteCountBySession[sessionId] ?? 0) === 0
+                ? {
+                    ...s.fileRefreshCountBySession,
+                    [sessionId]: (s.fileRefreshCountBySession[sessionId] ?? 0) + 1,
+                  }
+                : s.fileRefreshCountBySession,
           };
         });
       })
@@ -899,6 +925,13 @@ function applyEvent(
             ...s.agentEndCountBySession,
             [sessionId]: (s.agentEndCountBySession[sessionId] ?? 0) + 1,
           },
+          fileRefreshCountBySession:
+            (s.turnWriteCountBySession[sessionId] ?? 0) === 0
+              ? {
+                  ...s.fileRefreshCountBySession,
+                  [sessionId]: (s.fileRefreshCountBySession[sessionId] ?? 0) + 1,
+                }
+              : s.fileRefreshCountBySession,
         }));
       });
     return;
@@ -951,8 +984,21 @@ function applyEvent(
   }
 
   if (event.type === "tool_execution_end") {
+    const isWrite = isToolEventNamed(event, "write");
     set((s) => ({
       activeToolBySession: { ...s.activeToolBySession, [sessionId]: undefined },
+      ...(isWrite
+        ? {
+            fileRefreshCountBySession: {
+              ...s.fileRefreshCountBySession,
+              [sessionId]: (s.fileRefreshCountBySession[sessionId] ?? 0) + 1,
+            },
+            turnWriteCountBySession: {
+              ...s.turnWriteCountBySession,
+              [sessionId]: (s.turnWriteCountBySession[sessionId] ?? 0) + 1,
+            },
+          }
+        : {}),
     }));
     // Refetch so the toolResult message (and any updated assistant
     // bubble) shows up before the next tool fires. Without this the
@@ -1271,6 +1317,11 @@ function scheduleMessagesRefetch(
       refetchState.delete(sessionId);
     }
   });
+}
+
+/** True when an SSE tool event identifies a particular tool by name. */
+function isToolEventNamed(event: IncomingEvent, name: string): boolean {
+  return typeof event.toolName === "string" && event.toolName === name;
 }
 
 /**

--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -139,7 +139,7 @@ const TREE_SKIP_DIRS = new Set([
  */
 export const SEARCH_SKIP_DIRS: ReadonlySet<string> = TREE_SKIP_DIRS;
 
-const DEFAULT_TREE_DEPTH = 6;
+const DEFAULT_TREE_DEPTH = 32;
 
 /* ----------------------------- guards ----------------------------- */
 

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -309,8 +309,8 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
           "Recursive directory tree for the project. Skips noisy folders " +
           "(node_modules, .git, dist, build, __pycache__, .next, .nuxt, " +
           "coverage, .vite, .turbo, .cache). Default max depth 6 — deeper " +
-          "directories are returned with `truncated: true` so the UI can " +
-          "lazy-fetch them on demand.",
+          "directories are returned with `truncated: true`; callers may " +
+          "request a clamped `maxDepth` between 1 and 32.",
         tags: ["files"],
         querystring: {
           type: "object",

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -308,9 +308,8 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
         description:
           "Recursive directory tree for the project. Skips noisy folders " +
           "(node_modules, .git, dist, build, __pycache__, .next, .nuxt, " +
-          "coverage, .vite, .turbo, .cache). Default max depth 6 — deeper " +
-          "directories are returned with `truncated: true`; callers may " +
-          "request a clamped `maxDepth` between 1 and 32.",
+          "coverage, .vite, .turbo, .cache). Recursion is capped at " +
+          "max depth 32 to avoid unbounded filesystem walks.",
         tags: ["files"],
         querystring: {
           type: "object",
@@ -327,10 +326,10 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
       const project = await resolveProject(req.query.projectId, reply);
       if (project === undefined) return reply;
       try {
-        // Clamp client-supplied maxDepth to a sane window. The schema
-        // already gates on `^[0-9]+$`, so parseInt is safe; we cap at
-        // 32 because anything past that is either a misconfiguration
-        // or someone trying to force a deep recursion DoS.
+        // Clamp client-supplied maxDepth to the same hard cap used by
+        // the default tree load so callers cannot force unbounded
+        // recursion. The schema already gates on `^[0-9]+$`, so
+        // parseInt is safe.
         let maxDepth: number | undefined;
         if (req.query.maxDepth !== undefined) {
           const n = Number.parseInt(req.query.maxDepth, 10);

--- a/tests/test-files.ts
+++ b/tests/test-files.ts
@@ -117,6 +117,15 @@ function flattenTree(node: TreeNode): string[] {
   return out;
 }
 
+function findTreeNode(node: TreeNode, path: string): TreeNode | undefined {
+  if (node.path.replaceAll("\\", "/") === path) return node;
+  for (const child of node.children ?? []) {
+    const found = findTreeNode(child, path);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
 async function main(): Promise<void> {
   const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-ws-"));
   const configDir = await mkdtemp(join(tmpdir(), "pi-forge-cfg-"));
@@ -126,11 +135,14 @@ async function main(): Promise<void> {
   // Seed a project tree with the noisy dirs the route should skip.
   await mkdir(join(projectPath, "src"), { recursive: true });
   await mkdir(join(projectPath, "src", "deep"), { recursive: true });
+  const tooDeepDir = join(projectPath, "d1", "d2", "d3", "d4", "d5", "d6", "d7");
+  await mkdir(tooDeepDir, { recursive: true });
   await mkdir(join(projectPath, "node_modules", "fake-pkg"), { recursive: true });
   await mkdir(join(projectPath, ".git", "objects"), { recursive: true });
   await mkdir(join(projectPath, "dist"), { recursive: true });
   await fsWrite(join(projectPath, "src", "index.ts"), "export const x = 1;\n", "utf8");
   await fsWrite(join(projectPath, "src", "deep", "nested.txt"), "deep content\n", "utf8");
+  await fsWrite(join(tooDeepDir, "leaf.txt"), "too deep\n", "utf8");
   await symlink(join("src", "index.ts"), join(projectPath, "linked-index.ts"));
   await fsWrite(join(projectPath, "node_modules", "fake-pkg", "index.js"), "module.exports={};\n");
   await fsWrite(join(projectPath, ".git", "HEAD"), "ref: refs/heads/main\n");
@@ -212,7 +224,23 @@ async function main(): Promise<void> {
       );
       assert("tree EXCLUDES .git", !paths.some((p) => p.startsWith("directory:.git")));
       assert("tree EXCLUDES dist", !paths.some((p) => p.startsWith("directory:dist")));
+      const d6 = findTreeNode(tree, "d1/d2/d3/d4/d5/d6");
+      assert("tree default depth truncates level 6 directory", d6?.truncated === true);
+      assert(
+        "tree default depth excludes level 7 leaf",
+        !paths.includes("file:d1/d2/d3/d4/d5/d6/d7/leaf.txt"),
+      );
       assert("tree project_not_found → 404", true); // sanity: covered below
+    }
+    {
+      const r = await jget(
+        `${base}/api/v1/files/tree?projectId=${encodeURIComponent(projectId)}&maxDepth=2`,
+        auth,
+      );
+      assert("GET /files/tree?maxDepth=2 → 200", r.status === 200);
+      const tree = r.body as TreeNode;
+      const deep = findTreeNode(tree, "src/deep");
+      assert("tree honors maxDepth query", deep?.truncated === true);
     }
     {
       const r = await jget(

--- a/tests/test-files.ts
+++ b/tests/test-files.ts
@@ -135,14 +135,18 @@ async function main(): Promise<void> {
   // Seed a project tree with the noisy dirs the route should skip.
   await mkdir(join(projectPath, "src"), { recursive: true });
   await mkdir(join(projectPath, "src", "deep"), { recursive: true });
-  const tooDeepDir = join(projectPath, "d1", "d2", "d3", "d4", "d5", "d6", "d7");
-  await mkdir(tooDeepDir, { recursive: true });
+  const deepVisibleDir = join(projectPath, "d1", "d2", "d3", "d4", "d5", "d6", "d7");
+  await mkdir(deepVisibleDir, { recursive: true });
+  const cappedParts = Array.from({ length: 33 }, (_, i) => `cap${i + 1}`);
+  const cappedDir = join(projectPath, ...cappedParts);
+  await mkdir(cappedDir, { recursive: true });
   await mkdir(join(projectPath, "node_modules", "fake-pkg"), { recursive: true });
   await mkdir(join(projectPath, ".git", "objects"), { recursive: true });
   await mkdir(join(projectPath, "dist"), { recursive: true });
   await fsWrite(join(projectPath, "src", "index.ts"), "export const x = 1;\n", "utf8");
   await fsWrite(join(projectPath, "src", "deep", "nested.txt"), "deep content\n", "utf8");
-  await fsWrite(join(tooDeepDir, "leaf.txt"), "too deep\n", "utf8");
+  await fsWrite(join(deepVisibleDir, "leaf.txt"), "visible deep leaf\n", "utf8");
+  await fsWrite(join(cappedDir, "leaf.txt"), "capped leaf\n", "utf8");
   await symlink(join("src", "index.ts"), join(projectPath, "linked-index.ts"));
   await fsWrite(join(projectPath, "node_modules", "fake-pkg", "index.js"), "module.exports={};\n");
   await fsWrite(join(projectPath, ".git", "HEAD"), "ref: refs/heads/main\n");
@@ -224,23 +228,27 @@ async function main(): Promise<void> {
       );
       assert("tree EXCLUDES .git", !paths.some((p) => p.startsWith("directory:.git")));
       assert("tree EXCLUDES dist", !paths.some((p) => p.startsWith("directory:dist")));
-      const d6 = findTreeNode(tree, "d1/d2/d3/d4/d5/d6");
-      assert("tree default depth truncates level 6 directory", d6?.truncated === true);
       assert(
-        "tree default depth excludes level 7 leaf",
-        !paths.includes("file:d1/d2/d3/d4/d5/d6/d7/leaf.txt"),
+        "tree default depth includes level 7 leaf",
+        paths.includes("file:d1/d2/d3/d4/d5/d6/d7/leaf.txt"),
+      );
+      const cap32 = findTreeNode(tree, cappedParts.slice(0, 32).join("/"));
+      assert("tree default depth caps at level 32", cap32?.truncated === true);
+      assert(
+        "tree default depth excludes level 33 leaf",
+        !paths.includes(`file:${cappedParts.join("/")}/leaf.txt`),
       );
       assert("tree project_not_found → 404", true); // sanity: covered below
     }
     {
       const r = await jget(
-        `${base}/api/v1/files/tree?projectId=${encodeURIComponent(projectId)}&maxDepth=2`,
+        `${base}/api/v1/files/tree?projectId=${encodeURIComponent(projectId)}&maxDepth=999`,
         auth,
       );
-      assert("GET /files/tree?maxDepth=2 → 200", r.status === 200);
+      assert("GET /files/tree?maxDepth=999 → 200", r.status === 200);
       const tree = r.body as TreeNode;
-      const deep = findTreeNode(tree, "src/deep");
-      assert("tree honors maxDepth query", deep?.truncated === true);
+      const cap32 = findTreeNode(tree, cappedParts.slice(0, 32).join("/"));
+      assert("tree clamps requested maxDepth to 32", cap32?.truncated === true);
     }
     {
       const r = await jget(


### PR DESCRIPTION
## Summary

The file browser only refreshed after an agent turn ended, so files created by the agent's `write` tool could stay missing from the file pane until the full session completed. This PR adds a session-store refresh signal that fires as soon as a `write` tool execution ends, while keeping a once-per-turn fallback for non-`write` workspace mutations.

The side-panel file tree already had bounded recursion, but its default depth was low. This PR raises the default to the hard cap of 32 and keeps `maxDepth` clamped at 32 to avoid unbounded filesystem walks without treating normal deep project folders as a UX truncation case.

## Usage

No new user-facing controls are required.

Behavior after this change:

- Agent/session `write` tool completion refreshes the file tree and reconciles open editor tabs immediately.
- Turns with no `write` calls still refresh files once on `agent_end` as a catch-all for bash/MCP/external mutations.
- `GET /api/v1/files/tree?projectId=<id>` defaults to depth 32.
- `GET /api/v1/files/tree?projectId=<id>&maxDepth=<n>` remains accepted and is clamped to `1..32`.

## What changed (6 files, +105/-28)

- `packages/client/src/store/session-store.ts` — added `fileRefreshCountBySession` and per-turn write tracking; bumps file refresh state on completed `write` tool calls and falls back on `agent_end` only when no write ran.
- `packages/client/src/App.tsx` — switched file tree/open-tab reconciliation to the new file-refresh counter instead of waiting on streaming/agent-end state.
- `packages/server/src/file-manager.ts` — raised the default tree depth cap from 6 to 32.
- `packages/server/src/routes/files.ts` — updated `/files/tree` docs/comments to describe the 32-level recursion safety cap and preserve request clamping.
- `docs/agent/filesystem.md` — documented the 32-level cap and `maxDepth` clamp.
- `tests/test-files.ts` — added coverage for default depth 32, maxDepth clamping, and preservation of traversal/symlink protections in the existing file-route test.

## Test plan

- [x] `npm run build`
- [x] `npx tsx tests/test-files.ts`
- [x] `npm run check`
- [ ] CI green before merge

## Risks

- The immediate refresh depends on SSE `tool_execution_end` events carrying `toolName: "write"`; SDK/provider variants that only emit `tool_result` will still refresh at `agent_end` via the fallback.
- Raising the default file-tree depth to 32 may load more nested folders than before, but recursion remains bounded and noisy directories are still skipped.
