### PR TITLE
feat: add sandbox tool env settings

### DIFF
--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -10,6 +10,7 @@ import {
   type ProvidersListing,
   type PromptSummary,
   type SkillDiagnostic,
+  type SandboxSettingsResponse,
   type SkillSummary,
   type ToolListing,
 } from "../lib/api-client";
@@ -28,6 +29,7 @@ type Tab =
   | "agent"
   | "mcp"
   | "tools"
+  | "sandbox"
   | "skills"
   | "prompts"
   | "systemPrompt"
@@ -88,6 +90,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
             "prompts",
             "systemPrompt",
             "tools",
+            "sandbox",
             "quickActions",
             "appearance",
             "backup",
@@ -98,6 +101,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
             "agent",
             "mcp",
             "tools",
+            "sandbox",
             "skills",
             "prompts",
             "systemPrompt",
@@ -170,21 +174,23 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
                         ? "MCP"
                         : t === "tools"
                           ? "Tools"
-                          : t === "skills"
-                            ? "Skills"
-                            : t === "prompts"
-                              ? "Prompts"
-                              : t === "systemPrompt"
-                                ? "System Prompt"
-                                : t === "quickActions"
-                                  ? "Quick Actions"
-                                  : t === "webhooks"
-                                    ? "Webhooks"
-                                    : t === "appearance"
-                                      ? "Appearance"
-                                      : t === "backup"
-                                        ? "Backup"
-                                        : "General"}
+                          : t === "sandbox"
+                            ? "Sandbox"
+                            : t === "skills"
+                              ? "Skills"
+                              : t === "prompts"
+                                ? "Prompts"
+                                : t === "systemPrompt"
+                                  ? "System Prompt"
+                                  : t === "quickActions"
+                                    ? "Quick Actions"
+                                    : t === "webhooks"
+                                      ? "Webhooks"
+                                      : t === "appearance"
+                                        ? "Appearance"
+                                        : t === "backup"
+                                          ? "Backup"
+                                          : "General"}
                 </button>
               ))}
             </div>
@@ -233,6 +239,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           {tab === "agent" && <AgentTab onError={setError} />}
           {tab === "mcp" && <McpTab onError={setError} />}
           {tab === "tools" && <ToolsTab onError={setError} />}
+          {tab === "sandbox" && <SandboxTab onError={setError} />}
           {tab === "skills" && <SkillsTab onError={setError} />}
           {tab === "prompts" && <PromptsTab onError={setError} />}
           {tab === "systemPrompt" && <SystemPromptTab onError={setError} />}
@@ -1453,6 +1460,147 @@ function AddOverrideDropdown({
         Cancel
       </button>
     </div>
+  );
+}
+
+// ---------------- Sandbox tab ----------------
+
+function envToText(toolEnv: Record<string, string>): string {
+  return Object.entries(toolEnv)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join("\n");
+}
+
+function parseEnvText(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [idx, rawLine] of text.split(/\r?\n/).entries()) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) throw new Error(`Line ${idx + 1}: expected NAME=value`);
+    const name = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new Error(`Line ${idx + 1}: invalid environment variable name`);
+    }
+    out[name] = value;
+  }
+  return out;
+}
+
+function SandboxTab({ onError }: { onError: (msg: string | undefined) => void }) {
+  const [settings, setSettings] = useState<SandboxSettingsResponse | undefined>(undefined);
+  const [envText, setEnvText] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    api
+      .getSandboxSettings()
+      .then((res) => {
+        if (cancelled) return;
+        setSettings(res);
+        setEnvText(envToText(res.toolEnv));
+        onError(undefined);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) onError(errorCode(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [onError]);
+
+  async function submit(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    setSaved(false);
+    let parsed: Record<string, string>;
+    try {
+      parsed = parseEnvText(envText);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await api.updateSandboxSettings(parsed);
+      setSettings(res);
+      setEnvText(envToText(res.toolEnv));
+      onError(undefined);
+      setSaved(true);
+    } catch (err) {
+      onError(errorCode(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-neutral-100">Sandbox mode</h2>
+        <p className="mt-1 text-xs text-neutral-400">
+          Configure environment variables injected into future agent tool calls. Sandbox enablement
+          and UID/GID are deploy-time settings; changes here take effect for new or refreshed
+          sessions.
+        </p>
+      </div>
+
+      <div className="rounded border border-neutral-800 bg-neutral-950 p-3 text-xs text-neutral-300">
+        {loading ? (
+          <span className="text-neutral-500">Loading sandbox settings…</span>
+        ) : settings?.enabled ? (
+          <span>
+            Enabled{settings.uid !== undefined ? ` · uid ${settings.uid}` : ""}
+            {settings.gid !== undefined ? ` · gid ${settings.gid}` : ""}
+          </span>
+        ) : (
+          <span className="text-amber-300">
+            Sandbox tool overrides are disabled. Saved variables are persisted, but only injected
+            into forge-managed tool shells; full filesystem sandboxing requires
+            AGENT_TOOL_SANDBOX_ENABLED=true.
+          </span>
+        )}
+      </div>
+
+      <label className="block">
+        <span className="text-xs font-medium text-neutral-300">Tool environment</span>
+        <textarea
+          value={envText}
+          onChange={(e) => {
+            setEnvText(e.target.value);
+            setSaved(false);
+          }}
+          rows={12}
+          spellCheck={false}
+          placeholder={"HTTP_PROXY=http://proxy.internal:8080\nNO_COLOR=1"}
+          className="mt-2 w-full rounded border border-neutral-800 bg-neutral-950 px-3 py-2 font-mono text-xs text-neutral-100 outline-none focus:border-neutral-600"
+        />
+      </label>
+      <p className="text-xs text-neutral-500">
+        Use one <code>NAME=value</code> entry per line. Blank lines and <code># comments</code> are
+        ignored. Values are stored in pi-forge data, so avoid secrets unless that storage is
+        protected.
+      </p>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={loading || saving}
+          className="rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-500 disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Save sandbox env"}
+        </button>
+        {saved && <span className="text-xs text-green-400">Saved</span>}
+      </div>
+    </form>
   );
 }
 

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -1465,33 +1465,35 @@ function AddOverrideDropdown({
 
 // ---------------- Sandbox tab ----------------
 
-function envToText(toolEnv: Record<string, string>): string {
-  return Object.entries(toolEnv)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${k}=${v}`)
-    .join("\n");
+interface SandboxEnvRow {
+  id: string;
+  name: string;
+  value: string;
+  revealed: boolean;
 }
 
-function parseEnvText(text: string): Record<string, string> {
+function sandboxRowsFromEnv(toolEnv: Record<string, string>): SandboxEnvRow[] {
+  return Object.entries(toolEnv)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, value]) => ({ id: crypto.randomUUID(), name, value, revealed: false }));
+}
+
+function sandboxRowsToEnv(rows: readonly SandboxEnvRow[]): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const [idx, rawLine] of text.split(/\r?\n/).entries()) {
-    const line = rawLine.trim();
-    if (line.length === 0 || line.startsWith("#")) continue;
-    const eq = line.indexOf("=");
-    if (eq <= 0) throw new Error(`Line ${idx + 1}: expected NAME=value`);
-    const name = line.slice(0, eq).trim();
-    const value = line.slice(eq + 1);
+  for (const [idx, row] of rows.entries()) {
+    const name = row.name.trim();
+    if (name.length === 0 && row.value.length === 0) continue;
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
-      throw new Error(`Line ${idx + 1}: invalid environment variable name`);
+      throw new Error(`Row ${idx + 1}: invalid environment variable name`);
     }
-    out[name] = value;
+    out[name] = row.value;
   }
   return out;
 }
 
 function SandboxTab({ onError }: { onError: (msg: string | undefined) => void }) {
   const [settings, setSettings] = useState<SandboxSettingsResponse | undefined>(undefined);
-  const [envText, setEnvText] = useState("");
+  const [rows, setRows] = useState<SandboxEnvRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -1504,7 +1506,7 @@ function SandboxTab({ onError }: { onError: (msg: string | undefined) => void })
       .then((res) => {
         if (cancelled) return;
         setSettings(res);
-        setEnvText(envToText(res.toolEnv));
+        setRows(sandboxRowsFromEnv(res.toolEnv));
         onError(undefined);
       })
       .catch((err: unknown) => {
@@ -1523,7 +1525,7 @@ function SandboxTab({ onError }: { onError: (msg: string | undefined) => void })
     setSaved(false);
     let parsed: Record<string, string>;
     try {
-      parsed = parseEnvText(envText);
+      parsed = sandboxRowsToEnv(rows);
     } catch (err) {
       onError(err instanceof Error ? err.message : String(err));
       return;
@@ -1532,7 +1534,7 @@ function SandboxTab({ onError }: { onError: (msg: string | undefined) => void })
     try {
       const res = await api.updateSandboxSettings(parsed);
       setSettings(res);
-      setEnvText(envToText(res.toolEnv));
+      setRows(sandboxRowsFromEnv(res.toolEnv));
       onError(undefined);
       setSaved(true);
     } catch (err) {
@@ -1570,24 +1572,88 @@ function SandboxTab({ onError }: { onError: (msg: string | undefined) => void })
         )}
       </div>
 
-      <label className="block">
-        <span className="text-xs font-medium text-neutral-300">Tool environment</span>
-        <textarea
-          value={envText}
-          onChange={(e) => {
-            setEnvText(e.target.value);
-            setSaved(false);
-          }}
-          rows={12}
-          spellCheck={false}
-          placeholder={"HTTP_PROXY=http://proxy.internal:8080\nNO_COLOR=1"}
-          className="mt-2 w-full rounded border border-neutral-800 bg-neutral-950 px-3 py-2 font-mono text-xs text-neutral-100 outline-none focus:border-neutral-600"
-        />
-      </label>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-xs font-medium text-neutral-300">Tool environment</span>
+          <button
+            type="button"
+            onClick={() => {
+              setRows((current) => [
+                ...current,
+                { id: crypto.randomUUID(), name: "", value: "", revealed: false },
+              ]);
+              setSaved(false);
+            }}
+            className="rounded border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:border-neutral-500"
+          >
+            Add variable
+          </button>
+        </div>
+        <div className="space-y-2">
+          {rows.length === 0 && (
+            <div className="rounded border border-dashed border-neutral-800 px-3 py-4 text-xs text-neutral-500">
+              No sandbox tool environment variables configured.
+            </div>
+          )}
+          {rows.map((row) => (
+            <div
+              key={row.id}
+              className="grid gap-2 rounded border border-neutral-800 p-2 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_auto_auto]"
+            >
+              <input
+                value={row.name}
+                onChange={(e) => {
+                  const name = e.target.value;
+                  setRows((current) => current.map((r) => (r.id === row.id ? { ...r, name } : r)));
+                  setSaved(false);
+                }}
+                placeholder="HTTP_PROXY"
+                spellCheck={false}
+                className="rounded border border-neutral-800 bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 outline-none focus:border-neutral-600"
+                aria-label="Environment variable name"
+              />
+              <input
+                value={row.value}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setRows((current) => current.map((r) => (r.id === row.id ? { ...r, value } : r)));
+                  setSaved(false);
+                }}
+                type={row.revealed ? "text" : "password"}
+                placeholder="value"
+                spellCheck={false}
+                autoComplete="off"
+                className="rounded border border-neutral-800 bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 outline-none focus:border-neutral-600"
+                aria-label="Environment variable value"
+              />
+              <button
+                type="button"
+                onClick={() =>
+                  setRows((current) =>
+                    current.map((r) => (r.id === row.id ? { ...r, revealed: !r.revealed } : r)),
+                  )
+                }
+                className="rounded border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:border-neutral-500"
+              >
+                {row.revealed ? "Hide" : "Reveal"}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setRows((current) => current.filter((r) => r.id !== row.id));
+                  setSaved(false);
+                }}
+                className="rounded border border-red-900/60 px-2 py-1 text-xs text-red-300 hover:border-red-700"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
       <p className="text-xs text-neutral-500">
-        Use one <code>NAME=value</code> entry per line. Blank lines and <code># comments</code> are
-        ignored. Values are stored in pi-forge data, so avoid secrets unless that storage is
-        protected.
+        Values are masked by default and only revealed per row. They are still stored in pi-forge
+        data and passed to tool processes, so avoid secrets unless that storage is protected.
       </p>
 
       <div className="flex items-center gap-3">

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -25,6 +25,7 @@ import {
   type BrowseEntry,
   type BrowseResponse,
   type HealthResponse,
+  type SandboxSettingsResponse,
   type UiConfigResponse,
   type UnifiedSession,
   type SessionSummary,
@@ -157,6 +158,21 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
     passwordAuthEnabled,
     orchestrationEnabled,
   };
+}
+
+function vSandboxSettings(value: unknown, status: number): SandboxSettingsResponse {
+  if (!isObject(value) || typeof value.enabled !== "boolean" || !isObject(value.toolEnv)) {
+    fail(status, "expected SandboxSettingsResponse");
+  }
+  const toolEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value.toolEnv)) {
+    if (typeof v !== "string") fail(status, "toolEnv values must be strings");
+    toolEnv[k] = v;
+  }
+  const out: SandboxSettingsResponse = { enabled: value.enabled, toolEnv };
+  if (typeof value.uid === "number") out.uid = value.uid;
+  if (typeof value.gid === "number") out.gid = value.gid;
+  return out;
 }
 
 function vHealth(value: unknown, status: number): HealthResponse {
@@ -1858,6 +1874,12 @@ export const api = {
   getSettings: () => request("/api/v1/config/settings", vSettings),
   updateSettings: (patch: Record<string, unknown>) =>
     request("/api/v1/config/settings", vSettings, { method: "PUT", body: patch }),
+  getSandboxSettings: () => request("/api/v1/config/sandbox", vSandboxSettings),
+  updateSandboxSettings: (toolEnv: Record<string, string>) =>
+    request("/api/v1/config/sandbox", vSandboxSettings, {
+      method: "PUT",
+      body: { toolEnv },
+    }),
   getAuthSummary: () => request("/api/v1/config/auth", vAuthSummary),
   setApiKey: (provider: string, apiKey: string) =>
     request(

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -258,6 +258,13 @@ export interface HealthResponse {
   activePtys: number;
 }
 
+export interface SandboxSettingsResponse {
+  enabled: boolean;
+  uid?: number;
+  gid?: number;
+  toolEnv: Record<string, string>;
+}
+
 export interface UiConfigResponse {
   /** Frontend "minimal" mode — see server config.minimalUi. */
   minimal: boolean;

--- a/packages/server/src/agent-bash-operations.ts
+++ b/packages/server/src/agent-bash-operations.ts
@@ -2,19 +2,23 @@ import { spawn } from "node:child_process";
 import type { BashOperations } from "@earendil-works/pi-coding-agent";
 import { config } from "./config.js";
 import { scrubbedEnv } from "./pty-manager.js";
+import { mergeToolEnv } from "./sandbox-settings.js";
 
 export function sandboxSpawnIdentity(): { uid?: number; gid?: number } {
   if (!config.agentToolSandbox.enabled) return {};
   return { uid: config.agentToolSandbox.uid!, gid: config.agentToolSandbox.gid! };
 }
 
-export function createForgeBashOperations(workspacePath: string): BashOperations {
+export function createForgeBashOperations(
+  workspacePath: string,
+  toolEnv: Record<string, string> = {},
+): BashOperations {
   return {
     exec: (command, _cwd, options) => {
       return new Promise<{ exitCode: number | null }>((resolve, reject) => {
         const proc = spawn("/bin/sh", ["-c", command], {
           cwd: workspacePath,
-          env: scrubbedEnv(),
+          env: mergeToolEnv(scrubbedEnv(), toolEnv),
           stdio: ["ignore", "pipe", "pipe"],
           ...sandboxSpawnIdentity(),
         });

--- a/packages/server/src/agent-tool-overrides.ts
+++ b/packages/server/src/agent-tool-overrides.ts
@@ -24,7 +24,10 @@ function guard(workspacePath: string, absolutePath: string): string {
   return resolveAgentToolPath(workspacePath, absolutePath);
 }
 
-export function createSandboxedToolDefinitions(workspacePath: string): ToolDefinition[] {
+export function createSandboxedToolDefinitions(
+  workspacePath: string,
+  toolEnv: Record<string, string> = {},
+): ToolDefinition[] {
   const readOps: ReadOperations = {
     readFile: async (absolutePath) => readFile(guard(workspacePath, absolutePath)),
     access: async (absolutePath) => access(guard(workspacePath, absolutePath)),
@@ -107,7 +110,7 @@ export function createSandboxedToolDefinitions(workspacePath: string): ToolDefin
     createEditToolDefinition(workspacePath, { operations: editOps }),
     createWriteToolDefinition(workspacePath, { operations: writeOps }),
     createBashToolDefinition(workspacePath, {
-      operations: createForgeBashOperations(workspacePath),
+      operations: createForgeBashOperations(workspacePath, toolEnv),
     }),
   ] as unknown as ToolDefinition[];
 }

--- a/packages/server/src/agent-tool-policy.ts
+++ b/packages/server/src/agent-tool-policy.ts
@@ -91,11 +91,9 @@ export function resolveAgentToolPath(workspacePath: string, requestedPath: strin
   if (requestedPath.trim() === "") {
     throw new AgentToolPathDeniedError("empty path is not allowed");
   }
-  const workspaceReal = realpathExistingOrParent(resolve(workspacePath));
-  const piConfigResolved = resolve(config.piConfigDir);
-  const piConfigReal = realpathExistingOrParent(piConfigResolved);
-  const forgeDataResolved = resolve(config.forgeDataDir);
-  const forgeDataReal = realpathExistingOrParent(forgeDataResolved);
+  const workspaceReal = realpathExistingOrParent(resolve(config.workspacePath));
+  const piConfigReal = realpathExistingOrParent(resolve(config.piConfigDir));
+  const forgeDataReal = realpathExistingOrParent(resolve(config.forgeDataDir));
   const baseResolved = isAbsolute(requestedPath)
     ? resolve(requestedPath)
     : resolve(workspacePath, requestedPath);
@@ -103,20 +101,16 @@ export function resolveAgentToolPath(workspacePath: string, requestedPath: strin
 
   denyIfSensitiveAbsolute(baseResolved, workspaceReal, piConfigReal);
   denyIfSensitiveAbsolute(resolvedReal, workspaceReal, piConfigReal);
-  if (
-    pathWithin(baseResolved, forgeDataResolved) ||
-    pathWithin(baseResolved, forgeDataReal) ||
-    pathWithin(resolvedReal, forgeDataReal)
-  ) {
+  if (pathWithin(baseResolved, forgeDataReal) || pathWithin(resolvedReal, forgeDataReal)) {
     throw new AgentToolPathDeniedError(`${baseResolved} is inside FORGE_DATA_DIR`);
   }
 
-  const isPiConfigPath = assertPiConfigPathAllowed(baseResolved, resolvedReal, piConfigResolved);
+  const isPiConfigPath = assertPiConfigPathAllowed(baseResolved, resolvedReal, piConfigReal);
 
   if (pathWithin(resolvedReal, workspaceReal)) return baseResolved;
 
   if (isPiConfigPath) {
-    const rel = piConfigRelativePath(baseResolved, resolvedReal, piConfigResolved);
+    const rel = piConfigRelativePath(baseResolved, resolvedReal, piConfigReal);
     if (rel === undefined) {
       throw new AgentToolPathDeniedError(`${baseResolved} is outside PI_CONFIG_DIR`);
     }

--- a/packages/server/src/agent-tool-policy.ts
+++ b/packages/server/src/agent-tool-policy.ts
@@ -91,9 +91,11 @@ export function resolveAgentToolPath(workspacePath: string, requestedPath: strin
   if (requestedPath.trim() === "") {
     throw new AgentToolPathDeniedError("empty path is not allowed");
   }
-  const workspaceReal = realpathExistingOrParent(resolve(config.workspacePath));
-  const piConfigReal = realpathExistingOrParent(resolve(config.piConfigDir));
-  const forgeDataReal = realpathExistingOrParent(resolve(config.forgeDataDir));
+  const workspaceReal = realpathExistingOrParent(resolve(workspacePath));
+  const piConfigResolved = resolve(config.piConfigDir);
+  const piConfigReal = realpathExistingOrParent(piConfigResolved);
+  const forgeDataResolved = resolve(config.forgeDataDir);
+  const forgeDataReal = realpathExistingOrParent(forgeDataResolved);
   const baseResolved = isAbsolute(requestedPath)
     ? resolve(requestedPath)
     : resolve(workspacePath, requestedPath);
@@ -101,16 +103,20 @@ export function resolveAgentToolPath(workspacePath: string, requestedPath: strin
 
   denyIfSensitiveAbsolute(baseResolved, workspaceReal, piConfigReal);
   denyIfSensitiveAbsolute(resolvedReal, workspaceReal, piConfigReal);
-  if (pathWithin(baseResolved, forgeDataReal) || pathWithin(resolvedReal, forgeDataReal)) {
+  if (
+    pathWithin(baseResolved, forgeDataResolved) ||
+    pathWithin(baseResolved, forgeDataReal) ||
+    pathWithin(resolvedReal, forgeDataReal)
+  ) {
     throw new AgentToolPathDeniedError(`${baseResolved} is inside FORGE_DATA_DIR`);
   }
 
-  const isPiConfigPath = assertPiConfigPathAllowed(baseResolved, resolvedReal, piConfigReal);
+  const isPiConfigPath = assertPiConfigPathAllowed(baseResolved, resolvedReal, piConfigResolved);
 
   if (pathWithin(resolvedReal, workspaceReal)) return baseResolved;
 
   if (isPiConfigPath) {
-    const rel = piConfigRelativePath(baseResolved, resolvedReal, piConfigReal);
+    const rel = piConfigRelativePath(baseResolved, resolvedReal, piConfigResolved);
     if (rel === undefined) {
       throw new AgentToolPathDeniedError(`${baseResolved} is outside PI_CONFIG_DIR`);
     }

--- a/packages/server/src/processes/manager.ts
+++ b/packages/server/src/processes/manager.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { sandboxSpawnIdentity } from "../agent-bash-operations.js";
 import { config } from "../config.js";
 import { scrubbedEnv } from "../pty-manager.js";
+import { mergeToolEnv } from "../sandbox-settings.js";
 import { LogChannel, processLogDir } from "./log-store.js";
 import { buildMatchEvent, compileWatches, evaluateWatches, type CompiledWatch } from "./watches.js";
 import {
@@ -105,7 +106,7 @@ class ProcessManagerRegistry {
     // secrets leak to the child.
     const child = spawn("/bin/sh", ["-c", command], {
       cwd,
-      env: scrubbedEnv(),
+      env: mergeToolEnv(scrubbedEnv(), opts.toolEnv ?? {}),
       stdio: ["pipe", "pipe", "pipe"],
       ...sandboxSpawnIdentity(),
       // Put each managed command in its own process group. The

--- a/packages/server/src/processes/tool.ts
+++ b/packages/server/src/processes/tool.ts
@@ -152,7 +152,11 @@ function validateLogWatches(watches: LogWatch[] | undefined): string | null {
  * is independent; see `manager.ts` for the spawn/lifecycle code
  * and `docs/processes.md` for the cross-reference.
  */
-export function createProcessTool(sessionId: string, workspacePath: string): ToolDefinition {
+export function createProcessTool(
+  sessionId: string,
+  workspacePath: string,
+  toolEnv: Record<string, string> = {},
+): ToolDefinition {
   return {
     name: TOOL_NAME,
     label: TOOL_LABEL,
@@ -164,7 +168,7 @@ export function createProcessTool(sessionId: string, workspacePath: string): Too
       const p = params as ToolParams;
       switch (p.action) {
         case "start":
-          return executeStart(sessionId, workspacePath, p);
+          return executeStart(sessionId, workspacePath, p, toolEnv);
         case "list":
           return executeList(sessionId);
         case "output":
@@ -184,7 +188,12 @@ export function createProcessTool(sessionId: string, workspacePath: string): Too
   } satisfies ToolDefinition;
 }
 
-function executeStart(sessionId: string, workspacePath: string, p: ToolParams): ExecuteResult {
+function executeStart(
+  sessionId: string,
+  workspacePath: string,
+  p: ToolParams,
+  toolEnv: Record<string, string>,
+): ExecuteResult {
   // Defense in depth — the client also hides the tool under
   // MINIMAL_UI, but a stale tab or scripted caller could still
   // invoke it. Refuse at the tool boundary.
@@ -207,6 +216,7 @@ function executeStart(sessionId: string, workspacePath: string, p: ToolParams): 
     if (p.alertOnFailure !== undefined) startOpts.alertOnFailure = p.alertOnFailure;
     if (p.alertOnKill !== undefined) startOpts.alertOnKill = p.alertOnKill;
     if (p.logWatches !== undefined) startOpts.logWatches = p.logWatches;
+    startOpts.toolEnv = toolEnv;
     info = processManager.start(sessionId, p.name, p.command, workspacePath, startOpts);
   } catch (e) {
     return err("start", `Failed to start: ${e instanceof Error ? e.message : String(e)}`);

--- a/packages/server/src/processes/types.ts
+++ b/packages/server/src/processes/types.ts
@@ -82,6 +82,7 @@ export interface StartOptions {
   alertOnFailure?: boolean;
   alertOnKill?: boolean;
   logWatches?: LogWatch[];
+  toolEnv?: Record<string, string>;
 }
 
 /**

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -19,6 +19,7 @@ import {
   writeModelsJson,
   type ModelsJson,
 } from "../config-manager.js";
+import { config } from "../config.js";
 import { buildExportTar, importConfigFromBuffer, MAX_IMPORT_BYTES } from "../config-export.js";
 import {
   buildSkillsExportTar,
@@ -44,6 +45,11 @@ import {
   type ToolOverrideState,
 } from "../tool-overrides.js";
 import { getProject } from "../project-manager.js";
+import {
+  readSandboxSettings,
+  validateSandboxToolEnv,
+  writeSandboxSettings,
+} from "../sandbox-settings.js";
 import { errorSchema } from "./_schemas.js";
 
 const modelsJsonSchema = {
@@ -71,6 +77,27 @@ const settingsSchema = {
     defaultThinkingLevel: { type: ["string", "null"] },
     skills: { type: ["array", "null"], items: { type: "string" } },
     enableSkillCommands: { type: ["boolean", "null"] },
+  },
+} as const;
+
+const sandboxSettingsSchema = {
+  type: "object",
+  required: ["enabled", "toolEnv"],
+  additionalProperties: false,
+  properties: {
+    enabled: { type: "boolean" },
+    uid: { type: "integer" },
+    gid: { type: "integer" },
+    toolEnv: { type: "object", additionalProperties: { type: "string" } },
+  },
+} as const;
+
+const sandboxSettingsBodySchema = {
+  type: "object",
+  required: ["toolEnv"],
+  additionalProperties: false,
+  properties: {
+    toolEnv: { type: "object", additionalProperties: { type: "string" } },
   },
 } as const;
 
@@ -321,6 +348,67 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
     async (req, reply) => {
       try {
         return await updateSettings(req.body);
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  // ---------------------- sandbox settings ----------------------
+  fastify.get(
+    "/config/sandbox",
+    {
+      schema: {
+        description:
+          "Read sandbox mode status and the persisted environment variables injected into agent tool calls.",
+        tags: ["config"],
+        response: { 200: sandboxSettingsSchema, 500: errorSchema },
+      },
+    },
+    async (_req, reply) => {
+      try {
+        const settings = await readSandboxSettings();
+        return {
+          enabled: config.agentToolSandbox.enabled,
+          uid: config.agentToolSandbox.uid,
+          gid: config.agentToolSandbox.gid,
+          toolEnv: settings.toolEnv,
+        };
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  fastify.put<{ Body: { toolEnv: Record<string, string> } }>(
+    "/config/sandbox",
+    {
+      schema: {
+        description:
+          "Replace the persisted environment variables injected into future agent tool calls. Sandbox enablement and UID/GID remain deploy-time configuration.",
+        tags: ["config"],
+        body: sandboxSettingsBodySchema,
+        response: { 200: sandboxSettingsSchema, 400: errorSchema, 500: errorSchema },
+      },
+    },
+    async (req, reply) => {
+      let toolEnv: Record<string, string>;
+      try {
+        toolEnv = validateSandboxToolEnv(req.body.toolEnv);
+      } catch (err) {
+        return reply.code(400).send({
+          error: "invalid_sandbox_settings",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+      try {
+        const settings = await writeSandboxSettings({ toolEnv });
+        return {
+          enabled: config.agentToolSandbox.enabled,
+          uid: config.agentToolSandbox.uid,
+          gid: config.agentToolSandbox.gid,
+          toolEnv: settings.toolEnv,
+        };
       } catch (err) {
         return internalError(reply, err);
       }

--- a/packages/server/src/sandbox-settings.ts
+++ b/packages/server/src/sandbox-settings.ts
@@ -1,0 +1,89 @@
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { config } from "./config.js";
+import { makeLock } from "./concurrency.js";
+
+const SANDBOX_SETTINGS_FILE = (): string => join(config.forgeDataDir, "sandbox-settings.json");
+const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const MAX_ENV_VARS = 100;
+const MAX_ENV_VALUE_BYTES = 16 * 1024;
+
+export interface SandboxSettings {
+  toolEnv: Record<string, string>;
+}
+
+const lock = makeLock();
+
+async function ensureDataDir(): Promise<void> {
+  await mkdir(config.forgeDataDir, { recursive: true });
+}
+
+async function atomicWriteJson(path: string, data: unknown): Promise<void> {
+  await ensureDataDir();
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
+}
+
+function normalizeToolEnv(input: unknown): Record<string, string> {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return {};
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(input)) {
+    if (!ENV_NAME_RE.test(name)) continue;
+    if (typeof value !== "string") continue;
+    if (Buffer.byteLength(value, "utf8") > MAX_ENV_VALUE_BYTES) continue;
+    out[name] = value;
+    if (Object.keys(out).length >= MAX_ENV_VARS) break;
+  }
+  return out;
+}
+
+export function validateSandboxToolEnv(input: Record<string, string>): Record<string, string> {
+  const entries = Object.entries(input);
+  if (entries.length > MAX_ENV_VARS) {
+    throw new Error(`too many environment variables (max ${MAX_ENV_VARS})`);
+  }
+  const out: Record<string, string> = {};
+  for (const [name, value] of entries) {
+    if (!ENV_NAME_RE.test(name)) {
+      throw new Error(`invalid environment variable name: ${name}`);
+    }
+    if (Buffer.byteLength(value, "utf8") > MAX_ENV_VALUE_BYTES) {
+      throw new Error(`environment variable ${name} exceeds ${MAX_ENV_VALUE_BYTES} bytes`);
+    }
+    out[name] = value;
+  }
+  return out;
+}
+
+export async function readSandboxSettings(): Promise<SandboxSettings> {
+  return lock(async () => {
+    try {
+      const raw = await readFile(SANDBOX_SETTINGS_FILE(), "utf8");
+      const parsed = JSON.parse(raw) as { toolEnv?: unknown };
+      return { toolEnv: normalizeToolEnv(parsed.toolEnv) };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return { toolEnv: {} };
+      throw err;
+    }
+  });
+}
+
+export async function writeSandboxSettings(settings: SandboxSettings): Promise<SandboxSettings> {
+  const safe: SandboxSettings = { toolEnv: validateSandboxToolEnv(settings.toolEnv) };
+  await lock(async () => atomicWriteJson(SANDBOX_SETTINGS_FILE(), safe));
+  return safe;
+}
+
+export function mergeToolEnv(
+  base: Record<string, string>,
+  toolEnv: Record<string, string>,
+): Record<string, string> {
+  return { ...base, ...toolEnv };
+}

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -40,6 +40,7 @@ import { bridgeWorkerAgentEvent } from "./orchestration/event-bridge.js";
 import { notifySupervisorDisposed, notifySupervisorIdle } from "./orchestration/inbox.js";
 import { archiveSessionFiles } from "./session-archive.js";
 import { getExternalSubagentStatusForSession } from "./subagents-external.js";
+import { readSandboxSettings } from "./sandbox-settings.js";
 
 /**
  * Minimal SSE client contract used by the registry to fan out events.
@@ -622,9 +623,10 @@ async function resolveOrchestrationTools(sessionId: string): Promise<ToolDefinit
 function applyAgentToolSandbox(
   workspacePath: string,
   customTools: readonly ToolDefinition[],
+  toolEnv: Record<string, string>,
 ): ToolDefinition[] {
   if (!config.agentToolSandbox.enabled) return [...customTools];
-  return [...customTools, ...createSandboxedToolDefinitions(workspacePath)];
+  return [...customTools, ...createSandboxedToolDefinitions(workspacePath, toolEnv)];
 }
 
 export async function createSession(
@@ -645,9 +647,10 @@ export async function createSession(
   // create() onward — read it BEFORE createAgentSession so the
   // forge-native ask_user_question tool can bind to the right
   // session in its execute() closure.
+  const toolEnv = (await readSandboxSettings()).toolEnv;
   const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
   const todoTool = createTodoTool(sessionManager.getSessionId(), sessionManager);
-  const processTool = createProcessTool(sessionManager.getSessionId(), workspacePath);
+  const processTool = createProcessTool(sessionManager.getSessionId(), workspacePath, toolEnv);
   const orchestrationTools = await resolveOrchestrationTools(sessionManager.getSessionId());
   const customTools: ToolDefinition[] = [
     ...mcpTools,
@@ -656,7 +659,7 @@ export async function createSession(
     processTool,
     ...orchestrationTools,
   ];
-  const effectiveCustomTools = applyAgentToolSandbox(workspacePath, customTools);
+  const effectiveCustomTools = applyAgentToolSandbox(workspacePath, customTools, toolEnv);
   const settingsManager = await buildSessionSettingsManager(workspacePath, projectId);
   const resourceLoader = await buildForgeResourceLoader(
     workspacePath,
@@ -938,9 +941,10 @@ export async function resumeSession(
     const childSessionDir = match.parentSessionId !== undefined ? join(match.path, "..") : dir;
     const sessionManager = SessionManager.open(match.path, childSessionDir, workspacePath);
     const mcpTools = await resolveMcpCustomTools(projectId, workspacePath);
+    const toolEnv = (await readSandboxSettings()).toolEnv;
     const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
     const todoTool = createTodoTool(sessionManager.getSessionId(), sessionManager);
-    const processTool = createProcessTool(sessionManager.getSessionId(), workspacePath);
+    const processTool = createProcessTool(sessionManager.getSessionId(), workspacePath, toolEnv);
     const orchestrationTools = await resolveOrchestrationTools(sessionManager.getSessionId());
     const customTools: ToolDefinition[] = [
       ...mcpTools,
@@ -949,7 +953,7 @@ export async function resumeSession(
       processTool,
       ...orchestrationTools,
     ];
-    const effectiveCustomTools = applyAgentToolSandbox(workspacePath, customTools);
+    const effectiveCustomTools = applyAgentToolSandbox(workspacePath, customTools, toolEnv);
     // Resumed session — refresh the todo cache from the branch so
     // the UI panel sees the persisted state on first SSE connect,
     // not an empty list.
@@ -1612,9 +1616,14 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
   const dir = sessionDirFor(source.projectId);
   const sessionManager = SessionManager.open(newPath, dir, source.workspacePath);
   const mcpTools = await resolveMcpCustomTools(source.projectId, source.workspacePath);
+  const toolEnv = (await readSandboxSettings()).toolEnv;
   const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
   const todoTool = createTodoTool(sessionManager.getSessionId(), sessionManager);
-  const processTool = createProcessTool(sessionManager.getSessionId(), source.workspacePath);
+  const processTool = createProcessTool(
+    sessionManager.getSessionId(),
+    source.workspacePath,
+    toolEnv,
+  );
   const orchestrationTools = await resolveOrchestrationTools(sessionManager.getSessionId());
   const customTools: ToolDefinition[] = [
     ...mcpTools,
@@ -1623,7 +1632,7 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
     processTool,
     ...orchestrationTools,
   ];
-  const effectiveCustomTools = applyAgentToolSandbox(source.workspacePath, customTools);
+  const effectiveCustomTools = applyAgentToolSandbox(source.workspacePath, customTools, toolEnv);
   // Forked session — replay the branch (which now belongs to the
   // fork) so the new session's todo cache reflects the inherited
   // state, not the parent's stale entry.
@@ -1702,11 +1711,13 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
       source.unsubscribe();
       const restoredManager = SessionManager.open(originalSourceFile, dir, source.workspacePath);
       const restoredMcpTools = await resolveMcpCustomTools(source.projectId, source.workspacePath);
+      const restoredToolEnv = (await readSandboxSettings()).toolEnv;
       const restoredAskTool = createAskUserQuestionTool(restoredManager.getSessionId());
       const restoredTodoTool = createTodoTool(restoredManager.getSessionId(), restoredManager);
       const restoredProcessTool = createProcessTool(
         restoredManager.getSessionId(),
         source.workspacePath,
+        restoredToolEnv,
       );
       const restoredOrchestrationTools = await resolveOrchestrationTools(
         restoredManager.getSessionId(),
@@ -1721,6 +1732,7 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
       const restoredEffectiveCustomTools = applyAgentToolSandbox(
         source.workspacePath,
         restoredCustomTools,
+        restoredToolEnv,
       );
       // Re-derive the original source's todo cache from the (now
       // un-mutated) source JSONL — the SDK's fork machinery left
@@ -1845,9 +1857,10 @@ export async function rebuildAgentSessionForTools(
   // file the SessionManager points at.
   const sessionManager = live.session.sessionManager;
   const mcpTools = await resolveMcpCustomTools(live.projectId, live.workspacePath);
+  const toolEnv = (await readSandboxSettings()).toolEnv;
   const askTool = createAskUserQuestionTool(sessionManager.getSessionId());
   const todoTool = createTodoTool(sessionManager.getSessionId(), sessionManager);
-  const processTool = createProcessTool(sessionManager.getSessionId(), live.workspacePath);
+  const processTool = createProcessTool(sessionManager.getSessionId(), live.workspacePath, toolEnv);
   const orchestrationTools = await resolveOrchestrationTools(sessionManager.getSessionId());
   const customTools: ToolDefinition[] = [
     ...mcpTools,
@@ -1856,7 +1869,7 @@ export async function rebuildAgentSessionForTools(
     processTool,
     ...orchestrationTools,
   ];
-  const effectiveCustomTools = applyAgentToolSandbox(live.workspacePath, customTools);
+  const effectiveCustomTools = applyAgentToolSandbox(live.workspacePath, customTools, toolEnv);
   const settingsManager = await buildSessionSettingsManager(live.workspacePath, live.projectId);
   const resourceLoader = await buildForgeResourceLoader(
     live.workspacePath,

--- a/tests/test-sandbox-settings.ts
+++ b/tests/test-sandbox-settings.ts
@@ -1,0 +1,128 @@
+/**
+ * Sandbox settings regression coverage:
+ * - persisted tool env validates and round-trips atomically-owned FORGE_DATA_DIR state
+ * - bash/process tool shells receive configured env
+ * - sandbox filesystem overrides include ls path-guard behavior, not only read/write/bash
+ */
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const root = await mkdtemp(join(tmpdir(), "pi-forge-sandbox-test-"));
+const workspace = join(root, "workspace");
+process.env.WORKSPACE_PATH = workspace;
+process.env.FORGE_DATA_DIR = join(root, "data");
+process.env.PI_CONFIG_DIR = join(root, "pi");
+process.env.SESSION_DIR = join(root, "sessions");
+process.env.SERVE_CLIENT = "false";
+process.env.AGENT_TOOL_SANDBOX_ENABLED = "false";
+
+const failures: string[] = [];
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures.push(`${label}${detail ? ` — ${detail}` : ""}`);
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const { readSandboxSettings, writeSandboxSettings, validateSandboxToolEnv } =
+  await import("../packages/server/src/sandbox-settings.js");
+const { createForgeBashOperations } =
+  await import("../packages/server/src/agent-bash-operations.js");
+const { createSandboxedToolDefinitions } =
+  await import("../packages/server/src/agent-tool-overrides.js");
+const { createProcessTool } = await import("../packages/server/src/processes/tool.js");
+const { processManager } = await import("../packages/server/src/processes/manager.js");
+
+try {
+  console.log("sandbox settings");
+  const initial = await readSandboxSettings();
+  assert("default toolEnv is empty", Object.keys(initial.toolEnv).length === 0);
+
+  await writeSandboxSettings({ toolEnv: { FOO: "bar", EMPTY: "" } });
+  const stored = await readSandboxSettings();
+  assert("toolEnv round-trips", stored.toolEnv.FOO === "bar" && stored.toolEnv.EMPTY === "");
+
+  let rejected = false;
+  try {
+    validateSandboxToolEnv({ "BAD-NAME": "x" });
+  } catch {
+    rejected = true;
+  }
+  assert("invalid env names rejected", rejected);
+
+  console.log("tool env injection");
+  await mkdir(workspace, { recursive: true });
+  const bashOps = createForgeBashOperations(workspace, { PI_FORGE_SANDBOX_TEST: "bash-ok" });
+  let output = "";
+  await bashOps.exec('printf %s "$PI_FORGE_SANDBOX_TEST"', workspace, {
+    signal: undefined,
+    onData: (chunk: Buffer) => {
+      output += chunk.toString("utf8");
+    },
+  });
+  assert("bash tool receives sandbox env", output === "bash-ok", output);
+
+  const processTool = createProcessTool("session-test", workspace, {
+    PI_FORGE_SANDBOX_TEST: "process-ok",
+  });
+  const call = (params: Record<string, unknown>) =>
+    processTool.execute("call", params, undefined, undefined, {}) as Promise<{
+      details: Record<string, unknown>;
+    }>;
+  const start = await call({
+    action: "start",
+    name: "env-check",
+    command: 'printf %s "$PI_FORGE_SANDBOX_TEST"',
+  });
+  assert("process start succeeds", start.details.success === true, JSON.stringify(start.details));
+  const pid = (start.details.process as { id: string } | undefined)?.id ?? "";
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  const out = await call({ action: "output", id: pid });
+  const stdout = ((out.details.output as { stdout: string[] }).stdout ?? []).join("");
+  assert("process tool receives sandbox env", stdout.includes("process-ok"), stdout);
+  processManager.disposeSession("session-test");
+
+  console.log("filesystem sandbox overrides");
+  await writeFile(join(workspace, "inside.txt"), "ok", "utf8");
+  const outside = join(root, "outside");
+  await mkdir(outside, { recursive: true });
+  await writeFile(join(outside, "outside.txt"), "no", "utf8");
+  const ls = createSandboxedToolDefinitions(workspace).find((tool) => tool.name === "ls");
+  assert("sandbox override includes ls", ls !== undefined);
+  const insideResult = await ls!.execute("ls-ok", { path: "." }, undefined, undefined, {});
+  const insideText = JSON.stringify(insideResult);
+  assert(
+    "ls can list inside workspace",
+    insideText.includes("inside.txt"),
+    insideText.slice(0, 200),
+  );
+  let blockedText = "";
+  try {
+    const blockedResult = await ls!.execute(
+      "ls-block",
+      { path: outside },
+      undefined,
+      undefined,
+      {},
+    );
+    blockedText = JSON.stringify(blockedResult);
+  } catch (err) {
+    blockedText = err instanceof Error ? err.message : String(err);
+  }
+  assert(
+    "ls blocks outside workspace",
+    blockedText.includes("outside allowed roots") || blockedText.includes("not allowed"),
+    blockedText.slice(0, 300),
+  );
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} failure(s):`);
+  for (const f of failures) console.error(` - ${f}`);
+  process.exit(1);
+}
+console.log("\nSandbox settings tests passed");

--- a/tests/test-sandbox-settings.ts
+++ b/tests/test-sandbox-settings.ts
@@ -2,7 +2,8 @@
  * Sandbox settings regression coverage:
  * - persisted tool env validates and round-trips atomically-owned FORGE_DATA_DIR state
  * - bash/process tool shells receive configured env
- * - sandbox filesystem overrides include ls path-guard behavior, not only read/write/bash
+ * - sandbox filesystem overrides include ls without narrowing pre-existing workspace root access
+ * - Settings UI masks env values instead of rendering NAME=value plaintext
  */
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -10,6 +11,7 @@ import { tmpdir } from "node:os";
 
 const root = await mkdtemp(join(tmpdir(), "pi-forge-sandbox-test-"));
 const workspace = join(root, "workspace");
+const projectWorkspace = join(workspace, "project-a");
 process.env.WORKSPACE_PATH = workspace;
 process.env.FORGE_DATA_DIR = join(root, "data");
 process.env.PI_CONFIG_DIR = join(root, "pi");
@@ -53,8 +55,8 @@ try {
   assert("invalid env names rejected", rejected);
 
   console.log("tool env injection");
-  await mkdir(workspace, { recursive: true });
-  const bashOps = createForgeBashOperations(workspace, { PI_FORGE_SANDBOX_TEST: "bash-ok" });
+  await mkdir(projectWorkspace, { recursive: true });
+  const bashOps = createForgeBashOperations(projectWorkspace, { PI_FORGE_SANDBOX_TEST: "bash-ok" });
   let output = "";
   await bashOps.exec('printf %s "$PI_FORGE_SANDBOX_TEST"', workspace, {
     signal: undefined,
@@ -64,7 +66,7 @@ try {
   });
   assert("bash tool receives sandbox env", output === "bash-ok", output);
 
-  const processTool = createProcessTool("session-test", workspace, {
+  const processTool = createProcessTool("session-test", projectWorkspace, {
     PI_FORGE_SANDBOX_TEST: "process-ok",
   });
   const call = (params: Record<string, unknown>) =>
@@ -85,11 +87,14 @@ try {
   processManager.disposeSession("session-test");
 
   console.log("filesystem sandbox overrides");
-  await writeFile(join(workspace, "inside.txt"), "ok", "utf8");
-  const outside = join(root, "outside");
-  await mkdir(outside, { recursive: true });
-  await writeFile(join(outside, "outside.txt"), "no", "utf8");
-  const ls = createSandboxedToolDefinitions(workspace).find((tool) => tool.name === "ls");
+  await writeFile(join(projectWorkspace, "inside.txt"), "ok", "utf8");
+  const siblingUnderWorkspace = join(workspace, "project-b");
+  await mkdir(siblingUnderWorkspace, { recursive: true });
+  await writeFile(join(siblingUnderWorkspace, "sibling.txt"), "ok", "utf8");
+  const piDataDir = join(process.env.PI_CONFIG_DIR!, "sessions");
+  await mkdir(piDataDir, { recursive: true });
+  await writeFile(join(piDataDir, "session.jsonl"), "{}\n", "utf8");
+  const ls = createSandboxedToolDefinitions(projectWorkspace).find((tool) => tool.name === "ls");
   assert("sandbox override includes ls", ls !== undefined);
   const insideResult = await ls!.execute("ls-ok", { path: "." }, undefined, undefined, {});
   const insideText = JSON.stringify(insideResult);
@@ -98,23 +103,39 @@ try {
     insideText.includes("inside.txt"),
     insideText.slice(0, 200),
   );
-  let blockedText = "";
-  try {
-    const blockedResult = await ls!.execute(
-      "ls-block",
-      { path: outside },
-      undefined,
-      undefined,
-      {},
-    );
-    blockedText = JSON.stringify(blockedResult);
-  } catch (err) {
-    blockedText = err instanceof Error ? err.message : String(err);
-  }
+  const siblingResult = await ls!.execute(
+    "ls-sibling",
+    { path: siblingUnderWorkspace },
+    undefined,
+    undefined,
+    {},
+  );
+  const siblingText = JSON.stringify(siblingResult);
   assert(
-    "ls blocks outside workspace",
-    blockedText.includes("outside allowed roots") || blockedText.includes("not allowed"),
-    blockedText.slice(0, 300),
+    "ls preserves access to sibling paths under WORKSPACE_PATH",
+    siblingText.includes("sibling.txt"),
+    siblingText.slice(0, 300),
+  );
+  const piResult = await ls!.execute("ls-pi", { path: piDataDir }, undefined, undefined, {});
+  const piText = JSON.stringify(piResult);
+  assert(
+    "ls preserves access to allowed PI_CONFIG_DIR content",
+    piText.includes("session.jsonl"),
+    piText.slice(0, 300),
+  );
+
+  console.log("sandbox UI redaction");
+  const settingsPanelSource = await readFile(
+    join(process.cwd(), "packages/client/src/components/SettingsPanel.tsx"),
+    "utf8",
+  );
+  assert(
+    "sandbox UI uses masked inputs for values",
+    settingsPanelSource.includes('type={row.revealed ? "text" : "password"}'),
+  );
+  assert(
+    "sandbox UI avoids NAME=value plaintext textarea rendering",
+    !settingsPanelSource.includes("`${k}=${v}`"),
   );
 } finally {
   await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Sandbox mode can now carry operator-configured environment variables into agent tool processes without requiring host-level env changes. This adds a Settings → Sandbox section for managing those variables, persists them in pi-forge data, and wires them into forge-managed tool execution paths.

The follow-up fix preserves the pre-existing filesystem sandbox policy: sandboxed file tools remain scoped to the configured `WORKSPACE_PATH` and allowed `PI_CONFIG_DIR` content, rather than being narrowed to only the active session/project directory. The Sandbox settings UI masks values by default so potentially sensitive env values are not casually displayed.

## Usage

Open **Settings → Sandbox**, then add environment variable rows:

```text
HTTP_PROXY=<masked value>
NO_COLOR=<masked value>
```

- Values are masked by default; use per-row **Reveal** only when needed.
- Saved variables are persisted under `FORGE_DATA_DIR` and injected into future/refreshed agent tool executions.
- Sandbox enablement and UID/GID remain deploy-time settings via existing env/CLI configuration (`AGENT_TOOL_SANDBOX_ENABLED`, `AGENT_TOOL_UID`, `AGENT_TOOL_GID`).
- Existing live sessions keep their current tool closures until recreated/refreshed.

## What changed (13 files, +558 initial; follow-up masks UI and restores policy)

- `packages/server/src/sandbox-settings.ts` — new atomic owner for `sandbox-settings.json`, validation for env var names/count/value size, and helper to merge tool env.
- `packages/server/src/routes/config.ts` — adds authenticated `GET/PUT /api/v1/config/sandbox` with OpenAPI schemas.
- `packages/server/src/session-registry.ts` — reads sandbox settings while creating/resuming/forking/refreshing sessions and passes env into tool definitions consistently.
- `packages/server/src/agent-bash-operations.ts` — injects configured tool env into the overridden bash tool shell.
- `packages/server/src/processes/*` — injects configured tool env into the forge process tool start path.
- `packages/server/src/agent-tool-overrides.ts` — carries sandbox env into sandboxed tool definitions and keeps `ls` included with the other filesystem overrides.
- `packages/server/src/agent-tool-policy.ts` — restored pre-existing `WORKSPACE_PATH` / `PI_CONFIG_DIR` path behavior after follow-up review.
- `packages/client/src/lib/api-client/*` — typed API client support for sandbox settings.
- `packages/client/src/components/SettingsPanel.tsx` — new Sandbox tab with masked per-variable editing and reveal/remove controls.
- `tests/test-sandbox-settings.ts` — covers persistence validation, bash/process env injection, `ls` filesystem behavior for workspace/PI config access, and UI redaction guardrails.

## Test plan

- [x] `npx tsx tests/test-sandbox-settings.ts`
- [x] `npm run format:check`
- [ ] `npm run build` — attempted, currently blocked by existing dependency/type issues unrelated to this change:
  - missing `vite/client`
  - missing declaration files for `jsonwebtoken` and `ws`
  - existing implicit `any` in `packages/server/src/routes/terminal.ts`
- [ ] CI green before merge

## Risks / blockers

- The API persists and returns actual env values so the editor can save without destroying secrets; the browser UI masks values by default but a user with API/browser devtools access can still inspect them.
- Environment changes apply to new/refreshed sessions; live sessions retain tool closures created before the settings change.
- Full repo build remains blocked in this worktree by pre-existing type/dependency issues listed above.
