### PR TITLE
Fix sandbox skill permissions and terminal envs

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -221,6 +221,7 @@ export const config = Object.freeze({
   host: readEnv("HOST") ?? "127.0.0.1",
   logLevel: readEnv("LOG_LEVEL") ?? "info",
   isTest: (readEnv("NODE_ENV") ?? "") === "test",
+  isProduction: (readEnv("NODE_ENV") ?? "") === "production",
   trustProxy: readBool("TRUST_PROXY", false),
   workspacePath: WORKSPACE_PATH,
   piConfigDir: PI_CONFIG_DIR,

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as nodePty from "node-pty";
 import { config } from "./config.js";
+import { mergeToolEnv } from "./sandbox-settings.js";
 
 /**
  * Per-project PTY tracking with reattach support.
@@ -44,6 +45,8 @@ export interface SpawnOptions {
    * scenario of one project's tabId colliding with another's.
    */
   projectId: string;
+  /** Settings-managed env vars injected into sandbox terminal shells. */
+  toolEnv?: Record<string, string>;
 }
 
 export interface ManagedPty {
@@ -123,7 +126,7 @@ export function spawnPty(opts: SpawnOptions): ManagedPty {
     cols,
     rows,
     cwd: opts.cwd,
-    env: toolShellEnv(env),
+    env: mergeToolEnv(toolShellEnv(env), opts.toolEnv ?? {}),
     ...identity,
   });
   const ptyId = randomUUID();

--- a/packages/server/src/routes/terminal.ts
+++ b/packages/server/src/routes/terminal.ts
@@ -6,6 +6,7 @@ import { extractBearer, verifyApiKey, verifyToken } from "../auth.js";
 import { authEnabled, config } from "../config.js";
 import { getProject } from "../project-manager.js";
 import { attachSink, findPtyByTabId, killPty, spawnPty } from "../pty-manager.js";
+import { readSandboxSettings } from "../sandbox-settings.js";
 
 /**
  * WebSocket close codes used here. Per RFC 6455 §7.4, codes in
@@ -238,10 +239,12 @@ export const terminalRoutes: FastifyPluginAsync = async (fastify) => {
       }
       if (managed === undefined) {
         try {
+          const sandboxSettings = await readSandboxSettings();
           managed = spawnPty({
             cwd: project.path,
             tabId: requestedTabId ?? `srv-${Date.now().toString(36)}`,
             projectId: project.id,
+            toolEnv: sandboxSettings.toolEnv,
           });
         } catch (err) {
           log.error({ err }, "pty spawn failed");

--- a/packages/server/src/skills-export.ts
+++ b/packages/server/src/skills-export.ts
@@ -27,7 +27,17 @@
  * skills tree are OVERWRITTEN — the export is the source of truth on
  * restore, mirroring the config-export contract.
  */
-import { mkdir, mkdtemp, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  chown,
+  mkdir,
+  mkdtemp,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, normalize, relative, sep } from "node:path";
 import { Readable } from "node:stream";
@@ -41,6 +51,13 @@ import { config } from "./config.js";
  * still bounding accidental or malicious uploads.
  */
 export const MAX_SKILLS_IMPORT_BYTES = 50 * 1024 * 1024;
+
+const SANDBOX_SKILL_FILE_MODE = 0o664;
+const SANDBOX_SKILL_DIR_MODE = 0o775;
+const FALLBACK_SKILL_FILE_MODE = 0o666;
+const FALLBACK_SKILL_DIR_MODE = 0o777;
+
+let warnedAboutPermissiveSkillImportFallback = false;
 
 function skillsDir(): string {
   return join(config.piConfigDir, "skills");
@@ -106,6 +123,56 @@ export async function buildSkillsExportTar(): Promise<SkillsExportResult> {
   const pack = tarCreate({ gzip: true, cwd: src }, entries);
   const stream = pack as unknown as Readable;
   return { fileCount: entries.length, stream };
+}
+
+/**
+ * In sandbox mode, imported skills must be readable/writable by the
+ * `pi-tools` identity that runs terminals and model tools. Prefer
+ * ownership by AGENT_TOOL_UID:GID; fall back to permissive modes when
+ * local non-root dev/test runs cannot chown.
+ */
+async function ensureSandboxSkillPathPermissions(path: string, directory: boolean): Promise<void> {
+  if (!config.agentToolSandbox.enabled) return;
+  const mode = directory ? SANDBOX_SKILL_DIR_MODE : SANDBOX_SKILL_FILE_MODE;
+  await chmod(path, mode);
+  const uid = config.agentToolSandbox.uid!;
+  const gid = config.agentToolSandbox.gid!;
+  const currentUid = typeof process.getuid === "function" ? process.getuid() : undefined;
+  const currentGid = typeof process.getgid === "function" ? process.getgid() : undefined;
+  if (currentUid === uid && currentGid === gid) return;
+  try {
+    await chown(path, uid, gid);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EPERM") throw err;
+    if (config.isProduction) {
+      throw new Error(
+        "failed to set sandbox skill ownership; refusing permissive fallback in production",
+        { cause: err },
+      );
+    }
+    if (!warnedAboutPermissiveSkillImportFallback) {
+      warnedAboutPermissiveSkillImportFallback = true;
+      console.warn(
+        "[skills-import] unable to chown restored skills to the sandbox tool identity; " +
+          "using permissive fallback modes for this non-production import",
+      );
+    }
+    // Some non-root dev/test runs cannot chown to the sandbox identity.
+    // Fall back to world-writable import permissions so the configured
+    // pi-tools user can still read/write restored skills in sandbox mode.
+    await chmod(path, directory ? FALLBACK_SKILL_DIR_MODE : FALLBACK_SKILL_FILE_MODE);
+  }
+}
+
+async function ensureSandboxSkillDirectoryChain(root: string, dir: string): Promise<void> {
+  if (!config.agentToolSandbox.enabled) return;
+  await ensureSandboxSkillPathPermissions(root, true);
+  const rel = relative(root, dir).split(sep).filter(Boolean);
+  let current = root;
+  for (const part of rel) {
+    current = join(current, part);
+    await ensureSandboxSkillPathPermissions(current, true);
+  }
 }
 
 /**
@@ -259,15 +326,20 @@ async function commitStaged(
 ): Promise<SkillsImportSummary> {
   const dst = skillsDir();
   await mkdir(dst, { recursive: true });
+  await ensureSandboxSkillDirectoryChain(dst, dst);
   const imported: string[] = [];
   for (const name of accepted) {
     const src = join(stage, name);
     const target = join(dst, name);
-    await mkdir(dirname(target), { recursive: true });
+    const targetDir = dirname(target);
+    await mkdir(targetDir, { recursive: true });
+    await ensureSandboxSkillDirectoryChain(dst, targetDir);
     const tmpDst = `${target}.${Date.now()}.import.tmp`;
     try {
       await rename(src, tmpDst);
+      await ensureSandboxSkillPathPermissions(tmpDst, false);
       await rename(tmpDst, target);
+      await ensureSandboxSkillPathPermissions(target, false);
       imported.push(name);
     } catch (err) {
       // Best-effort cleanup of the .tmp if rename-into-place failed.

--- a/tests/test-agent-tool-sandbox.ts
+++ b/tests/test-agent-tool-sandbox.ts
@@ -4,7 +4,7 @@
  * Unit-style coverage for startup config validation, path policy,
  * sandboxed SDK tool overrides, and @file expansion scoping.
  */
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -130,11 +130,116 @@ try {
   )) as {
     toolShellEnv: (env?: NodeJS.ProcessEnv) => Record<string, string>;
   };
+  const { importSkillsFromFiles } = (await import(
+    resolve(repoRoot, "packages/server/dist/skills-export.js")
+  )) as {
+    importSkillsFromFiles: (
+      files: { filename: string; buffer: Buffer }[],
+    ) => Promise<{ imported: string[]; skipped: { name: string; reason: string }[] }>;
+  };
 
   console.log("\nsandbox shell env");
   const shellEnv = toolShellEnv({ ...process.env, HOME: "/home/pi", USER: "pi", LOGNAME: "pi" });
   assert("sandbox shell HOME uses AGENT_TOOL_HOME", shellEnv.HOME === toolHome, shellEnv.HOME);
   assert("sandbox shell USER uses tool identity", shellEnv.USER === "pi-tools", shellEnv.USER);
+
+  console.log("\nskills import permissions");
+  const skillsImport = await importSkillsFromFiles([
+    { filename: "demo/SKILL.md", buffer: Buffer.from("# Demo skill\n") },
+    { filename: "demo/assets/images/icon.txt", buffer: Buffer.from("icon\n") },
+  ]);
+  assert("skills import succeeds", skillsImport.imported.includes("demo/SKILL.md"));
+  assert(
+    "nested skills import succeeds",
+    skillsImport.imported.includes("demo/assets/images/icon.txt"),
+  );
+  const importedSkill = resolve(piConfig, "skills", "demo", "SKILL.md");
+  const importedSkillDirs = [
+    resolve(piConfig, "skills", "demo"),
+    resolve(piConfig, "skills", "demo", "assets"),
+    resolve(piConfig, "skills", "demo", "assets", "images"),
+  ];
+  const skillMode = statSync(importedSkill).mode & 0o777;
+  assert(
+    "imported skill file is writable by sandbox identity or fallback",
+    (skillMode & 0o600) === 0o600 || (skillMode & 0o006) === 0o006,
+    skillMode.toString(8),
+  );
+  for (const dir of importedSkillDirs) {
+    const skillDirMode = statSync(dir).mode & 0o777;
+    assert(
+      `imported skill dir ${dir.slice(piConfig.length + 1)} is writable/searchable`,
+      (skillDirMode & 0o700) === 0o700 || (skillDirMode & 0o007) === 0o007,
+      skillDirMode.toString(8),
+    );
+  }
+
+  if ((process.getuid?.() ?? 0) !== 0) {
+    const fallbackPiConfig = resolve(tmp, "fallback-pi");
+    const fallbackWorkspace = resolve(tmp, "fallback-workspace");
+    const fallbackData = resolve(tmp, "fallback-data");
+    mkdirSync(fallbackWorkspace, { recursive: true });
+    mkdirSync(fallbackData, { recursive: true });
+    const fallback = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+          import { statSync } from "node:fs";
+          import { resolve } from "node:path";
+          const { importSkillsFromFiles } = await import(${JSON.stringify(
+            resolve(repoRoot, "packages/server/dist/skills-export.js"),
+          )});
+          await importSkillsFromFiles([{ filename: "fallback/assets/file.txt", buffer: Buffer.from("x") }]);
+          const root = resolve(${JSON.stringify(fallbackPiConfig)}, "skills", "fallback");
+          const assets = resolve(root, "assets");
+          const file = resolve(assets, "file.txt");
+          console.log(JSON.stringify({
+            root: statSync(root).mode & 0o777,
+            assets: statSync(assets).mode & 0o777,
+            file: statSync(file).mode & 0o777,
+          }));
+        `,
+      ],
+      {
+        env: {
+          ...process.env,
+          NODE_ENV: "test",
+          WORKSPACE_PATH: fallbackWorkspace,
+          PI_CONFIG_DIR: fallbackPiConfig,
+          FORGE_DATA_DIR: fallbackData,
+          SESSION_DIR: resolve(fallbackWorkspace, ".pi", "sessions"),
+          AGENT_TOOL_SANDBOX_ENABLED: "true",
+          AGENT_TOOL_UID: "1",
+          AGENT_TOOL_GID: "1",
+          AGENT_TOOL_HOME: toolHome,
+          SERVE_CLIENT: "false",
+        },
+        encoding: "utf8",
+      },
+    );
+    assert("EPERM fallback import succeeds in test", fallback.status === 0, fallback.stderr);
+    assert(
+      "EPERM fallback logs server warning",
+      fallback.stderr.includes("unable to chown restored skills"),
+      fallback.stderr,
+    );
+    const fallbackJson = fallback.stdout.trim().split(/\r?\n/).at(-1) ?? "{}";
+    const fallbackModes = JSON.parse(fallbackJson) as {
+      root: number;
+      assets: number;
+      file: number;
+    };
+    assert(
+      "EPERM fallback makes nested dirs writable",
+      fallbackModes.root === 0o777 && fallbackModes.assets === 0o777,
+      fallback.stdout,
+    );
+    assert("EPERM fallback makes file writable", fallbackModes.file === 0o666, fallback.stdout);
+  } else {
+    assert("EPERM fallback coverage skipped as root", true);
+  }
 
   function allowed(label: string, requested: string): void {
     try {

--- a/tests/test-terminal.ts
+++ b/tests/test-terminal.ts
@@ -326,6 +326,15 @@ async function main(): Promise<void> {
       assert("unknown projectId → close 4404", code === 4404, `code=${code}`);
     }
 
+    const sandboxEnvName = "PI_FORGE_TERMINAL_ENV_" + randomBytes(3).toString("hex").toUpperCase();
+    const sandboxEnvValue = "terminal-ok-" + randomBytes(3).toString("hex");
+    const sandboxSettings = await fetch(`${base}/api/v1/config/sandbox`, {
+      method: "PUT",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ toolEnv: { [sandboxEnvName]: sandboxEnvValue } }),
+    });
+    assert("PUT /config/sandbox terminal env → 200", sandboxSettings.status === 200);
+
     // ---- Echo + resize ----
     let term: OpenedSocket;
     {
@@ -389,6 +398,22 @@ async function main(): Promise<void> {
         sawAdjacent,
         `expected sentinels ${sL} and ${sR} to appear adjacent (API_KEY empty); ` +
           `last output: ${term.output.slice(-400)}`,
+      );
+
+      const sandboxEnvMarker = "SANDBOX_ENV_" + randomBytes(3).toString("hex");
+      send(term.ws, {
+        type: "input",
+        data: `printf '${sandboxEnvMarker}=%s\\n' "$${sandboxEnvName}"\n`,
+      });
+      const sawSandboxEnv = await waitForOutput(
+        term,
+        `${sandboxEnvMarker}=${sandboxEnvValue}`,
+        5_000,
+      );
+      assert(
+        "settings sandbox env is inherited by PTY shell",
+        sawSandboxEnv,
+        `last output: ${term.output.slice(-400)}`,
       );
 
       // PATH must still come through — a shell with no PATH can't even


### PR DESCRIPTION
## Summary

Sandbox mode had two related ownership/env propagation gaps:

- Skills restored from Settings → Backup import could be written by the server user but not by the sandbox `pi-tools` identity, especially for nested skill paths where intermediate directories stayed server-owned with restrictive permissions.
- Sandbox environment variables configured in Settings were wired into agent bash/process tools, but not into integrated terminal PTYs.

This PR makes restored skills readable/writable by the sandbox tool identity across the entire restored directory chain, adds safer handling for non-root `chown` failures, and passes settings-managed sandbox env vars to newly spawned terminal sessions.

## Usage

No new user-facing commands are required. In sandbox deployments, continue configuring sandbox mode and Settings → Sandbox environment variables as before:

```bash
AGENT_TOOL_SANDBOX_ENABLED=true
AGENT_TOOL_UID=<pi-tools uid>
AGENT_TOOL_GID=<pi-tools gid>
AGENT_TOOL_HOME=/home/pi-tools
```

After importing skills from Settings → Backup, nested restored skill directories and files are adjusted so `pi-tools` can read/write them. In non-production dev/test runs where `chown` is unavailable, the import logs a warning and uses permissive fallback modes; production refuses that fallback instead of silently broadening permissions.

## What changed (6 files, +213)

- `packages/server/src/skills-export.ts` — applies sandbox-aware permissions to imported skill files and every intermediate restored directory; logs non-production permissive fallback and rejects it in production.
- `packages/server/src/config.ts` — exposes `config.isProduction` for production-only fallback gating.
- `packages/server/src/pty-manager.ts` — allows PTY spawn callers to pass settings-managed sandbox `toolEnv` and merges it into the scrubbed shell env.
- `packages/server/src/routes/terminal.ts` — reads sandbox settings before fresh PTY spawn and passes `toolEnv` through to the PTY manager.
- `tests/test-agent-tool-sandbox.ts` — adds nested skill directory permission coverage and EPERM fallback coverage with distinct UID/GID in non-root test runs.
- `tests/test-terminal.ts` — verifies Settings sandbox env vars are visible in integrated terminal shells while secret envs remain scrubbed.

## Test plan

- [x] `npx prettier --write packages/server/src/config.ts packages/server/src/skills-export.ts tests/test-agent-tool-sandbox.ts packages/server/src/pty-manager.ts packages/server/src/routes/terminal.ts tests/test-terminal.ts`
- [x] `npm run build`
- [x] `scripts/run-tests.sh --only agent-tool-sandbox,sandbox-settings,terminal`
- [x] `npm run check`
- [x] `git diff --check`
- [ ] CI green before merge
