### PR TITLE
chore(release): v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.4.2] — 2026-06-11
+
+### Added
+
+- **Prompt text box auto-grow.** The chat prompt input now grows and shrinks with multi-line content while keeping a bounded maximum height.
+- **Tea CLI in the container image.** The Docker image now includes the pinned `tea` Gitea/Forgejo CLI with checksum verification and Docker test coverage.
+
+### Changed
+
+- **Docker environment examples are focused on common settings.** Less-used and advanced environment variables moved out of the base compose/example files and into documentation, while sandbox-specific settings remain in the sandbox compose overlay.
+- **Settings pane has more room.** The Settings modal is wider on desktop and avoids unnecessary inner overflow from cramped flex sizing.
+- **Sandboxed tools get their own writable home.** Non-sandbox Docker keeps `/home/pi` writable for regular CLI config, while sandboxed tool and terminal surfaces use `AGENT_TOOL_HOME` (`/home/pi-tools`) instead of writing the server user home.
+
+### Fixed
+
+- **Stale session error banners no longer return on follow-up prompts.** Previous turn errors are cleared/scoped when a new run starts so only current failures show banners.
+- **Terminal paste wrapping stays aligned.** The terminal now keeps xterm fitting and backend PTY resize sync centralized across lifecycle events to prevent long pasted input from wrapping incorrectly.
+- **Client ID generation works without `crypto.randomUUID`.** Sandbox environment variable rows and other client IDs now use a shared helper with safe fallbacks for browsers that lack `crypto.randomUUID`.
+
 ## [1.4.1] — 2026-06-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "workspaces": [
         "packages/*"
       ],
@@ -16968,7 +16968,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17014,7 +17014,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.78.0",
         "@earendil-works/pi-ai": "0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the v1.4.2 release after the merged feature/fix PRs since v1.4.1. Release notes were generated from the changes since `v1.4.1`, covering prompt input auto-grow, bundled `tea`, Docker env cleanup, settings pane sizing, sandbox/regular tool homes, stale session error banners, terminal paste wrapping, and client ID fallback behavior.

## Usage

No runtime usage change for the release PR itself. After this PR merges, tag from updated `main`:

```bash
git checkout main
git pull --ff-only
git tag v1.4.2
git push origin v1.4.2
```

The release workflow should then build artifacts/images and publish the GitHub Release.

## What changed (5 files)

- `CHANGELOG.md` — moves populated `Unreleased` notes into `## [1.4.2] — 2026-06-11` and opens a fresh empty `Unreleased` section.
- `package.json` — bumps root package version to `1.4.2`.
- `package-lock.json` — refreshes lockfile package versions for `1.4.2`.
- `packages/client/package.json` — bumps client package version to `1.4.2`.
- `packages/server/package.json` — bumps server package version to `1.4.2`.

## Test plan

- [x] `npm run build`
- [x] `npm run format:check`
- [ ] `npm run check` — attempted; typecheck completed, then ESLint was killed by OOM/exit 134. Retried with `NODE_OPTIONS=--max-old-space-size=4096`; ESLint was killed with exit 137.
- [ ] CI green before merge
