### PR TITLE
chore: add vim to runtime container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -127,10 +127,11 @@ ARG TEA_VERSION=0.14.1
 #     shell. node-pty defaults to /bin/sh; we set SHELL=/bin/bash
 #     below so xterm sessions land in bash with readline + history +
 #     the prompt expansions users expect.
-#   - curl, ca-certificates, less, procps: minimum interactive-terminal
+#   - curl, ca-certificates, less, procps, vim: minimum interactive-terminal
 #     hygiene. curl for fetching, ca-certificates so HTTPS works, less
 #     so `git log` and similar pagers don't bomb, procps so `ps`/`top`
-#     are present for users debugging long-running tool processes.
+#     are present for users debugging long-running tool processes, and vim
+#     provides a familiar in-terminal editor.
 #   - python3/pip3: Python 3.12 package tooling from the official
 #     Python image. `python` and `py` are aliases for `python3`.
 #   - make, g++: native-module rebuild toolchain for people using the
@@ -143,7 +144,7 @@ ARG TEA_VERSION=0.14.1
 #     present when `apt-get install gh` runs.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      tini gosu git ripgrep bash curl ca-certificates less procps make g++ gnupg \
+      tini gosu git ripgrep bash curl ca-certificates less procps vim make g++ gnupg \
  && install -dm 0755 /etc/apt/keyrings \
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -22,7 +22,7 @@ runtime (Node + native bindings), and makes deploys reproducible.
 | `python-base` | `python:3.12-slim-bookworm` | Source for the Python 3.12 + pip runtime copied into the shared Node base |
 | `node-python-base` | `node:22-bookworm-slim` | Shared Debian slim base with Node.js 22 plus Python 3.12 + pip |
 | `builder` | `node-python-base` | Installs all deps including devDeps, compiles native bindings (`node-pty`), runs `npm run build` for both packages |
-| `runtime` | `node-python-base` | Production deps + built artifacts only. Adds `git`, `gh`, `tea`, `ripgrep`, `bash`, `curl`, `less`, `procps`, `gosu`, and the C++ toolchain needed for native-module rebuilds during in-container development. Default mode drops the server to `pi`; sandbox mode keeps the server as root so it can drop model/user tool processes to `pi-tools`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
+| `runtime` | `node-python-base` | Production deps + built artifacts only. Adds `git`, `gh`, `tea`, `ripgrep`, `bash`, `curl`, `less`, `procps`, `vim`, `gosu`, and the C++ toolchain needed for native-module rebuilds during in-container development. Default mode drops the server to `pi`; sandbox mode keeps the server as root so it can drop model/user tool processes to `pi-tools`; `SHELL=/bin/bash` so xterm sessions land in bash, not dash |
 
 Final image size varies by architecture and cache state. Debian-based
 (not Alpine) because the Node native-module ecosystem ships glibc
@@ -38,6 +38,7 @@ Installed at runtime:
 - **`tea`** — Gitea/Forgejo CLI, pinned from the upstream Gitea release
 - **`ripgrep`** — pi's `grep` tool delegates to `rg` when present;
   silently degrades to a Node walker without it
+- **`vim`** — familiar in-terminal editor for the integrated terminal
 - **`make`, `g++`** — keeps `npm install` / `npm rebuild` working
   inside the running container when native modules such as `node-pty`
   need to compile against the container's Node ABI


### PR DESCRIPTION
## Summary

The runtime container is intended to be a comfortable interactive environment for the integrated terminal and agent shell. It already includes common CLI tools, but not a familiar terminal editor. This PR adds `vim` to the user-facing runtime image so rebuilt containers have it available on `PATH`.

## Usage

After rebuilding the Docker image, `vim` is available inside the runtime container:

```bash
cd docker
docker compose up -d --build
# then open the integrated terminal or docker exec into the container
vim --version
```

No application configuration or TypeScript/client/server changes are required.

## What changed (2 files, +6/-4)

- `docker/Dockerfile` — adds `vim` to the runtime stage Debian package install list and updates the nearby runtime-tools comment.
- `docs/containers.md` — documents `vim` as part of the shipped runtime container toolset.

## Test plan

- [x] `npm run format:check -- docker/Dockerfile docs/containers.md`
- [x] `git diff --check`
- [x] Static validation: confirmed `vim` appears in the runtime `apt-get install -y --no-install-recommends` line.
- [ ] Docker build not run: Docker CLI was unavailable in the worker environment (`docker: command not found`).
- [ ] CI green before merge.
