### PR TITLE
fix: support pasted image attachments

### DIFF
--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ClipboardEvent,
   type KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
@@ -25,6 +26,7 @@ import { useUiStore } from "../store/ui-store";
 import { useComposerStore } from "../store/composer-store";
 import { deriveCounts, selectTodoState, useTodoStore } from "../store/todo-store";
 import { countRunning, selectProcesses, useProcessesStore } from "../store/processes-store";
+import { extractClipboardImageFiles } from "../lib/clipboard-images";
 import { ProcessesPopover, TodosPopover } from "./InputPopovers";
 
 /**
@@ -861,6 +863,25 @@ export function ChatInput({ sessionId }: Props) {
     previewUrlsRef.current.clear();
     setAttachments([]);
     setAttachmentError(undefined);
+  };
+
+  const onPaste = (e: ClipboardEvent<HTMLTextAreaElement>): void => {
+    const imageFiles = extractClipboardImageFiles(e.clipboardData);
+    if (imageFiles.length === 0) return;
+    if (isReadOnlyExternal) {
+      setAttachmentError("This pi-subagents child is running externally and is read-only.");
+      return;
+    }
+    if (isStreaming) {
+      setAttachmentError(
+        "Images pasted while streaming aren't attached. Wait for the current run to finish.",
+      );
+      return;
+    }
+    // Do not preventDefault: when the clipboard contains both images
+    // and text, the browser should still paste the text into the
+    // textarea while we queue the image files as prompt attachments.
+    addAttachments(imageFiles);
   };
 
   // Revoke any lingering object URLs when the component unmounts.
@@ -2030,6 +2051,7 @@ export function ChatInput({ sessionId }: Props) {
               autoCapitalize="none"
               spellCheck={false}
               onKeyDown={onKeyDown}
+              onPaste={onPaste}
               onBlur={() => {
                 // Close on blur — but only on the next tick so a
                 // mousedown on a popover item still fires its handler

--- a/packages/client/src/lib/clipboard-images.ts
+++ b/packages/client/src/lib/clipboard-images.ts
@@ -1,0 +1,85 @@
+/**
+ * Helpers for turning clipboard image payloads into File attachments.
+ * Kept DOM-light and pure enough to unit-test without a browser: tests can
+ * provide minimal item/file array-like objects instead of real DataTransfer.
+ */
+
+interface ClipboardFileLike {
+  readonly name?: string;
+  readonly type: string;
+}
+
+interface ClipboardItemLike {
+  readonly kind: string;
+  readonly type: string;
+  getAsFile(): File | null;
+}
+
+interface ClipboardListLike<T> {
+  readonly length: number;
+  item?(index: number): T | null;
+  [index: number]: T | undefined;
+}
+
+export interface ClipboardImageDataLike {
+  readonly items?: ClipboardListLike<ClipboardItemLike>;
+  readonly files?: ClipboardListLike<File>;
+}
+
+const IMAGE_EXTENSIONS: Record<string, string> = {
+  "image/gif": "gif",
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
+
+function listEntry<T>(list: ClipboardListLike<T>, index: number): T | undefined {
+  return list.item?.(index) ?? list[index];
+}
+
+function isImageFile(file: ClipboardFileLike | null | undefined): file is File {
+  return file instanceof File && file.type.startsWith("image/");
+}
+
+function clipboardImageName(file: File, index: number): string {
+  if (file.name.trim().length > 0) return file.name;
+  const extension = IMAGE_EXTENSIONS[file.type.toLowerCase()] ?? "png";
+  return `clipboard-image-${index + 1}.${extension}`;
+}
+
+function normalizeClipboardImage(file: File, index: number): File {
+  const name = clipboardImageName(file, index);
+  if (name === file.name) return file;
+  return new File([file], name, { type: file.type, lastModified: file.lastModified });
+}
+
+/**
+ * Extract image files from clipboard data.
+ *
+ * Prefer DataTransferItemList because it reliably exposes typed clipboard
+ * image payloads in Chromium/Firefox. Fall back to DataTransfer.files for
+ * browsers that only expose pasted images there. Text/HTML items are ignored.
+ */
+export function extractClipboardImageFiles(data: ClipboardImageDataLike): File[] {
+  const fromItems: File[] = [];
+  const items = data.items;
+  if (items !== undefined) {
+    for (let i = 0; i < items.length; i++) {
+      const item = listEntry(items, i);
+      if (item === undefined) continue;
+      if (item.kind !== "file" || !item.type.startsWith("image/")) continue;
+      const file = item.getAsFile();
+      if (isImageFile(file)) fromItems.push(normalizeClipboardImage(file, fromItems.length));
+    }
+  }
+  if (fromItems.length > 0) return fromItems;
+
+  const fromFiles: File[] = [];
+  const files = data.files;
+  if (files === undefined) return fromFiles;
+  for (let i = 0; i < files.length; i++) {
+    const file = listEntry(files, i);
+    if (isImageFile(file)) fromFiles.push(normalizeClipboardImage(file, fromFiles.length));
+  }
+  return fromFiles;
+}

--- a/tests/test-clipboard-images.ts
+++ b/tests/test-clipboard-images.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for clipboard image extraction used by ChatInput paste handling.
+ * Pure helper, no DOM events required — minimal array-like clipboard objects
+ * are enough to verify image files become prompt attachments while text items
+ * are ignored.
+ */
+import { extractClipboardImageFiles } from "../packages/client/src/lib/clipboard-images";
+
+let failures = 0;
+
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`  PASS  ${label}`);
+  } else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail !== undefined ? ` — ${detail}` : ""}`);
+  }
+}
+
+function arrayLike<T>(values: T[]): { readonly length: number; item(index: number): T | null } {
+  return {
+    length: values.length,
+    item: (index) => values[index] ?? null,
+  };
+}
+
+function image(name = "pasted.png", type = "image/png"): File {
+  return new File([new Uint8Array([1, 2, 3])], name, { type, lastModified: 123 });
+}
+
+{
+  const pasted = image("screenshot.png");
+  const got = extractClipboardImageFiles({
+    items: arrayLike([
+      { kind: "string", type: "text/plain", getAsFile: () => null },
+      { kind: "file", type: "image/png", getAsFile: () => pasted },
+    ]),
+  });
+  assert("extracts image file items", got.length === 1 && got[0] === pasted);
+}
+
+{
+  const pasted = image("fallback.webp", "image/webp");
+  const got = extractClipboardImageFiles({
+    items: arrayLike([{ kind: "string", type: "text/plain", getAsFile: () => null }]),
+    files: arrayLike([pasted]),
+  });
+  assert(
+    "falls back to clipboard files when items have no images",
+    got.length === 1 && got[0] === pasted,
+  );
+}
+
+{
+  const got = extractClipboardImageFiles({
+    items: arrayLike([
+      { kind: "string", type: "text/plain", getAsFile: () => null },
+      {
+        kind: "file",
+        type: "application/pdf",
+        getAsFile: () => new File(["pdf"], "doc.pdf", { type: "application/pdf" }),
+      },
+    ]),
+  });
+  assert("ignores text and non-image clipboard items", got.length === 0);
+}
+
+{
+  const unnamed = new File([new Uint8Array([4, 5, 6])], "", {
+    type: "image/jpeg",
+    lastModified: 456,
+  });
+  const got = extractClipboardImageFiles({ files: arrayLike([unnamed]) });
+  assert(
+    "names unnamed clipboard images",
+    got.length === 1 && got[0]?.name === "clipboard-image-1.jpg",
+  );
+  assert("preserves unnamed clipboard image type", got[0]?.type === "image/jpeg");
+}
+
+if (failures > 0) {
+  console.error(`clipboard image tests failed: ${failures}`);
+  process.exit(1);
+}
+console.log("clipboard image tests passed");


### PR DESCRIPTION
## Summary

Pasting an image into the prompt text box previously did nothing because the composer only accepted attachments through the file picker. This PR handles clipboard image files on the textarea paste event and queues them through the existing prompt attachment flow.

Text paste behavior is preserved: the paste handler does not call `preventDefault()`, so normal text paste continues to be handled by the browser while any clipboard image files are added as attachments.

## Usage

Paste an image from the clipboard directly into the chat composer. The image appears as an attachment preview and is sent with the next prompt the same way file-picker image uploads are sent.

## What changed (3 files, +192)

- `packages/client/src/components/ChatInput.tsx` — wires textarea `onPaste` to extract clipboard images and pass them into the existing `addAttachments()` path, with existing read-only/streaming guards.
- `packages/client/src/lib/clipboard-images.ts` — adds a small helper to extract image `File`s from `clipboardData.items` or `clipboardData.files`, including stable names for unnamed pasted images.
- `tests/test-clipboard-images.ts` — adds pure helper coverage for image item extraction, file fallback, non-image ignoring, and unnamed image naming.

## Test plan

- [x] `npx prettier --write packages/client/src/components/ChatInput.tsx packages/client/src/lib/clipboard-images.ts tests/test-clipboard-images.ts`
- [x] `npx tsx tests/test-clipboard-images.ts`
- [x] `scripts/run-tests.sh --only clipboard-images`
- [x] `npm run build`
- [x] `npm run check`
- [ ] `scripts/run-tests.sh --only clipboard-images,attachments` — attempted, but `test-attachments.ts` failed during startup because the local shared checkout is missing the native `node-pty` module (`Failed to load native module: pty.node`).
- [ ] CI green before merge
