### PR TITLE
docs: move advanced Docker env vars into docs

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -6,12 +6,18 @@
 # `docker/.env` is gitignored — never commit real secrets. The compose
 # file reads variables from this file via Compose's auto-load (when run
 # from the docker/ directory) or with `--env-file docker/.env`.
+#
+# This sample intentionally lists only the common Docker settings. Advanced
+# server env vars (LDAP, JWT lifetime, CORS pinning, minimal UI, orchestration,
+# rate limits, terminal tuning, sandbox mode, etc.) are documented in
+# ../docs/configuration.md, ../docs/deployment.md, and
+# ../docs/agent-tool-sandbox.md.
 
 # ---- Container + network ----
 # Override the container name if you run multiple instances.
 CONTAINER_NAME=pi-forge
-# Host-side port. Bind to 127.0.0.1 explicitly via the compose file if
-# you only want loopback access (default exposes on all interfaces).
+# Host-side port. The compose file binds this to 127.0.0.1 by default.
+# To expose to the LAN, edit docker-compose.yml (and set auth first).
 HOST_PORT=3000
 
 # ---- User mapping ----
@@ -22,16 +28,6 @@ HOST_PORT=3000
 # automatically — defaults usually work.
 PUID=1000
 PGID=1000
-
-# ---- Agent tool identity sandbox ----
-# Disabled by default. Regular compose starts the server as `pi` directly
-# and drops all Linux capabilities. When enabling sandbox mode, use the
-# docker-compose.sandbox.yml overlay so the pi-forge server runs as root
-# with only SETUID/SETGID and model/user shell surfaces run as the
-# restricted `pi-tools` UID/GID.
-AGENT_TOOL_SANDBOX_ENABLED=false
-AGENT_TOOL_UID=1001
-AGENT_TOOL_GID=1001
 
 # ---- Volume sources ----
 # Where your project code lives on the host. Projects are subfolders.
@@ -48,65 +44,16 @@ PI_CONFIG_HOST_PATH=~/.pi/agent
 FORGE_DATA_HOST_PATH=~/.pi-forge-docker
 
 # ---- Authentication ----
-# Browser password login. Leave empty to disable browser auth.
-# Treated as the INITIAL password — once the user changes it via the
-# UI, a scrypt hash is persisted to ${FORGE_DATA_DIR}/password-hash
-# (mode 0600) and this env value is ignored on subsequent logins. The
-# data dir is bind-mounted, so the hash survives container restarts.
-# Delete the password-hash file (and unset/rotate UI_PASSWORD if you
-# want a different initial value) to reset.
+# Set UI_PASSWORD and/or API_KEY before any non-loopback deploy.
+# Both empty = auth disabled (okay for loopback-only local use).
+# JWT_SECRET is optional: when auth is enabled, pi-forge auto-generates
+# and persists a signing key in the forge data dir.
 UI_PASSWORD=
-# When `true` and the user logs in with the env-supplied UI_PASSWORD
-# AND no on-disk hash exists yet, the issued JWT is scoped to
-# POST /auth/change-password — the UI forces the user to pick a new
-# password before any other API call works. Defaults to `false`:
-# pi-forge is single-tenant and a user setting their own UI_PASSWORD
-# does so deliberately, so forcing a change is friction without a
-# real win. Set to `true` for deployments where UI_PASSWORD comes
-# from a sealed secret (helm, vault, sealed-secrets) and the operator
-# should rotate it on first login.
-REQUIRE_PASSWORD_CHANGE=false
-# JWT signing key. OPTIONAL — if UI_PASSWORD is set and JWT_SECRET is
-# empty, the server auto-generates one and persists it to
-# ${FORGE_DATA_DIR}/jwt-secret (mode 0600). The data dir is already
-# bind-mounted, so issued tokens survive container restarts.
-# Set explicitly to override (e.g. `openssl rand -hex 32`); delete the
-# file to rotate.
-JWT_SECRET=
-# Static bearer token for programmatic / CLI use. Independent from
-# UI_PASSWORD; both can be set together.
 API_KEY=
 
 # ---- Reverse proxy / logging ----
 # Set to `true` when running behind nginx / Caddy / Traefik so req.ip
 # reflects the real client IP — required for the login rate limit.
 TRUST_PROXY=false
-# Pin to a specific origin in production (e.g. https://pi.example.com).
-# Empty = reflect any origin (fine for same-origin browser use).
-CORS_ORIGIN=
 # pino log level: trace, debug, info, warn, error, fatal.
 LOG_LEVEL=info
-
-# ---- Frontend mode ----
-# Minimal UI: hides terminal, git pane, last-turn pane, and the
-# providers/agent settings sections; project creation drops the
-# folder browser and auto-mkdirs `<workspace>/<name>`. Server routes
-# are unchanged. Useful for locked-down deployments where provider
-# config is set at deploy time and end users only need chat + files.
-# Truthy values: 1, true, yes, on. Default off.
-MINIMAL_UI=false
-
-# ---- Session orchestration ----
-# Enabled by default: the chat-view `Orch` toggle is available so a
-# session can opt in to "supervisor mode" — it gets the
-# `orchestrate_*` tool group and can spawn, observe, message, and
-# control worker sessions in the same project. Hard-disabled under
-# MINIMAL_UI regardless. Set this to true to remove the instance-level
-# surface entirely. `ORCHESTRATION_ENABLED=false` is also accepted as a
-# backward-compatible disable switch. See `docs/orchestration.md`.
-ORCHESTRATION_DISABLED=false
-# Per-supervisor live-worker cap. The bound applies only to LIVE
-# (in-memory) workers — killed/cold workers don't count. Raise for
-# heavy fan-out workflows; lower for cost control on token-expensive
-# setups. Bounded to [1, 100].
-ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR=8

--- a/docker/docker-compose.sandbox.yml
+++ b/docker/docker-compose.sandbox.yml
@@ -13,6 +13,8 @@ services:
     user: "0:0"
     environment:
       AGENT_TOOL_SANDBOX_ENABLED: ${AGENT_TOOL_SANDBOX_ENABLED:-true}
+      AGENT_TOOL_UID: ${AGENT_TOOL_UID:-1001}
+      AGENT_TOOL_GID: ${AGENT_TOOL_GID:-1001}
     cap_add:
       - SETUID
       - SETGID

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,8 @@ services:
         # Override in .env to match `id -u` / `id -g` for writable bind mounts.
         PUID: ${PUID:-1000}
         PGID: ${PGID:-1000}
+        # Advanced: set when using docker-compose.sandbox.yml with
+        # non-default pi-tools IDs (see ../docs/agent-tool-sandbox.md).
         PTOOLS_UID: ${AGENT_TOOL_UID:-1001}
         PTOOLS_GID: ${AGENT_TOOL_GID:-1001}
     image: pi-forge:latest
@@ -41,28 +43,14 @@ services:
       PORT: "3000"
       # Auth — read from .env. Both empty = auth disabled.
       UI_PASSWORD: ${UI_PASSWORD:-}
-      REQUIRE_PASSWORD_CHANGE: ${REQUIRE_PASSWORD_CHANGE:-false}
-      JWT_SECRET: ${JWT_SECRET:-}
       API_KEY: ${API_KEY:-}
       # Logging + reverse-proxy hint.
       LOG_LEVEL: ${LOG_LEVEL:-info}
       TRUST_PROXY: ${TRUST_PROXY:-false}
-      CORS_ORIGIN: ${CORS_ORIGIN:-}
-      MINIMAL_UI: ${MINIMAL_UI:-false}
-      # Session orchestration — enabled by default. Hard-disabled under
-      # MINIMAL_UI; set ORCHESTRATION_DISABLED=true to remove the surface.
-      # ORCHESTRATION_ENABLED=false remains a compatibility disable switch.
-      # See docs/orchestration.md.
-      ORCHESTRATION_DISABLED: ${ORCHESTRATION_DISABLED:-false}
-      ORCHESTRATION_ENABLED: ${ORCHESTRATION_ENABLED:-}
-      ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR: ${ORCHESTRATION_MAX_WORKERS_PER_SUPERVISOR:-8}
-      # Identity sandbox — disabled by default. Use
-      # docker-compose.sandbox.yml when enabling it so the server runs
-      # as root with only the SETUID/SETGID capabilities needed to drop
-      # model/user shell surfaces to pi-tools.
-      AGENT_TOOL_SANDBOX_ENABLED: ${AGENT_TOOL_SANDBOX_ENABLED:-false}
-      AGENT_TOOL_UID: ${AGENT_TOOL_UID:-1001}
-      AGENT_TOOL_GID: ${AGENT_TOOL_GID:-1001}
+      # Less-used server env vars (JWT_SECRET, CORS_ORIGIN, MINIMAL_UI,
+      # LDAP, orchestration, rate limits, terminal tuning, sandbox, etc.)
+      # are intentionally documentation-only; add them in your own compose
+      # override when needed. See ../docs/configuration.md.
     # Hardening. Not read-only because the agent's bash tool needs to
     # write to /home/pi/.npm, /tmp, etc. Regular mode does not need any
     # Linux capabilities because the container starts as pi directly.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,10 @@ the `FLAGS` table there.
 ## Environment variables
 
 The exhaustive list lives in `pi-forge --help` (and the `FLAGS` table
-in `cli.ts`). The most-touched ones:
+in `cli.ts`). Docker's `.env.example` intentionally mirrors only a
+small common subset; use this section when adding advanced values to a
+compose override (or compose `environment:` block), Kubernetes manifest,
+or shell environment. The most-touched ones:
 
 | Variable | Default | Notes |
 |---|---|---|
@@ -303,6 +306,13 @@ The shipped `docker-compose.yml` mounts these paths by default:
 | `/home/pi/.pi/agent` | `${PI_CONFIG_HOST_PATH:-~/.pi/agent}` | Shared with host pi CLI by default — same provider keys, custom providers, agent defaults |
 | `/home/pi/.pi-forge` | `${FORGE_DATA_HOST_PATH:-~/.pi-forge-docker}` | **Separate** from the host's `~/.pi-forge` so the container has its own project list — host project paths wouldn't resolve inside the container anyway |
 | `/workspace` | `${WORKSPACE_HOST_PATH:-../workspace}` | User code; sessions under `.pi/sessions/` here |
+
+`docker/.env.example` intentionally keeps to common values (host port,
+UID/GID, bind mounts, auth, logging/proxy hints). Less-used values such
+as `JWT_SECRET`, `CORS_ORIGIN`, `MINIMAL_UI`, LDAP settings,
+orchestration toggles, rate limits, terminal tuning, and sandbox mode
+remain supported; add them to your own compose override or compose
+`environment:` block using the reference above when needed.
 
 See [`containers.md`](./containers.md) for UID/GID handling, image
 internals, and override env vars.

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -127,8 +127,12 @@ bind mount.
 
 The full env-var reference lives in
 [`configuration.md`](./configuration.md#environment-variables). The
-container fixes the path-related vars; everything else is yours to set
-in `docker/.env`:
+container fixes the path-related vars; the shipped `docker/.env.example`
+only includes the settings most Docker users edit on day one. Add
+less-used server knobs (LDAP, CORS pinning, minimal UI, orchestration,
+rate limits, terminal tuning, explicit JWT rotation, etc.) in your own
+compose override (or by adding them to the compose `environment:` block)
+when you need them.
 
 | Variable | Container value |
 |---|---|
@@ -142,12 +146,17 @@ in `docker/.env`:
 | `AGENT_TOOL_UID` / `AGENT_TOOL_GID` | `1001` / `1001` in compose defaults |
 
 Set `UI_PASSWORD` and / or `API_KEY` in `.env` for any non-loopback
-deploy — without them, auth is disabled.
+deploy — without them, auth is disabled. `JWT_SECRET` is intentionally
+not in the sample `.env`; when auth is enabled, pi-forge auto-generates
+and persists it under `${FORGE_DATA_DIR}/jwt-secret` unless you choose
+to manage rotation yourself.
 
 ## Compose recipe
 
 The shipped compose file (`docker/docker-compose.yml`) covers a typical
-single-host deploy. Quickstart:
+single-host deploy. Its `.env.example` is deliberately concise; advanced
+server env vars remain supported but are documented instead of being
+listed as runtime defaults. Quickstart:
 
 ```bash
 cp docker/.env.example docker/.env


### PR DESCRIPTION
## Summary

The Docker examples exposed many advanced environment variables directly in `docker/.env.example` and the base compose file, making the common setup look more complex than it needs to be. This PR keeps the default Docker examples focused on common settings and moves less-used/advanced environment variable guidance into the docs.

## Usage

Use the trimmed Docker env example for common configuration:

```bash
cp docker/.env.example docker/.env
```

For advanced settings, add explicit `environment:` entries or compose overrides as documented in `docs/configuration.md` and `docs/containers.md`.

## What changed (5 files)

- `docker/.env.example` — reduced the example to common Docker settings.
- `docker/docker-compose.yml` — removed less-used advanced runtime defaults from the base compose service.
- `docker/docker-compose.sandbox.yml` — kept sandbox-specific environment in the sandbox compose overlay.
- `docs/configuration.md` — documented advanced env variable usage outside the example file.
- `docs/containers.md` — documented compose override guidance for advanced configuration.

## Test plan

- [x] `npm run format:check`
- [x] `npm run build`
- [ ] `npm run check` — attempted; typecheck completed, then ESLint was killed with exit 137 in the worker environment
- [ ] Docker compose config validation — not run because Docker is unavailable in the worker environment
- [ ] CI green before merge
