### PR TITLE
fix: stop git status polling on login

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -229,10 +229,14 @@ export function App() {
   const openFilesCount = useFileStore((s) => s.openFiles.length);
   const editorVisible = editorOpen && openFilesCount > 0;
 
-  // Drives the modified-file count badge on the Git tab. Polls every
-  // 5s via the hook regardless of which tab is currently visible —
-  // we want the badge to update even when the user is on Files.
-  const gitStatus = useGitStatus(active?.id);
+  // Drives the modified-file count badge on the Git tab. Polls via
+  // the hook regardless of which tab is currently visible — we want
+  // the badge to update even when the user is on Files. Gate the
+  // project id on auth so a stale active project from the previous
+  // session does not keep polling protected git routes on the login
+  // or change-password screens.
+  const canPollGit = ready && isAuthenticated && !mustChangePassword;
+  const gitStatus = useGitStatus(canPollGit ? active?.id : undefined);
   const gitChangedCount = gitStatus.status?.files.length ?? 0;
   // Running-process count drives the Processes tab badge and the
   // chat-input top-right Activity icon. Reads the SSE-hydrated

--- a/packages/server/src/routes/git.ts
+++ b/packages/server/src/routes/git.ts
@@ -208,11 +208,8 @@ function mapError(reply: FastifyReply, err: unknown): FastifyReply {
 
 /**
  * Resolve the project for a request. On miss, sends 404 + returns
- * undefined; caller MUST `return reply` immediately. Returning bare
- * `undefined` trips Fastify's `FST_ERR_REP_ALREADY_SENT` because the
- * route handler's resolved `undefined` is interpreted as "send this,"
- * which races the 404 the helper already sent. See
- * files.ts:resolveProject for the same contract.
+ * undefined; caller MUST stop immediately. Returning a payload after
+ * this helper has sent the 404 makes Fastify attempt a second send.
  */
 async function resolveProject(
   projectId: string,
@@ -234,11 +231,11 @@ async function resolveProject(
  * to a one-liner.
  *
  * On project-not-found the resolveProject helper has already sent the
- * 404 reply; we return its `undefined` so the route handler short-
- * circuits without trying to return a value Fastify would re-send.
- * On runner success the result is returned verbatim (Fastify
- * serializes via the response schema). On runner throw we route to
- * mapError for the typed-error → wire-shape mapping.
+ * 404 reply; return bare `undefined` so Fastify observes that the reply
+ * is already sent and does not try to serialize a returned payload. On
+ * runner success the result is returned verbatim (Fastify serializes
+ * via the response schema). On runner throw we route to mapError for
+ * the typed-error → wire-shape mapping.
  */
 async function withProject<T>(
   projectId: string,
@@ -246,10 +243,7 @@ async function withProject<T>(
   fn: (project: { id: string; path: string }) => Promise<T>,
 ): Promise<T | FastifyReply | undefined> {
   const project = await resolveProject(projectId, reply);
-  // resolveProject already called reply.send for the 404 path —
-  // returning the reply here tells Fastify the response was handled,
-  // avoiding the FST_ERR_REP_ALREADY_SENT double-send error.
-  if (project === undefined) return reply;
+  if (project === undefined) return undefined;
   try {
     return await fn(project);
   } catch (err) {
@@ -275,7 +269,7 @@ async function withGitCwd<T>(
   fn: (cwd: string) => Promise<T>,
 ): Promise<T | FastifyReply | undefined> {
   const project = await resolveProject(projectId, reply);
-  if (project === undefined) return reply;
+  if (project === undefined) return undefined;
   try {
     const cwd = await resolveGitCwd(project, worktreePath);
     return await fn(cwd);
@@ -331,7 +325,7 @@ export const gitRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       const project = await resolveProject(req.body.projectId, reply);
-      if (project === undefined) return reply;
+      if (project === undefined) return undefined;
       try {
         if (await isGitRepo(project.path)) {
           return { alreadyInitialised: true, isGitRepo: true };


### PR DESCRIPTION
## Summary

When a browser is left on the login page with a stale active project in client state, `App.tsx` still mounted `useGitStatus(active?.id)` before returning `<LoginScreen />`. That allowed background polling of the protected git status route while unauthenticated.

Those stale requests could also hit the git route's project-not-found path, where the helper had already sent a 404 but returned the `FastifyReply` object from the async route, triggering Fastify's double-send warning:

```text
FST_ERR_REP_ALREADY_SENT: Reply was already sent, did you forget to "return reply" in "/api/v1/git/status?..." (GET)?
```

This PR gates git status polling behind authenticated, non-change-password UI state and fixes the git route helper to stop cleanly after sending a project-not-found 404.

## Usage

No operator-facing usage change. The fix is exercised automatically:

```bash
npm run build
npx tsx tests/test-git.ts
```

After logging out or landing on the login screen, the client no longer polls `/api/v1/git/status` for a stale active project.

## What changed (2 files)

- `packages/client/src/App.tsx` — only passes an active project id to `useGitStatus` when auth bootstrap is ready, the user is authenticated, and the token is not scoped to password change.
- `packages/server/src/routes/git.ts` — returns `undefined` after `resolveProject()` has already sent a 404 so Fastify does not try to serialize a returned `reply` object.

## Test plan

- [x] `npm run build`
- [x] `npx tsx tests/test-git.ts`
- [x] `npm run format:check -- packages/client/src/App.tsx packages/server/src/routes/git.ts`
- [ ] CI green before merge
