### PR TITLE
fix: provide writable homes for tool CLIs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -170,7 +170,7 @@ RUN apt-get update \
  && groupadd -g $PGID pi \
  && useradd -m -u $PUID -g $PGID -s /bin/bash pi \
  && groupadd -g $PTOOLS_GID pi-tools \
- && useradd -M -u $PTOOLS_UID -g $PTOOLS_GID -s /usr/sbin/nologin pi-tools \
+ && useradd -m -d /home/pi-tools -u $PTOOLS_UID -g $PTOOLS_GID -s /usr/sbin/nologin pi-tools \
  && usermod -aG pi-tools pi
 
 WORKDIR /app
@@ -192,14 +192,14 @@ COPY --from=builder --chown=pi:pi /app/packages/client/dist ./packages/client/di
 # the server runs as `pi`, and pi-owned config/data dirs are writable by it.
 # Sandbox deployments must explicitly permission their mounts; see
 # docs/agent-tool-sandbox.md.
-RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm \
- && chown -R pi-tools:pi-tools /workspace \
- && chown root:root /home/pi \
+RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm /home/pi-tools/.config \
+ && chown -R pi-tools:pi-tools /workspace /home/pi-tools \
+ && chown pi:pi /home/pi \
  && chown root:pi-tools /home/pi/.pi \
  && chown -R pi:pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm \
  && chmod 0775 /workspace \
  && chmod 0755 /home/pi /home/pi/.pi \
- && chmod 0700 /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm
+ && chmod 0700 /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm /home/pi-tools
 
 RUN cat >/usr/local/bin/pi-forge-entrypoint <<'EOF'
 #!/bin/sh

--- a/docker/docker-compose.sandbox.yml
+++ b/docker/docker-compose.sandbox.yml
@@ -15,6 +15,7 @@ services:
       AGENT_TOOL_SANDBOX_ENABLED: ${AGENT_TOOL_SANDBOX_ENABLED:-true}
       AGENT_TOOL_UID: ${AGENT_TOOL_UID:-1001}
       AGENT_TOOL_GID: ${AGENT_TOOL_GID:-1001}
+      AGENT_TOOL_HOME: ${AGENT_TOOL_HOME:-/home/pi-tools}
     cap_add:
       - SETUID
       - SETGID

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -19,6 +19,7 @@ Set:
 AGENT_TOOL_SANDBOX_ENABLED=true
 AGENT_TOOL_UID=<numeric uid>
 AGENT_TOOL_GID=<numeric gid>
+AGENT_TOOL_HOME=<writable sandbox tool home>
 ```
 
 In the Docker image defaults, `pi-tools` is:
@@ -26,6 +27,7 @@ In the Docker image defaults, `pi-tools` is:
 ```txt
 AGENT_TOOL_UID=1001
 AGENT_TOOL_GID=1001
+AGENT_TOOL_HOME=/home/pi-tools
 ```
 
 When enabled:
@@ -38,6 +40,9 @@ When enabled:
 - quick-action command chips run as `AGENT_TOOL_UID:GID`
 - chat `!` / `!!` exec commands run as `AGENT_TOOL_UID:GID`
 - shell/process/terminal env is scrubbed
+- shell/process/terminal `HOME` points at `AGENT_TOOL_HOME` (the Docker
+  default is `/home/pi-tools`) so CLIs such as `gh` can create sandbox-owned
+  config without writing the server user's `/home/pi`
 
 ## What is protected
 
@@ -96,6 +101,7 @@ the container or pod**.
 | `/home/pi/.pi/agent/models.json` | Not readable by `AGENT_TOOL_UID:GID`. Recommended: `root:root` `0600`. Also blocked by file-tool policy. |
 | `/home/pi/.pi/agent/settings.json` | Not readable by `AGENT_TOOL_UID:GID`. Recommended: `root:root` `0600`. Also blocked by file-tool policy. |
 | `/home/pi/.pi-forge` | Not readable by `AGENT_TOOL_UID:GID`. Recommended: `root:root` `0700`. |
+| `/home/pi-tools` (`AGENT_TOOL_HOME`) | Writable by `AGENT_TOOL_UID:GID`; this is where sandbox terminals/processes/model bash create per-user CLI config such as `~/.config/gh`. Treat credentials stored here as available to model/user shell surfaces. |
 | mounted secret dirs/files | Not readable by `AGENT_TOOL_UID:GID`; prefer root-owned `0700` dirs and `0600` files. |
 
 Why `.pi` is partially readable: pi package skills and other non-secret pi
@@ -104,9 +110,12 @@ secret Pi config files by policy and filesystem mode, while leaving non-secret
 resources loadable.
 
 The Docker image's built-in directory ownership remains optimized for regular
-mode (`pi` owns `/home/pi/.pi/agent` and `/home/pi/.pi-forge`). Enabling sandbox
-with bind mounts or persistent volumes is an explicit operator step: adjust the
-mount permissions to the table above before relying on filesystem isolation.
+mode (`pi` owns `/home/pi` plus `/home/pi/.pi/agent` and `/home/pi/.pi-forge`) so
+non-sandbox tools can create ordinary per-user config such as `~/.config/gh`.
+Enabling sandbox with bind mounts or persistent volumes is an explicit operator
+step: adjust the mount permissions to the table above before relying on
+filesystem isolation. Sandbox tool children should still run as a different
+`AGENT_TOOL_UID:GID` so they cannot write the `pi` user's home by default.
 Switching an existing deployment between regular and sandbox mode may require
 changing volume ownership/modes.
 
@@ -176,6 +185,7 @@ Set sandbox env in `docker/.env`:
 AGENT_TOOL_SANDBOX_ENABLED=true
 AGENT_TOOL_UID=1001
 AGENT_TOOL_GID=1001
+AGENT_TOOL_HOME=/home/pi-tools
 ```
 
 Start sandbox mode with the sandbox compose overlay. The base compose file runs
@@ -317,6 +327,7 @@ Set sandbox env in `docker/.env`:
 AGENT_TOOL_SANDBOX_ENABLED=true
 AGENT_TOOL_UID=1001
 AGENT_TOOL_GID=1001
+AGENT_TOOL_HOME=/home/pi-tools
 ```
 
 Start pi-forge with the sandbox overlay:
@@ -382,6 +393,8 @@ env:
     value: "1001"
   - name: AGENT_TOOL_GID
     value: "1001"
+  - name: AGENT_TOOL_HOME
+    value: /home/pi-tools
 ```
 
 ### Init container
@@ -545,7 +558,8 @@ model file tools reject the path even if the server process could read it.
 
 | Path | `pi` regular server/tools | `root` sandbox server | `pi-tools` sandbox shell tools | Sandbox model file tools |
 |---|---|---|---|---|
-| `/home/pi` | `r-x`; home parent is not general scratch space | `rwx` | `r-x` | usually not used directly |
+| `/home/pi` | `rwx`; regular CLIs can create per-user config such as `~/.config/gh` | `rwx` | `r-x` when `AGENT_TOOL_UID` differs from `pi`; not used as HOME | usually not used directly |
+| `/home/pi-tools` (`AGENT_TOOL_HOME`) | not used | `rwx` | `rwx`; sandbox CLIs create `~/.config`, `~/.gitconfig`, caches here | outside allowed roots |
 | `/home/pi/.npm` | `rwx`; npm logs/cache | `rwx` | denied unless explicitly permissioned | outside allowed roots |
 | `/home/pi/.local` | `rwx`; user installs and Python user base | `rwx` | denied unless explicitly permissioned | outside allowed roots |
 | `/home/pi/.pi` | `r-x`; parent for Pi config | `rwx` | deployment-dependent traversal only | parent traversal only |

--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -29,7 +29,8 @@ Production deploys should set at least one. Setting both is common — browser
 users log in with the password, scripts use the API key.
 
 `AGENT_TOOL_SANDBOX_ENABLED` defaults false. When true, config startup requires
-numeric `AGENT_TOOL_UID` and `AGENT_TOOL_GID`, and LDAP bind-password file
+numeric `AGENT_TOOL_UID` and `AGENT_TOOL_GID`, sandbox shell surfaces receive
+`HOME=${AGENT_TOOL_HOME}` (default `/home/pi-tools`), and LDAP bind-password file
 references are rejected. Keep sandbox env parsing in `config.ts` and the CLI
 surface in `cli.ts` together.
 

--- a/docs/agent/terminal.md
+++ b/docs/agent/terminal.md
@@ -11,7 +11,9 @@ connected over a WebSocket (not SSE — terminals need bidirectional communicati
 - Default shell: `process.env.SHELL || '/bin/sh'`
 - When `AGENT_TOOL_SANDBOX_ENABLED=true`, `pty-manager.ts` passes `uid`/`gid`
   to `node-pty.spawn()` so terminals run as the restricted tool identity with
-  the scrubbed terminal env, not as the root/server identity.
+  the scrubbed terminal env, not as the root/server identity. It also rewrites
+  `HOME` to `AGENT_TOOL_HOME` (Docker default: `/home/pi-tools`) so sandboxed
+  CLIs can create their own config without writing the server user's home.
 - WebSocket endpoint: `ws://localhost:3000/api/v1/terminal?projectId=<id>&tabId=<optional>&token=<jwt-or-api-key>`
   - `projectId` is required; `tabId` is the stable client-side tab identifier used for reattach across reconnects; `token` is required when auth is enabled (browsers can't attach `Authorization` headers on WebSocket upgrades).
 - Fastify WebSocket support via `@fastify/websocket`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,7 @@ or shell environment. The most-touched ones:
 | `AGENT_TOOL_SANDBOX_ENABLED` | `false` | Opt-in identity/path sandbox for model/user tool surfaces. When `true`, `AGENT_TOOL_UID` and `AGENT_TOOL_GID` are required. |
 | `AGENT_TOOL_UID` | (unset) | Numeric UID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled. |
 | `AGENT_TOOL_GID` | (unset) | Numeric GID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled. |
+| `AGENT_TOOL_HOME` | `/home/pi-tools` | Writable HOME injected into sandboxed bash/process/terminal/quick-action/exec children. The Docker image creates this directory owned by `pi-tools`. |
 
 Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
 are documented in [`deployment.md`](./deployment.md).
@@ -80,9 +81,9 @@ are documented in [`deployment.md`](./deployment.md).
 The identity sandbox is off by default and has a strict mount-permission
 contract. Read [`agent-tool-sandbox.md`](./agent-tool-sandbox.md) before
 enabling it. In short: pi-forge runs the server as root, drops
-model/user shell surfaces to `AGENT_TOOL_UID:GID`, scopes model file
-access, and requires workspace / Pi config / forge data mounts to have
-specific ownership and mode bits.
+model/user shell surfaces to `AGENT_TOOL_UID:GID`, points their `HOME`
+at `AGENT_TOOL_HOME`, scopes model file access, and requires workspace /
+Pi config / forge data mounts to have specific ownership and mode bits.
 
 When this mode is enabled, LDAP bind password file references are
 rejected (`LDAP_BIND_PASSWORD_FILE` and CLI/env `@file` forms). Use a
@@ -314,8 +315,12 @@ orchestration toggles, rate limits, terminal tuning, and sandbox mode
 remain supported; add them to your own compose override or compose
 `environment:` block using the reference above when needed.
 
-See [`containers.md`](./containers.md) for UID/GID handling, image
-internals, and override env vars.
+In regular/non-sandbox containers, `$HOME` is `/home/pi` and is writable by the
+`pi` user so terminal/tool CLIs can create per-user files (`~/.config/gh`,
+`~/.gitconfig`, caches, and similar). In sandbox mode, tool/terminal children
+instead receive `HOME=${AGENT_TOOL_HOME}` (`/home/pi-tools` in the Docker image).
+See [`containers.md`](./containers.md) for UID/GID handling, image internals,
+sandbox-mode differences, and override env vars.
 
 ## See also
 

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -50,7 +50,8 @@ The image creates two users:
   preserves legacy path/env expectations.
 - `pi-tools` (`AGENT_TOOL_UID` / `AGENT_TOOL_GID` in compose, default
   `1001:1001`) is the restricted identity used when
-  `AGENT_TOOL_SANDBOX_ENABLED=true`.
+  `AGENT_TOOL_SANDBOX_ENABLED=true`. It has its own writable home at
+  `/home/pi-tools`, exposed to sandboxed shells as `AGENT_TOOL_HOME`.
 
 By default (`AGENT_TOOL_SANDBOX_ENABLED=false`), compose starts the
 server as the legacy `pi` user directly and drops all Linux
@@ -144,8 +145,10 @@ when you need them.
 | `PI_CONFIG_DIR` | `/home/pi/.pi/agent` |
 | `FORGE_DATA_DIR` | `/home/pi/.pi-forge` |
 | `PYTHONUSERBASE` | `/home/pi/.local` |
+| `HOME` | `/home/pi`; writable by the `pi` user in regular/non-sandbox mode so CLIs such as `gh` can create `~/.config`, `~/.gitconfig`, and similar per-user files |
 | `AGENT_TOOL_SANDBOX_ENABLED` | `false` by default; set `true` to run tool children as `pi-tools` |
 | `AGENT_TOOL_UID` / `AGENT_TOOL_GID` | `1001` / `1001` in compose defaults |
+| `AGENT_TOOL_HOME` | `/home/pi-tools`; writable home injected as `HOME` for sandboxed terminals/processes/model bash |
 
 Set `UI_PASSWORD` and / or `API_KEY` in `.env` for any non-loopback
 deploy — without them, auth is disabled. `JWT_SECRET` is intentionally
@@ -252,9 +255,11 @@ SSE-buffering and WebSocket-upgrade settings live in
   directories). The sandbox also blocks `/run/secrets` and
   `/var/run/secrets` from model file tools.
 - **Read-only root filesystem (optional).** Add `read_only: true` to
-  compose with `tmpfs` mounts for `/tmp` and `/home/pi/.npm` if you
-  want a hardened deploy. Native modules + node_modules live in the
-  image, so they're already read-only.
+  compose with `tmpfs` mounts for `/tmp`, `/home/pi/.npm`, and any other
+  regular-mode home/config paths you expect tools to write (for example
+  `/home/pi/.config` for GitHub CLI auth) if you want a hardened deploy.
+  Native modules + node_modules live in the image, so they're already
+  read-only.
 
 ## Updating
 

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -1559,9 +1559,9 @@ function SandboxTab({ onError }: { onError: (msg: string | undefined) => void })
       <div>
         <h2 className="text-sm font-semibold text-neutral-100">Sandbox mode</h2>
         <p className="mt-1 text-xs text-neutral-400">
-          Configure environment variables injected into future agent tool calls. Sandbox enablement
-          and UID/GID are deploy-time settings; changes here take effect for new or refreshed
-          sessions.
+          Configure environment variables injected into future agent tool calls. Sandbox enablement,
+          UID/GID, and tool HOME are deploy-time settings; changes here take effect for new or
+          refreshed sessions.
         </p>
       </div>
 
@@ -1572,6 +1572,7 @@ function SandboxTab({ onError }: { onError: (msg: string | undefined) => void })
           <span>
             Enabled{settings.uid !== undefined ? ` · uid ${settings.uid}` : ""}
             {settings.gid !== undefined ? ` · gid ${settings.gid}` : ""}
+            {settings.home !== undefined ? ` · home ${settings.home}` : ""}
           </span>
         ) : (
           <span className="text-amber-300">

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -172,6 +172,7 @@ function vSandboxSettings(value: unknown, status: number): SandboxSettingsRespon
   const out: SandboxSettingsResponse = { enabled: value.enabled, toolEnv };
   if (typeof value.uid === "number") out.uid = value.uid;
   if (typeof value.gid === "number") out.gid = value.gid;
+  if (typeof value.home === "string") out.home = value.home;
   return out;
 }
 

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -262,6 +262,7 @@ export interface SandboxSettingsResponse {
   enabled: boolean;
   uid?: number;
   gid?: number;
+  home?: string;
   toolEnv: Record<string, string>;
 }
 

--- a/packages/server/src/agent-bash-operations.ts
+++ b/packages/server/src/agent-bash-operations.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import type { BashOperations } from "@earendil-works/pi-coding-agent";
 import { config } from "./config.js";
-import { scrubbedEnv } from "./pty-manager.js";
+import { toolShellEnv } from "./pty-manager.js";
 import { mergeToolEnv } from "./sandbox-settings.js";
 
 export function sandboxSpawnIdentity(): { uid?: number; gid?: number } {
@@ -18,7 +18,7 @@ export function createForgeBashOperations(
       return new Promise<{ exitCode: number | null }>((resolve, reject) => {
         const proc = spawn("/bin/sh", ["-c", command], {
           cwd: workspacePath,
-          env: mergeToolEnv(scrubbedEnv(), toolEnv),
+          env: mergeToolEnv(toolShellEnv(), toolEnv),
           stdio: ["ignore", "pipe", "pipe"],
           ...sandboxSpawnIdentity(),
         });

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -356,6 +356,14 @@ const FLAGS: readonly FlagDef[] = [
     desc: "Numeric GID for sandboxed model/user shell processes",
     defaultText: "(required when sandbox enabled)",
   },
+  {
+    name: "agent-tool-home",
+    env: "AGENT_TOOL_HOME",
+    type: "string",
+    group: "sandbox",
+    desc: "Writable HOME for sandboxed model/user shell processes",
+    defaultText: "/home/pi-tools",
+  },
   // rate limits
   {
     name: "rate-limit-login-max",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -146,6 +146,7 @@ const PASSWORD_HASH_FILE = join(FORGE_DATA_DIR, "password-hash");
 const AGENT_TOOL_SANDBOX_ENABLED = readBool("AGENT_TOOL_SANDBOX_ENABLED", false);
 const AGENT_TOOL_UID = readOptionalInt("AGENT_TOOL_UID");
 const AGENT_TOOL_GID = readOptionalInt("AGENT_TOOL_GID");
+const AGENT_TOOL_HOME = resolve(readEnv("AGENT_TOOL_HOME") ?? "/home/pi-tools");
 if (AGENT_TOOL_SANDBOX_ENABLED && (AGENT_TOOL_UID === undefined || AGENT_TOOL_GID === undefined)) {
   throw new Error(
     "config: AGENT_TOOL_SANDBOX_ENABLED=true requires numeric AGENT_TOOL_UID and AGENT_TOOL_GID",
@@ -458,6 +459,7 @@ export const config = Object.freeze({
     enabled: AGENT_TOOL_SANDBOX_ENABLED,
     uid: AGENT_TOOL_UID,
     gid: AGENT_TOOL_GID,
+    home: AGENT_TOOL_HOME,
   }),
   /**
    * How long a detached PTY (its WebSocket closed but no replacement

--- a/packages/server/src/processes/manager.ts
+++ b/packages/server/src/processes/manager.ts
@@ -4,7 +4,7 @@ import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 import { sandboxSpawnIdentity } from "../agent-bash-operations.js";
 import { config } from "../config.js";
-import { scrubbedEnv } from "../pty-manager.js";
+import { toolShellEnv } from "../pty-manager.js";
 import { mergeToolEnv } from "../sandbox-settings.js";
 import { LogChannel, processLogDir } from "./log-store.js";
 import { buildMatchEvent, compileWatches, evaluateWatches, type CompiledWatch } from "./watches.js";
@@ -106,7 +106,7 @@ class ProcessManagerRegistry {
     // secrets leak to the child.
     const child = spawn("/bin/sh", ["-c", command], {
       cwd,
-      env: mergeToolEnv(scrubbedEnv(), opts.toolEnv ?? {}),
+      env: mergeToolEnv(toolShellEnv(), opts.toolEnv ?? {}),
       stdio: ["pipe", "pipe", "pipe"],
       ...sandboxSpawnIdentity(),
       // Put each managed command in its own process group. The

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -123,7 +123,7 @@ export function spawnPty(opts: SpawnOptions): ManagedPty {
     cols,
     rows,
     cwd: opts.cwd,
-    env: filterEnv(env),
+    env: toolShellEnv(env),
     ...identity,
   });
   const ptyId = randomUUID();
@@ -437,12 +437,29 @@ function filterEnv(env: NodeJS.ProcessEnv): Record<string, string> {
   return out;
 }
 
+function applySandboxToolHome(env: Record<string, string>): Record<string, string> {
+  if (!config.agentToolSandbox.enabled) return env;
+  return {
+    ...env,
+    HOME: config.agentToolSandbox.home,
+    USER: "pi-tools",
+    LOGNAME: "pi-tools",
+  };
+}
+
 /**
- * Re-export so non-PTY callers (the user-bash `!` exec route) get the
- * same env allowlist without having to re-implement it. The PTY and
- * the one-shot user-bash share an identical threat model: an
- * authenticated browser user must not be able to `echo
- * $JWT_SECRET` (or any other host-env secret) from a shell the
- * pi-forge spawned on their behalf.
+ * Re-export so server-owned subprocess callers can get the same allowlist
+ * without inheriting pi-forge / provider secrets. This does NOT rewrite HOME
+ * for the sandbox tool identity; server-owned commands should keep the server
+ * process identity/env semantics.
  */
 export const scrubbedEnv = (): Record<string, string> => filterEnv(process.env);
+
+/**
+ * Env for shell-like user/model surfaces (PTY terminals, `!` exec,
+ * quick actions, process tool, and agent bash). In sandbox mode these
+ * surfaces also run as `AGENT_TOOL_UID:GID`, so HOME must point at the
+ * sandbox tool user's writable home instead of the server user's home.
+ */
+export const toolShellEnv = (env: NodeJS.ProcessEnv = process.env): Record<string, string> =>
+  applySandboxToolHome(filterEnv(env));

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -88,6 +88,7 @@ const sandboxSettingsSchema = {
     enabled: { type: "boolean" },
     uid: { type: "integer" },
     gid: { type: "integer" },
+    home: { type: "string" },
     toolEnv: { type: "object", additionalProperties: { type: "string" } },
   },
 } as const;
@@ -372,6 +373,7 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
           enabled: config.agentToolSandbox.enabled,
           uid: config.agentToolSandbox.uid,
           gid: config.agentToolSandbox.gid,
+          home: config.agentToolSandbox.home,
           toolEnv: settings.toolEnv,
         };
       } catch (err) {
@@ -407,6 +409,7 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
           enabled: config.agentToolSandbox.enabled,
           uid: config.agentToolSandbox.uid,
           gid: config.agentToolSandbox.gid,
+          home: config.agentToolSandbox.home,
           toolEnv: settings.toolEnv,
         };
       } catch (err) {

--- a/packages/server/src/routes/exec.ts
+++ b/packages/server/src/routes/exec.ts
@@ -31,8 +31,10 @@ import { createForgeBashOperations } from "../agent-bash-operations.js";
  * inject context.
  *
  * Security posture: BashOperations is overridden to inject our
- * `scrubbedEnv()` — an allowlist-based filter that only passes
- * known-harmless system vars (PATH, HOME, TERM, locales, …). pi-forge
+ * `toolShellEnv()` — an allowlist-based filter that only passes
+ * known-harmless system vars (PATH, HOME, TERM, locales, …), with HOME
+ * rewritten to the sandbox tool home when the identity sandbox is enabled.
+ * pi-forge
  * secrets, provider keys, cloud credentials, and any other host-env
  * vars are dropped unless the operator opts them back in via
  * `TERMINAL_PASSTHROUGH_ENV`. Matches the integrated terminal's

--- a/packages/server/src/routes/quick-actions.ts
+++ b/packages/server/src/routes/quick-actions.ts
@@ -3,7 +3,7 @@ import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import { sandboxSpawnIdentity } from "../agent-bash-operations.js";
 import { config } from "../config.js";
 import { getProject } from "../project-manager.js";
-import { scrubbedEnv } from "../pty-manager.js";
+import { toolShellEnv } from "../pty-manager.js";
 import {
   createQuickAction,
   DEFAULT_TIMEOUT_MS,
@@ -146,7 +146,7 @@ async function runCommand(
   return new Promise((resolve) => {
     const proc = spawn("/bin/sh", ["-c", command], {
       cwd,
-      env: scrubbedEnv(),
+      env: toolShellEnv(),
       stdio: ["ignore", "pipe", "pipe"],
       ...sandboxSpawnIdentity(),
     });

--- a/tests/test-agent-tool-sandbox.ts
+++ b/tests/test-agent-tool-sandbox.ts
@@ -29,12 +29,14 @@ const project = resolve(workspace, "project-a");
 const shared = resolve(workspace, "shared");
 const piConfig = resolve(workspace, ".pi", "agent");
 const forgeData = resolve(tmp, "forge-data");
+const toolHome = resolve(tmp, "pi-tools-home");
 const outside = resolve(tmp, "outside");
 mkdirSync(workspace, { recursive: true });
 mkdirSync(project, { recursive: true });
 mkdirSync(shared, { recursive: true });
 mkdirSync(piConfig, { recursive: true });
 mkdirSync(forgeData, { recursive: true });
+mkdirSync(toolHome, { recursive: true });
 mkdirSync(outside, { recursive: true });
 writeFileSync(resolve(project, "hello.txt"), "hello workspace\n");
 writeFileSync(resolve(shared, "shared.txt"), "hello shared workspace\n");
@@ -52,6 +54,7 @@ process.env.FORGE_DATA_DIR = forgeData;
 process.env.AGENT_TOOL_SANDBOX_ENABLED = "true";
 process.env.AGENT_TOOL_UID = String(process.getuid?.() ?? 1000);
 process.env.AGENT_TOOL_GID = String(process.getgid?.() ?? 1000);
+process.env.AGENT_TOOL_HOME = toolHome;
 process.env.SERVE_CLIENT = "false";
 
 try {
@@ -122,6 +125,16 @@ try {
   const { expandFileReferences } = (await import(
     resolve(repoRoot, "packages/server/dist/file-references.js")
   )) as { expandFileReferences: (text: string, workspacePath: string) => Promise<string> };
+  const { toolShellEnv } = (await import(
+    resolve(repoRoot, "packages/server/dist/pty-manager.js")
+  )) as {
+    toolShellEnv: (env?: NodeJS.ProcessEnv) => Record<string, string>;
+  };
+
+  console.log("\nsandbox shell env");
+  const shellEnv = toolShellEnv({ ...process.env, HOME: "/home/pi", USER: "pi", LOGNAME: "pi" });
+  assert("sandbox shell HOME uses AGENT_TOOL_HOME", shellEnv.HOME === toolHome, shellEnv.HOME);
+  assert("sandbox shell USER uses tool identity", shellEnv.USER === "pi-tools", shellEnv.USER);
 
   function allowed(label: string, requested: string): void {
     try {

--- a/tests/test-docker.ts
+++ b/tests/test-docker.ts
@@ -172,7 +172,11 @@ services:
       "python3 -m pip --version",
       'test "$PYTHONUSERBASE" = /home/pi/.local',
       'test "$(python3 -m site --user-base)" = /home/pi/.local',
+      "test -w /home/pi",
       "test -w /home/pi/.local",
+      "mkdir -p /home/pi/.config/pi-forge-home-test",
+      "printf ok > /home/pi/.config/pi-forge-home-test/probe",
+      "test -s /home/pi/.config/pi-forge-home-test/probe",
       "make --version",
       "g++ --version",
       "npm rebuild node-pty --build-from-source",
@@ -183,7 +187,7 @@ services:
       true,
     );
     assert(
-      "runtime image has Python 3.12/pip and can rebuild node-pty from source",
+      "runtime image has writable HOME plus Python 3.12/pip and can rebuild node-pty",
       rebuild.status === 0,
       `exit=${rebuild.status}; stdout=${rebuild.stdout.slice(-1000)}; stderr=${rebuild.stderr.slice(-1000)}`,
     );


### PR DESCRIPTION
## Summary

Non-sandbox Docker runs advertised `HOME=/home/pi`, but the image made `/home/pi` root-owned and non-writable to the `pi` runtime user. CLIs such as GitHub CLI then failed to create normal per-user files like `~/.config/gh` or `~/.gitconfig` from terminals/tool shells.

This PR makes `/home/pi` writable by the regular `pi` user, and gives sandboxed tool processes their own separate writable home at `/home/pi-tools`. In sandbox mode, terminal/process/model bash env now rewrites `HOME` to `AGENT_TOOL_HOME`, preserving the split from the server user's `/home/pi` while allowing tools such as `gh` to store sandbox-owned config intentionally available to model/user shell surfaces.

## Usage

Regular/non-sandbox mode continues to use:

```bash
HOME=/home/pi
```

Sandbox mode uses the new deploy-time home setting:

```bash
AGENT_TOOL_SANDBOX_ENABLED=true
AGENT_TOOL_UID=1001
AGENT_TOOL_GID=1001
AGENT_TOOL_HOME=/home/pi-tools
```

The base Docker Compose env remains intentionally minimal. Add less-used env vars in a compose override or shell environment; the sandbox overlay now sets `AGENT_TOOL_HOME` by default.

Credentials created under `/home/pi-tools` are readable/usable by sandboxed terminals/processes/model bash. That is intentional for CLIs like `gh`, but operators should treat those credentials as available to model/user shell surfaces.

## What changed (20 files)

- `docker/Dockerfile` — makes `/home/pi` owned by `pi`, creates `/home/pi-tools` as the `pi-tools` home, and keeps both homes permissioned for their intended identities.
- `docker/docker-compose.sandbox.yml` — sets the sandbox overlay default `AGENT_TOOL_HOME=/home/pi-tools` without adding sandbox env bloat to the base compose/env example.
- `packages/server/src/config.ts`, `packages/server/src/cli.ts` — add `AGENT_TOOL_HOME` / `--agent-tool-home` with default `/home/pi-tools`.
- `packages/server/src/pty-manager.ts` — splits server subprocess scrubbed env from shell/tool env, and rewrites sandbox shell `HOME`/`USER`/`LOGNAME` for terminal/tool surfaces.
- `packages/server/src/agent-bash-operations.ts`, `packages/server/src/processes/manager.ts`, `packages/server/src/routes/quick-actions.ts`, `packages/server/src/routes/exec.ts` — use the shell/tool env helper for model/user shell commands.
- `packages/server/src/routes/config.ts`, client API types/validator/settings UI — expose and display sandbox tool home in sandbox settings.
- `tests/test-agent-tool-sandbox.ts`, `tests/test-docker.ts` — cover sandbox shell HOME rewriting and regular image HOME writability.
- `docs/*` — document `AGENT_TOOL_HOME`, regular HOME writability, sandbox trade-offs, and the intentionally minimal Docker env surface.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run format:check`
- [x] `npx tsx tests/test-agent-tool-sandbox.ts`
- [x] `npx tsx tests/test-terminal.ts`
- [x] `npx tsx tests/test-cli-flags.ts`
- [x] `npx tsx tests/test-docker.ts` (skipped: Docker not available in PATH or daemon not reachable)
- [ ] CI green before merge
