### PR TITLE
chore(release): v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,42 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.4.1] — 2026-06-08
+
+### Added
+
+- **Sandbox tool environment settings.** Settings now includes a Sandbox tab for
+  persisted tool environment variables, with masked values in the browser UI and
+  injection into forge-managed shell and process tool calls.
+- **Automatic session tab titles.** New sessions can derive a short,
+  deterministic title from the first prompt, persist it, and deliver live title
+  updates to open panes without an extra LLM call.
+
+### Changed
+
+- **File tree loading defaults to the full bounded depth.** The file browser now
+  defaults to the maximum supported tree depth of 32 while keeping recursion
+  bounded for safety.
+
+### Fixed
+
+- **Git auth failures are clearer and safer.** Pull/push/fetch failures that
+  require credentials are classified as auth-required errors with actionable
+  guidance instead of exposing confusing git stderr or hanging on prompts.
+- **Terminal idle connections are kept alive.** Terminal WebSockets now send a
+  configurable keepalive ping to reduce idle disconnects behind proxies, and
+  browser autocomplete is disabled for terminal and prompt text inputs.
+- **File panes refresh after write tools.** Completed agent `write` tool calls
+  refresh the file pane immediately while preserving the end-of-turn fallback.
+- **Orchestration can be enabled before the first prompt.** Per-session
+  orchestration tools now become available when a supervisor session is enabled
+  before any prompt is sent, without enabling orchestration globally.
+- **Sandbox settings CI checks pass.** The sandbox settings form and regression
+  tests were adjusted to satisfy typecheck, lint, and formatting checks.
+- **Compose sandbox capabilities are scoped correctly.** The regular compose
+  file no longer includes sandbox setuid/setgid capabilities; they remain in the
+  sandbox compose override.
+
 ## [1.4.0] — 2026-06-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "workspaces": [
         "packages/*"
       ],
@@ -16968,7 +16968,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17014,7 +17014,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.78.0",
         "@earendil-works/pi-ai": "0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepares the v1.4.1 release after the post-v1.4.0 fixes and follow-up CI cleanup landed on `main`. The release bump uses the repository release tooling so package versions stay in lockstep and the changelog is rolled into a dated release section.

This PR does not add runtime behavior by itself; it packages the already-merged v1.4.1 changes into release metadata.

## Usage

After this PR merges, tag the merged `main` commit to trigger the release workflow:

```bash
git checkout main
git pull --ff-only
git tag v1.4.1
git push origin v1.4.1
```

The release workflow will build the multi-arch image and create the GitHub Release automatically.

## What changed (5 files, +43/-7)

- `CHANGELOG.md` — added v1.4.1 release notes under `## [1.4.1] — 2026-06-08` and restored an empty `## [Unreleased]` section for the next cycle.
- `package.json` — bumped the root package version from `1.4.0` to `1.4.1`.
- `packages/client/package.json` — bumped the client workspace version to `1.4.1`.
- `packages/server/package.json` — bumped the server workspace version to `1.4.1`.
- `package-lock.json` — refreshed lockfile package metadata for the v1.4.1 version bump.

## Test plan

- [x] `npm run check`
- [ ] CI green before merge
