### PR TITLE
Add local admin username configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,7 @@ or shell environment. The most-touched ones:
 | `FORGE_DATA_DIR` | `~/.pi-forge` | Pi-forge state — `projects.json`, override files, `jwt-secret`, `password-hash`. |
 | `UI_PASSWORD` | (unset) | Enables browser JWT auth. Literal env value only; it does not expand `@/path`. After the user changes it via the UI, a scrypt hash is persisted to `${FORGE_DATA_DIR}/password-hash` and the env value is ignored. |
 | `UI_PASSWORD_FILE` | (unset) | File containing the browser login password (for Kubernetes/OpenShift mounted Secrets). Takes precedence over `UI_PASSWORD`. Equivalent CLI: `--ui-password-file`; CLI `--ui-password @/path` is also supported. |
+| `FORGE_LOCAL_ADMIN_USERNAME` | `admin` | Username that selects the local admin password when LDAP login is enabled. Equivalent CLI: `--local-admin-username`. Must be 1-256 characters using only letters, numbers, `.`, `_`, `@`, or `-`. |
 | `API_KEY` | (unset) | Static bearer token for programmatic access. |
 | `JWT_SECRET` | (auto-generated) | HS256 signing key. Auto-generated and persisted to `${FORGE_DATA_DIR}/jwt-secret` (mode 0600) when `UI_PASSWORD`, LDAP auth, or `password-hash` is in play. Set explicitly (`openssl rand -hex 32`) to override; delete the file to rotate. |
 | `LDAP_ENABLED` | `false` | Enables LDAP username/password browser login. Requires the LDAP variables below. |
@@ -93,10 +94,11 @@ tool processes receive the scrubbed env and do not inherit it.
 ### LDAP browser login
 
 LDAP is opt-in and off by default. When `LDAP_ENABLED=true`, pi-forge's
-login form asks for a username and password. Username `admin` (and
-password-only API calls) always use the local pi-forge admin password
-from `UI_PASSWORD`, `UI_PASSWORD_FILE`, or the persisted password hash;
-all other usernames use LDAP. The server binds with the
+login form asks for a username and password. The configured local admin
+username (default `admin`, set with `FORGE_LOCAL_ADMIN_USERNAME` or
+`--local-admin-username`) and password-only API calls always use the
+local pi-forge admin password from `UI_PASSWORD`, `UI_PASSWORD_FILE`, or
+the persisted password hash; all other usernames use LDAP. The server binds with the
 configured service account, searches under `LDAP_BASE_DN` using
 `LDAP_USER_FILTER`, optionally checks the returned user's `memberOf`
 (or `LDAP_GROUP_ATTRIBUTE`) against `LDAP_REQUIRED_GROUP_DN`, and then
@@ -128,12 +130,13 @@ use a mounted secret file or the CLI `--ldap-bind-password @/path/to/file`
 form instead.
 
 If both LDAP and local `UI_PASSWORD` / `UI_PASSWORD_FILE` / stored-password
-auth are present, username `admin` and password-only login use the local
-pi-forge password. Other usernames use LDAP. The username `admin` is
-reserved for local pi-forge admin auth while LDAP is enabled; an LDAP
-account named `admin` cannot be used unless this policy changes later.
-This preserves existing single-tenant admin access while allowing LDAP
-to be enabled during migration. LDAP login attempts write sanitized
+auth are present, the configured local admin username and password-only
+login use the local pi-forge password. Other usernames use LDAP. The
+local admin username is reserved for local pi-forge admin auth while
+LDAP is enabled; an LDAP account with that name cannot be used unless
+you choose a different `FORGE_LOCAL_ADMIN_USERNAME`. This preserves
+existing single-tenant admin access while allowing LDAP to be enabled
+during migration. LDAP login attempts write sanitized
 `[ldap]` lines to the server logs with the URL, base DN, username, TLS
 validation mode, and failure category; passwords are not logged.
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -136,6 +136,14 @@ const FLAGS: readonly FlagDef[] = [
     defaultText: "(unset)",
   },
   {
+    name: "local-admin-username",
+    env: "FORGE_LOCAL_ADMIN_USERNAME",
+    type: "string",
+    group: "auth",
+    desc: "Username that selects the local admin password when LDAP login is enabled",
+    defaultText: "admin",
+  },
+  {
     name: "api-key",
     env: "API_KEY",
     type: "string",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -41,6 +41,20 @@ function readStringList(key: string): string[] {
     .filter((s) => s.length > 0);
 }
 
+function readUsername(key: string, fallback: string): string {
+  const value = readEnv(key) ?? fallback;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`config: ${key} must be a non-empty username`);
+  }
+  if (trimmed.length > 256 || !/^[A-Za-z0-9._@-]+$/.test(trimmed)) {
+    throw new Error(
+      `config: ${key} must be 1-256 characters using only letters, numbers, '.', '_', '@', or '-'`,
+    );
+  }
+  return trimmed;
+}
+
 function readSecretFile(path: string, envKey: string): string {
   try {
     const value = readFileSync(path, "utf8").trim();
@@ -141,6 +155,7 @@ const UI_PASSWORD = UI_PASSWORD_FILE
   ? readSecretFile(UI_PASSWORD_FILE, "UI_PASSWORD_FILE")
   : readEnv("UI_PASSWORD");
 const API_KEY = readEnv("API_KEY");
+const LOCAL_ADMIN_USERNAME = readUsername("FORGE_LOCAL_ADMIN_USERNAME", "admin");
 const CORS_ORIGIN = readEnv("CORS_ORIGIN");
 const PASSWORD_HASH_FILE = join(FORGE_DATA_DIR, "password-hash");
 const AGENT_TOOL_SANDBOX_ENABLED = readBool("AGENT_TOOL_SANDBOX_ENABLED", false);
@@ -350,6 +365,7 @@ export const config = Object.freeze({
     uiPasswordFile: UI_PASSWORD_FILE,
     jwtSecret: JWT_SECRET,
     apiKey: API_KEY,
+    localAdminUsername: LOCAL_ADMIN_USERNAME,
     ldap: Object.freeze({
       enabled: LDAP_ENABLED,
       url: readEnv("LDAP_URL"),

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -61,7 +61,7 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
       schema: {
         description:
           "Exchange a local admin password or LDAP username/password for a short-lived JWT. " +
-          "LDAP is opt-in; username `admin` and password-only requests use local " +
+          `LDAP is opt-in; username \`${config.auth.localAdminUsername}\` and password-only requests use local ` +
           "UI_PASSWORD / stored-hash auth, while other usernames use LDAP. Returns 401 if the " +
           "credentials are wrong, or 503 if the selected auth backend is not configured.",
         tags: ["auth"],
@@ -93,7 +93,9 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const { username, password } = req.body;
-      const loginAsLocalAdmin = username === undefined || username.toLowerCase() === "admin";
+      const loginAsLocalAdmin =
+        username === undefined ||
+        username.toLowerCase() === config.auth.localAdminUsername.toLowerCase();
 
       if (config.auth.ldap.enabled && !loginAsLocalAdmin) {
         const result = await verifyLdapLogin(username, password);

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -7,6 +7,7 @@
  *   C) Neither set                                  → auth fully disabled
  *   E) LDAP enabled, no local password              → auth enabled; local login unavailable
  *   F) LDAP enabled + UI_PASSWORD_FILE              → admin/password-only use local auth
+ *   G) LDAP enabled + FORGE_LOCAL_ADMIN_USERNAME    → custom username uses local auth
  *
  * Asserts the matrix of expected status codes plus a deterministic rate-limit
  * check (RATE_LIMIT_LOGIN_MAX=3 → 4th login attempt returns 429).
@@ -374,6 +375,59 @@ async function scenarioLdapAdminUsesLocalPassword(): Promise<void> {
   }
 }
 
+async function scenarioCustomLocalAdminUsername(): Promise<void> {
+  console.log("\n[scenario G] LDAP enabled, custom local admin username");
+  const localPassword = "custom-local-admin-secret";
+  const srv = await startServer({
+    UI_PASSWORD: localPassword,
+    JWT_SECRET: undefined,
+    API_KEY: undefined,
+    FORGE_LOCAL_ADMIN_USERNAME: "ops-admin",
+    // Deliberately omit LDAP_URL/BIND_DN/BIND_PASSWORD/BASE_DN:
+    // only password-only and the configured local-admin username may
+    // use local auth without a configured LDAP backend.
+    LDAP_ENABLED: "true",
+    REQUIRE_PASSWORD_CHANGE: "false",
+  });
+  try {
+    const passwordOnly = await jsonPost(`${srv.base}/api/v1/auth/login`, {
+      password: localPassword,
+    });
+    assert(
+      "password-only login remains local with custom admin username",
+      passwordOnly.status === 200,
+    );
+
+    const customAdmin = await jsonPost(`${srv.base}/api/v1/auth/login`, {
+      username: "ops-admin",
+      password: localPassword,
+    });
+    assert("configured local admin username uses local password", customAdmin.status === 200);
+
+    const customAdminUpper = await jsonPost(`${srv.base}/api/v1/auth/login`, {
+      username: "OPS-ADMIN",
+      password: localPassword,
+    });
+    assert(
+      "configured local admin username match is case-insensitive",
+      customAdminUpper.status === 200,
+    );
+
+    const oldAdmin = await jsonPost(`${srv.base}/api/v1/auth/login`, {
+      username: "admin",
+      password: localPassword,
+    });
+    assert(
+      "default admin username no longer selects local auth when overridden",
+      oldAdmin.status === 503,
+    );
+    const oldAdminBody = (await oldAdmin.json()) as { error?: string };
+    assert("  old admin falls through to LDAP", oldAdminBody.error === "ldap_not_configured");
+  } finally {
+    await srv.stop();
+  }
+}
+
 /**
  * Scenario D — persisted password-hash but NO env credentials.
  *
@@ -480,6 +534,7 @@ async function main(): Promise<void> {
   await scenarioPersistedHashOnly();
   await scenarioLdapEnabledWithoutLocalPassword();
   await scenarioLdapAdminUsesLocalPassword();
+  await scenarioCustomLocalAdminUsername();
 
   if (failures > 0) {
     console.log(`\n[test-auth] FAIL — ${failures} assertion(s) failed`);


### PR DESCRIPTION
## Summary

LDAP login currently reserves the hard-coded `admin` username for the local pi-forge admin password. Operators that need a different local admin username cannot configure it without changing code.

This PR adds configurable local admin username support while preserving the existing default. When unset, `admin` continues to select local admin auth. When set, the configured username selects local admin auth and other usernames continue through LDAP.

## Usage

```bash
# Environment variable
FORGE_LOCAL_ADMIN_USERNAME=ops-admin

# Equivalent CLI flag
pi-forge --local-admin-username ops-admin
```

Accepted username values are 1-256 characters using only letters, numbers, `.`, `_`, `@`, or `-`. Password-only login remains local admin auth for compatibility.

## What changed (5 files, +96)

- `packages/server/src/config.ts` — reads and validates `FORGE_LOCAL_ADMIN_USERNAME`, defaults it to `admin`, and exposes it as `config.auth.localAdminUsername`.
- `packages/server/src/cli.ts` — adds the matching `--local-admin-username` auth flag mapped to `FORGE_LOCAL_ADMIN_USERNAME`.
- `packages/server/src/routes/auth.ts` — uses the configured local admin username, case-insensitively, when deciding local-vs-LDAP login routing.
- `tests/test-auth.ts` — adds LDAP/local-auth coverage for a custom local admin username, password-only login compatibility, and old `admin` falling through to LDAP when overridden.
- `docs/configuration.md` — documents `FORGE_LOCAL_ADMIN_USERNAME`, `--local-admin-username`, defaults, allowed characters, and LDAP behavior.

## Test plan

- [x] Prettier: `npx prettier --write packages/server/src/config.ts packages/server/src/cli.ts packages/server/src/routes/auth.ts tests/test-auth.ts docs/configuration.md`
- [x] `npm run build`
- [x] `scripts/run-tests.sh --only auth,cli-flags`
- [x] `npm run check`
- [ ] CI green before merge
