### PR TITLE
fix: correct Group 5 orchestration dashboard theme colors

### DIFF
--- a/packages/client/src/components/OrchestrationPanel.tsx
+++ b/packages/client/src/components/OrchestrationPanel.tsx
@@ -85,7 +85,7 @@ export function OrchestrationPanel({ sessionId, onClose }: Props) {
   const role = link?.role ?? "standalone";
 
   return (
-    <div className="rounded-md border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 p-3 text-sm">
+    <div className="rounded-md border border-neutral-800 bg-neutral-900/50 p-3 text-sm text-neutral-200">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 font-medium">
           <Users size={14} />
@@ -99,7 +99,7 @@ export function OrchestrationPanel({ sessionId, onClose }: Props) {
               void reload();
             }}
             title="Refresh"
-            className="p-1 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100"
+            className="p-1 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-100"
           >
             {loading ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
           </button>
@@ -108,7 +108,7 @@ export function OrchestrationPanel({ sessionId, onClose }: Props) {
               type="button"
               onClick={onClose}
               title="Close"
-              className="p-1 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100"
+              className="p-1 text-neutral-400 hover:bg-neutral-800 hover:text-neutral-100"
             >
               <X size={14} />
             </button>
@@ -117,7 +117,7 @@ export function OrchestrationPanel({ sessionId, onClose }: Props) {
       </div>
 
       {error !== undefined && (
-        <div className="mt-2 rounded bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300 px-2 py-1 text-xs">
+        <div className="mt-2 rounded bg-red-900/30 px-2 py-1 text-xs text-red-300 light:bg-red-100 light:text-red-800">
           {error}
         </div>
       )}
@@ -152,10 +152,10 @@ export function OrchestrationPanel({ sessionId, onClose }: Props) {
 function RoleBadge({ role }: { role: "supervisor" | "worker" | "standalone" }) {
   const styles =
     role === "supervisor"
-      ? "bg-violet-100 text-violet-800 dark:bg-violet-900/40 dark:text-violet-200"
+      ? "bg-violet-900/40 text-violet-200 light:bg-violet-100 light:text-violet-800"
       : role === "worker"
-        ? "bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200"
-        : "bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300";
+        ? "bg-sky-900/40 text-sky-200 light:bg-sky-100 light:text-sky-800"
+        : "bg-neutral-800 text-neutral-300";
   return (
     <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${styles}`}>
       {role === "supervisor" ? "Supervisor" : role === "worker" ? "Worker" : "Standalone"}
@@ -195,7 +195,7 @@ function StandaloneControls({
   };
   return (
     <div className="mt-2 space-y-2">
-      <p className="text-xs text-zinc-600 dark:text-zinc-400">
+      <p className="text-xs text-neutral-400">
         This session is standalone. Enable supervisor mode to give this session the{" "}
         <code className="text-xs">orchestrate_*</code> tools — letting it spawn, observe, and
         coordinate other worker sessions in the same project.
@@ -206,11 +206,11 @@ function StandaloneControls({
           void onEnable();
         }}
         disabled={busy}
-        className="rounded bg-violet-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-violet-500 disabled:opacity-50"
+        className="rounded bg-violet-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-violet-500 disabled:opacity-70"
       >
         {busy ? "Enabling…" : "Enable supervisor mode"}
       </button>
-      <p className="text-[11px] text-zinc-500 dark:text-zinc-400">
+      <p className="text-[11px] text-neutral-400">
         The agent's tool list refreshes immediately — no reload needed.
       </p>
     </div>
@@ -314,7 +314,7 @@ function SupervisorControls({
   return (
     <div className="mt-2 space-y-2">
       <div className="flex items-center justify-between">
-        <div className="text-xs text-zinc-600 dark:text-zinc-400">
+        <div className="text-xs text-neutral-400">
           {workers.length} worker{workers.length === 1 ? "" : "s"}
         </div>
         <button
@@ -323,18 +323,18 @@ function SupervisorControls({
             void onDisable();
           }}
           disabled={busy}
-          className="rounded text-xs text-zinc-600 dark:text-zinc-400 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 px-1.5 py-0.5"
+          className="rounded px-1.5 py-0.5 text-xs text-neutral-400 hover:bg-neutral-800 hover:text-red-400 disabled:opacity-70 light:hover:text-red-600"
         >
           Disable supervisor mode
         </button>
       </div>
       {workers.length === 0 ? (
-        <p className="text-xs italic text-zinc-500 dark:text-zinc-400">
+        <p className="text-xs italic text-neutral-400">
           No workers yet. The agent can spawn one with{" "}
           <code className="text-xs">orchestrate_spawn_worker</code>.
         </p>
       ) : (
-        <ul className="divide-y divide-zinc-200 dark:divide-zinc-800 rounded border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950">
+        <ul className="divide-y divide-neutral-800 rounded border border-neutral-800 bg-neutral-950">
           {workers.map((w) => (
             <li key={w.workerId} className="flex items-center gap-2 px-2 py-1.5">
               <StateDot state={w.state ?? (w.isLive ? "idle" : "cold")} />
@@ -346,7 +346,9 @@ function SupervisorControls({
               >
                 <span className="font-medium">{w.name ?? w.workerId.slice(0, 8)}</span>
                 {w.messageCount !== undefined && (
-                  <span className="ml-1 text-zinc-500">({w.messageCount} msgs)</span>
+                  <span className="ml-1 text-neutral-400">
+                    ({w.messageCount} msgs)
+                  </span>
                 )}
               </button>
               <div className="flex items-center gap-1">
@@ -357,7 +359,7 @@ function SupervisorControls({
                       void onResume(w.workerId);
                     }}
                     disabled={busy}
-                    className="text-[11px] text-zinc-600 dark:text-zinc-400 hover:text-violet-700 dark:hover:text-violet-300 disabled:opacity-50 px-1 py-0.5"
+                    className="px-1 py-0.5 text-[11px] text-neutral-400 hover:bg-neutral-800 hover:text-violet-300 disabled:opacity-70 light:hover:text-violet-700"
                   >
                     Resume
                   </button>
@@ -368,7 +370,7 @@ function SupervisorControls({
                     void onDetach(w.workerId);
                   }}
                   disabled={busy}
-                  className="text-[11px] text-zinc-600 dark:text-zinc-400 hover:text-amber-700 dark:hover:text-amber-300 disabled:opacity-50 px-1 py-0.5"
+                  className="px-1 py-0.5 text-[11px] text-neutral-400 hover:bg-neutral-800 hover:text-amber-300 disabled:opacity-70 light:hover:text-amber-700"
                   title="Detach (worker continues as standalone)"
                 >
                   Detach
@@ -379,7 +381,7 @@ function SupervisorControls({
                     void onKill(w.workerId);
                   }}
                   disabled={busy}
-                  className="text-[11px] text-zinc-600 dark:text-zinc-400 hover:text-red-700 dark:hover:text-red-300 disabled:opacity-50 px-1 py-0.5"
+                  className="px-1 py-0.5 text-[11px] text-neutral-400 hover:bg-neutral-800 hover:text-red-300 disabled:opacity-70 light:hover:text-red-700"
                   title="Kill (dispose live session; transcript stays on disk)"
                 >
                   Kill
@@ -391,14 +393,16 @@ function SupervisorControls({
       )}
 
       <details open={showInbox} onToggle={(e) => setShowInbox(e.currentTarget.open)}>
-        <summary className="cursor-pointer text-xs text-zinc-600 dark:text-zinc-400 select-none">
+        <summary className="cursor-pointer select-none text-xs text-neutral-400">
           Worker event history ({inbox.length})
         </summary>
         {inbox.length === 0 ? (
-          <p className="text-xs italic text-zinc-500 dark:text-zinc-400 mt-1">No worker events.</p>
+          <p className="mt-1 text-xs italic text-neutral-400">
+            No worker events.
+          </p>
         ) : (
           <div className="mt-1 space-y-1">
-            <ul className="divide-y divide-zinc-200 dark:divide-zinc-800 rounded border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 max-h-48 overflow-auto">
+            <ul className="max-h-48 divide-y divide-neutral-800 overflow-auto rounded border border-neutral-800 bg-neutral-950">
               {inbox.map((item) => (
                 <InboxRow key={item.id} item={item} />
               ))}
@@ -409,7 +413,7 @@ function SupervisorControls({
                 void onClearInbox();
               }}
               disabled={busy}
-              className="text-[11px] text-zinc-500 dark:text-zinc-400 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50"
+              className="text-[11px] text-neutral-400 hover:text-red-400 disabled:opacity-70 light:hover:text-red-600"
             >
               Clear event history
             </button>
@@ -427,16 +431,16 @@ function InboxRow({ item }: { item: InboxItemWire }) {
       <span
         className={`rounded px-1 py-0.5 ${
           item.delivered
-            ? "bg-zinc-200 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
-            : "bg-amber-200 text-amber-900 dark:bg-amber-700/40 dark:text-amber-200"
+            ? "bg-neutral-800 text-neutral-400"
+            : "bg-amber-700/40 text-amber-200 light:bg-amber-200 light:text-amber-900"
         }`}
       >
         {label}
       </span>
-      <span className="font-mono text-zinc-500" title={item.workerId}>
+      <span className="font-mono text-neutral-400" title={item.workerId}>
         {item.workerId.slice(0, 8)}
       </span>
-      <span className="text-zinc-500 ml-auto">
+      <span className="ml-auto text-neutral-400">
         {new Date(item.occurredAt).toLocaleTimeString()}
       </span>
     </li>
@@ -463,12 +467,12 @@ function WorkerControls({ link }: { link: SessionLink }) {
   const supervisorId = link.supervisorId;
   if (supervisorId === undefined) return null;
   return (
-    <div className="mt-2 text-xs text-zinc-600 dark:text-zinc-400">
+    <div className="mt-2 text-xs text-neutral-400">
       Owned by supervisor{" "}
       <button
         type="button"
         onClick={() => openSession(supervisorId)}
-        className="font-mono underline hover:text-violet-700 dark:hover:text-violet-300"
+        className="font-mono underline hover:text-violet-300 light:hover:text-violet-700"
         title={supervisorId}
       >
         {supervisorId.slice(0, 8)}
@@ -486,7 +490,7 @@ function StateDot({ state }: { state: "streaming" | "idle" | "cold" }) {
       ? "bg-emerald-500 animate-pulse"
       : state === "idle"
         ? "bg-sky-500"
-        : "bg-zinc-400";
+        : "bg-neutral-400";
   return (
     <span className={`inline-block h-2 w-2 rounded-full ${cls}`} title={state} aria-label={state} />
   );

--- a/packages/client/src/components/OrchestrationPanel.tsx
+++ b/packages/client/src/components/OrchestrationPanel.tsx
@@ -346,9 +346,7 @@ function SupervisorControls({
               >
                 <span className="font-medium">{w.name ?? w.workerId.slice(0, 8)}</span>
                 {w.messageCount !== undefined && (
-                  <span className="ml-1 text-neutral-400">
-                    ({w.messageCount} msgs)
-                  </span>
+                  <span className="ml-1 text-neutral-400">({w.messageCount} msgs)</span>
                 )}
               </button>
               <div className="flex items-center gap-1">
@@ -397,9 +395,7 @@ function SupervisorControls({
           Worker event history ({inbox.length})
         </summary>
         {inbox.length === 0 ? (
-          <p className="mt-1 text-xs italic text-neutral-400">
-            No worker events.
-          </p>
+          <p className="mt-1 text-xs italic text-neutral-400">No worker events.</p>
         ) : (
           <div className="mt-1 space-y-1">
             <ul className="max-h-48 divide-y divide-neutral-800 overflow-auto rounded border border-neutral-800 bg-neutral-950">

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -2290,10 +2290,8 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
   return (
     <div className="space-y-4">
       <div>
-        <h2 className="text-sm font-semibold text-neutral-100 light:text-neutral-900">
-          Quick action chips
-        </h2>
-        <p className="mt-1 text-xs text-neutral-400 light:text-neutral-600">
+        <h2 className="text-sm font-semibold text-neutral-100">Quick action chips</h2>
+        <p className="mt-1 text-xs text-neutral-400">
           One-click buttons on the chat toolbar. Two kinds:{" "}
           <span className="text-amber-400 light:text-amber-700">command</span> chips run a shell
           snippet in the active project&apos;s folder;{" "}
@@ -2312,7 +2310,7 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
 
       <div className="space-y-1">
         {actions.length === 0 && loaded && (
-          <p className="text-xs italic text-neutral-500 light:text-neutral-600">
+          <p className="text-xs italic text-neutral-500">
             No chips defined yet. Click &ldquo;New&rdquo; below to add one.
           </p>
         )}
@@ -2335,9 +2333,7 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
               >
                 {isCmd ? "cmd" : "prompt"}
               </span>
-              <span className="flex-1 truncate font-medium text-neutral-200 light:text-neutral-900">
-                {a.name}
-              </span>
+              <span className="flex-1 truncate font-medium text-neutral-200">{a.name}</span>
               {a.enabled === false && (
                 <span className="text-[10px] uppercase tracking-wider text-neutral-500">
                   disabled
@@ -2350,7 +2346,7 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
               )}
               <button
                 onClick={() => startEdit(a)}
-                className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-300 hover:border-neutral-500 light:border-neutral-400 light:text-neutral-700"
+                className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-300 hover:border-neutral-500 light:border-neutral-400"
               >
                 Edit
               </button>
@@ -2365,7 +2361,7 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
                   </button>
                   <button
                     onClick={() => setPendingDeleteId(undefined)}
-                    className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-400 hover:border-neutral-500 light:border-neutral-400 light:text-neutral-600"
+                    className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-400 hover:border-neutral-500 light:border-neutral-400"
                   >
                     Cancel
                   </button>
@@ -2373,7 +2369,7 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
               ) : (
                 <button
                   onClick={() => setPendingDeleteId(a.id)}
-                  className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-400 hover:border-red-500 hover:text-red-300 light:border-neutral-400 light:text-neutral-600"
+                  className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-400 hover:border-red-500 hover:text-red-300 light:border-neutral-400"
                 >
                   Delete
                 </button>
@@ -2386,7 +2382,7 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
       {draft === undefined && (
         <button
           onClick={() => setDraft(emptyActionDraft("prompt"))}
-          className="rounded border border-neutral-700 px-3 py-1 text-xs text-neutral-200 hover:border-neutral-500 light:border-neutral-400 light:text-neutral-800"
+          className="rounded border border-neutral-700 px-3 py-1 text-xs text-neutral-200 hover:border-neutral-500 light:border-neutral-400"
         >
           + New chip
         </button>
@@ -2395,21 +2391,21 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
       {draft !== undefined && (
         <div className="space-y-3 rounded border border-neutral-700 bg-neutral-900/60 p-3 light:border-neutral-300 light:bg-white">
           <div>
-            <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+            <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400">
               Name
             </label>
             <input
               value={draft.name}
               onChange={(e) => setDraft({ ...draft, name: e.target.value })}
               placeholder="e.g. Run tests"
-              className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 light:border-neutral-300 light:bg-white light:text-neutral-900"
+              className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 light:border-neutral-300 light:bg-white"
             />
           </div>
           <div>
-            <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+            <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400">
               Kind
             </label>
-            <div className="flex items-center gap-3 text-xs text-neutral-300 light:text-neutral-800">
+            <div className="flex items-center gap-3 text-xs text-neutral-300">
               <label className="flex items-center gap-1.5">
                 <input
                   type="radio"
@@ -2439,7 +2435,7 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
           {draft.kind === "command" ? (
             <>
               <div>
-                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400">
                   Command
                 </label>
                 <textarea
@@ -2447,25 +2443,25 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
                   onChange={(e) => setDraft({ ...draft, command: e.target.value })}
                   rows={3}
                   placeholder="npm test"
-                  className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 light:border-neutral-300 light:bg-white light:text-neutral-900"
+                  className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 light:border-neutral-300 light:bg-white"
                 />
-                <p className="mt-1 text-[11px] text-neutral-500 light:text-neutral-600">
+                <p className="mt-1 text-[11px] text-neutral-500">
                   Runs in the active project&apos;s folder via <code>/bin/sh -c</code>. Multi-line
                   is fine (<code>&amp;&amp;</code>, <code>;</code>, etc.). Environment is scrubbed
                   of pi-forge and provider secrets (same as the integrated terminal).
                 </p>
               </div>
               <div>
-                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400">
                   Timeout (seconds)
                 </label>
                 <input
                   value={draft.timeoutSec}
                   onChange={(e) => setDraft({ ...draft, timeoutSec: e.target.value })}
                   placeholder="30"
-                  className="w-24 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 light:border-neutral-300 light:bg-white light:text-neutral-900"
+                  className="w-24 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-sm text-neutral-100 light:border-neutral-300 light:bg-white"
                 />
-                <p className="mt-1 text-[11px] text-neutral-500 light:text-neutral-600">
+                <p className="mt-1 text-[11px] text-neutral-500">
                   Max 300 (five minutes). Past that, use the integrated terminal.
                 </p>
               </div>
@@ -2473,7 +2469,7 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
           ) : (
             <>
               <div>
-                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400">
                   Prompt text
                 </label>
                 <textarea
@@ -2481,14 +2477,14 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
                   onChange={(e) => setDraft({ ...draft, text: e.target.value })}
                   rows={4}
                   placeholder="Review the staged changes for security issues."
-                  className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs text-neutral-100 light:border-neutral-300 light:bg-white light:text-neutral-900"
+                  className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs text-neutral-100 light:border-neutral-300 light:bg-white"
                 />
               </div>
               <div>
-                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400 light:text-neutral-600">
+                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-400">
                   Mode
                 </label>
-                <div className="flex items-center gap-3 text-xs text-neutral-300 light:text-neutral-800">
+                <div className="flex items-center gap-3 text-xs text-neutral-300">
                   <label className="flex items-center gap-1.5">
                     <input
                       type="radio"
@@ -2510,7 +2506,7 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
             </>
           )}
           <div>
-            <label className="flex items-center gap-1.5 text-xs text-neutral-300 light:text-neutral-800">
+            <label className="flex items-center gap-1.5 text-xs text-neutral-300">
               <input
                 type="checkbox"
                 checked={draft.enabled}
@@ -2529,7 +2525,7 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
             </button>
             <button
               onClick={() => setDraft(undefined)}
-              className="rounded border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:border-neutral-500 light:border-neutral-400 light:text-neutral-700"
+              className="rounded border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:border-neutral-500 light:border-neutral-400"
             >
               Cancel
             </button>


### PR DESCRIPTION
## Summary

Fixes the v1.4.4 Group 5 orchestration dashboard/theme regression where the orchestrator/orchestration panel could render near-white text in the selected Light appearance.

The root cause was the app's selected theme model: `index.css` inverts the Tailwind neutral scale under `html[data-theme="light"]`, so explicit overrides such as `light:text-neutral-900` resolve to very light text instead of dark text. Browser/system `dark:` variants are also not appropriate for this surface because pi-forge follows the app-selected `data-theme` appearance.

This PR updates the orchestration panel and preserves the Quick Actions settings text fix by relying on the existing theme-aware neutral scale for neutral UI colors, while keeping `light:` overrides only for semantic color palettes such as red, amber, violet, and sky badges/buttons.

## Usage

No user-facing commands or configuration changes are required. Select the Light appearance in Settings and open the orchestration dashboard/panel; neutral text should render dark/readable on light surfaces. Select a dark appearance and the same panel should remain light/readable on dark surfaces.

## What changed (2 files)

- `packages/client/src/components/OrchestrationPanel.tsx` — removes browser/system `dark:` variants and neutral `light:*` overrides from the panel, letting the app-selected inverted neutral scale drive light/dark readability. Semantic badge/error/hover colors keep explicit `light:` counterparts where Tailwind color palettes do not invert.
- `packages/client/src/components/SettingsPanel.tsx` — preserves the Quick Actions settings pane text fix by removing incorrect neutral `light:text-neutral-*` overrides so settings text also follows the selected app theme's neutral scale.

## Test plan

- [x] `npx prettier --write packages/client/src/components/OrchestrationPanel.tsx packages/client/src/components/SettingsPanel.tsx`
- [x] `npm run build`
- [x] `npx eslint packages/client/src/components/OrchestrationPanel.tsx packages/client/src/components/SettingsPanel.tsx`
- [x] `npm run format:check`
- [x] `git diff --check`
- [ ] `npm run check` — attempted; typecheck passed, but repo-wide ESLint hit a Node heap out-of-memory failure (`FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`, exit 134), so targeted lint plus formatting checks were run instead.
- [ ] Manual browser verification in Light and Dark appearances before merge.
