### PR TITLE
feat: auto-name sessions from first prompt

### DIFF
--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -322,9 +322,16 @@ function vSessionSummary(value: unknown, status: number): SessionSummary {
   return out;
 }
 
-function vAccepted(value: unknown, status: number): { accepted: true } {
+export interface AcceptedResponse {
+  accepted: true;
+  sessionName?: string;
+}
+
+function vAccepted(value: unknown, status: number): AcceptedResponse {
   if (!isObject(value) || value.accepted !== true) fail(status, "expected { accepted: true }");
-  return { accepted: true };
+  const out: AcceptedResponse = { accepted: true };
+  if (typeof value.sessionName === "string") out.sessionName = value.sessionName;
+  return out;
 }
 
 function vSkillSummary(s: unknown, status: number): SkillSummary {

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -673,7 +673,11 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     try {
       const opts: Parameters<typeof api.prompt>[2] = {};
       if (attachments !== undefined && attachments.length > 0) opts.attachments = attachments;
-      await api.prompt(sessionId, text, opts);
+      const res = await api.prompt(sessionId, text, opts);
+      if (res.sessionName !== undefined) {
+        set((s) => renameSessionInLists(s, sessionId, res.sessionName));
+        postCrossTab({ type: "session_renamed", sessionId, name: res.sessionName });
+      }
     } catch (err) {
       // Roll back the optimistic append on failure. Revoke any blob
       // URLs the optimistic message owns BEFORE we drop the
@@ -777,7 +781,10 @@ function applyEvent(
     // back online with fresh server state. Active-tool also resets:
     // tool execution events fire fresh after a reconnect; an old badge
     // would otherwise stick around indefinitely.
+    const hasSnapshotName = Object.prototype.hasOwnProperty.call(event, "name");
+    const snapshotName = typeof event.name === "string" ? event.name : undefined;
     set((s) => ({
+      ...(hasSnapshotName ? renameSessionInLists(s, sessionId, snapshotName) : {}),
       messagesBySession: {
         ...s.messagesBySession,
         [sessionId]: event.messages ?? [],

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -429,19 +429,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       // Propagate the new name into every project's session list so the
       // sidebar updates without a refetch. The summary's `name` is
       // undefined when cleared — mirror that into the unified shape.
-      set((s) => {
-        const byProject: Record<string, UnifiedSession[]> = {};
-        for (const [pid, list] of Object.entries(s.byProject)) {
-          byProject[pid] = list.map((u) => {
-            if (u.sessionId !== sessionId) return u;
-            const next: UnifiedSession = { ...u };
-            if (summary.name !== undefined) next.name = summary.name;
-            else delete next.name;
-            return next;
-          });
-        }
-        return { byProject };
-      });
+      set((s) => renameSessionInLists(s, sessionId, summary.name));
       // Cross-tab: other browser tabs reflect the rename in their
       // sidebar without a refetch.
       postCrossTab({ type: "session_renamed", sessionId, name: summary.name });
@@ -974,6 +962,14 @@ function applyEvent(
     return;
   }
 
+  if (event.type === "session_renamed") {
+    const renamedSessionId = typeof event.sessionId === "string" ? event.sessionId : sessionId;
+    const name = typeof event.name === "string" ? event.name : undefined;
+    set((s) => renameSessionInLists(s, renamedSessionId, name));
+    postCrossTab({ type: "session_renamed", sessionId: renamedSessionId, name });
+    return;
+  }
+
   if (event.type === "message_end" || event.type === "tool_result") {
     // Fallbacks for SDK variants that don't emit tool_execution_end (or
     // that finalize an assistant message containing a toolCall before
@@ -1278,6 +1274,24 @@ function scheduleMessagesRefetch(
  * input shapes are tool-specific; we try the common fields and fall
  * back to undefined (the badge then renders the tool name only).
  */
+function renameSessionInLists(
+  state: SessionState,
+  sessionId: string,
+  name: string | undefined,
+): Pick<SessionState, "byProject"> {
+  const byProject: Record<string, UnifiedSession[]> = {};
+  for (const [pid, list] of Object.entries(state.byProject)) {
+    byProject[pid] = list.map((u) => {
+      if (u.sessionId !== sessionId) return u;
+      const next: UnifiedSession = { ...u };
+      if (name !== undefined) next.name = name;
+      else delete next.name;
+      return next;
+    });
+  }
+  return { byProject };
+}
+
 function summarizeToolInput(name: string, input: Record<string, unknown>): string | undefined {
   const get = (k: string): string | undefined => {
     const v = input[k];
@@ -1374,19 +1388,7 @@ if (!globalThis.__piForgeSessionCrossTabRegistered) {
       return;
     }
     if (msg.type === "session_renamed") {
-      useSessionStore.setState((st) => {
-        const byProject: Record<string, UnifiedSession[]> = {};
-        for (const [pid, list] of Object.entries(st.byProject)) {
-          byProject[pid] = list.map((u) => {
-            if (u.sessionId !== msg.sessionId) return u;
-            const next: UnifiedSession = { ...u };
-            if (msg.name !== undefined) next.name = msg.name;
-            else delete next.name;
-            return next;
-          });
-        }
-        return { byProject };
-      });
+      useSessionStore.setState((st) => renameSessionInLists(st, msg.sessionId, msg.name));
       return;
     }
   });

--- a/packages/server/src/routes/prompt.ts
+++ b/packages/server/src/routes/prompt.ts
@@ -409,7 +409,10 @@ export const promptRoutes: FastifyPluginAsync = async (fastify) => {
           202: {
             type: "object",
             required: ["accepted"],
-            properties: { accepted: { type: "boolean", const: true } },
+            properties: {
+              accepted: { type: "boolean", const: true },
+              sessionName: { type: "string" },
+            },
           },
           400: errorSchema,
           404: errorSchema,
@@ -498,7 +501,7 @@ export const promptRoutes: FastifyPluginAsync = async (fastify) => {
       // extra LLM call), best-effort, and uses the user's typed text
       // rather than expanded @file blocks / attachment bodies so large
       // context blobs do not dominate the tab title.
-      maybeNameSessionFromFirstPrompt(live, titleSourceText);
+      const generatedSessionName = maybeNameSessionFromFirstPrompt(live, titleSourceText);
 
       // No app-level composed-prompt cap: per-file size limits
       // already prevent runaway memory pressure during multipart
@@ -596,7 +599,13 @@ export const promptRoutes: FastifyPluginAsync = async (fastify) => {
         );
         synthesizeFailureEvent(err);
       }
-      return reply.code(202).send({ accepted: true });
+      return reply
+        .code(202)
+        .send(
+          generatedSessionName !== undefined
+            ? { accepted: true, sessionName: generatedSessionName }
+            : { accepted: true },
+        );
     },
   );
 };

--- a/packages/server/src/routes/prompt.ts
+++ b/packages/server/src/routes/prompt.ts
@@ -8,6 +8,7 @@ import {
   findSessionLocation,
   getSession,
   listSessionsForProject,
+  maybeNameSessionFromFirstPrompt,
   rejectOrDisposeExternallyActiveSession,
   type LiveSession,
 } from "../session-registry.js";
@@ -435,6 +436,7 @@ export const promptRoutes: FastifyPluginAsync = async (fastify) => {
       if (live === undefined) return reply;
 
       let promptText: string;
+      let titleSourceText: string;
       let streamingBehavior: "steer" | "followUp" | undefined;
       let images: ParsedImage[] = [];
 
@@ -473,10 +475,12 @@ export const promptRoutes: FastifyPluginAsync = async (fastify) => {
         if ("error" in parsed) {
           return reply.code(400).send(parsed);
         }
+        titleSourceText = parsed.text;
         promptText = composePromptText(parsed);
         streamingBehavior = parsed.streamingBehavior;
         images = parsed.images;
       } else {
+        titleSourceText = req.body.text;
         promptText = req.body.text;
         streamingBehavior = req.body.streamingBehavior;
       }
@@ -488,6 +492,13 @@ export const promptRoutes: FastifyPluginAsync = async (fastify) => {
       // to a real file inside the workspace passes through untouched
       // — see file-references.ts for the rules.
       promptText = await expandFileReferences(promptText, live.workspacePath);
+
+      // Name a brand-new, still-generic session from the user's first
+      // prompt before the agent run starts. This is deterministic (no
+      // extra LLM call), best-effort, and uses the user's typed text
+      // rather than expanded @file blocks / attachment bodies so large
+      // context blobs do not dominate the tab title.
+      maybeNameSessionFromFirstPrompt(live, titleSourceText);
 
       // No app-level composed-prompt cap: per-file size limits
       // already prevent runaway memory pressure during multipart

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -39,6 +39,7 @@ import { createOrchestrationTools } from "./orchestration/tools.js";
 import { bridgeWorkerAgentEvent } from "./orchestration/event-bridge.js";
 import { notifySupervisorDisposed, notifySupervisorIdle } from "./orchestration/inbox.js";
 import { archiveSessionFiles } from "./session-archive.js";
+import { generateSessionTitleFromPrompt, isGenericSessionName } from "./session-title.js";
 import { getExternalSubagentStatusForSession } from "./subagents-external.js";
 
 /**
@@ -750,6 +751,45 @@ export function listSessions(projectId?: string): LiveSession[] {
 export function touchSession(sessionId: string): void {
   const live = registry.get(sessionId);
   if (live !== undefined) live.lastActivityAt = new Date();
+}
+
+export function maybeNameSessionFromFirstPrompt(
+  live: LiveSession,
+  promptText: string,
+): string | undefined {
+  if (!isGenericSessionName(live.session.sessionName)) return undefined;
+  if (live.session.messages.some((message) => message.role === "user")) return undefined;
+
+  const title = generateSessionTitleFromPrompt(promptText);
+  if (title === undefined) return undefined;
+
+  try {
+    live.session.setSessionName(title);
+  } catch (err) {
+    logAgentEvent("warn", {
+      msg: "failed to set automatic session name",
+      sessionId: live.sessionId,
+      projectId: live.projectId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+
+  live.lastActivityAt = new Date();
+  const event = {
+    type: "session_renamed" as const,
+    sessionId: live.sessionId,
+    projectId: live.projectId,
+    name: title,
+  };
+  for (const client of live.clients) {
+    try {
+      client.send(event);
+    } catch {
+      live.clients.delete(client);
+    }
+  }
+  return title;
 }
 
 /**

--- a/packages/server/src/session-title.ts
+++ b/packages/server/src/session-title.ts
@@ -1,0 +1,97 @@
+const GENERIC_SESSION_NAME_RE = /^New session(?: \(\d+\))?$/;
+const MAX_TITLE_LENGTH = 60;
+const MAX_TITLE_WORDS = 8;
+
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "can",
+  "could",
+  "for",
+  "from",
+  "how",
+  "i",
+  "in",
+  "is",
+  "it",
+  "me",
+  "of",
+  "on",
+  "please",
+  "the",
+  "this",
+  "to",
+  "with",
+  "would",
+  "you",
+]);
+
+export function isGenericSessionName(name: string | undefined): boolean {
+  return name === undefined || GENERIC_SESSION_NAME_RE.test(name);
+}
+
+export function generateSessionTitleFromPrompt(prompt: string): string | undefined {
+  const cleaned = normalizePromptForTitle(prompt);
+  if (cleaned.length === 0) return undefined;
+
+  const words = cleaned
+    .split(/\s+/)
+    .map((word) => cleanWord(word))
+    .filter((word) => word.length > 0);
+  if (words.length === 0) return undefined;
+
+  const selected = words.slice(0, MAX_TITLE_WORDS);
+  const significant = selected.filter((word) => !STOP_WORDS.has(word.toLowerCase()));
+  const titleWords = significant.length >= 2 ? significant : selected;
+  const title = toTitleCase(titleWords.join(" "));
+  return truncateTitle(title);
+}
+
+function normalizePromptForTitle(prompt: string): string {
+  return prompt
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/^\s*\/[\w:-]+\s*/u, "")
+    .replace(/@([^\s]+)/g, (_match, path: string) => ` ${basenameLike(path)} `)
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/[\r\n]+/g, " ")
+    .replace(/[_*#[\]()>~|{}]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function basenameLike(path: string): string {
+  const trimmed = path.replace(/[.,;:!?]+$/g, "");
+  const parts = trimmed.split(/[\\/]/).filter((part) => part.length > 0);
+  return parts[parts.length - 1] ?? trimmed;
+}
+
+function cleanWord(word: string): string {
+  return word
+    .replace(/^[^\p{L}\p{N}]+/u, "")
+    .replace(/[^\p{L}\p{N}+.:-]+$/u, "")
+    .trim();
+}
+
+function toTitleCase(text: string): string {
+  return text
+    .split(/\s+/)
+    .map((word) => {
+      if (/^[A-Z0-9._+-]{2,}$/.test(word)) return word;
+      if (/^[\p{L}][\p{L}'’-]*$/u.test(word)) {
+        return word.charAt(0).toLocaleUpperCase() + word.slice(1);
+      }
+      return word;
+    })
+    .join(" ");
+}
+
+function truncateTitle(title: string): string {
+  if (title.length <= MAX_TITLE_LENGTH) return title;
+  const cut = title.slice(0, MAX_TITLE_LENGTH - 1);
+  const lastSpace = cut.lastIndexOf(" ");
+  if (lastSpace >= 24) return `${cut.slice(0, lastSpace)}…`;
+  return `${cut.trimEnd()}…`;
+}

--- a/packages/server/src/sse-bridge.ts
+++ b/packages/server/src/sse-bridge.ts
@@ -115,6 +115,11 @@ const SESSION_LIST_CHANGED_PADDING_LINE = `: session-list-changed ${"_".repeat(
   SESSION_LIST_CHANGED_PADDING_BYTES - 24,
 )}\n\n`;
 
+const SESSION_RENAMED_PADDING_BYTES = 2048;
+const SESSION_RENAMED_PADDING_LINE = `: session-renamed ${"_".repeat(
+  SESSION_RENAMED_PADDING_BYTES - 20,
+)}\n\n`;
+
 /**
  * One-shot snapshot event sent immediately on SSE connect so the browser can
  * hydrate full session state without a separate HTTP round-trip.
@@ -125,6 +130,7 @@ export interface SnapshotEvent {
   projectId: string;
   messages: AgentMessage[];
   isStreaming: boolean;
+  name?: string;
 }
 
 /**
@@ -174,6 +180,9 @@ const ALLOWED_EVENT_TYPES = new Set<string>([
   // out-of-band relative to the user's current sidebar list: pi-subagents'
   // `subagent` and orchestration's `orchestrate_spawn_worker`.
   "session_list_changed",
+  // Forge-native per-session rename event. Used for deterministic first-
+  // prompt names and manual/cross-tab-compatible sidebar updates.
+  "session_renamed",
 ]);
 
 export function isAllowedEvent(event: { type: string }): boolean {
@@ -357,13 +366,15 @@ export function serializeSSE(event: { type: string; [k: string]: unknown }): str
  * (and tests) can assert the same shape the bridge sends on connect.
  */
 export function buildSnapshot(live: LiveSession): SnapshotEvent {
-  return {
+  const snapshot: SnapshotEvent = {
     type: "snapshot",
     sessionId: live.sessionId,
     projectId: live.projectId,
     messages: live.session.messages,
     isStreaming: live.session.isStreaming,
   };
+  if (live.session.sessionName !== undefined) snapshot.name = live.session.sessionName;
+  return snapshot;
 }
 
 /**
@@ -483,6 +494,9 @@ export function createSSEClient(reply: FastifyReply, live: LiveSession): SSEClie
       }
       if (event.type === "session_list_changed") {
         writeRaw(SESSION_LIST_CHANGED_PADDING_LINE);
+      }
+      if (event.type === "session_renamed") {
+        writeRaw(SESSION_RENAMED_PADDING_LINE);
       }
     };
 

--- a/tests/test-session-title.ts
+++ b/tests/test-session-title.ts
@@ -1,0 +1,41 @@
+import {
+  generateSessionTitleFromPrompt,
+  isGenericSessionName,
+} from "../packages/server/src/session-title";
+
+let failures = 0;
+function assertEqual<T>(label: string, actual: T, expected: T): void {
+  const ok = Object.is(actual, expected);
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(
+      `  FAIL  ${label}\n    expected: ${JSON.stringify(expected)}\n    actual:   ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+assertEqual(
+  "summarizes first prompt into meaningful title",
+  generateSessionTitleFromPrompt("Please implement session tab title summaries for the browser UI"),
+  "Implement Session Tab Title Summaries",
+);
+assertEqual(
+  "uses referenced file basename",
+  generateSessionTitleFromPrompt("Review @packages/server/src/session-registry.ts for title bugs"),
+  "Review session-registry.ts Title Bugs",
+);
+assertEqual(
+  "ignores fenced code blocks",
+  generateSessionTitleFromPrompt("Fix this crash\n```ts\nconst secret = hugeContext();\n```"),
+  "Fix Crash",
+);
+assertEqual("empty prompt has no title", generateSessionTitleFromPrompt("   \n\t"), undefined);
+assertEqual("default name is generic", isGenericSessionName("New session (2)"), true);
+assertEqual("manual name is not generic", isGenericSessionName("Release notes"), false);
+
+if (failures > 0) {
+  console.error(`test-session-title failed with ${failures} failure(s)`);
+  process.exit(1);
+}
+console.log("test-session-title passed");

--- a/tests/test-session.ts
+++ b/tests/test-session.ts
@@ -75,6 +75,7 @@ async function main(): Promise<void> {
     sessionFile?: string;
     subscribe: (l: (e: unknown) => void) => () => void;
     sessionId: string;
+    sessionName?: string;
     prompt: (text: string) => Promise<void>;
     sessionManager: { appendMessage: (msg: unknown) => string };
   }
@@ -98,6 +99,7 @@ async function main(): Promise<void> {
     disposeSession: (id: string) => Promise<boolean>;
     resumeSession: (id: string, projectId: string, workspacePath: string) => Promise<TestLive>;
     discoverSessionsOnDisk: (projectId: string, workspacePath: string) => Promise<TestDiscovered[]>;
+    maybeNameSessionFromFirstPrompt: (live: TestLive, promptText: string) => string | undefined;
     sessionCount: () => number;
     disposeAllSessions: () => void;
   }
@@ -251,6 +253,62 @@ async function main(): Promise<void> {
       `got ${rediscovered[0]?.name}`,
     );
     await registry.disposeSession(resumed.sessionId);
+
+    // 6a. Automatic first-prompt naming: deterministic summary, SSE nudge,
+    // and persisted session_info entry once the session flushes to disk.
+    const titleSession = await registry.createSession(projectId, workspacePath);
+    try {
+      const titleEvents: { type: string; name?: string }[] = [];
+      const titleClient = {
+        id: "title-client",
+        send: (e: { type: string; name?: string }) => titleEvents.push(e),
+        close: () => undefined,
+      };
+      titleSession.clients.add(titleClient);
+      const title = registry.maybeNameSessionFromFirstPrompt(
+        titleSession,
+        "Please implement session tab title summaries for the browser UI",
+      );
+      assert(
+        "first prompt generated a session title",
+        title === "Implement Session Tab Title Summaries",
+      );
+      assert("SDK sessionName updated", titleSession.session.sessionName === title);
+      assert(
+        "automatic rename emitted session_renamed",
+        titleEvents.some((e) => e.type === "session_renamed" && e.name === title),
+      );
+      titleSession.session.sessionManager.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "title fixture", id: "stub-title" }],
+        api: "messages",
+        provider: "anthropic",
+        model: "test-fixture",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      });
+      const titleDiscovered = await registry.discoverSessionsOnDisk(projectId, workspacePath);
+      assert(
+        "automatic title persists to discovery",
+        titleDiscovered.find((s) => s.sessionId === titleSession.sessionId)?.name === title,
+      );
+      titleSession.session.setSessionName("manual title");
+      assert(
+        "manual title is not overwritten",
+        registry.maybeNameSessionFromFirstPrompt(titleSession, "try to overwrite") === undefined &&
+          titleSession.session.sessionName === "manual title",
+      );
+    } finally {
+      await registry.disposeSession(titleSession.sessionId);
+    }
 
     // 6b. Multi-client fan-out: in a fresh session (so it doesn't disturb
     // the resume-name assertion above), inject two stub SSEClients and

--- a/tests/test-sse.ts
+++ b/tests/test-sse.ts
@@ -44,6 +44,7 @@ function assert(label: string, ok: boolean, detail?: string): void {
 interface TestSession {
   setSessionName: (n: string) => void;
   sessionId: string;
+  sessionName?: string;
   prompt: (text: string) => Promise<void>;
   subscribe: (l: (e: unknown) => void) => () => void;
   sessionManager: { appendMessage: (msg: unknown) => string };
@@ -69,6 +70,7 @@ interface TestBridge {
     projectId: string;
     messages: unknown[];
     isStreaming: boolean;
+    name?: string;
   };
 }
 
@@ -110,6 +112,10 @@ async function main(): Promise<void> {
     bridge.isAllowedEvent({ type: "session_list_changed" }),
   );
   assert(
+    "isAllowedEvent('session_renamed') === true",
+    bridge.isAllowedEvent({ type: "session_renamed" }),
+  );
+  assert(
     "isAllowedEvent('session_info_changed') === false (filtered)",
     !bridge.isAllowedEvent({ type: "session_info_changed" }),
   );
@@ -141,6 +147,7 @@ async function main(): Promise<void> {
     assert("snapshot.projectId matches", snap.projectId === projectId);
     assert("snapshot.messages is an array", Array.isArray(snap.messages));
     assert("snapshot.isStreaming === false on idle session", snap.isStreaming === false);
+    assert("snapshot carries current session name", snap.name === live.session.sessionName);
 
     // 4. End-to-end SSE: open the stream and parse the first frame.
     const ctrl = new AbortController();
@@ -268,7 +275,33 @@ async function main(): Promise<void> {
       `type=${listChanged.type}`,
     );
 
-    // 9. Unknown sessionId → 404.
+    // 9. Session rename events must also pass the bridge filter so
+    // generated first-prompt titles repaint the visible sidebar/tab
+    // immediately instead of waiting for a manual list refresh.
+    remainingClient?.send({
+      type: "session_renamed",
+      sessionId: live.sessionId,
+      projectId,
+      name: "Auto Title",
+    });
+    const renamed: { type: string; name?: unknown } = await Promise.race([
+      (async (): Promise<{ type: string; name?: unknown }> => {
+        while (true) {
+          const evt = await readUntilEvent();
+          if (evt.type === "session_renamed") return evt;
+        }
+      })(),
+      new Promise<{ type: string; name?: unknown }>((resolve) =>
+        setTimeout(() => resolve({ type: "__timeout__" }), 1000),
+      ),
+    ]);
+    assert(
+      "session_renamed is delivered over SSE",
+      renamed.type === "session_renamed" && renamed.name === "Auto Title",
+      `type=${renamed.type}`,
+    );
+
+    // 10. Unknown sessionId → 404.
     const res404 = await fetch(
       `${listenAddr}/api/v1/sessions/00000000-0000-0000-0000-000000000000/stream`,
       { headers: { Accept: "text/event-stream" } },
@@ -285,7 +318,7 @@ async function main(): Promise<void> {
       // expected
     }
 
-    // 10. Optional: live prompt with PI_TEST_LIVE_PROMPT=1.
+    // 11. Optional: live prompt with PI_TEST_LIVE_PROMPT=1.
     if (process.env.PI_TEST_LIVE_PROMPT === "1") {
       console.log("\n[test-sse] PI_TEST_LIVE_PROMPT=1 — running live prompt");
       const promptSession = await registry.createSession(projectId, workspacePath);


### PR DESCRIPTION
## Summary

New sessions were staying on generic tab/sidebar names like `New session` after the first prompt, making multiple open sessions hard to distinguish. This PR generates a deterministic short title from the user's first prompt, persists it through the SDK session name mechanism, and updates the live UI immediately.

A follow-up refresh bug is also fixed: generated titles were persisted, but the browser did not repaint visible session lists/tabs because `session_renamed` was emitted server-side but filtered by the SSE bridge. The rename now reaches live clients, snapshots include the current name for reconnects, and the prompt response carries the generated title as a race-safe fallback for the sending tab.

## Usage

No new operator-facing commands or configuration are required.

Behavior after this change:

1. Create a new session.
2. Send the first prompt, for example `Please implement session tab title summaries for the browser UI`.
3. The session row/tab updates automatically to a concise generated title such as `Implement Session Tab Title Summaries`.
4. Manual session renames are not overwritten, and empty/unusable prompts leave the existing generic title unchanged.

## What changed (9 files)

- `packages/server/src/session-title.ts` — added deterministic first-prompt title generation with prompt cleanup, stop-word filtering, title casing, and length limits.
- `packages/server/src/session-registry.ts` — added `maybeNameSessionFromFirstPrompt()` to set the SDK session name only for generic, first-prompt sessions and fan out a `session_renamed` event.
- `packages/server/src/routes/prompt.ts` — invokes title generation before starting the agent run and returns `sessionName` in the 202 response when a title was generated.
- `packages/server/src/sse-bridge.ts` — allows `session_renamed` through SSE, includes names in snapshots, and adds a padding flush so small rename events are not buffered by proxies.
- `packages/client/src/lib/api-client/index.ts` — accepts optional `sessionName` on prompt accepted responses.
- `packages/client/src/store/session-store.ts` — updates visible session lists from prompt response fallback, SSE `session_renamed`, cross-tab broadcasts, and named snapshots.
- `tests/test-session-title.ts` — covers deterministic title generation edge cases.
- `tests/test-session.ts` — covers automatic first-prompt naming, persistence, SSE client fan-out, and manual-name non-overwrite behavior.
- `tests/test-sse.ts` — covers `session_renamed` bridge allowlisting/delivery and snapshot name hydration.

## Test plan

- [x] `npm run build`
- [x] `npx tsx tests/test-session-title.ts`
- [x] `npx tsx tests/test-session.ts`
- [x] `npx tsx tests/test-sse.ts`
- [x] `npm run check`
- [ ] CI green before merge
