### PR TITLE
fix: clear stale session error banners

### DIFF
--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -642,7 +642,10 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   },
 
   sendPrompt: async (sessionId, text, attachments) => {
-    set({ error: undefined });
+    set((s) => ({
+      error: undefined,
+      bannerBySession: { ...s.bannerBySession, [sessionId]: undefined },
+    }));
     // Optimistically append the user message so the chat reflects the input
     // immediately. If the server rejects (no API key, no model, etc.) the
     // catch below rolls it back. If it accepts, the eventual messages

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -340,8 +340,12 @@ export function shouldSuppressCodexProviderErrorFromWebUi(
  * SDK's openai-completions catch path; we scope the scan to those
  * to avoid surfacing a stale errorMessage from a previous turn.
  */
-function findLastAssistantErrorMessage(messages: readonly unknown[]): string | undefined {
-  for (let i = messages.length - 1; i >= 0; i--) {
+export function findLastAssistantErrorMessage(
+  messages: readonly unknown[],
+  startIndex = 0,
+): string | undefined {
+  const from = Math.max(0, Math.min(startIndex, messages.length));
+  for (let i = messages.length - 1; i >= from; i--) {
     const m = messages[i] as {
       role?: string;
       stopReason?: string;
@@ -366,6 +370,15 @@ function makeSubscribeHandler(live: LiveSession): () => void {
       // at the first message of the new turn (the user prompt or the
       // steered/follow-up entry).
       live.lastAgentStartIndex = live.session.messages.length;
+      // The SDK may leave `session.errorMessage` populated after a failed
+      // turn. A follow-up prompt starts a new run, so acknowledge the stale
+      // session-level error here; if this new run fails, the SDK will set a
+      // fresh value before `agent_end` and the banner still appears.
+      try {
+        (live.session as unknown as { errorMessage: string | undefined }).errorMessage = undefined;
+      } catch {
+        // Best-effort only — never let error clearing break event fan-out.
+      }
     }
 
     // Surface SDK-level provider errors to stderr. The pi SDK swallows
@@ -474,7 +487,10 @@ function makeSubscribeHandler(live: LiveSession): () => void {
       // spinner mid-tool-chain). Scan the post-turn messages for the
       // most-recent assistant with an error and surface that.
       if (errMsg === undefined || errMsg === "") {
-        const fromMessage = findLastAssistantErrorMessage(live.session.messages);
+        const fromMessage = findLastAssistantErrorMessage(
+          live.session.messages,
+          live.lastAgentStartIndex ?? 0,
+        );
         if (fromMessage !== undefined && fromMessage !== "") {
           errMsg = fromMessage;
           logAgentEvent("warn", {

--- a/tests/test-session.ts
+++ b/tests/test-session.ts
@@ -100,6 +100,10 @@ async function main(): Promise<void> {
     resumeSession: (id: string, projectId: string, workspacePath: string) => Promise<TestLive>;
     discoverSessionsOnDisk: (projectId: string, workspacePath: string) => Promise<TestDiscovered[]>;
     maybeNameSessionFromFirstPrompt: (live: TestLive, promptText: string) => string | undefined;
+    findLastAssistantErrorMessage: (
+      messages: readonly unknown[],
+      startIndex?: number,
+    ) => string | undefined;
     sessionCount: () => number;
     disposeAllSessions: () => void;
   }
@@ -113,6 +117,27 @@ async function main(): Promise<void> {
   )) as unknown as TestRegistry;
 
   try {
+    const boundedErrorMessages = [
+      { role: "user", content: "old failing prompt" },
+      { role: "assistant", stopReason: "error", errorMessage: "old provider error" },
+      { role: "user", content: "successful follow-up" },
+      { role: "assistant", stopReason: "stop", content: "ok" },
+    ];
+    assert(
+      "agent_end error fallback ignores prior-turn assistant errors",
+      registry.findLastAssistantErrorMessage(boundedErrorMessages, 2) === undefined,
+    );
+    assert(
+      "agent_end error fallback still reports current-turn assistant errors",
+      registry.findLastAssistantErrorMessage(
+        [
+          ...boundedErrorMessages,
+          { role: "assistant", stopReason: "error", errorMessage: "new error" },
+        ],
+        2,
+      ) === "new error",
+    );
+
     const projectId = "proj-" + Date.now().toString(36);
 
     // 1. Create


### PR DESCRIPTION
## Summary

After a session hit an error, later follow-up prompts could resurface the old error banner even when the new run had not failed. The stale error state was not being cleared/scoped to the current turn. This PR clears prior session error banners when a new prompt/run starts and scopes server-side fallback error handling to the current agent turn.

## Usage

No new user-facing controls. Reproduce by causing a session error, then sending a follow-up prompt; the previous error banner should not reappear unless the new run fails.

## What changed (3 files)

- `packages/client/src/store/session-store.ts` — clears the per-session banner optimistically when `sendPrompt` starts while preserving genuine new prompt rejection/agent errors.
- `packages/server/src/session-registry.ts` — clears stale `session.errorMessage` on `agent_start` and scopes assistant error fallback to the current turn using `lastAgentStartIndex`.
- `tests/test-session.ts` — adds coverage for current-turn vs prior-turn error fallback behavior.

## Test plan

- [x] `npm run build`
- [x] `npx tsx tests/test-session.ts`
- [x] `npm run check`
- [ ] CI green before merge
