### PR TITLE
fix: support multiline chat prompts

### DIFF
--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -25,6 +25,7 @@ import { useUiStore } from "../store/ui-store";
 import { useComposerStore } from "../store/composer-store";
 import { deriveCounts, selectTodoState, useTodoStore } from "../store/todo-store";
 import { countRunning, selectProcesses, useProcessesStore } from "../store/processes-store";
+import { isChatSubmitShortcut } from "../lib/chat-input-keys";
 import { ProcessesPopover, TodosPopover } from "./InputPopovers";
 
 /**
@@ -222,7 +223,7 @@ function scoreOption(opt: ModelOption, query: string): number | undefined {
  *   600 ms) also fires Abort — keyboard-only path for users who
  *   never leave the input.
  *
- * Enter submits, Shift+Enter inserts a newline. The model selector
+ * Enter inserts a newline; Cmd/Ctrl+Enter submits. The model selector
  * lives alongside in this same phase; attachments and token/cost
  * display land in later phases.
  */
@@ -1179,7 +1180,8 @@ export function ChatInput({ sessionId }: Props) {
   };
 
   const submit = async (): Promise<void> => {
-    const value = text.trim();
+    const rawValue = text;
+    const value = rawValue.trim();
     // Allow empty text only when there's at least one attachment —
     // sending "look at this" with an image but no caption is a
     // common path. Server still rejects entirely-empty prompts.
@@ -1256,9 +1258,9 @@ export function ChatInput({ sessionId }: Props) {
           clearAttachments();
           setAttachmentError("Attachments aren't sent on steer (mid-turn). Cleared.");
         }
-        await sendSteer(sessionId, value);
+        await sendSteer(sessionId, rawValue);
       } else {
-        await sendPrompt(sessionId, value, attachments.length > 0 ? attachments : undefined);
+        await sendPrompt(sessionId, rawValue, attachments.length > 0 ? attachments : undefined);
       }
       setText("");
       clearAttachments();
@@ -1311,13 +1313,14 @@ export function ChatInput({ sessionId }: Props) {
         }
         if (e.key === "Enter" || e.key === "Tab") {
           // Pi-prompt invocation form (`/<knownname>` or
-          // `/<knownname> ...args`) — fall through to the normal
-          // Enter-submits path. Without this branch the Enter key
-          // would re-fire the prompt entry's `run()` and clobber
-          // any args the user typed.
-          if (isPromptInvocation && e.key === "Enter" && !e.shiftKey) {
-            // Don't preventDefault — let the regular Enter handler
-            // below pick it up. (Tab still discovers / fills in.)
+          // `/<knownname> ...args`) — fall through to normal textarea
+          // handling. Plain Enter inserts a newline for multiline
+          // prompt args; Cmd/Ctrl+Enter submits and lets pi expand the
+          // template at send time. Without this branch, Enter would
+          // re-fire the prompt entry's `run()` and clobber any args
+          // the user typed. (Tab still discovers / fills in.)
+          if (isPromptInvocation && e.key === "Enter") {
+            // Intentionally fall through.
           } else {
             e.preventDefault();
             slashRunSelected();
@@ -1350,7 +1353,7 @@ export function ChatInput({ sessionId }: Props) {
         setAcSelectedIdx((i) => Math.max(i - 1, 0));
         return;
       }
-      if (e.key === "Enter" || e.key === "Tab") {
+      if ((e.key === "Enter" && !isChatSubmitShortcut(e)) || e.key === "Tab") {
         const pick = acSuggestions[acSelectedIdx];
         if (pick !== undefined) {
           e.preventDefault();
@@ -1364,15 +1367,12 @@ export function ChatInput({ sessionId }: Props) {
         return;
       }
     }
-    // Plain-Enter submits on desktop. On mobile we let the keyboard's
-    // Enter key insert a newline (default browser behavior) — sending
-    // happens via the explicit Send button. Mobile virtual keyboards
-    // don't expose Shift conveniently, so the desktop "Shift+Enter
-    // for newline" rule would force users into multi-line workflows
-    // with no working escape. The slash-palette and @-completion
-    // popover Enter paths above are unaffected — they still pick the
-    // highlighted suggestion regardless of viewport.
-    if (e.key === "Enter" && !e.shiftKey && !isMobile) {
+    // Plain Enter belongs to the textarea and inserts a newline.
+    // Cmd/Ctrl+Enter is the explicit send shortcut on both desktop
+    // and mobile; the Send button remains the pointer/touch path.
+    // This keeps multiline prompts and prompt-template arguments
+    // possible without relying on Shift+Enter discoverability.
+    if (isChatSubmitShortcut(e)) {
       e.preventDefault();
       void submit();
       return;
@@ -2048,14 +2048,14 @@ export function ChatInput({ sessionId }: Props) {
                     : isStreaming
                       ? isMobile
                         ? "Steer the agent…"
-                        : "Steer the agent (Enter to send, Shift+Enter for newline)…"
+                        : "Steer the agent (Cmd/Ctrl+Enter to send; Enter for newline)…"
                       : isMobile
                         ? minimalUi
-                          ? "Ask pi — `/` runs commands, `@path` references files…"
-                          : "Ask pi — `/` runs commands, `!` runs bash, `@path` references files…"
+                          ? "Ask pi — Enter for newline; Send to submit; `/` runs commands, `@path` references files…"
+                          : "Ask pi — Enter for newline; Send to submit; `/` runs commands, `!` runs bash, `@path` references files…"
                         : minimalUi
-                          ? "Ask pi (Enter to send, Shift+Enter for newline) — `/` runs commands, `@path` references files…"
-                          : "Ask pi (Enter to send, Shift+Enter for newline) — `/` runs commands, `!` runs bash, `@path` references files…"
+                          ? "Ask pi (Cmd/Ctrl+Enter to send; Enter for newline) — `/` runs commands, `@path` references files…"
+                          : "Ask pi (Cmd/Ctrl+Enter to send; Enter for newline) — `/` runs commands, `!` runs bash, `@path` references files…"
               }
               title={
                 isAutoRetrying
@@ -2136,8 +2136,8 @@ export function ChatInput({ sessionId }: Props) {
               className="flex-1 rounded-md bg-neutral-100 px-4 text-sm font-medium text-neutral-900 disabled:cursor-not-allowed disabled:opacity-50 md:flex-none md:py-2"
               title={
                 isStreaming
-                  ? "Send (Pi queues at the next agent break — steer or follow-up depending on agent state)"
-                  : "Send (Enter)"
+                  ? "Send (Cmd/Ctrl+Enter; Pi queues at the next agent break — steer or follow-up depending on agent state)"
+                  : "Send (Cmd/Ctrl+Enter)"
               }
             >
               Send
@@ -2155,8 +2155,8 @@ export function ChatInput({ sessionId }: Props) {
         </div>
         {isStreaming && (
           <p className="text-[10px] text-neutral-600">
-            Send queues at the next agent break — Pi picks steer or follow-up. Abort: stop the agent
-            (or press Esc twice in the textbox).
+            Cmd/Ctrl+Enter or Send queues at the next agent break — Pi picks steer or follow-up.
+            Abort: stop the agent (or press Esc twice in the textbox).
           </p>
         )}
       </div>

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -223,9 +223,9 @@ function scoreOption(opt: ModelOption, query: string): number | undefined {
  *   600 ms) also fires Abort — keyboard-only path for users who
  *   never leave the input.
  *
- * Enter inserts a newline; Cmd/Ctrl+Enter submits. The model selector
- * lives alongside in this same phase; attachments and token/cost
- * display land in later phases.
+ * Desktop Enter submits, Shift+Enter inserts a newline, and
+ * Cmd/Ctrl+Enter submits everywhere. The model selector lives alongside
+ * in this same phase; attachments and token/cost display land in later phases.
  */
 const DOUBLE_ESC_WINDOW_MS = 600;
 
@@ -1314,11 +1314,12 @@ export function ChatInput({ sessionId }: Props) {
         if (e.key === "Enter" || e.key === "Tab") {
           // Pi-prompt invocation form (`/<knownname>` or
           // `/<knownname> ...args`) — fall through to normal textarea
-          // handling. Plain Enter inserts a newline for multiline
-          // prompt args; Cmd/Ctrl+Enter submits and lets pi expand the
-          // template at send time. Without this branch, Enter would
-          // re-fire the prompt entry's `run()` and clobber any args
-          // the user typed. (Tab still discovers / fills in.)
+          // handling. Shift+Enter inserts a newline for multiline
+          // prompt args; regular desktop Enter and Cmd/Ctrl+Enter
+          // submit and let pi expand the template at send time.
+          // Without this branch, Enter would re-fire the prompt
+          // entry's `run()` and clobber any args the user typed.
+          // (Tab still discovers / fills in.)
           if (isPromptInvocation && e.key === "Enter") {
             // Intentionally fall through.
           } else {
@@ -1353,7 +1354,7 @@ export function ChatInput({ sessionId }: Props) {
         setAcSelectedIdx((i) => Math.max(i - 1, 0));
         return;
       }
-      if ((e.key === "Enter" && !isChatSubmitShortcut(e)) || e.key === "Tab") {
+      if ((e.key === "Enter" && e.metaKey !== true && e.ctrlKey !== true) || e.key === "Tab") {
         const pick = acSuggestions[acSelectedIdx];
         if (pick !== undefined) {
           e.preventDefault();
@@ -1367,12 +1368,11 @@ export function ChatInput({ sessionId }: Props) {
         return;
       }
     }
-    // Plain Enter belongs to the textarea and inserts a newline.
-    // Cmd/Ctrl+Enter is the explicit send shortcut on both desktop
-    // and mobile; the Send button remains the pointer/touch path.
-    // This keeps multiline prompts and prompt-template arguments
-    // possible without relying on Shift+Enter discoverability.
-    if (isChatSubmitShortcut(e)) {
+    // Desktop plain Enter submits; Shift+Enter inserts a newline.
+    // Mobile plain Enter still inserts a newline because virtual
+    // keyboards do not expose Shift consistently; Cmd/Ctrl+Enter and
+    // the Send button remain explicit submit paths everywhere.
+    if (isChatSubmitShortcut(e, { isMobile })) {
       e.preventDefault();
       void submit();
       return;
@@ -2048,14 +2048,14 @@ export function ChatInput({ sessionId }: Props) {
                     : isStreaming
                       ? isMobile
                         ? "Steer the agent…"
-                        : "Steer the agent (Cmd/Ctrl+Enter to send; Enter for newline)…"
+                        : "Steer the agent (Enter to send; Shift+Enter for newline)…"
                       : isMobile
                         ? minimalUi
                           ? "Ask pi — Enter for newline; Send to submit; `/` runs commands, `@path` references files…"
                           : "Ask pi — Enter for newline; Send to submit; `/` runs commands, `!` runs bash, `@path` references files…"
                         : minimalUi
-                          ? "Ask pi (Cmd/Ctrl+Enter to send; Enter for newline) — `/` runs commands, `@path` references files…"
-                          : "Ask pi (Cmd/Ctrl+Enter to send; Enter for newline) — `/` runs commands, `!` runs bash, `@path` references files…"
+                          ? "Ask pi (Enter to send; Shift+Enter for newline) — `/` runs commands, `@path` references files…"
+                          : "Ask pi (Enter to send; Shift+Enter for newline) — `/` runs commands, `!` runs bash, `@path` references files…"
               }
               title={
                 isAutoRetrying
@@ -2136,8 +2136,8 @@ export function ChatInput({ sessionId }: Props) {
               className="flex-1 rounded-md bg-neutral-100 px-4 text-sm font-medium text-neutral-900 disabled:cursor-not-allowed disabled:opacity-50 md:flex-none md:py-2"
               title={
                 isStreaming
-                  ? "Send (Cmd/Ctrl+Enter; Pi queues at the next agent break — steer or follow-up depending on agent state)"
-                  : "Send (Cmd/Ctrl+Enter)"
+                  ? "Send (Enter or Cmd/Ctrl+Enter; Pi queues at the next agent break — steer or follow-up depending on agent state)"
+                  : "Send (Enter or Cmd/Ctrl+Enter)"
               }
             >
               Send
@@ -2155,8 +2155,8 @@ export function ChatInput({ sessionId }: Props) {
         </div>
         {isStreaming && (
           <p className="text-[10px] text-neutral-600">
-            Cmd/Ctrl+Enter or Send queues at the next agent break — Pi picks steer or follow-up.
-            Abort: stop the agent (or press Esc twice in the textbox).
+            Enter, Cmd/Ctrl+Enter, or Send queues at the next agent break — Pi picks steer or
+            follow-up. Abort: stop the agent (or press Esc twice in the textbox).
           </p>
         )}
       </div>

--- a/packages/client/src/lib/chat-input-keys.ts
+++ b/packages/client/src/lib/chat-input-keys.ts
@@ -1,0 +1,16 @@
+/**
+ * Keyboard policy for submitting the chat composer. Kept outside the
+ * React component so the newline-vs-submit contract has a tiny,
+ * DOM-free test: regular Enter belongs to the textarea (newline), and
+ * Cmd/Ctrl+Enter is the explicit submit shortcut.
+ */
+export interface ChatInputKeyLike {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+}
+
+export function isChatSubmitShortcut(event: ChatInputKeyLike): boolean {
+  return event.key === "Enter" && (event.metaKey === true || event.ctrlKey === true);
+}

--- a/packages/client/src/lib/chat-input-keys.ts
+++ b/packages/client/src/lib/chat-input-keys.ts
@@ -1,8 +1,8 @@
 /**
  * Keyboard policy for submitting the chat composer. Kept outside the
  * React component so the newline-vs-submit contract has a tiny,
- * DOM-free test: regular Enter belongs to the textarea (newline), and
- * Cmd/Ctrl+Enter is the explicit submit shortcut.
+ * DOM-free test: desktop Enter submits, Shift+Enter inserts a newline,
+ * and Cmd/Ctrl+Enter is an explicit submit shortcut everywhere.
  */
 export interface ChatInputKeyLike {
   key: string;
@@ -11,6 +11,11 @@ export interface ChatInputKeyLike {
   shiftKey?: boolean;
 }
 
-export function isChatSubmitShortcut(event: ChatInputKeyLike): boolean {
-  return event.key === "Enter" && (event.metaKey === true || event.ctrlKey === true);
+export function isChatSubmitShortcut(
+  event: ChatInputKeyLike,
+  opts: { isMobile: boolean },
+): boolean {
+  if (event.key !== "Enter") return false;
+  if (event.metaKey === true || event.ctrlKey === true) return true;
+  return !opts.isMobile && event.shiftKey !== true;
 }

--- a/tests/test-chat-input-keys.ts
+++ b/tests/test-chat-input-keys.ts
@@ -9,11 +9,27 @@ function assert(label: string, ok: boolean): void {
   }
 }
 
-assert("plain Enter does not submit", !isChatSubmitShortcut({ key: "Enter" }));
-assert("Shift+Enter does not submit", !isChatSubmitShortcut({ key: "Enter", shiftKey: true }));
-assert("Cmd+Enter submits", isChatSubmitShortcut({ key: "Enter", metaKey: true }));
-assert("Ctrl+Enter submits", isChatSubmitShortcut({ key: "Enter", ctrlKey: true }));
-assert("other keys do not submit", !isChatSubmitShortcut({ key: "Tab", ctrlKey: true }));
+assert("desktop plain Enter submits", isChatSubmitShortcut({ key: "Enter" }, { isMobile: false }));
+assert(
+  "desktop Shift+Enter does not submit",
+  !isChatSubmitShortcut({ key: "Enter", shiftKey: true }, { isMobile: false }),
+);
+assert(
+  "mobile plain Enter does not submit",
+  !isChatSubmitShortcut({ key: "Enter" }, { isMobile: true }),
+);
+assert(
+  "Cmd+Enter submits",
+  isChatSubmitShortcut({ key: "Enter", metaKey: true }, { isMobile: true }),
+);
+assert(
+  "Ctrl+Enter submits",
+  isChatSubmitShortcut({ key: "Enter", ctrlKey: true }, { isMobile: false }),
+);
+assert(
+  "other keys do not submit",
+  !isChatSubmitShortcut({ key: "Tab", ctrlKey: true }, { isMobile: false }),
+);
 
 if (failures > 0) {
   console.log(`\n[test-chat-input-keys] FAIL — ${failures} assertion(s) failed`);

--- a/tests/test-chat-input-keys.ts
+++ b/tests/test-chat-input-keys.ts
@@ -1,0 +1,22 @@
+import { isChatSubmitShortcut } from "../packages/client/src/lib/chat-input-keys.js";
+
+let failures = 0;
+function assert(label: string, ok: boolean): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}`);
+  }
+}
+
+assert("plain Enter does not submit", !isChatSubmitShortcut({ key: "Enter" }));
+assert("Shift+Enter does not submit", !isChatSubmitShortcut({ key: "Enter", shiftKey: true }));
+assert("Cmd+Enter submits", isChatSubmitShortcut({ key: "Enter", metaKey: true }));
+assert("Ctrl+Enter submits", isChatSubmitShortcut({ key: "Enter", ctrlKey: true }));
+assert("other keys do not submit", !isChatSubmitShortcut({ key: "Tab", ctrlKey: true }));
+
+if (failures > 0) {
+  console.log(`\n[test-chat-input-keys] FAIL — ${failures} assertion(s) failed`);
+  process.exit(1);
+}
+console.log("\n[test-chat-input-keys] PASS");


### PR DESCRIPTION
## Summary

The chat composer previously captured desktop `Enter` for submit unconditionally, which made it hard to author multiline prompts. The first pass restored multiline input but made regular desktop `Enter` stop submitting after using `Shift+Enter`. This PR makes the shortcut policy explicit: desktop `Enter` submits, `Shift+Enter` inserts a newline, mobile `Enter` inserts a newline, and `Cmd/Ctrl+Enter` submits everywhere.

It also sends the raw textarea value through the prompt/steer path instead of trimming it before submission, so newline characters entered by the user are preserved for the session prompt path.

## Usage

No operator action required. In the chat composer:

```text
Desktop: Enter submits; Shift+Enter inserts a newline; Cmd/Ctrl+Enter also submits.
Mobile: Enter inserts a newline; Send button submits; Cmd/Ctrl+Enter also submits when available.
```

## What changed (3 files, +91/-32)

- `packages/client/src/components/ChatInput.tsx` — updates key handling, prompt-template invocation handling, and UI hints to support multiline prompts while preserving desktop Enter-submit behavior.
- `packages/client/src/lib/chat-input-keys.ts` — adds a small shared keyboard-policy helper for submit shortcut decisions.
- `tests/test-chat-input-keys.ts` — adds targeted coverage for desktop/mobile Enter, Shift+Enter, and Cmd/Ctrl+Enter behavior.

## Test plan

- [x] `npx prettier --write packages/client/src/components/ChatInput.tsx packages/client/src/lib/chat-input-keys.ts tests/test-chat-input-keys.ts`
- [x] `npx tsx tests/test-chat-input-keys.ts`
- [x] `npm run build`
- [x] `npm run check`
- [x] Manual browser verification from requester: newline entry works and desktop Enter submits after Shift+Enter.
