### PR TITLE
fix: support file moves and folder uploads

### DIFF
--- a/packages/client/src/components/FileBrowserPanel.tsx
+++ b/packages/client/src/components/FileBrowserPanel.tsx
@@ -292,13 +292,16 @@ export function FileBrowserPanel() {
     e.preventDefault();
     e.stopPropagation();
     setDropTarget(undefined);
-    // OS file drop: upload into the target directory.
-    if (e.dataTransfer.files.length > 0) {
-      const files = Array.from(e.dataTransfer.files);
+    const src = e.dataTransfer.getData("application/x-pi-path");
+    // In-app drags also pass through the browser's drag/drop plumbing;
+    // prefer the explicit pi path when present so a row drag never gets
+    // misclassified as an OS file upload.
+    if (src.length === 0 && hasTransferType(e.dataTransfer, "Files")) {
+      const files = await collectDroppedUploadFiles(e.dataTransfer);
       await runUpload(targetDirAbsPath, files);
       return;
     }
-    const src = e.dataTransfer.getData("application/x-pi-path");
+
     if (src.length === 0) return;
     // basename of src
     const name = src.split("/").pop() ?? "";
@@ -496,12 +499,11 @@ export function FileBrowserPanel() {
         // MUST preventDefault to enable the drop. We accept either an
         // in-app drag (custom mime) or a native OS file drag (`Files`).
         onDragOver={(e) => {
-          if (
-            e.dataTransfer.types.includes("application/x-pi-path") ||
-            e.dataTransfer.types.includes("Files")
-          ) {
+          const isPiPath = hasTransferType(e.dataTransfer, "application/x-pi-path");
+          const isFiles = hasTransferType(e.dataTransfer, "Files");
+          if (isPiPath || isFiles) {
             e.preventDefault();
-            e.dataTransfer.dropEffect = e.dataTransfer.types.includes("Files") ? "copy" : "move";
+            e.dataTransfer.dropEffect = isFiles ? "copy" : "move";
           }
         }}
         onDrop={(e) => void handleDrop(e, project.path)}
@@ -889,8 +891,8 @@ function Tree(props: TreeProps) {
         onDragOver={
           isDir
             ? (e) => {
-                const isFile = e.dataTransfer.types.includes("Files");
-                const isPiPath = e.dataTransfer.types.includes("application/x-pi-path");
+                const isFile = hasTransferType(e.dataTransfer, "Files");
+                const isPiPath = hasTransferType(e.dataTransfer, "application/x-pi-path");
                 if (!isFile && !isPiPath) return;
                 e.preventDefault();
                 e.stopPropagation();
@@ -1097,4 +1099,93 @@ function formatBytes(n: number): string {
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
   if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
   return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+type UploadFile = File & { uploadRelativePath?: string; webkitRelativePath?: string };
+
+function hasTransferType(dataTransfer: DataTransfer, type: string): boolean {
+  return Array.from(dataTransfer.types).some((candidate) => candidate === type);
+}
+
+interface FileSystemEntryLike {
+  name: string;
+  isFile: boolean;
+  isDirectory: boolean;
+}
+
+interface FileSystemFileEntryLike extends FileSystemEntryLike {
+  isFile: true;
+  file: (success: (file: File) => void, failure?: (error: DOMException) => void) => void;
+}
+
+interface FileSystemDirectoryEntryLike extends FileSystemEntryLike {
+  isDirectory: true;
+  createReader: () => FileSystemDirectoryReaderLike;
+}
+
+interface FileSystemDirectoryReaderLike {
+  readEntries: (
+    success: (entries: FileSystemEntryLike[]) => void,
+    failure?: (error: DOMException) => void,
+  ) => void;
+}
+
+function getDataTransferEntry(item: DataTransferItem): FileSystemEntryLike | null {
+  const withEntry = item as unknown as { webkitGetAsEntry?: () => FileSystemEntryLike | null };
+  return withEntry.webkitGetAsEntry?.() ?? null;
+}
+
+async function collectDroppedUploadFiles(dataTransfer: DataTransfer): Promise<File[]> {
+  const entries = Array.from(dataTransfer.items)
+    .map((item) => getDataTransferEntry(item))
+    .filter((entry): entry is FileSystemEntryLike => entry !== null);
+  if (entries.length === 0) {
+    return Array.from(dataTransfer.files).map((file) => withUploadRelativePath(file, file.name));
+  }
+  const files: File[] = [];
+  for (const entry of entries) {
+    await collectEntryFiles(entry, entry.name, files);
+  }
+  return files;
+}
+
+async function collectEntryFiles(
+  entry: FileSystemEntryLike,
+  relativePath: string,
+  out: File[],
+): Promise<void> {
+  if (entry.isFile) {
+    const file = await readFileEntry(entry as FileSystemFileEntryLike);
+    out.push(withUploadRelativePath(file, relativePath));
+    return;
+  }
+  if (!entry.isDirectory) return;
+  const children = await readDirectoryEntries(entry as FileSystemDirectoryEntryLike);
+  await Promise.all(
+    children.map((child) => collectEntryFiles(child, `${relativePath}/${child.name}`, out)),
+  );
+}
+
+function readFileEntry(entry: FileSystemFileEntryLike): Promise<File> {
+  return new Promise((resolveFile, reject) => entry.file(resolveFile, reject));
+}
+
+async function readDirectoryEntries(
+  entry: FileSystemDirectoryEntryLike,
+): Promise<FileSystemEntryLike[]> {
+  const reader = entry.createReader();
+  const all: FileSystemEntryLike[] = [];
+  for (;;) {
+    const batch = await new Promise<FileSystemEntryLike[]>((resolveEntries, reject) =>
+      reader.readEntries(resolveEntries, reject),
+    );
+    if (batch.length === 0) return all;
+    all.push(...batch);
+  }
+}
+
+function withUploadRelativePath(file: File, relativePath: string): File {
+  const uploadFile = file as UploadFile;
+  uploadFile.uploadRelativePath = relativePath;
+  return uploadFile;
 }

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1437,6 +1437,12 @@ async function streamSha256(blob: Blob, onChunk?: (delta: number) => void): Prom
   return hasher.digest("hex");
 }
 
+function getUploadPath(file: File): string {
+  const withPath = file as File & { uploadRelativePath?: string; webkitRelativePath?: string };
+  const path = withPath.uploadRelativePath ?? withPath.webkitRelativePath;
+  return path !== undefined && path.length > 0 ? path : file.name;
+}
+
 /**
  * Parse the filename out of a Content-Disposition header. Prefers
  * `filename*` (RFC 5987) when present so we get the original
@@ -2612,15 +2618,17 @@ export const api = {
     if (opts?.overwrite === true) fd.append("overwrite", "1");
     const totalBytes = files.reduce((acc, f) => acc + f.size, 0);
     let hashedSoFar = 0;
-    for (const file of files) {
+    for (const [index, file] of files.entries()) {
+      const uploadPath = getUploadPath(file);
       const digest = await streamSha256(file, (delta) => {
         hashedSoFar += delta;
         opts?.onHashProgress?.(hashedSoFar, totalBytes);
       });
-      fd.append(`sha256:${file.name}`, digest);
+      fd.append(`path:${index}`, uploadPath);
+      fd.append(`sha256:${index}`, digest);
     }
-    for (const file of files) {
-      fd.append("files", file, file.name);
+    for (const [index, file] of files.entries()) {
+      fd.append(`file:${index}`, file, getUploadPath(file));
     }
     return request("/api/v1/files/upload", vUploadResponse, {
       method: "POST",

--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -13,7 +13,7 @@ import {
 } from "node:fs/promises";
 import { createReadStream, createWriteStream } from "node:fs";
 import { once } from "node:events";
-import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { create as tarCreate } from "tar";
 import type { Readable } from "node:stream";
@@ -595,15 +595,50 @@ export async function writeFileBytes(
   source: AsyncIterable<Buffer | Uint8Array>,
   opts?: { expectedSha256?: string; overwrite?: boolean },
 ): Promise<{ path: string; size: number; sha256: string }> {
+  return writeFileBytesAtPath(parentAbsPath, [name], root, source, opts);
+}
+
+/**
+ * Stream bytes into a target under `parentAbsPath` using a browser-provided
+ * relative path. This is used for drag-and-drop folder uploads where each file
+ * arrives with a path such as `src/components/Button.tsx` relative to the
+ * dropped folder. The path is split into safe single-name segments before the
+ * final absolute target is verified against the project root.
+ */
+export async function writeFileBytesRelative(
+  parentAbsPath: string,
+  relativePath: string,
+  root: string,
+  source: AsyncIterable<Buffer | Uint8Array>,
+  opts?: { expectedSha256?: string; overwrite?: boolean },
+): Promise<{ path: string; size: number; sha256: string }> {
+  if (isAbsolute(relativePath) || relativePath.includes("\0")) {
+    throw new PathOutsideRootError(relativePath, root);
+  }
+  const parts = relativePath.replaceAll("\\", "/").split("/");
+  if (parts.some((part) => part === "..")) {
+    throw new PathOutsideRootError(relativePath, root);
+  }
+  return writeFileBytesAtPath(parentAbsPath, parts, root, source, opts);
+}
+
+async function writeFileBytesAtPath(
+  parentAbsPath: string,
+  relativeParts: string[],
+  root: string,
+  source: AsyncIterable<Buffer | Uint8Array>,
+  opts?: { expectedSha256?: string; overwrite?: boolean },
+): Promise<{ path: string; size: number; sha256: string }> {
   const parent = await verifyPathSafe(parentAbsPath, root);
-  const trimmed = validateName(name);
-  const target = await verifyPathSafe(join(parent, trimmed), root);
+  const trimmedParts = relativeParts.map((part) => validateName(part));
+  if (trimmedParts.length === 0) throw new InvalidNameError();
+  const target = await verifyPathSafe(join(parent, ...trimmedParts), root);
   const existing = await stat(target).catch(() => undefined);
   if (existing !== undefined) {
     if (opts?.overwrite !== true) throw new TargetExistsError(target);
     if (!existing.isFile()) throw new InvalidNameError("target is a directory");
   }
-  await mkdir(parent, { recursive: true });
+  await mkdir(dirname(target), { recursive: true });
   const tmp = `${target}.${randomUUID()}.upload.tmp`;
   const hash = createHash("sha256");
   let size = 0;

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -18,6 +18,7 @@ import {
   renameEntry,
   writeFile,
   writeFileBytes,
+  writeFileBytesRelative,
 } from "../file-manager.js";
 import { config } from "../config.js";
 import { getProject } from "../project-manager.js";
@@ -25,7 +26,7 @@ import { searchFiles, SearchEngineUnavailableError } from "../file-searcher.js";
 import { errorSchema } from "./_schemas.js";
 
 const MAX_UPLOAD_BYTES = 500 * 1024 * 1024;
-const MAX_UPLOAD_FILES = 16;
+const MAX_UPLOAD_FILES = 512;
 // Aggregate cap across all files in a single upload request. The
 // per-file cap × file count gives 8 GB of theoretical headroom — the
 // aggregate cap puts a tighter ceiling on memory + disk pressure when
@@ -767,8 +768,9 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
   //   - projectId: string (required)
   //   - parentPath: string — absolute, inside project (required)
   //   - overwrite: "1"/"true" — replace existing files
-  //   - sha256:<filename>: 64-char lowercase hex (optional, per file)
-  //   - <any-field-name>: file part(s)
+  //   - path:<index>: slash-separated relative path below parentPath (optional, per file)
+  //   - sha256:<filename-or-index>: 64-char lowercase hex (optional, per file)
+  //   - file:<index> or <any-field-name>: file part(s)
   fastify.post<{
     Body: unknown;
   }>(
@@ -788,7 +790,9 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
           `(when the client supplied one via the \`sha256:<filename>\` text field). ` +
           `Per-file cap: ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB. Aggregate cap: ` +
           `${MAX_TOTAL_UPLOAD_BYTES / (1024 * 1024)} MB across all parts. Max ` +
-          `${MAX_UPLOAD_FILES} files per request. Existing targets return 409 unless ` +
+          `${MAX_UPLOAD_FILES} files per request. Folder uploads may include a ` +
+          `per-file \`path:<index>\` field for the project-relative path below ` +
+          `the selected parent folder. Existing targets return 409 unless ` +
           `\`overwrite=1\` is sent. Per-file overflows return 413 \`file_too_large\`; ` +
           `aggregate overflows return 413 \`aggregate_too_large\`.`,
         tags: ["files"],
@@ -832,13 +836,14 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
       let overwrite = false;
       let aggregateBytes = 0;
       const expectedHashes = new Map<string, string>();
+      const relativePaths = new Map<string, string>();
       const written: { path: string; size: number; sha256: string }[] = [];
       try {
         const parts = req.parts({
           limits: {
             fileSize: MAX_UPLOAD_BYTES,
             files: MAX_UPLOAD_FILES,
-            fields: 64,
+            fields: MAX_UPLOAD_FILES * 2 + 8,
           },
         });
         for await (const part of parts) {
@@ -852,6 +857,9 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
             } else if (part.fieldname.startsWith("sha256:") && typeof part.value === "string") {
               const name = part.fieldname.slice("sha256:".length);
               if (name.length > 0) expectedHashes.set(name, part.value.toLowerCase());
+            } else if (part.fieldname.startsWith("path:") && typeof part.value === "string") {
+              const key = part.fieldname.slice("path:".length);
+              if (key.length > 0) relativePaths.set(key, part.value);
             }
             continue;
           }
@@ -878,7 +886,16 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
           if (filename === undefined || filename.length === 0) {
             return reply.code(400).send({ error: "missing_filename" });
           }
-          const expected = expectedHashes.get(filename);
+          const indexedKey = file.fieldname.startsWith("file:")
+            ? file.fieldname.slice("file:".length)
+            : undefined;
+          const uploadPath =
+            indexedKey !== undefined ? (relativePaths.get(indexedKey) ?? filename) : filename;
+          const isNestedUpload = uploadPath.includes("/") || uploadPath.includes("\\");
+          const expected =
+            (indexedKey !== undefined ? expectedHashes.get(indexedKey) : undefined) ??
+            expectedHashes.get(uploadPath) ??
+            expectedHashes.get(filename);
           // Stream the part body straight through writeFileBytes so we
           // never buffer the whole file in memory. We wrap the part
           // stream in an aggregate-tracking iterator so the request
@@ -895,10 +912,15 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
           );
           let result;
           try {
-            result = await writeFileBytes(parentPath, filename, project.path, trackedSource, {
-              ...(expected !== undefined ? { expectedSha256: expected } : {}),
-              overwrite,
-            });
+            result = !isNestedUpload
+              ? await writeFileBytes(parentPath, uploadPath, project.path, trackedSource, {
+                  ...(expected !== undefined ? { expectedSha256: expected } : {}),
+                  overwrite,
+                })
+              : await writeFileBytesRelative(parentPath, uploadPath, project.path, trackedSource, {
+                  ...(expected !== undefined ? { expectedSha256: expected } : {}),
+                  overwrite,
+                });
           } catch (err) {
             if (err instanceof AggregateLimitError) {
               // Roll back every previously-written file in this same

--- a/tests/test-files.ts
+++ b/tests/test-files.ts
@@ -22,7 +22,14 @@
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { mkdir, mkdtemp, rm, symlink, writeFile as fsWrite } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile as fsRead,
+  rm,
+  symlink,
+  writeFile as fsWrite,
+} from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -332,6 +339,44 @@ async function main(): Promise<void> {
       assert("DELETE /files/delete (file) → 204", d.status === 204);
       const read = await jget(`${base}/api/v1/files/read?${qs}`, auth);
       assert("file gone after delete → 404", read.status === 404);
+    }
+
+    // ---- upload files with folder-relative paths ----
+    {
+      const fd = new FormData();
+      fd.append("projectId", projectId);
+      fd.append("parentPath", canonicalProjectPath);
+      fd.append("path:0", "dropped-folder/alpha.txt");
+      fd.append("sha256:0", "8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8");
+      fd.append("path:1", "dropped-folder/nested/beta.txt");
+      fd.append("sha256:1", "f44e64e75f3948e9f73f8dfa94721c4ce8cbb4f265c4790c702b2d41cfbf2753");
+      fd.append("file:0", new Blob(["alpha"]), "dropped-folder/alpha.txt");
+      fd.append("file:1", new Blob(["beta"]), "dropped-folder/nested/beta.txt");
+      const res = await fetch(`${base}/api/v1/files/upload`, {
+        method: "POST",
+        headers: auth,
+        body: fd,
+      });
+      const body = (await res.json()) as { files?: { path: string }[] };
+      assert("POST /files/upload folder paths → 200", res.status === 200, JSON.stringify(body));
+      assert("upload returns two files", body.files?.length === 2, JSON.stringify(body));
+      const alpha = await fsRead(join(projectPath, "dropped-folder", "alpha.txt"), "utf8");
+      const beta = await fsRead(join(projectPath, "dropped-folder", "nested", "beta.txt"), "utf8");
+      assert("folder upload writes top-level file", alpha === "alpha");
+      assert("folder upload writes nested file", beta === "beta");
+    }
+    {
+      const fd = new FormData();
+      fd.append("projectId", projectId);
+      fd.append("parentPath", canonicalProjectPath);
+      fd.append("path:0", "../escape.txt");
+      fd.append("file:0", new Blob(["escape"]), "escape.txt");
+      const res = await fetch(`${base}/api/v1/files/upload`, {
+        method: "POST",
+        headers: auth,
+        body: fd,
+      });
+      assert("POST /files/upload traversal folder path → 403", res.status === 403);
     }
 
     // ---- mkdir + duplicate + delete empty ----


### PR DESCRIPTION
## Summary

Group 1 file browser fixes: this PR enables moving files into folders from the web UI and adds drag-and-drop folder upload support. Folder uploads now preserve browser-provided relative paths while keeping all writes behind the server-side file-manager safety checks, so traversal attempts still return `403` instead of escaping the workspace.

## Usage

Use the existing file browser UI:

```text
- Drag a file row onto a folder row to move it into that folder.
- Drag a local folder from the OS into the file browser to upload its files with nested paths preserved.
```

Existing flat multi-file upload behavior remains compatible. Folder upload metadata is sent as indexed multipart fields so duplicate basenames in different folders are handled safely.

## What changed (5 files, +231/-30)

- `packages/client/src/components/FileBrowserPanel.tsx` — distinguishes internal file-browser drags from OS file drops, traverses dropped folders with `webkitGetAsEntry()`, and falls back to flat upload when folder traversal is unavailable.
- `packages/client/src/lib/api-client/index.ts` — sends indexed multipart `path:<index>`, `sha256:<index>`, and `file:<index>` fields for relative-path uploads while preserving existing upload compatibility.
- `packages/server/src/file-manager.ts` — adds safe relative byte-write support that rejects absolute paths, NUL bytes, and `..` traversal segments.
- `packages/server/src/routes/files.ts` — accepts indexed upload metadata, writes folder-relative uploads through file-manager validation, preserves legacy flat uploads, and raises the upload file-count limit.
- `tests/test-files.ts` — covers nested folder-relative uploads and verifies traversal upload paths are rejected with `403`.

## Test plan

- [x] `npm run format`
- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only files`
- [x] `npm run test:ci`
