### PR TITLE
feat: add tea CLI to container image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,6 +99,7 @@ ARG PUID=1000
 ARG PGID=1000
 ARG PTOOLS_UID=1001
 ARG PTOOLS_GID=1001
+ARG TEA_VERSION=0.14.1
 
 # Some upstream base images have shipped a pre-baked `node` user/group
 # at UID/GID 1000 — the same default we want for `pi`. Drop it before
@@ -117,6 +118,9 @@ ARG PTOOLS_GID=1001
 #     `gh pr`, `gh issue`, `gh repo`, etc. Not in Debian's default
 #     repos — installed from GitHub's apt source (the keyring and
 #     sources.list lines below).
+#   - tea: the Gitea/Forgejo CLI. Debian bookworm does not reliably
+#     provide the upstream Gitea tea CLI package, so install a pinned
+#     upstream release with per-architecture SHA-256 verification.
 #   - ripgrep: pi's `grep` tool delegates to ripgrep when present.
 #     Without it, code search inside the agent silently degrades.
 #   - bash: replaces dash as the integrated terminal's interactive
@@ -148,6 +152,18 @@ RUN apt-get update \
       > /etc/apt/sources.list.d/github-cli.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends gh \
+ && tea_arch="$(dpkg --print-architecture)" \
+ && case "$tea_arch" in \
+      amd64) tea_sha256="3cf7c5d1c20808c9ba2efb9ac125cee10d969daf398e653ea2b33cde201ea317" ;; \
+      arm64) tea_sha256="0947b07f15fd2dde1768e0eb8c8619f280f45fb08b8895a11b64f6ba94b13dbf" ;; \
+      armhf) tea_arch="arm-7"; tea_sha256="5c648d888cc016fd2a95cbeedc3688c7de03fd71c8902c4c14a78d812e7d6bc9" ;; \
+      *) echo "unsupported tea architecture: $tea_arch" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL "https://dl.gitea.com/tea/${TEA_VERSION}/tea-${TEA_VERSION}-linux-${tea_arch}" \
+      -o /usr/local/bin/tea \
+ && echo "$tea_sha256  /usr/local/bin/tea" | sha256sum -c - \
+ && chmod 0755 /usr/local/bin/tea \
+ && tea --version \
  && rm -rf /var/lib/apt/lists/* \
  && (userdel node 2>/dev/null || true) \
  && (groupdel node 2>/dev/null || true) \

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -22,7 +22,7 @@ runtime (Node + native bindings), and makes deploys reproducible.
 | `python-base` | `python:3.12-slim-bookworm` | Source for the Python 3.12 + pip runtime copied into the shared Node base |
 | `node-python-base` | `node:22-bookworm-slim` | Shared Debian slim base with Node.js 22 plus Python 3.12 + pip |
 | `builder` | `node-python-base` | Installs all deps including devDeps, compiles native bindings (`node-pty`), runs `npm run build` for both packages |
-| `runtime` | `node-python-base` | Production deps + built artifacts only. Adds `git`, `ripgrep`, `bash`, `curl`, `less`, `procps`, `gosu`, and the C++ toolchain needed for native-module rebuilds during in-container development. Default mode drops the server to `pi`; sandbox mode keeps the server as root so it can drop model/user tool processes to `pi-tools`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
+| `runtime` | `node-python-base` | Production deps + built artifacts only. Adds `git`, `gh`, `tea`, `ripgrep`, `bash`, `curl`, `less`, `procps`, `gosu`, and the C++ toolchain needed for native-module rebuilds during in-container development. Default mode drops the server to `pi`; sandbox mode keeps the server as root so it can drop model/user tool processes to `pi-tools`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
 
 Final image size varies by architecture and cache state. Debian-based
 (not Alpine) because the Node native-module ecosystem ships glibc
@@ -34,6 +34,8 @@ Installed at runtime:
 - **Python 3.12 + pip** — callable as `python3`, `python`, or `py`
 - **`tini`** — init for signal forwarding + zombie reaping
 - **`git`** — required by the agent's `bash` tool and the GitPanel routes
+- **`gh`** — GitHub CLI for working with GitHub and GitHub Enterprise
+- **`tea`** — Gitea/Forgejo CLI, pinned from the upstream Gitea release
 - **`ripgrep`** — pi's `grep` tool delegates to `rg` when present;
   silently degrades to a Node walker without it
 - **`make`, `g++`** — keeps `npm install` / `npm rebuild` working

--- a/docs/quick-actions.md
+++ b/docs/quick-actions.md
@@ -131,7 +131,7 @@ schemas at `/api/docs`.
 PATH. Pi-forge launches commands with the same PATH as the
 parent process; for chips that need `gh`, `kubectl`, etc.,
 ensure they're installed in the container (the shipped image
-already has `git`, `gh`, `ripgrep`, `bash`, `curl`, `less`,
+already has `git`, `gh`, `tea`, `ripgrep`, `bash`, `curl`, `less`,
 `procps`).
 
 **Chip ran successfully but the output looks cut off.** Stream

--- a/tests/test-docker.ts
+++ b/tests/test-docker.ts
@@ -8,6 +8,7 @@
  * - Polls `GET /api/v1/health` until 200, then asserts:
  *     - runtime image has Python 3.12 + pip and can rebuild `node-pty` from source
  *       (dev-container npm install path)
+ *     - runtime image has the Gitea/Forgejo `tea` CLI on PATH
  *     - `/manifest.webmanifest` returns 200 with `display: "standalone"`
  *     - `/sw.js` returns 200 (service worker present)
  *     - `/icons/icon.svg` returns 200
@@ -185,6 +186,17 @@ services:
       "runtime image has Python 3.12/pip and can rebuild node-pty from source",
       rebuild.status === 0,
       `exit=${rebuild.status}; stdout=${rebuild.stdout.slice(-1000)}; stderr=${rebuild.stderr.slice(-1000)}`,
+    );
+
+    const tea = compose(
+      ["exec", "-T", "pi-forge", "sh", "-lc", "command -v tea && tea --version"],
+      { composeFile, projectName },
+      true,
+    );
+    assert(
+      "runtime image has tea CLI on PATH",
+      tea.status === 0,
+      `exit=${tea.status}; stdout=${tea.stdout.slice(-1000)}; stderr=${tea.stderr.slice(-1000)}`,
     );
 
     // ---- PWA assets ----


### PR DESCRIPTION
## Summary

Adds the Gitea/Forgejo `tea` CLI to the production container image so agents and terminal users can interact with Gitea/Forgejo hosts from inside the app container. Debian bookworm does not reliably provide the upstream Gitea `tea` package, so the Dockerfile installs a pinned upstream release with SHA-256 verification and keeps the binary on `PATH` as `/usr/local/bin/tea`.

## Usage

```bash
tea --version
```

The Docker build installs `tea` version `0.14.1` for supported Debian architectures (`amd64`, `arm64`, `armhf`) and verifies the checksum before marking it executable.

## What changed (4 files, +32/-2)

- `docker/Dockerfile` — installs pinned `tea` release `0.14.1`, maps supported Debian architectures to upstream release assets, verifies SHA-256 checksums, and runs `tea --version` during build.
- `tests/test-docker.ts` — adds a container smoke assertion for `command -v tea && tea --version`.
- `docs/containers.md` — documents `tea` as a bundled runtime CLI.
- `docs/quick-actions.md` — updates bundled CLI troubleshooting docs to include `tea`.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `npx tsx tests/test-docker.ts` — skipped cleanly because Docker is not available in this environment (`docker: command not found`).
- [x] Manual pinned binary verification: downloaded `tea-0.14.1-linux-amd64`, verified SHA-256, and ran `tea --version` successfully.
- [ ] Docker image build and in-container `tea --version` verification in an environment with Docker available.
- [ ] CI green before merge.
