### PR TITLE
chore(release): v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.4.4] — 2026-06-22
+
+### Added
+
+- **Configurable local admin username.** Deployments can set `PI_FORGE_ADMIN_USERNAME` / `--admin-username` to rename the built-in local admin login while keeping the default `admin` behavior and auth summaries safe.
+- **Vim in the runtime container.** The container image now includes `vim` for lightweight in-container editing/debugging, with container documentation updated accordingly.
+
+### Changed
+
+- **Sandbox permission setup is better documented.** The sandbox guide now calls out ownership, writable-home, and deployment permission requirements for agent tool sandboxing.
+- **Dependency updates for v1.4.4.** Updated the pinned pi SDK trio to 0.79.10 and refreshed selected runtime/dev dependencies including `lucide-react` 1.21.0, `@types/node` 26.0.0, `typescript-eslint` 8.62.0, `globals` 17.7.0, and `actions/checkout` 7.
+
+### Fixed
+
+- **File browser moves and folder uploads work correctly.** File operations now support moving files and uploading folders through the validated file API, with client and server coverage for the expanded behavior.
+- **Git fetch and pull errors are easier to act on.** The Git panel now surfaces clearer fetch/pull status and failure messages instead of generic command output.
+- **Chat scrolling and prompt sizing are preserved.** Chat input auto-sizing and transcript scroll position now stay stable across message updates and prompt changes.
+- **Orchestration Group 5 theme colors are corrected.** Orchestration dashboard and settings colors now align with the intended theme palette.
+- **Sandbox environment and skill permissions propagate correctly.** Tool sandbox environment settings now reach terminal/tool surfaces and exported skills carry the intended permissions, with regression coverage.
+- **LDAP login wording is simpler.** Login copy now describes LDAP availability more plainly.
+
 ## [1.4.3] — 2026-06-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "workspaces": [
         "packages/*"
       ],
@@ -2817,7 +2817,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -17113,7 +17113,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17159,7 +17159,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.79.10",
         "@earendil-works/pi-ai": "0.79.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepares the v1.4.4 release branch from the latest `origin/main`. Release notes were generated from changes since v1.4.3, then `scripts/bump-version.sh 1.4.4` updated package versions and the lockfile in lockstep.

This is release preparation only: no release tag is created by this PR.

## Usage

No direct runtime usage change for this PR. After this PR merges into `main`, the release can be tagged from `main` using the normal release workflow:

```bash
git checkout main
git pull --ff-only
git tag v1.4.4
git push origin v1.4.4
```

Install-script policy was checked before opening the PR:

```text
No packages with unreviewed install scripts.
```

## What changed (5 files, +29/-8)

- `CHANGELOG.md` — added v1.4.4 release notes covering configurable local admin username, runtime container vim, sandbox docs, dependency updates, file browser fixes, Git message improvements, chat/orchestration UI fixes, sandbox permission propagation, and LDAP wording cleanup.
- `package.json` — bumped root package version to `1.4.4`.
- `packages/server/package.json` — bumped server package version to `1.4.4`.
- `packages/client/package.json` — bumped client package version to `1.4.4`.
- `package-lock.json` — refreshed lockfile package metadata for `1.4.4`.

## Test plan

- [x] `npx npm@latest approve-scripts --allow-scripts-pending`
- [x] `npm run build`
- [x] `npm run check`
- [ ] CI green before merge
