### PR TITLE
fix(processes): clarify async process notifications

### DIFF
--- a/docs/processes.md
+++ b/docs/processes.md
@@ -24,12 +24,18 @@ conversation continues.
 Per-`start` flags control whether the agent gets a turn to react
 on lifecycle events:
 
-- `alertOnSuccess` (default: `false`) — non-zero exit gates this off
+- `alertOnSuccess` (default: `false`) — records an informational clean-exit card, but does not wake the agent
 - `alertOnFailure` (default: `true`) — fires on crash / non-zero exit
 - `alertOnKill` (default: `false`) — fires only on external signal; killing via the tool never triggers a turn
 
+When one of these enabled lifecycle alerts fires, pi-forge appends a
+`process-notify` status card. Clean success is informational and does
+not wake the agent; failure and external-kill alerts start/steer an
+agent turn because they usually require intervention.
+
 `logWatches` adds runtime regex matchers per process. On match, the
-manager emits a watch event the UI surfaces as an alert badge.
+manager emits a watch event the UI surfaces as an alert badge and a
+`process-watch` status card that starts/steers an agent turn.
 `stream: "stdout" | "stderr" | "both"`; `repeat: false` is the
 default (single-fire) — set `true` for repeat alerts.
 

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1120,7 +1120,10 @@ function Message({
   // Forge lifecycle/status notifications are custom SDK messages, not
   // user-authored chat. Render them as compact status cards so they don't
   // look like the user asked the agent something.
-  if (message.role === "custom" && message.customType === "process-notify") {
+  if (
+    message.role === "custom" &&
+    (message.customType === "process-notify" || message.customType === "process-watch")
+  ) {
     return <LifecycleStatusCard message={message} kind="process" />;
   }
   if (message.role === "custom" && message.customType === "orchestration-notify") {
@@ -1216,6 +1219,7 @@ function processStatusTitle(details: Record<string, unknown>, state: string): st
   if (state === "success") return `Process completed: ${name}`;
   if (state === "failure") return `Process failed: ${name}`;
   if (state === "killed") return `Process killed: ${name}`;
+  if (state === "watch") return `Process watch matched: ${name}`;
   return `Process update: ${name}`;
 }
 

--- a/packages/server/src/processes/prompt-strings.ts
+++ b/packages/server/src/processes/prompt-strings.ts
@@ -21,12 +21,12 @@ export const PROMPT_GUIDELINES: string[] = [
   "Use the process tool for long-running commands such as dev servers, test watchers, build watchers, and log tails instead of bash.",
   "Avoid shell background patterns such as &, nohup, disown, or setsid when the process tool fits.",
   "After starting a process, continue other work instead of waiting for it. Do not repeatedly call list/output just to see whether it has finished.",
-  "Use the pi-forge process tool's notify flags (alertOnSuccess / alertOnFailure / alertOnKill) and logWatches when you need to react to events without polling.",
+  "Use bash instead when you need a command's result before continuing. Use process notify flags/logWatches only for asynchronous follow-up, especially failures or specific output patterns.",
 ];
 
 export const TOOL_DESCRIPTION = `Manage background processes. Actions:
 - start: Run command in background (requires 'name' and 'command')
-  - alertOnSuccess (default: false): Get a turn to react when process completes successfully
+  - alertOnSuccess (default: false): Show an informational notification on clean completion; does not wake the agent
   - alertOnFailure (default: true): Get a turn to react when process crashes/fails
   - alertOnKill (default: false): Get a turn to react if killed by external signal (killing via tool never triggers a turn)
   - logWatches (optional): Runtime output watches that trigger immediate alerts while running
@@ -40,6 +40,6 @@ export const TOOL_DESCRIPTION = `Manage background processes. Actions:
 - clear: Remove all finished processes from the list
 - write: Write to process stdin (requires 'id' and 'input', optional 'end' to close stdin)
 
-Important: You DON'T need to poll or wait for processes. Do not repeatedly call list/output after start just to check whether the process has completed. Repeated list/output calls while live process state/output is unchanged are suppressed; notifications arrive automatically based on your preferences. Start processes and continue with other work — you'll be informed if something requires attention.
+Important: Use bash when you need a command's result before continuing in the current turn. Use process for asynchronous/background work only. You DON'T need to poll or wait for processes. Do not repeatedly call list/output after start just to check whether the process has completed. Repeated list/output calls while live process state/output is unchanged are suppressed; failure/kill notifications and logWatches arrive automatically when they require attention. Start processes and continue other work.
 
 Note: User always sees process updates in the UI. The notify flags control whether YOU (the agent) get a turn to react (e.g. check results, fix code, restart).`;

--- a/packages/server/src/processes/tool.ts
+++ b/packages/server/src/processes/tool.ts
@@ -48,7 +48,7 @@ const inputSchema = {
     alertOnSuccess: {
       type: "boolean",
       description:
-        "Get a turn to react when process completes successfully (default: false). Use for builds/tests where you need confirmation.",
+        "Show an informational notification when the process completes successfully (default: false). Does not wake the agent; use bash for synchronous work.",
     },
     alertOnFailure: {
       type: "boolean",
@@ -118,7 +118,7 @@ function shouldSuppressPoll(key: string, signature: string, now = Date.now()): b
 }
 
 function pollingSuppressedMessage(action: "list" | "output"): string {
-  return `Polling suppressed: process.${action} was called again while live process state/output had not changed. Do not call process.${action} repeatedly to wait; continue other work or rely on alertOnSuccess / alertOnFailure / logWatches notifications.`;
+  return `Polling suppressed: process.${action} was called again while live process state/output had not changed. Do not call process.${action} repeatedly to wait; use bash for synchronous work, continue other work, or rely on alertOnFailure / alertOnKill / logWatches notifications for asynchronous follow-up.`;
 }
 
 function validateLogWatches(watches: LogWatch[] | undefined): string | null {

--- a/packages/server/src/sse-bridge.ts
+++ b/packages/server/src/sse-bridge.ts
@@ -236,6 +236,43 @@ export function initProcessesFanout(): () => void {
           // best-effort fanout
         }
       }
+      const content =
+        `Process "${event.match.processName}" (id=${event.match.processId}) matched ` +
+        `log watch /${event.match.watch.pattern}/ on ${event.match.source}: ` +
+        event.match.line;
+      sendCustomLifecycleMessage(
+        live.session,
+        {
+          customType: "process-watch",
+          content,
+          display: true,
+          details: {
+            source: "process",
+            state: "watch",
+            processId: event.match.processId,
+            name: event.match.processName,
+            command: event.match.processCommand,
+            stream: event.match.source,
+            line: event.match.line,
+            watch: event.match.watch,
+          },
+        },
+        {
+          triggerTurn: true,
+          onError: (err: unknown) => {
+            process.stderr.write(
+              JSON.stringify({
+                level: "warn",
+                time: new Date().toISOString(),
+                msg: "process-watch sendCustomMessage failed",
+                sessionId: event.sessionId,
+                processId: event.match.processId,
+                err: err instanceof Error ? err.message : String(err),
+              }) + "\n",
+            );
+          },
+        },
+      );
       return;
     }
     if (event.type === "process_output_changed") {
@@ -255,10 +292,10 @@ export function initProcessesFanout(): () => void {
     }
     if (event.type === "process_alert") {
       // Lifecycle alerts are status messages, not user-authored chat.
-      // Custom messages let the client render a compact status card
-      // and let the server decide per outcome whether the parent
-      // agent should take a turn. Clean exits are informational;
-      // failures/kills preserve the old "wake the agent" behavior.
+      // Success is intentionally informational: background processes
+      // are async work, so a clean exit should not wake the agent back
+      // up just to acknowledge success. Failures/kills still wake the
+      // agent because they usually require intervention.
       const reasonText =
         event.reason === "success"
           ? `finished successfully (exit ${event.info.exitCode ?? "?"})`

--- a/tests/test-processes.ts
+++ b/tests/test-processes.ts
@@ -6,12 +6,13 @@
  * Coverage:
  *   - start/list/output/kill/clear lifecycle via the tool factory
  *   - write to stdin (with end:true closing)
- *   - logWatches: regex match fires the manager's watch event
+ *   - logWatches: regex match fires the manager's watch event and agent alert
  *   - Validation: missing name/command, bad regex, unknown action
  *   - REST routes: GET list, POST kill, DELETE clear,
  *     POST stdin, GET output, GET logs/file
  *   - Cross-session 404
  *   - MINIMAL_UI gate on start (existing list still readable)
+ *   - Process failure/watch notifications trigger agent turns when requested
  *   - Session dispose terminates live processes
  */
 import { spawn, type ChildProcess } from "node:child_process";
@@ -608,8 +609,9 @@ async function main(): Promise<void> {
     // -------- agent alerts on process completion --------
     // alertOnSuccess, alertOnFailure, alertOnKill fire `process_alert`
     // events on the manager; the SSE bridge translates those into
-    // custom status messages. Clean exit cards do not trigger a parent
-    // turn; non-zero failures do.
+    // custom status messages. Clean exits are informational because
+    // process work is async/background; failures trigger/steer a turn
+    // because they usually require intervention.
     {
       const alerts: {
         reason: string;
@@ -730,22 +732,58 @@ async function main(): Promise<void> {
       );
     }
 
-    // -------- logWatches: regex match fires manager event --------
+    // -------- logWatches: regex match fires manager event + agent alert --------
     {
       const events: { type: string }[] = [];
+      const customMessages: {
+        customType: string;
+        details?: { processId?: string; state?: string; stream?: string };
+        triggerTurn?: boolean;
+      }[] = [];
+      const originalSendCustom = live.session.sendCustomMessage;
+      live.session.sendCustomMessage = async (message, options) => {
+        const captured: {
+          customType: string;
+          details?: { processId?: string; state?: string; stream?: string };
+          triggerTurn?: boolean;
+        } = { customType: message.customType };
+        if (message.details !== undefined) {
+          captured.details = message.details as {
+            processId?: string;
+            state?: string;
+            stream?: string;
+          };
+        }
+        if (options?.triggerTurn !== undefined) captured.triggerTurn = options.triggerTurn;
+        customMessages.push(captured);
+      };
       const unsub = managerMod.processManager.subscribe((e) => {
         if (e.type === "process_watch_matched") events.push(e);
       });
-      const r = await call({
-        action: "start",
-        name: "watcher",
-        command: "echo MATCH-ME && sleep 0.2",
-        logWatches: [{ pattern: "MATCH-ME", stream: "stdout" }],
-      });
-      assert("start with logWatch → success", r.details.success === true);
-      await sleep(400);
-      unsub();
-      assert("watch matched event fired", events.length >= 1);
+      try {
+        const r = await call({
+          action: "start",
+          name: "watcher",
+          command: "echo MATCH-ME && sleep 0.2",
+          logWatches: [{ pattern: "MATCH-ME", stream: "stdout" }],
+        });
+        assert("start with logWatch → success", r.details.success === true);
+        const watchId = (r.details.process as { id: string }).id;
+        await sleep(400);
+        assert("watch matched event fired", events.length >= 1);
+        const watchCustom = customMessages.find((m) => m.details?.processId === watchId);
+        assert(
+          "watch match becomes process-watch custom card",
+          watchCustom?.customType === "process-watch" &&
+            watchCustom.details?.state === "watch" &&
+            watchCustom.details.stream === "stdout",
+          JSON.stringify(customMessages),
+        );
+        assert("watch match DOES trigger turn", watchCustom?.triggerTurn === true);
+      } finally {
+        unsub();
+        live.session.sendCustomMessage = originalSendCustom;
+      }
     }
 
     // -------- REST: GET /processes --------


### PR DESCRIPTION
## Summary

Agents were still tempted to poll `process list` / `process output` while waiting on background commands because the process tool guidance blurred synchronous and asynchronous usage, and `logWatches` only surfaced to the UI/SSE stream rather than creating an agent-visible wake-up. This PR clarifies that `process` is for async/background work only: use `bash` when a command result is needed before continuing. It also makes log-watch matches create an agent lifecycle message so agents can wait for pushed watch notifications instead of polling.

Clean successful completion remains informational only and does not wake the agent; async failures, external kills, and explicit log-watch matches are the cases that can trigger/steer a follow-up turn.

## Usage

For synchronous command results, use `bash`:

```bash
npm run build
```

For background work, use `process` and optionally configure async follow-up:

```json
{
  "action": "start",
  "name": "dev-server",
  "command": "npm run dev",
  "logWatches": [
    { "pattern": "ready in .*ms", "stream": "stdout" },
    { "pattern": "error|failed|EADDRINUSE", "stream": "both" }
  ]
}
```

Do not repeatedly call `process list` or `process output` to wait for completion; unchanged live polling remains suppressed.

## What changed (5 files)

- `packages/server/src/sse-bridge.ts` — forwards `process_watch_matched` events into `process-watch` lifecycle messages that trigger/steer the agent; preserves success notifications as informational and failure/kill notifications as agent-waking.
- `packages/server/src/processes/prompt-strings.ts` — clarifies `bash` vs `process`, async-only process usage, and non-waking success notifications.
- `packages/server/src/processes/tool.ts` — updates `alertOnSuccess` schema text and polling suppression guidance.
- `tests/test-processes.ts` — covers non-waking success alerts, waking failure alerts, and waking log-watch lifecycle messages.
- `docs/processes.md` — documents async notification semantics.

## Test plan

- [x] `npm run format -- packages/server/src/sse-bridge.ts packages/server/src/processes/tool.ts packages/server/src/processes/prompt-strings.ts tests/test-processes.ts docs/processes.md`
- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only processes,sse`
- [ ] CI green before merge
