### PR TITLE
fix: guard client id generation without randomUUID

### DIFF
--- a/packages/client/src/components/QuickActionsMenu.tsx
+++ b/packages/client/src/components/QuickActionsMenu.tsx
@@ -10,6 +10,7 @@ import {
 import { useUiConfigStore } from "../store/ui-config-store";
 import { useSessionStore } from "../store/session-store";
 import { useComposerStore } from "../store/composer-store";
+import { createClientId } from "../lib/client-id";
 
 /**
  * Toolbar chip rendered in `ChatView`'s top bar (left-aligned). Two
@@ -41,10 +42,7 @@ function isPromptAction(a: QuickAction): boolean {
 }
 
 function randomId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  return `run-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return createClientId("run");
 }
 
 export function QuickActionsMenu({ sessionId, projectId }: Props) {

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -20,6 +20,7 @@ import { useUiStore } from "../store/ui-store";
 import { EMPTY_STATUS, useMcpStore } from "../store/mcp-store";
 import { useQuickActionsStore } from "../store/quick-actions-store";
 import { THEME_DEFS, useThemeStore, type ThemeId } from "../lib/theme";
+import { createClientId } from "../lib/client-id";
 import { getStoredToken } from "../lib/auth-client";
 import { WebhooksTab } from "./WebhooksTab";
 import { useAuthStore } from "../store/auth-store";
@@ -1475,7 +1476,7 @@ interface SandboxEnvRow {
 function sandboxRowsFromEnv(toolEnv: Record<string, string>): SandboxEnvRow[] {
   return Object.entries(toolEnv)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([name, value]) => ({ id: crypto.randomUUID(), name, value, revealed: false }));
+    .map(([name, value]) => ({ id: createClientId("sandbox-env"), name, value, revealed: false }));
 }
 
 function sandboxRowsToEnv(rows: readonly SandboxEnvRow[]): Record<string, string> {
@@ -1585,7 +1586,7 @@ function SandboxTab({ onError }: { onError: (msg: string | undefined) => void })
             onClick={() => {
               setRows((current) => [
                 ...current,
-                { id: crypto.randomUUID(), name: "", value: "", revealed: false },
+                { id: createClientId("sandbox-env"), name: "", value: "", revealed: false },
               ]);
               setSaved(false);
             }}

--- a/packages/client/src/lib/client-id.ts
+++ b/packages/client/src/lib/client-id.ts
@@ -1,0 +1,26 @@
+let fallbackCounter = 0;
+
+function fallbackRandomPart(): string {
+  const cryptoObject = globalThis.crypto;
+  if (cryptoObject !== undefined && typeof cryptoObject.getRandomValues === "function") {
+    const bytes = new Uint8Array(16);
+    cryptoObject.getRandomValues(bytes);
+    bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+    bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+
+  fallbackCounter = (fallbackCounter + 1) % Number.MAX_SAFE_INTEGER;
+  return `${Date.now().toString(36)}-${fallbackCounter.toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2)}`;
+}
+
+export function createClientId(prefix: string): string {
+  const cryptoObject = globalThis.crypto;
+  const id =
+    cryptoObject !== undefined && typeof cryptoObject.randomUUID === "function"
+      ? cryptoObject.randomUUID()
+      : fallbackRandomPart();
+  return `${prefix}-${id}`;
+}

--- a/packages/client/src/lib/cross-tab.ts
+++ b/packages/client/src/lib/cross-tab.ts
@@ -18,6 +18,8 @@
  * and suspenders.
  */
 
+import { createClientId } from "./client-id";
+
 const CHANNEL_NAME = "pi-forge";
 
 /**
@@ -39,7 +41,7 @@ interface Envelope {
   msg: CrossTabMessage;
 }
 
-const TAB_ID = `tab-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+const TAB_ID = createClientId("tab");
 
 let channel: BroadcastChannel | undefined;
 function getChannel(): BroadcastChannel | undefined {

--- a/packages/client/src/store/file-store.ts
+++ b/packages/client/src/store/file-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { api, ApiError, type FileTreeNode } from "../lib/api-client";
 import { parseUnifiedDiff, type DiffLine } from "../lib/diff-parser";
+import { createClientId } from "../lib/client-id";
 
 /**
  * Per-tab editor state. Tracks an in-memory `draft` separately from
@@ -705,10 +706,7 @@ export const useFileStore = create<FileState>((set, get) => ({
 }));
 
 function newTabId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  return `tab-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  return createClientId("tab");
 }
 
 function omitKey<V>(record: Record<string, V>, key: string): Record<string, V> {

--- a/tests/test-client-id.ts
+++ b/tests/test-client-id.ts
@@ -1,0 +1,64 @@
+import { createClientId } from "../packages/client/src/lib/client-id";
+
+interface CryptoStub {
+  randomUUID?: () => string;
+  getRandomValues?: (array: Uint8Array) => Uint8Array;
+}
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`PASS ${label}`);
+  } else {
+    failures += 1;
+    console.error(`FAIL ${label}${detail === undefined ? "" : `: ${detail}`}`);
+  }
+}
+
+const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+
+function setCrypto(value: CryptoStub | undefined): void {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value,
+  });
+}
+
+try {
+  setCrypto({ randomUUID: () => "uuid-from-browser" });
+  assert(
+    "uses crypto.randomUUID when available",
+    createClientId("row") === "row-uuid-from-browser",
+  );
+
+  let fill = 0;
+  setCrypto({
+    getRandomValues: (array: Uint8Array) => {
+      array.fill(fill++);
+      return array;
+    },
+  });
+  const getRandomValuesId = createClientId("row");
+  assert(
+    "falls back to getRandomValues when randomUUID is missing",
+    getRandomValuesId.startsWith("row-") && getRandomValuesId.length > "row-".length,
+    getRandomValuesId,
+  );
+
+  setCrypto(undefined);
+  const ids = new Set(Array.from({ length: 20 }, () => createClientId("sandbox-env")));
+  assert("does not throw without crypto", ids.size === 20, [...ids].join(", "));
+  assert(
+    "fallback IDs keep the requested prefix",
+    [...ids].every((id) => id.startsWith("sandbox-env-")),
+    [...ids].join(", "),
+  );
+} finally {
+  if (originalDescriptor === undefined) {
+    delete (globalThis as { crypto?: unknown }).crypto;
+  } else {
+    Object.defineProperty(globalThis, "crypto", originalDescriptor);
+  }
+}
+
+if (failures > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Clicking **Add variable** in sandbox settings could crash in browsers/environments where `crypto` exists but `crypto.randomUUID` is unavailable:

```txt
TypeError: crypto.randomUUID is not a function
```

This PR routes sandbox environment row IDs through a shared client ID helper that keeps using `crypto.randomUUID()` when available, falls back to `crypto.getRandomValues()`, and only then uses a timestamp/counter/random fallback. The same helper replaces the other ad hoc client ID generators for consistency.

## Usage

No user-facing configuration required. In affected browsers, clicking **Settings → Sandbox → Add variable** now creates a new env var row instead of crashing.

## What changed

- `packages/client/src/lib/client-id.ts` — added shared `createClientId(prefix)` helper with feature-detected randomUUID/getRandomValues fallbacks.
- `packages/client/src/components/SettingsPanel.tsx` — sandbox env rows now use the safe helper for stable client row IDs.
- `packages/client/src/components/QuickActionsMenu.tsx` — quick action run IDs use the shared helper.
- `packages/client/src/store/file-store.ts` — file tab IDs use the shared helper.
- `packages/client/src/lib/cross-tab.ts` — cross-tab sender ID uses the shared helper.
- `tests/test-client-id.ts` — covers randomUUID, getRandomValues fallback, and no-crypto fallback behavior.

## Test plan

- [x] `npx tsx tests/test-client-id.ts`
- [x] `npm run build`
- [x] `npm run check`
- [ ] CI green before merge
