### PR TITLE
chore: approve npm install scripts

### DIFF
--- a/docs/agent/releases.md
+++ b/docs/agent/releases.md
@@ -29,8 +29,18 @@ When cutting a version, use the repository release tooling. Do not hand-edit pac
    `CHANGELOG.md` from `## [Unreleased]` to the dated release heading, stages the changes, and
    prints next-step instructions. It does **not** commit, push, or tag.
 
-5. Include the changelog updates and version bumps together in the version bump PR. The PR should
+5. Check npm install-script approvals before opening the version bump PR:
+
+   ```bash
+   npx npm@latest approve-scripts --allow-scripts-pending
+   ```
+
+   This is a read-only check of the root `package.json` `allowScripts` policy. If it reports
+   unreviewed install scripts, audit each package and update `allowScripts` with
+   `npm approve-scripts` or `npm deny-scripts` before release.
+6. Include the changelog updates and version bumps together in the version bump PR. The PR should
    clearly call out that release notes were generated from changes since the previous version.
+
 ## Important Rules
 
 - Do not bypass `scripts/bump-version.sh` for normal releases.

--- a/docs/agent/releases.md
+++ b/docs/agent/releases.md
@@ -36,8 +36,10 @@ When cutting a version, use the repository release tooling. Do not hand-edit pac
    ```
 
    This is a read-only check of the root `package.json` `allowScripts` policy. If it reports
-   unreviewed install scripts, audit each package and update `allowScripts` with
-   `npm approve-scripts` or `npm deny-scripts` before release.
+   unreviewed install scripts, audit each package and ask the user whether to approve or deny each
+   script before changing `allowScripts`. Do not make approval or denial decisions without explicit
+   user direction. After the user decides, update `allowScripts` with `npm approve-scripts` or
+   `npm deny-scripts` before release.
 6. Include the changelog updates and version bumps together in the version bump PR. The PR should
    clearly call out that release notes were generated from changes since the previous version.
 

--- a/package.json
+++ b/package.json
@@ -40,5 +40,12 @@
     "tsx": "^4.22.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.0"
+  },
+  "allowScripts": {
+    "esbuild@0.28.0": true,
+    "fsevents@2.3.3": true,
+    "node-pty@1.1.0": true,
+    "@google/genai": false,
+    "protobufjs": false
   }
 }


### PR DESCRIPTION
## Summary

Prepare pi-forge for npm's upcoming install-script approval model by recording reviewed dependency lifecycle scripts in the root `package.json`. The project has no first-party install lifecycle scripts, but `node-pty` requires its install script to make the native terminal binding available, and dev/build tooling includes install-script packages as well.

Also updates release guidance so future releases check for pending script approvals and require explicit user approval/denial decisions before changing the policy.

## Usage

Release/checklist command:

```bash
npx npm@latest approve-scripts --allow-scripts-pending
```

If pending scripts are reported, agents must audit the packages and ask the user whether to approve or deny each script before updating `allowScripts`.

## What changed (2 files)

- `package.json` — added `allowScripts` entries allowing reviewed required/dev install scripts and denying reviewed nonessential scripts.
- `docs/agent/releases.md` — added the install-script pending check to release guidance, with an explicit requirement for user direction before approve/deny changes.

## Test plan

- [x] `npx prettier --check docs/agent/releases.md`
- [x] `npx prettier --check package.json`
- [x] `npx npm@11.16.0 approve-scripts --allow-scripts-pending`
- [x] `npx npm@11.16.0 ci --workspaces --include-workspace-root`
- [x] Verified `require("node-pty")`, `require("esbuild")`, and `require("protobufjs")` load after install.
- [ ] CI green before merge
