### PR TITLE
fix(orchestration): enable supervisor tools pre-prompt

### DIFF
--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -35,7 +35,7 @@ import { processManager } from "./processes/manager.js";
 import { bridgeAgentSessionEvent, bridgeSessionCreated } from "./webhooks/event-bridge.js";
 import { isOrchestrationEnabled } from "./orchestration/config.js";
 import { isSupervisor, readStore } from "./orchestration/store.js";
-import { createOrchestrationTools } from "./orchestration/tools.js";
+import { createOrchestrationTools, ORCHESTRATION_TOOL_NAMES } from "./orchestration/tools.js";
 import { bridgeWorkerAgentEvent } from "./orchestration/event-bridge.js";
 import { notifySupervisorDisposed, notifySupervisorIdle } from "./orchestration/inbox.js";
 import { archiveSessionFiles } from "./session-archive.js";
@@ -241,16 +241,24 @@ async function buildToolsAllowlist(
 ): Promise<string[]> {
   const overrides = await readToolOverrides();
   // Pi extensions register tools programmatically — those names are
-  // invisible to BUILTIN_TOOL_NAMES and to `customTools` (which only
-  // covers our MCP shim). Without enumerating them here, the
-  // strict-allowlist semantics in the SDK's `_refreshToolRegistry`
-  // would silently drop every extension-contributed tool. See
-  // packages/server/src/extensions-discovery.ts for the discovery
-  // contract.
+  // invisible to BUILTIN_TOOL_NAMES and to `customTools` (which covers
+  // MCP plus forge-native custom tools like ask_user_question, process,
+  // todo, and supervisor-only orchestrate_*). Without enumerating
+  // extensions here, the strict-allowlist semantics in the SDK's
+  // `_refreshToolRegistry` would silently drop every extension-
+  // contributed tool. See packages/server/src/extensions-discovery.ts
+  // for the discovery contract.
   const extensionResources = await discoverExtensionResources(workspacePath);
+  const forgeNativeCustomToolNames = new Set<string>([
+    ...BUILTIN_TOOL_NAMES,
+    ...ORCHESTRATION_TOOL_NAMES,
+  ]);
   const candidates = [
     ...BUILTIN_TOOL_NAMES.map((name) => ({ family: "builtin" as const, name })),
-    ...customTools.map((t) => ({ family: "mcp" as const, name: t.name })),
+    ...customTools.map((t) => ({
+      family: forgeNativeCustomToolNames.has(t.name) ? ("builtin" as const) : ("mcp" as const),
+      name: t.name,
+    })),
     ...extensionResources.tools.map((t) => ({ family: "extension" as const, name: t.name })),
   ];
   return filterEnabledTools(overrides, projectId, candidates);

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -142,6 +142,23 @@ interface ToolsModule {
   }[];
 }
 
+interface SessionRegistryModule {
+  createSession: (
+    projectId: string,
+    workspacePath: string,
+  ) => Promise<{
+    sessionId: string;
+    session: { getActiveToolNames: () => string[] };
+  }>;
+  rebuildAgentSessionForTools: (sessionId: string) => Promise<
+    | {
+        session: { getActiveToolNames: () => string[] };
+      }
+    | undefined
+  >;
+  disposeSession: (sessionId: string) => Promise<void>;
+}
+
 let failures = 0;
 function assert(label: string, ok: boolean, detail?: string): void {
   if (ok) console.log(`  PASS  ${label}`);
@@ -317,6 +334,42 @@ async function main(): Promise<void> {
   const eventBridge = (await import(
     resolve(repoRoot, "packages/server/dist/orchestration/event-bridge.js")
   )) as unknown as EventBridgeModule;
+  const sessionRegistry = (await import(
+    resolve(repoRoot, "packages/server/dist/session-registry.js")
+  )) as unknown as SessionRegistryModule;
+
+  // ===== pre-prompt live-session tool rebuild =====
+  console.log("\n[test-orchestration] pre-prompt supervisor tool activation");
+  const prePromptProjectId = `preprompt-${randomUUID()}`;
+  const prePromptSession = await sessionRegistry.createSession(prePromptProjectId, sharedWs);
+  try {
+    assert(
+      "fresh pre-prompt session starts without orchestration tools",
+      !prePromptSession.session.getActiveToolNames().includes("orchestrate_spawn_worker"),
+      prePromptSession.session.getActiveToolNames().join(","),
+    );
+    await store.enableSupervisor(prePromptSession.sessionId);
+    const rebuilt = await sessionRegistry.rebuildAgentSessionForTools(prePromptSession.sessionId);
+    const enabledToolNames = rebuilt?.session.getActiveToolNames() ?? [];
+    assert(
+      "enable before first prompt activates orchestration tools",
+      enabledToolNames.includes("orchestrate_spawn_worker") &&
+        enabledToolNames.includes("orchestrate_list_workers"),
+      enabledToolNames.join(","),
+    );
+    await store.disableSupervisor(prePromptSession.sessionId);
+    const rebuiltDisabled = await sessionRegistry.rebuildAgentSessionForTools(
+      prePromptSession.sessionId,
+    );
+    const disabledToolNames = rebuiltDisabled?.session.getActiveToolNames() ?? [];
+    assert(
+      "disable before first prompt removes orchestration tools",
+      !disabledToolNames.includes("orchestrate_spawn_worker"),
+      disabledToolNames.join(","),
+    );
+  } finally {
+    await sessionRegistry.disposeSession(prePromptSession.sessionId).catch(() => undefined);
+  }
 
   // ===== enable / disable supervisor =====
   await store.enableSupervisor("sup-1");


### PR DESCRIPTION
## Summary

Enabling orchestration before a session's first prompt could leave the live `AgentSession` without the supervisor `orchestrate_*` tools. The rebuild path did create the supervisor-only custom tools, but the session tool allowlist classified every custom tool as MCP, so forge-native orchestration tools could be filtered out instead of becoming active.

This PR keeps orchestration per-session and fixes the pre-prompt enable path by classifying forge-native custom tools (`ask_user_question`, `todo`, `process`, and supervisor-only `orchestrate_*`) as built-in/native for tool override filtering. A session still only receives `orchestrate_*` tools after that specific session is marked as a supervisor.

## Usage

No new user-facing controls or commands. Existing behavior now works reliably:

1. Create/open a session.
2. Enable supervisor mode from the orchestration UI before sending the first prompt.
3. Send the first prompt; that session has `orchestrate_*` tools available.

Important scope note: orchestration remains per-session, not global. Non-supervisor sessions still start without `orchestrate_*` tools, and disabling supervisor mode removes them again.

## What changed (2 files)

- `packages/server/src/session-registry.ts` — treats forge-native custom tool names as built-in/native for the `tools` allowlist while preserving the existing `resolveOrchestrationTools(sessionId)` per-session supervisor gate.
- `tests/test-orchestration.ts` — adds focused coverage for a live pre-prompt session: fresh session has no orchestration tools, enabling that session activates them, and disabling removes them.

## Test plan

- [x] `npm run build`
- [x] `npx tsx tests/test-orchestration.ts`
- [x] `npx prettier --check packages/server/src/session-registry.ts tests/test-orchestration.ts`
- [ ] CI green before merge
