### PR TITLE
fix: keep terminal PTY size in sync

### DIFF
--- a/packages/client/src/components/TerminalPanel.tsx
+++ b/packages/client/src/components/TerminalPanel.tsx
@@ -50,6 +50,28 @@ function disableBrowserTextAssist(host: HTMLElement): void {
 }
 
 /**
+ * Push xterm's current grid size to the backing PTY whenever fit() changes it.
+ * Shell line editors use the PTY's kernel window size to decide where pasted
+ * input wraps; if xterm and the PTY drift apart, long paste echo wraps back over
+ * the same visual line. Keep the websocket resize in one helper so every fit()
+ * path (mount, remount, tab visibility, container resize) stays in sync.
+ */
+function syncPtySize(entry: Live, force = false): void {
+  const cols = entry.term.cols;
+  const rows = entry.term.rows;
+  if (!force && cols === entry.lastSize.cols && rows === entry.lastSize.rows) return;
+  entry.lastSize = { cols, rows };
+  if (entry.ws.readyState === WebSocket.OPEN) {
+    entry.ws.send(JSON.stringify({ type: "resize", cols, rows }));
+  }
+}
+
+function fitAndSyncPty(entry: Live, force = false): void {
+  entry.fit.fit();
+  syncPtySize(entry, force);
+}
+
+/**
  * Mirrors the SSE backoff in `streamSSE`: 1→2→4→8→16→30s then steady
  * at 30. The cap matches the SSE client so behavior is consistent
  * across the two transport channels.
@@ -232,8 +254,9 @@ function TerminalHost({
         disableBrowserTextAssist(host);
         // visibility:hidden (not display:none) is used for tab
         // switching, so `host` has real layout dimensions on every
-        // mount — fit always returns correct cols/rows.
-        existing.fit.fit();
+        // mount — fit always returns correct cols/rows. Force a resize
+        // frame because the socket may have reconnected while unmounted.
+        fitAndSyncPty(existing, true);
       } catch {
         // open() / appendChild can throw transiently if the host
         // hasn't been laid out yet; the visibility-change effect
@@ -242,16 +265,9 @@ function TerminalHost({
       }
       const observer = new ResizeObserver(() => {
         try {
-          existing.fit.fit();
+          fitAndSyncPty(existing);
         } catch {
           // host detached momentarily during tab/panel toggles
-        }
-        const cols = existing.term.cols;
-        const rows = existing.term.rows;
-        if (cols === existing.lastSize.cols && rows === existing.lastSize.rows) return;
-        existing.lastSize = { cols, rows };
-        if (existing.ws.readyState === WebSocket.OPEN) {
-          existing.ws.send(JSON.stringify({ type: "resize", cols, rows }));
         }
       });
       observer.observe(host);
@@ -265,7 +281,7 @@ function TerminalHost({
       existing.observer = observer;
       requestAnimationFrame(() => {
         try {
-          existing.fit.fit();
+          fitAndSyncPty(existing);
           existing.term.focus();
         } catch {
           // ignore
@@ -340,19 +356,12 @@ function TerminalHost({
     // ourselves. Reads the current WS each call (post-reconnect-safe).
     const observer = new ResizeObserver(() => {
       try {
-        fit.fit();
+        const entry = live.get(tab.id);
+        if (entry === undefined) return;
+        fitAndSyncPty(entry);
       } catch {
         // fit can throw if the host is detached momentarily during
         // tab toggles; harmless.
-      }
-      const cols = term.cols;
-      const rows = term.rows;
-      const entry = live.get(tab.id);
-      if (entry === undefined) return;
-      if (cols === entry.lastSize.cols && rows === entry.lastSize.rows) return;
-      entry.lastSize = { cols, rows };
-      if (entry.ws.readyState === WebSocket.OPEN) {
-        entry.ws.send(JSON.stringify({ type: "resize", cols, rows }));
       }
     });
     observer.observe(hostRef.current);
@@ -397,7 +406,7 @@ function TerminalHost({
     if (entry === undefined) return;
     requestAnimationFrame(() => {
       try {
-        entry.fit.fit();
+        fitAndSyncPty(entry);
         entry.term.focus();
       } catch {
         // see ResizeObserver comment
@@ -500,7 +509,10 @@ function attachWebSocket(
     // server resizes the existing PTY rather than spawning a new one.
     // visibility:hidden tab-switching means every host has real
     // dimensions at mount, so this size is always honest.
-    ws.send(JSON.stringify({ type: "resize", cols: size.cols, rows: size.rows }));
+    const entry = live.get(tabId);
+    const currentSize =
+      entry !== undefined ? { cols: entry.term.cols, rows: entry.term.rows } : size;
+    ws.send(JSON.stringify({ type: "resize", cols: currentSize.cols, rows: currentSize.rows }));
     // Note: no "reconnected" banner here. The server's buffer
     // replay (sent on attach) shows recent output, and the same PTY
     // is still alive — the user is back in the SAME shell, not a
@@ -508,8 +520,10 @@ function attachWebSocket(
     // succeeded; a fresh PTY only happens if the idle reaper killed
     // it (10 min) and that case looks indistinguishable from "new
     // tab" on the wire.
-    const entry = live.get(tabId);
-    if (entry !== undefined) entry.reconnectAttempt = 0;
+    if (entry !== undefined) {
+      entry.lastSize = currentSize;
+      entry.reconnectAttempt = 0;
+    }
     // Suppress the unused-arg lint without changing the function
     // signature (kept stable for future use, e.g. a server-side
     // "fresh_pty" hint frame).

--- a/tests/test-terminal.ts
+++ b/tests/test-terminal.ts
@@ -347,10 +347,20 @@ async function main(): Promise<void> {
       assert("echo output reaches client", sawSentinel, `output: ${term.output.slice(-200)}`);
 
       send(term.ws, { type: "resize", cols: 120, rows: 40 });
-      // Wait a tick — the resize is fire-and-forget; we just want to
-      // assert no error closes the socket.
+      // Wait a tick — the resize is fire-and-forget; we first assert
+      // no error closes the socket, then ask the shell for its PTY
+      // window size. Long pasted input wraps according to this kernel
+      // size, so it must stay in sync with xterm's grid.
       await new Promise((r) => setTimeout(r, 100));
       assert("socket still open after resize", term.ws.readyState === WebSocket.OPEN);
+      const sizeMarker = "SIZECHK_" + randomBytes(3).toString("hex");
+      send(term.ws, { type: "input", data: `printf '${sizeMarker}='; stty size\n` });
+      const sawPtySize = await waitForOutput(term, `${sizeMarker}=40 120`, 5_000);
+      assert(
+        "PTY receives terminal resize cols/rows",
+        sawPtySize,
+        `output: ${term.output.slice(-400)}`,
+      );
 
       // ---- Idle WebSocket keepalive ----
       // The PTY is idle here: no input and no shell output required.


### PR DESCRIPTION
## Summary

Long pasted input in the integrated terminal could wrap or echo incorrectly when xterm's fitted dimensions drifted from the backend PTY size. This PR centralizes terminal fit/resize synchronization so remounts, visibility changes, resize observer events, and WebSocket opens keep the frontend and PTY dimensions aligned.

## Usage

Open the integrated terminal and paste a long command. Wrapped input should follow normal terminal behavior instead of continuing incorrectly on the same visual line.

## What changed (2 files)

- `packages/client/src/components/TerminalPanel.tsx` — centralizes `fit()` and PTY resize sync across terminal lifecycle events.
- `tests/test-terminal.ts` — adds integration coverage asserting the PTY receives expected resized rows/cols.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only terminal`
- [ ] Manual browser paste verification
- [ ] CI green before merge
