### PR TITLE
Simplify LDAP login wording

### DIFF
--- a/packages/client/src/components/LoginScreen.tsx
+++ b/packages/client/src/components/LoginScreen.tsx
@@ -29,7 +29,7 @@ export function LoginScreen() {
           </div>
           <p className="text-sm text-neutral-400">
             {ldapEnabled
-              ? "Enter your LDAP username and password, or username admin for the local pi-forge password."
+              ? "Sign in with your LDAP account."
               : "Enter the pi-forge password to continue."}
           </p>
         </header>
@@ -61,7 +61,7 @@ export function LoginScreen() {
           <p role="alert" className="text-sm text-red-400">
             {error === "invalid_password"
               ? ldapEnabled
-                ? "Incorrect username/password, local admin password, or LDAP group."
+                ? "Incorrect username, password, or LDAP group."
                 : "Incorrect password."
               : error === "username_required"
                 ? "Username is required."


### PR DESCRIPTION
## Summary

The LDAP login page described a local admin fallback in the main helper text and invalid-login error. This PR removes that local-admin-specific wording so the LDAP login page stays concise and neutral while preserving the existing login behavior.

Final LDAP login-page wording:

- Title: `pi-forge`
- Helper text: `Sign in with your LDAP account.`
- Fields: `Username`, `Password`
- Button: `Sign in` / `Signing in…`
- LDAP invalid-login error: `Incorrect username, password, or LDAP group.`
- Empty username error: `Username is required.`
- Generic error: `Login failed: ${error}`

## Usage

No operator or developer action is required. When LDAP login is enabled, the browser login screen now shows the simplified LDAP wording automatically.

## What changed (1 file, 2 lines updated)

- `packages/client/src/components/LoginScreen.tsx` — replaced the LDAP helper text with `Sign in with your LDAP account.` and removed local-admin wording from the LDAP invalid-login error.

## Test plan

- [x] `npx prettier --write packages/client/src/components/LoginScreen.tsx`
- [x] `npm run build`
- [x] `npm run check`
- [x] Checked for focused `LoginScreen` auth/login UI copy tests; none were found.
- [ ] CI green before merge
