### PR TITLE
fix: preserve chat scroll and input sizing

### DIFF
--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -319,12 +319,14 @@ export function ChatInput({ sessionId }: Props) {
    * heights would just confuse (one preferred draft size beats N
    * session-scoped sizes the user has to re-discover on every
    * switch). Clamp on read so a stale absurd value gets corrected
-   * silently. Bounds: min 60 px (~2 rows), max 60 % viewport.
+   * silently. Bounds: min 60 px (~2 rows), max 40 % viewport.
    */
   const HEIGHT_KEY = "pi-forge:chat-input-height";
+  const DESKTOP_TEXTAREA_MAX_VIEWPORT_RATIO = 0.4;
+  const MOBILE_TEXTAREA_MAX_VIEWPORT_RATIO = 0.25;
   const heightBounds = (): { min: number; max: number } => ({
     min: 60,
-    max: Math.floor(window.innerHeight * 0.6),
+    max: Math.floor(window.innerHeight * DESKTOP_TEXTAREA_MAX_VIEWPORT_RATIO),
   });
   const [textareaHeight, setTextareaHeight] = useState<number | undefined>(() => {
     if (typeof window === "undefined") return undefined;
@@ -721,7 +723,8 @@ export function ChatInput({ sessionId }: Props) {
   const attachMenuRef = useRef<HTMLDivElement | null>(null);
   // Auto-grown textarea metrics (px). Recomputed on every text change:
   // shrink to the configured floor, expand with scrollHeight, then cap
-  // at a viewport-relative max and allow internal scrolling past it.
+  // at either the user's manual pane height or a viewport-relative max
+  // and allow internal scrolling past it.
   const [autoSize, setAutoSize] = useState<
     { height: number; maxHeight: number; overflowing: boolean } | undefined
   >(undefined);
@@ -1611,10 +1614,11 @@ export function ChatInput({ sessionId }: Props) {
 
   // Auto-grow the textarea on every input change. Collapse to "auto"
   // before measuring so deleting lines can shrink the box again; then
-  // clamp to a sensible floor/ceiling. Desktop keeps the drag handle as
-  // an optional preferred minimum height, while content can still grow
-  // beyond that up to 60vh. Mobile uses the tighter 30vh cap so the
-  // keyboard and transcript remain usable.
+  // clamp to a sensible floor/ceiling. On desktop, a user-resized
+  // composer is treated as the effective pane height (not just a
+  // preferred minimum), so dragging the divider down can shrink a long
+  // draft and make it scroll internally. Mobile keeps an even tighter
+  // cap so the keyboard and transcript remain usable.
   useLayoutEffect(() => {
     const ta = textareaRef.current;
     if (ta === null) return;
@@ -1624,10 +1628,15 @@ export function ChatInput({ sessionId }: Props) {
     const measured = ta.scrollHeight;
     ta.style.height = prevHeight;
 
-    const min = isMobile ? 44 : (textareaHeight ?? 80);
-    const max = Math.max(min, Math.round(window.innerHeight * (isMobile ? 0.3 : 0.6)));
-    const height = Math.max(min, Math.min(measured, max));
-    const overflowing = measured > max;
+    const manualMax = !isMobile ? textareaHeight : undefined;
+    const floor = isMobile ? 44 : manualMax !== undefined ? 60 : 80;
+    const viewportMax = Math.round(
+      window.innerHeight *
+        (isMobile ? MOBILE_TEXTAREA_MAX_VIEWPORT_RATIO : DESKTOP_TEXTAREA_MAX_VIEWPORT_RATIO),
+    );
+    const max = Math.max(floor, manualMax ?? viewportMax);
+    const height = manualMax !== undefined ? max : Math.max(floor, Math.min(measured, max));
+    const overflowing = measured > height;
     const next = { height, maxHeight: max, overflowing };
     setAutoSize((cur) =>
       cur?.height === next.height &&
@@ -2086,9 +2095,9 @@ export function ChatInput({ sessionId }: Props) {
               }
               // Starts at a comfortable minimum (2 rows on mobile,
               // 3 on desktop), then auto-grows with the user's input.
-              // Desktop drag-resize still works as a preferred minimum;
-              // once content exceeds that, the textarea grows up to the
-              // cap and then scrolls internally.
+              // Desktop drag-resize sets the effective pane height;
+              // long drafts scroll internally once they exceed that
+              // user-chosen size.
               rows={isMobile ? 2 : 3}
               disabled={isReadOnlyExternal}
               style={

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   AtSign,
   Check,
@@ -225,13 +233,21 @@ export function ChatView({ sessionId }: Props) {
     lastScrollTopRef.current = el.scrollTop;
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = scrollRef.current;
     if (el === null) return;
     if (isFollowingBottomRef.current) {
       el.scrollTop = el.scrollHeight;
       lastScrollTopRef.current = el.scrollTop;
+      return;
     }
+
+    // When the user has intentionally scrolled up, keep their viewport
+    // anchored on content changes below them (streaming text becoming a
+    // canonical assistant message, generated tool-call placeholders
+    // appearing/disappearing, etc.). Browser scroll anchoring can otherwise
+    // nudge the chat a few pixels when generation finishes.
+    el.scrollTop = lastScrollTopRef.current;
   }, [messages, streamingText, isStreaming, generatingToolCall]);
 
   const snapChatToBottom = (): void => {
@@ -240,6 +256,10 @@ export function ChatView({ sessionId }: Props) {
       el.scrollTop = el.scrollHeight;
       lastScrollTopRef.current = el.scrollTop;
     }
+  };
+
+  const followChatToBottom = (): void => {
+    if (isFollowingBottomRef.current) snapChatToBottom();
   };
 
   // Force scroll-to-bottom + re-engage follow mode whenever a NEW
@@ -599,7 +619,7 @@ export function ChatView({ sessionId }: Props) {
             {isStreaming && activeTool === undefined && generatingToolCall !== undefined && (
               <ToolCallGenerationPlaceholder
                 toolCall={generatingToolCall}
-                onVisibleOrUpdate={snapChatToBottom}
+                onVisibleOrUpdate={followChatToBottom}
               />
             )}
             {isStreaming && streamingText.length === 0 && generatingToolCall === undefined && (
@@ -724,7 +744,6 @@ function ToolCallGenerationPlaceholder({
 }) {
   const argsPreview = formatToolCallArgsPreview(toolCall);
   const argsRef = useRef<HTMLPreElement>(null);
-  const rootRef = useRef<HTMLDivElement>(null);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -740,7 +759,6 @@ function ToolCallGenerationPlaceholder({
 
   useEffect(() => {
     if (!visible) return;
-    rootRef.current?.scrollIntoView({ block: "end" });
     onVisibleOrUpdate();
     requestAnimationFrame(onVisibleOrUpdate);
   }, [visible, toolCall, onVisibleOrUpdate]);
@@ -749,7 +767,6 @@ function ToolCallGenerationPlaceholder({
 
   return (
     <div
-      ref={rootRef}
       className="w-full rounded border border-amber-900/50 bg-amber-950/20 px-2 py-1 text-[11px] text-amber-100 light:border-amber-300 light:bg-amber-50 light:text-amber-900"
       aria-live="polite"
       aria-label="Agent is generating a tool call"


### PR DESCRIPTION
## Summary

Fixes two Group 3 chat UI regressions. When a user intentionally scrolled up during model generation, completion-time DOM changes could nudge the chat viewport upward. The chat view now preserves the user's scroll position unless they are actively following the bottom. The chat composer textarea could also autosize beyond the usable input pane and resist shrinking after manual resize; the textarea now treats manual desktop resize as the effective pane height and uses shorter responsive auto-resize caps.

## Usage

No new commands or configuration. The behavior is exercised in the browser chat UI:

- If the user is at/near the bottom, streaming output continues to auto-scroll.
- If the user scrolls up during generation, completion no longer bumps the viewport.
- The chat input autosizes up to a shorter cap: `40vh` desktop and `25vh` mobile.
- Desktop manual input-pane resize still controls the effective textarea height; long drafts scroll internally.

## What changed (2 files)

- `packages/client/src/components/ChatView.tsx` — moved sticky-bottom/preserve-scroll reconciliation to `useLayoutEffect`, restores the previous `scrollTop` when the user is not following bottom, and prevents tool-call generation placeholders from unconditionally calling `scrollIntoView`.
- `packages/client/src/components/ChatInput.tsx` — added responsive textarea cap constants (`40vh` desktop, `25vh` mobile), clamps persisted/manual heights to the shorter desktop cap, and treats manual resize as the effective pane height so shrinking works and long drafts scroll internally.

## Test plan

- [x] `npm run format -- --write packages/client/src/components/ChatView.tsx packages/client/src/components/ChatInput.tsx`
- [x] `npm run build`
- [x] `npm run check` attempted; typecheck passed, but repo-wide `eslint .` was killed with exit 137/OOM in this environment.
- [x] Fallback: `npm run typecheck`
- [x] Fallback: `npx eslint packages/client/src/components/ChatInput.tsx packages/client/src/components/ChatView.tsx`
- [x] Fallback: `npm run format:check`
- [x] Fallback: `git diff --check`
- [ ] Manual browser verification: while scrolled up during generation, completion does not move the viewport; while at bottom, auto-scroll still follows output.
- [ ] Manual browser verification: textarea auto-resize caps at the shorter max, manual pane resize/shrink still works, and long drafts scroll internally.
- [ ] CI green before merge.
