### PR TITLE
feat: add server-managed custom themes

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -61,6 +61,7 @@ route handlers).
 | `skills-overrides.json` | Per-project skill enable/disable patterns | `skill-overrides.ts` |
 | `tool-overrides.json` | Per-project tool enable/disable (built-ins + MCP) | `tool-overrides.ts` |
 | `prompts-overrides.json` | Per-project pi-prompt enable/disable patterns | `prompt-overrides.ts` |
+| `theme.json` | Global server-side UI color overrides | `theme-config.ts` |
 | `webhooks.json` | Webhook configs (HMAC secrets stored here — mode 0600) | `webhooks/store.ts` |
 | `webhook-deliveries.json` | Rolling delivery history (cap 100 / webhook) | `webhooks/store.ts` |
 | `session-orchestration.json` | Supervisor opt-in + supervisor↔worker links (mode 0600) | `orchestration/store.ts` |

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -393,7 +393,7 @@ export function App() {
   if (mustChangePassword) return <ChangePasswordScreen />;
 
   return (
-    <div className="flex h-screen flex-col bg-neutral-950 text-neutral-100">
+    <div className="forge-app-shell flex h-screen flex-col bg-neutral-950 text-neutral-100">
       {/* Top-of-viewport chrome respects iOS Dynamic Island / notch
           and Android cutouts via safe-area-inset-top. The viewport
           meta in index.html already opts in with `viewport-fit=cover`
@@ -613,7 +613,7 @@ export function App() {
                 re-open chat from the header to reach the picker, or
                 use the sidebar's "+ New project" button. */}
             {chatOpen && (
-              <div className="flex flex-1 flex-col overflow-hidden">
+              <div className="forge-chat-column flex flex-1 flex-col overflow-hidden">
                 {projectsLoaded && projects.length === 0 ? (
                   setupPickerDismissed ? (
                     // Picker dismissed — show a friendly empty state

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -1648,7 +1648,7 @@ export function ChatInput({ sessionId }: Props) {
   }, [text, isMobile, textareaHeight]);
 
   return (
-    <div className="bg-neutral-950">
+    <div className="forge-chat-input-root bg-neutral-950">
       {/*
         Drag handle that lives where the composer's top border used to
         be. Plain visual: a 1-px hairline matching the rest of the
@@ -2176,7 +2176,7 @@ export function ChatInput({ sessionId }: Props) {
             {isStreaming && (
               <button
                 onClick={() => void abortSession(sessionId)}
-                className="flex-1 rounded-md border border-red-700/60 bg-red-950/30 px-3 text-sm font-medium text-red-300 hover:bg-red-900/40 hover:text-red-100 md:flex-none md:py-2"
+                className="flex-1 rounded-md border border-red-700/60 bg-red-950/30 px-3 text-sm font-medium text-red-300 hover:bg-red-900/40 hover:text-red-100 md:flex-none md:py-2 light:border-red-700 light:bg-red-600 light:text-white light:hover:bg-red-700 light:hover:text-white"
                 title="Stop the agent (or press Esc twice in the textbox)"
               >
                 Abort

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -606,7 +606,10 @@ export function ChatView({ sessionId }: Props) {
               return out;
             })()}
             {streamingText.length > 0 && (
-              <div className="message-bubble rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3">
+              <div
+                className="message-bubble rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3"
+                data-message-role="assistant"
+              >
                 <div className="mb-1 text-[10px] uppercase tracking-wider text-neutral-500">
                   assistant (streaming)
                 </div>

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -10,7 +10,11 @@ import {
   type ProvidersListing,
   type PromptSummary,
   type SkillDiagnostic,
+  SERVER_THEME_COLOR_KEYS,
   type SandboxSettingsResponse,
+  type ServerThemeColorKey,
+  type ServerThemeColors,
+  type ServerThemeConfigResponse,
   type SkillSummary,
   type ToolListing,
 } from "../lib/api-client";
@@ -2541,40 +2545,403 @@ function QuickActionsTab({ onError }: { onError: (msg: string | undefined) => vo
 function AppearanceTab() {
   const theme = useThemeStore((s) => s.theme);
   const setTheme = useThemeStore((s) => s.setTheme);
+  const currentServerTheme = useUiConfigStore((s) => s.serverTheme);
+  const setServerTheme = useUiConfigStore((s) => s.setServerTheme);
+  const [serverThemeDraft, setServerThemeDraft] = useState<ServerThemeConfigResponse | undefined>(
+    currentServerTheme,
+  );
+  const themeImportRef = useRef<HTMLInputElement>(null);
+  const [baseThemeId, setBaseThemeId] = useState<ThemeId>(theme);
+  const [serverThemeBusy, setServerThemeBusy] = useState(false);
+  const [serverThemeError, setServerThemeError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getServerTheme()
+      .then((next) => {
+        if (cancelled) return;
+        setServerThemeDraft(next);
+        setServerTheme(next);
+        setServerThemeError(undefined);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setServerThemeError(err instanceof ApiError ? err.code : (err as Error).message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [setServerTheme]);
+
+  const updateDraftColor = (key: ServerThemeColorKey, value: string): void => {
+    setServerThemeDraft((prev) => {
+      if (prev === undefined) return prev;
+      return { ...prev, colors: { ...prev.colors, [key]: value } };
+    });
+  };
+
+  const applyBaseTheme = (base: ThemeId): void => {
+    setServerThemeDraft((prev) => {
+      if (prev === undefined) return prev;
+      return { ...prev, enabled: true, colors: SERVER_THEME_BASE_COLORS[base] };
+    });
+  };
+
+  const exportServerTheme = (): void => {
+    if (serverThemeDraft === undefined) return;
+    const payload = {
+      kind: "pi-forge-server-theme",
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      enabled: serverThemeDraft.enabled,
+      colors: serverThemeDraft.colors,
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "pi-forge-theme.json";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  };
+
+  const importServerTheme = async (file: File): Promise<void> => {
+    setServerThemeBusy(true);
+    setServerThemeError(undefined);
+    try {
+      const parsed = JSON.parse(await file.text()) as unknown;
+      const imported = parseImportedServerTheme(parsed, serverThemeDraft?.defaults);
+      const saved = await api.updateServerTheme(imported);
+      setServerThemeDraft(saved);
+      setServerTheme(saved);
+    } catch (err) {
+      setServerThemeError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setServerThemeBusy(false);
+      if (themeImportRef.current !== null) themeImportRef.current.value = "";
+    }
+  };
+
+  const saveServerTheme = async (): Promise<void> => {
+    if (serverThemeDraft === undefined) return;
+    setServerThemeBusy(true);
+    setServerThemeError(undefined);
+    try {
+      const saved = await api.updateServerTheme({
+        enabled: serverThemeDraft.enabled,
+        colors: serverThemeDraft.colors,
+      });
+      setServerThemeDraft(saved);
+      setServerTheme(saved);
+    } catch (err) {
+      setServerThemeError(err instanceof ApiError ? err.message : (err as Error).message);
+    } finally {
+      setServerThemeBusy(false);
+    }
+  };
+
+  const resetServerTheme = async (): Promise<void> => {
+    setServerThemeBusy(true);
+    setServerThemeError(undefined);
+    try {
+      const reset = await api.resetServerTheme();
+      setServerThemeDraft(reset);
+      setServerTheme(reset);
+    } catch (err) {
+      setServerThemeError(err instanceof ApiError ? err.message : (err as Error).message);
+    } finally {
+      setServerThemeBusy(false);
+    }
+  };
+
   return (
-    <div className="space-y-4">
-      <div>
-        <h2 className="text-sm font-semibold text-neutral-100">Theme</h2>
-        <p className="mt-1 text-xs text-neutral-400">
-          Sets the color palette for the chrome, editor, and terminal. Persisted in this browser
-          only — open in another browser to use a different theme there.
-        </p>
-      </div>
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        {THEME_DEFS.map((def) => {
-          const active = def.id === theme;
-          return (
-            <button
-              key={def.id}
-              onClick={() => setTheme(def.id)}
-              className={`flex items-center justify-between gap-3 rounded border px-3 py-2 text-left ${
-                active
-                  ? "border-neutral-400 bg-neutral-800"
-                  : "border-neutral-700 hover:border-neutral-500"
-              }`}
-            >
-              <div>
-                <div className="text-sm text-neutral-100">{def.label}</div>
-                <div className="text-[10px] uppercase tracking-wider text-neutral-500">
-                  {def.mode}
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <div>
+          <h2 className="text-sm font-semibold text-neutral-100">Theme</h2>
+          <p className="mt-1 text-xs text-neutral-400">
+            Sets the base color palette for the chrome, editor, and terminal. Persisted in this
+            browser only — open in another browser to use a different base theme there.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {THEME_DEFS.map((def) => {
+            const active = def.id === theme;
+            return (
+              <button
+                key={def.id}
+                onClick={() => setTheme(def.id)}
+                className={`flex items-center justify-between gap-3 rounded border px-3 py-2 text-left ${
+                  active
+                    ? "border-neutral-400 bg-neutral-800"
+                    : "border-neutral-700 hover:border-neutral-500"
+                }`}
+              >
+                <div>
+                  <div className="text-sm text-neutral-100">{def.label}</div>
+                  <div className="text-[10px] uppercase tracking-wider text-neutral-500">
+                    {def.mode}
+                  </div>
                 </div>
-              </div>
-              <ThemeSwatch id={def.id} />
-            </button>
-          );
-        })}
+                <ThemeSwatch id={def.id} />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="space-y-3 border-t border-neutral-800 pt-4">
+        <div>
+          <h2 className="text-sm font-semibold text-neutral-100">Global custom colors</h2>
+          <p className="mt-1 text-xs text-neutral-400">
+            Server-side overrides for broad UI surfaces: app background, chat bubbles, text,
+            highlights, and selection. Applies globally to every browser using this instance.
+          </p>
+        </div>
+        {serverThemeError !== undefined && (
+          <div className="rounded border border-red-800 bg-red-950/40 px-3 py-2 text-xs text-red-200">
+            {serverThemeError}
+          </div>
+        )}
+        {serverThemeDraft === undefined ? (
+          <p className="text-xs text-neutral-500">Loading custom colors…</p>
+        ) : (
+          <>
+            <label className="flex items-center gap-2 text-sm text-neutral-200">
+              <input
+                type="checkbox"
+                checked={serverThemeDraft.enabled}
+                onChange={(e) =>
+                  setServerThemeDraft((prev) =>
+                    prev === undefined ? prev : { ...prev, enabled: e.target.checked },
+                  )
+                }
+              />
+              Enable global custom colors
+            </label>
+            <div className="flex flex-wrap items-end gap-2 rounded border border-neutral-800 bg-neutral-900/30 p-2">
+              <label className="min-w-48 flex-1 text-xs text-neutral-400">
+                Start from appearance
+                <select
+                  value={baseThemeId}
+                  onChange={(e) => setBaseThemeId(e.target.value as ThemeId)}
+                  className="mt-1 w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1.5 text-sm text-neutral-100"
+                >
+                  {THEME_DEFS.map((def) => (
+                    <option key={def.id} value={def.id}>
+                      {def.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                onClick={() => applyBaseTheme(baseThemeId)}
+                disabled={serverThemeBusy}
+                className="rounded border border-neutral-700 px-3 py-1.5 text-sm text-neutral-300 hover:border-neutral-500 disabled:opacity-50"
+              >
+                Copy colors
+              </button>
+            </div>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {SERVER_THEME_COLOR_KEYS.map((key) => (
+                <ServerThemeColorField
+                  key={key}
+                  colorKey={key}
+                  value={serverThemeDraft.colors[key]}
+                  defaultValue={serverThemeDraft.defaults[key]}
+                  onChange={(value) => updateDraftColor(key, value)}
+                />
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => void saveServerTheme()}
+                disabled={serverThemeBusy}
+                className="rounded bg-neutral-100 px-3 py-1.5 text-sm font-medium text-neutral-900 hover:bg-white disabled:opacity-50"
+              >
+                Save custom colors
+              </button>
+              <button
+                onClick={exportServerTheme}
+                disabled={serverThemeBusy}
+                className="rounded border border-neutral-700 px-3 py-1.5 text-sm text-neutral-300 hover:border-neutral-500 disabled:opacity-50"
+              >
+                Export theme
+              </button>
+              <button
+                onClick={() => themeImportRef.current?.click()}
+                disabled={serverThemeBusy}
+                className="rounded border border-neutral-700 px-3 py-1.5 text-sm text-neutral-300 hover:border-neutral-500 disabled:opacity-50"
+              >
+                Import theme
+              </button>
+              <input
+                ref={themeImportRef}
+                type="file"
+                accept="application/json,.json"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.currentTarget.files?.[0];
+                  if (file !== undefined) void importServerTheme(file);
+                }}
+              />
+              <button
+                onClick={() => void resetServerTheme()}
+                disabled={serverThemeBusy}
+                className="rounded border border-neutral-700 px-3 py-1.5 text-sm text-neutral-300 hover:border-neutral-500 disabled:opacity-50"
+              >
+                Reset
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
+  );
+}
+
+const SERVER_THEME_LABELS: Record<ServerThemeColorKey, string> = {
+  appBackground: "App background",
+  panelBackground: "Panel background",
+  userBubbleBackground: "User bubble",
+  assistantBubbleBackground: "Assistant bubble",
+  primaryText: "Text 1 — primary",
+  secondaryText: "Text 2 — secondary",
+  mutedText: "Text 3 — muted",
+  highlightBackground: "Highlight background",
+  highlightText: "Highlight text",
+  selectionBackground: "Selection background",
+};
+
+const SERVER_THEME_BASE_COLORS: Record<ThemeId, ServerThemeColors> = {
+  dark: {
+    appBackground: "#0a0a0a",
+    panelBackground: "#171717",
+    userBubbleBackground: "#262626",
+    assistantBubbleBackground: "#171717",
+    primaryText: "#f5f5f5",
+    secondaryText: "#d4d4d4",
+    mutedText: "#a3a3a3",
+    highlightBackground: "#facc15",
+    highlightText: "#111827",
+    selectionBackground: "#525252",
+  },
+  light: {
+    appBackground: "#ffffff",
+    panelBackground: "#f3f4f6",
+    userBubbleBackground: "#e5e7eb",
+    assistantBubbleBackground: "#f3f4f6",
+    primaryText: "#171717",
+    secondaryText: "#374151",
+    mutedText: "#64748b",
+    highlightBackground: "#fde68a",
+    highlightText: "#78350f",
+    selectionBackground: "#cbd5e1",
+  },
+  dracula: {
+    appBackground: "#191a21",
+    panelBackground: "#21222c",
+    userBubbleBackground: "#2a2c3d",
+    assistantBubbleBackground: "#21222c",
+    primaryText: "#f8f8f2",
+    secondaryText: "#c8c8c0",
+    mutedText: "#9c9ca0",
+    highlightBackground: "#ffb86c",
+    highlightText: "#191a21",
+    selectionBackground: "#44475a",
+  },
+  "solarized-dark": {
+    appBackground: "#002b36",
+    panelBackground: "#04212a",
+    userBubbleBackground: "#052b36",
+    assistantBubbleBackground: "#04212a",
+    primaryText: "#eee8d5",
+    secondaryText: "#93a1a1",
+    mutedText: "#839496",
+    highlightBackground: "#b58900",
+    highlightText: "#002b36",
+    selectionBackground: "#586e75",
+  },
+  "catppuccin-mocha": {
+    appBackground: "#11111b",
+    panelBackground: "#1e1e2e",
+    userBubbleBackground: "#313244",
+    assistantBubbleBackground: "#1e1e2e",
+    primaryText: "#cdd6f4",
+    secondaryText: "#9399b2",
+    mutedText: "#7f849c",
+    highlightBackground: "#f9e2af",
+    highlightText: "#11111b",
+    selectionBackground: "#585b70",
+  },
+};
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isHexColor(value: string): boolean {
+  return /^#[0-9a-fA-F]{6}$/.test(value);
+}
+
+function parseImportedServerTheme(
+  input: unknown,
+  fallbackDefaults: ServerThemeColors | undefined,
+): { enabled: boolean; colors: ServerThemeColors } {
+  const source = isObject(input) && isObject(input.colors) ? input.colors : input;
+  if (!isObject(source)) throw new Error("Theme import must be a JSON object with colors.");
+  const defaults = fallbackDefaults ?? SERVER_THEME_BASE_COLORS.dark;
+  const colors = { ...defaults };
+  for (const key of SERVER_THEME_COLOR_KEYS) {
+    const value = source[key];
+    if (value === undefined) continue;
+    if (typeof value !== "string" || !isHexColor(value)) {
+      throw new Error(`${SERVER_THEME_LABELS[key]} must be a 6-digit hex color like #0a0a0a.`);
+    }
+    colors[key] = value;
+  }
+  return {
+    enabled: isObject(input) && typeof input.enabled === "boolean" ? input.enabled : true,
+    colors,
+  };
+}
+
+function ServerThemeColorField({
+  colorKey,
+  value,
+  defaultValue,
+  onChange,
+}: {
+  colorKey: ServerThemeColorKey;
+  value: string;
+  defaultValue: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3 rounded border border-neutral-800 bg-neutral-900/40 px-3 py-2">
+      <div>
+        <div className="text-sm text-neutral-100">{SERVER_THEME_LABELS[colorKey]}</div>
+        <div className="font-mono text-[10px] text-neutral-500">Default {defaultValue}</div>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={isHexColor(value) ? value : defaultValue}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-8 w-10 cursor-pointer rounded border border-neutral-700 bg-transparent p-0"
+        />
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          pattern="^#[0-9a-fA-F]{6}$"
+          className="w-24 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100"
+        />
+      </div>
+    </label>
   );
 }
 

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -54,8 +54,8 @@
   --color-neutral-100: #171717;
   --color-neutral-200: #1f2937;
   --color-neutral-300: #374151;
-  --color-neutral-400: #6b7280;
-  --color-neutral-500: #9ca3af;
+  --color-neutral-400: #4b5563;
+  --color-neutral-500: #64748b;
   --color-neutral-600: #cbd5e1;
   --color-neutral-700: #e2e8f0;
   --color-neutral-800: #e5e7eb;
@@ -118,6 +118,102 @@
   --pi-editor-bg: #1e1e2e;
   --pi-terminal-bg: #11111b;
   --pi-terminal-fg: #cdd6f4;
+}
+
+:root {
+  --forge-app-bg: var(--color-neutral-950);
+  --forge-panel-bg: var(--color-neutral-900);
+  --forge-user-bubble-bg: var(--color-neutral-800);
+  --forge-assistant-bubble-bg: var(--color-neutral-900);
+  --forge-text-primary: var(--color-neutral-100);
+  --forge-text-secondary: var(--color-neutral-300);
+  --forge-text-muted: var(--color-neutral-500);
+  --forge-highlight-bg: #facc15;
+  --forge-highlight-text: #111827;
+  --forge-selection-bg: var(--color-neutral-600);
+}
+
+[data-server-theme="on"] body,
+[data-server-theme="on"] .forge-app-shell,
+[data-server-theme="on"] .forge-chat-column,
+[data-server-theme="on"] .forge-chat-input-root {
+  background: var(--forge-app-bg);
+  color: var(--forge-text-primary);
+}
+
+[data-server-theme="on"] .text-neutral-50,
+[data-server-theme="on"] .text-neutral-100,
+[data-server-theme="on"] .text-neutral-200 {
+  color: var(--forge-text-primary);
+}
+
+[data-server-theme="on"] .text-neutral-300,
+[data-server-theme="on"] .text-neutral-400 {
+  color: var(--forge-text-secondary);
+}
+
+[data-server-theme="on"] .text-neutral-500,
+[data-server-theme="on"] .text-neutral-600 {
+  color: var(--forge-text-muted);
+}
+
+[data-server-theme="on"] .forge-chat-input-root textarea,
+[data-server-theme="on"] .forge-chat-input-root button,
+[data-server-theme="on"] .forge-chat-input-root [role="menu"] {
+  background-color: var(--forge-panel-bg);
+  color: var(--forge-text-primary);
+}
+
+[data-server-theme="on"] .message-bubble[data-message-role="user"] {
+  background: var(--forge-user-bubble-bg);
+  color: var(--forge-text-primary);
+}
+
+[data-server-theme="on"] .message-bubble[data-message-role="assistant"] {
+  background: var(--forge-assistant-bubble-bg);
+  color: var(--forge-text-primary);
+}
+
+[data-server-theme="on"] .message-bubble ::selection {
+  background: var(--forge-selection-bg);
+  color: var(--forge-text-primary);
+}
+
+[data-server-theme="on"] mark {
+  background: var(--forge-highlight-bg) !important;
+  color: var(--forge-highlight-text) !important;
+}
+
+/* `light:text-neutral-*` classes are separate escaped class names,
+   not plain `text-neutral-*`, so standardize them explicitly too. */
+[data-theme="light"] .light\:text-neutral-400,
+[data-theme="light"] .light\:text-neutral-500,
+[data-theme="light"] .light\:text-neutral-600 {
+  color: #475569;
+}
+
+[data-theme="light"] .light\:text-neutral-700,
+[data-theme="light"] .light\:text-neutral-800 {
+  color: #334155;
+}
+
+[data-theme="light"] .light\:text-neutral-900 {
+  color: #111827;
+}
+
+[data-server-theme="on"] .light\:text-neutral-400,
+[data-server-theme="on"] .light\:text-neutral-500,
+[data-server-theme="on"] .light\:text-neutral-600 {
+  color: var(--forge-text-muted);
+}
+
+[data-server-theme="on"] .light\:text-neutral-700,
+[data-server-theme="on"] .light\:text-neutral-800 {
+  color: var(--forge-text-secondary);
+}
+
+[data-server-theme="on"] .light\:text-neutral-900 {
+  color: var(--forge-text-primary);
 }
 
 /* react-diff-view dark-theme overrides. The library declares its

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -160,7 +160,8 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
     version,
     passwordAuthEnabled,
     orchestrationEnabled,
-    serverTheme: value.serverTheme === undefined ? undefined : vServerThemeConfig(value.serverTheme, status),
+    serverTheme:
+      value.serverTheme === undefined ? undefined : vServerThemeConfig(value.serverTheme, status),
   };
 }
 
@@ -1927,8 +1928,7 @@ export const api = {
   getServerTheme: () => request("/api/v1/config/theme", vServerThemeConfig),
   updateServerTheme: (theme: { enabled: boolean; colors: ServerThemeColors }) =>
     request("/api/v1/config/theme", vServerThemeConfig, { method: "PUT", body: theme }),
-  resetServerTheme: () =>
-    request("/api/v1/config/theme", vServerThemeConfig, { method: "DELETE" }),
+  resetServerTheme: () => request("/api/v1/config/theme", vServerThemeConfig, { method: "DELETE" }),
   getAuthSummary: () => request("/api/v1/config/auth", vAuthSummary),
   setApiKey: (provider: string, apiKey: string) =>
     request(

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -25,7 +25,10 @@ import {
   type BrowseEntry,
   type BrowseResponse,
   type HealthResponse,
+  SERVER_THEME_COLOR_KEYS,
   type SandboxSettingsResponse,
+  type ServerThemeConfigResponse,
+  type ServerThemeColors,
   type UiConfigResponse,
   type UnifiedSession,
   type SessionSummary,
@@ -157,6 +160,33 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
     version,
     passwordAuthEnabled,
     orchestrationEnabled,
+    serverTheme: value.serverTheme === undefined ? undefined : vServerThemeConfig(value.serverTheme, status),
+  };
+}
+
+function isHexColor(value: unknown): value is string {
+  return typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value);
+}
+
+function vServerThemeColors(value: unknown, status: number, path: string): ServerThemeColors {
+  if (!isObject(value)) fail(status, `${path}: expected object`);
+  const out = {} as ServerThemeColors;
+  for (const key of SERVER_THEME_COLOR_KEYS) {
+    const color = value[key];
+    if (!isHexColor(color)) fail(status, `${path}.${key}: expected #rrggbb`);
+    out[key] = color;
+  }
+  return out;
+}
+
+function vServerThemeConfig(value: unknown, status: number): ServerThemeConfigResponse {
+  if (!isObject(value) || typeof value.enabled !== "boolean") {
+    fail(status, "expected server theme config");
+  }
+  return {
+    enabled: value.enabled,
+    colors: vServerThemeColors(value.colors, status, "colors"),
+    defaults: vServerThemeColors(value.defaults, status, "defaults"),
   };
 }
 
@@ -1894,6 +1924,11 @@ export const api = {
       method: "PUT",
       body: { toolEnv },
     }),
+  getServerTheme: () => request("/api/v1/config/theme", vServerThemeConfig),
+  updateServerTheme: (theme: { enabled: boolean; colors: ServerThemeColors }) =>
+    request("/api/v1/config/theme", vServerThemeConfig, { method: "PUT", body: theme }),
+  resetServerTheme: () =>
+    request("/api/v1/config/theme", vServerThemeConfig, { method: "DELETE" }),
   getAuthSummary: () => request("/api/v1/config/auth", vAuthSummary),
   setApiKey: (provider: string, apiKey: string) =>
     request(

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -258,6 +258,28 @@ export interface HealthResponse {
   activePtys: number;
 }
 
+export const SERVER_THEME_COLOR_KEYS = [
+  "appBackground",
+  "panelBackground",
+  "userBubbleBackground",
+  "assistantBubbleBackground",
+  "primaryText",
+  "secondaryText",
+  "mutedText",
+  "highlightBackground",
+  "highlightText",
+  "selectionBackground",
+] as const;
+
+export type ServerThemeColorKey = (typeof SERVER_THEME_COLOR_KEYS)[number];
+export type ServerThemeColors = Record<ServerThemeColorKey, string>;
+
+export interface ServerThemeConfigResponse {
+  enabled: boolean;
+  colors: ServerThemeColors;
+  defaults: ServerThemeColors;
+}
+
 export interface SandboxSettingsResponse {
   enabled: boolean;
   uid?: number;
@@ -287,6 +309,8 @@ export interface UiConfigResponse {
    * render at all. Defaults to false on older servers (forward-compatible).
    */
   orchestrationEnabled: boolean;
+  /** Global server-side color overrides for broad UI surfaces. */
+  serverTheme: ServerThemeConfigResponse | undefined;
 }
 
 export interface UnifiedSession {

--- a/packages/client/src/lib/server-theme.ts
+++ b/packages/client/src/lib/server-theme.ts
@@ -1,0 +1,30 @@
+import type { ServerThemeColors, ServerThemeConfigResponse } from "./api-client";
+
+const CSS_VAR_BY_KEY: Record<keyof ServerThemeColors, string> = {
+  appBackground: "--forge-app-bg",
+  panelBackground: "--forge-panel-bg",
+  userBubbleBackground: "--forge-user-bubble-bg",
+  assistantBubbleBackground: "--forge-assistant-bubble-bg",
+  primaryText: "--forge-text-primary",
+  secondaryText: "--forge-text-secondary",
+  mutedText: "--forge-text-muted",
+  highlightBackground: "--forge-highlight-bg",
+  highlightText: "--forge-highlight-text",
+  selectionBackground: "--forge-selection-bg",
+};
+
+export function applyServerTheme(theme: ServerThemeConfigResponse | undefined): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (theme === undefined || !theme.enabled) {
+    root.dataset.serverTheme = "off";
+    for (const cssVar of Object.values(CSS_VAR_BY_KEY)) {
+      root.style.removeProperty(cssVar);
+    }
+    return;
+  }
+  root.dataset.serverTheme = "on";
+  for (const [key, cssVar] of Object.entries(CSS_VAR_BY_KEY)) {
+    root.style.setProperty(cssVar, theme.colors[key as keyof ServerThemeColors]);
+  }
+}

--- a/packages/client/src/store/ui-config-store.ts
+++ b/packages/client/src/store/ui-config-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { api, ApiError } from "../lib/api-client";
+import { api, ApiError, type ServerThemeConfigResponse } from "../lib/api-client";
+import { applyServerTheme } from "../lib/server-theme";
 
 /**
  * Server-driven UI configuration. Fetched once at boot from the
@@ -36,9 +37,12 @@ interface UiConfigState {
    * expose the field keep the old hidden posture.
    */
   orchestrationEnabled: boolean;
+  /** Global server-side color overrides for broad UI surfaces. */
+  serverTheme: ServerThemeConfigResponse | undefined;
   /** Last load error (sticky until a retry succeeds), for diagnostics. */
   error: string | undefined;
   load: () => Promise<void>;
+  setServerTheme: (theme: ServerThemeConfigResponse) => void;
 }
 
 export const useUiConfigStore = create<UiConfigState>((set) => ({
@@ -48,10 +52,16 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
   version: "",
   passwordAuthEnabled: true,
   orchestrationEnabled: false,
+  serverTheme: undefined,
   error: undefined,
+  setServerTheme: (theme) => {
+    applyServerTheme(theme);
+    set({ serverTheme: theme });
+  },
   load: async () => {
     try {
       const cfg = await api.uiConfig();
+      applyServerTheme(cfg.serverTheme);
       set({
         loaded: true,
         minimal: cfg.minimal,
@@ -59,6 +69,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
         version: cfg.version,
         passwordAuthEnabled: cfg.passwordAuthEnabled,
         orchestrationEnabled: cfg.orchestrationEnabled,
+        serverTheme: cfg.serverTheme,
         error: undefined,
       });
     } catch (err) {

--- a/packages/server/src/config-export.ts
+++ b/packages/server/src/config-export.ts
@@ -7,6 +7,7 @@
  *   - `models.json`           — pi-owned custom providers
  *   - `skills-overrides.json` — pi-forge-private per-project skill enable/disable state
  *   - `tool-overrides.json`   — pi-forge-private per-project tool enable/disable state
+ *   - `theme.json`            — pi-forge-private global UI color theme
  *
  * The two `*-overrides.json` files live in `${FORGE_DATA_DIR}` (not
  * `${PI_CONFIG_DIR}` like the other three). They're included because
@@ -64,6 +65,7 @@ const ALLOWED_FILES = [
   "models.json",
   "skills-overrides.json",
   "tool-overrides.json",
+  "theme.json",
 ] as const;
 type AllowedFile = (typeof ALLOWED_FILES)[number];
 const ALLOWED_SET: ReadonlySet<string> = new Set<string>(ALLOWED_FILES);
@@ -82,6 +84,7 @@ const TARGETS: Record<AllowedFile, () => string> = {
   "models.json": () => join(config.piConfigDir, "models.json"),
   "skills-overrides.json": () => config.skillOverridesFile,
   "tool-overrides.json": () => config.toolOverridesFile,
+  "theme.json": () => join(config.forgeDataDir, "theme.json"),
 };
 
 export interface ExportResult {

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -50,6 +50,15 @@ import {
   validateSandboxToolEnv,
   writeSandboxSettings,
 } from "../sandbox-settings.js";
+import {
+  DEFAULT_THEME_COLORS,
+  readThemeConfig,
+  resetThemeConfig,
+  THEME_COLOR_KEYS,
+  validateThemeConfig,
+  writeThemeConfig,
+  type ServerThemeConfig,
+} from "../theme-config.js";
 import { errorSchema } from "./_schemas.js";
 
 const modelsJsonSchema = {
@@ -99,6 +108,36 @@ const sandboxSettingsBodySchema = {
   additionalProperties: false,
   properties: {
     toolEnv: { type: "object", additionalProperties: { type: "string" } },
+  },
+} as const;
+
+const themeColorsSchema = {
+  type: "object",
+  required: [...THEME_COLOR_KEYS],
+  additionalProperties: false,
+  properties: Object.fromEntries(
+    THEME_COLOR_KEYS.map((key) => [key, { type: "string", pattern: "^#[0-9a-fA-F]{6}$" }]),
+  ),
+} as const;
+
+const themeConfigSchema = {
+  type: "object",
+  required: ["enabled", "colors", "defaults"],
+  additionalProperties: false,
+  properties: {
+    enabled: { type: "boolean" },
+    colors: themeColorsSchema,
+    defaults: themeColorsSchema,
+  },
+} as const;
+
+const themeConfigBodySchema = {
+  type: "object",
+  required: ["enabled", "colors"],
+  additionalProperties: false,
+  properties: {
+    enabled: { type: "boolean" },
+    colors: themeColorsSchema,
   },
 } as const;
 
@@ -412,6 +451,76 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
           home: config.agentToolSandbox.home,
           toolEnv: settings.toolEnv,
         };
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  // ---------------------- global UI theme ----------------------
+  fastify.get(
+    "/config/theme",
+    {
+      schema: {
+        description:
+          "Read the global server-side UI color theme. Colors are 6-digit hex values and apply to broad chat/chrome surfaces.",
+        tags: ["config"],
+        response: { 200: themeConfigSchema, 500: errorSchema },
+      },
+    },
+    async (_req, reply) => {
+      try {
+        const theme = await readThemeConfig();
+        return { ...theme, defaults: DEFAULT_THEME_COLORS };
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  fastify.put<{ Body: ServerThemeConfig }>(
+    "/config/theme",
+    {
+      schema: {
+        description:
+          "Replace the global server-side UI color theme. Colors are 6-digit hex values and affect future and current browser tabs after reload/save.",
+        tags: ["config"],
+        body: themeConfigBodySchema,
+        response: { 200: themeConfigSchema, 400: errorSchema, 500: errorSchema },
+      },
+    },
+    async (req, reply) => {
+      let theme: ServerThemeConfig;
+      try {
+        theme = validateThemeConfig(req.body);
+      } catch (err) {
+        return reply.code(400).send({
+          error: "invalid_theme_config",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+      try {
+        const saved = await writeThemeConfig(theme);
+        return { ...saved, defaults: DEFAULT_THEME_COLORS };
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  fastify.delete(
+    "/config/theme",
+    {
+      schema: {
+        description: "Reset the global server-side UI color theme to built-in defaults and disable it.",
+        tags: ["config"],
+        response: { 200: themeConfigSchema, 500: errorSchema },
+      },
+    },
+    async (_req, reply) => {
+      try {
+        const reset = await resetThemeConfig();
+        return { ...reset, defaults: DEFAULT_THEME_COLORS };
       } catch (err) {
         return internalError(reply, err);
       }

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -512,7 +512,8 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
     "/config/theme",
     {
       schema: {
-        description: "Reset the global server-side UI color theme to built-in defaults and disable it.",
+        description:
+          "Reset the global server-side UI color theme to built-in defaults and disable it.",
         tags: ["config"],
         response: { 200: themeConfigSchema, 500: errorSchema },
       },

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -6,6 +6,7 @@ import { sessionCount } from "../session-registry.js";
 import { ptyCount } from "../pty-manager.js";
 import { config, passwordAuthEnabled } from "../config.js";
 import { isOrchestrationEnabled } from "../orchestration/config.js";
+import { DEFAULT_THEME_COLORS, readThemeConfig, THEME_COLOR_KEYS } from "../theme-config.js";
 
 /**
  * Read the server's own package.json once at module load. Used by the
@@ -50,6 +51,26 @@ const SERVER_VERSION: string = (() => {
   }
   return "0.0.0";
 })();
+
+const themeColorsSchema = {
+  type: "object",
+  required: [...THEME_COLOR_KEYS],
+  additionalProperties: false,
+  properties: Object.fromEntries(
+    THEME_COLOR_KEYS.map((key) => [key, { type: "string", pattern: "^#[0-9a-fA-F]{6}$" }]),
+  ),
+} as const;
+
+const themeConfigSchema = {
+  type: "object",
+  required: ["enabled", "colors", "defaults"],
+  additionalProperties: false,
+  properties: {
+    enabled: { type: "boolean" },
+    colors: themeColorsSchema,
+    defaults: themeColorsSchema,
+  },
+} as const;
 
 export const healthRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get(
@@ -103,6 +124,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
               "version",
               "passwordAuthEnabled",
               "orchestrationEnabled",
+              "serverTheme",
             ],
             properties: {
               // True when MINIMAL_UI is set: hides terminal, git pane,
@@ -128,17 +150,23 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
               // by default, but false when disabled by instance config
               // OR when MINIMAL_UI is true (MINIMAL_UI is a hard gate).
               orchestrationEnabled: { type: "boolean" },
+              // Global server-side color overrides for broad UI surfaces.
+              serverTheme: themeConfigSchema,
             },
           },
         },
       },
     },
-    async () => ({
-      minimal: config.minimalUi,
-      workspaceRoot: config.workspacePath,
-      version: SERVER_VERSION,
-      passwordAuthEnabled: passwordAuthEnabled(),
-      orchestrationEnabled: isOrchestrationEnabled(),
-    }),
+    async () => {
+      const serverTheme = await readThemeConfig();
+      return {
+        minimal: config.minimalUi,
+        workspaceRoot: config.workspacePath,
+        version: SERVER_VERSION,
+        passwordAuthEnabled: passwordAuthEnabled(),
+        orchestrationEnabled: isOrchestrationEnabled(),
+        serverTheme: { ...serverTheme, defaults: DEFAULT_THEME_COLORS },
+      };
+    },
   );
 };

--- a/packages/server/src/theme-config.ts
+++ b/packages/server/src/theme-config.ts
@@ -1,0 +1,136 @@
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { config } from "./config.js";
+import { makeLock } from "./concurrency.js";
+
+export const THEME_CONFIG_FILE = (): string => join(config.forgeDataDir, "theme.json");
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+export const THEME_COLOR_KEYS = [
+  "appBackground",
+  "panelBackground",
+  "userBubbleBackground",
+  "assistantBubbleBackground",
+  "primaryText",
+  "secondaryText",
+  "mutedText",
+  "highlightBackground",
+  "highlightText",
+  "selectionBackground",
+] as const;
+
+export type ThemeColorKey = (typeof THEME_COLOR_KEYS)[number];
+
+export type ThemeColors = Record<ThemeColorKey, string>;
+
+export interface ServerThemeConfig {
+  enabled: boolean;
+  colors: ThemeColors;
+}
+
+export const DEFAULT_THEME_COLORS: ThemeColors = {
+  appBackground: "#0a0a0a",
+  panelBackground: "#171717",
+  userBubbleBackground: "#262626",
+  assistantBubbleBackground: "#171717",
+  primaryText: "#f5f5f5",
+  secondaryText: "#d4d4d4",
+  mutedText: "#a3a3a3",
+  highlightBackground: "#facc15",
+  highlightText: "#111827",
+  selectionBackground: "#525252",
+};
+
+export const DEFAULT_THEME_CONFIG: ServerThemeConfig = {
+  enabled: false,
+  colors: DEFAULT_THEME_COLORS,
+};
+
+const lock = makeLock();
+
+async function ensureDataDir(): Promise<void> {
+  await mkdir(config.forgeDataDir, { recursive: true });
+}
+
+async function atomicWriteJson(path: string, data: unknown): Promise<void> {
+  await ensureDataDir();
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
+}
+
+function isThemeColorKey(k: string): k is ThemeColorKey {
+  return (THEME_COLOR_KEYS as readonly string[]).includes(k);
+}
+
+function normalizeColor(value: unknown, fallback: string): string {
+  return typeof value === "string" && HEX_COLOR_RE.test(value) ? value : fallback;
+}
+
+function normalizeThemeConfig(input: unknown): ServerThemeConfig {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return DEFAULT_THEME_CONFIG;
+  }
+  const obj = input as { enabled?: unknown; colors?: unknown };
+  const colorsInput =
+    typeof obj.colors === "object" && obj.colors !== null && !Array.isArray(obj.colors)
+      ? (obj.colors as Record<string, unknown>)
+      : {};
+  const colors = { ...DEFAULT_THEME_COLORS };
+  for (const key of THEME_COLOR_KEYS) {
+    colors[key] = normalizeColor(colorsInput[key], DEFAULT_THEME_COLORS[key]);
+  }
+  return {
+    enabled: typeof obj.enabled === "boolean" ? obj.enabled : false,
+    colors,
+  };
+}
+
+export function validateThemeConfig(input: ServerThemeConfig): ServerThemeConfig {
+  if (typeof input.enabled !== "boolean") {
+    throw new Error("enabled must be a boolean");
+  }
+  const colorsInput = input.colors;
+  if (typeof colorsInput !== "object" || colorsInput === null || Array.isArray(colorsInput)) {
+    throw new Error("colors must be an object");
+  }
+  const colors = { ...DEFAULT_THEME_COLORS };
+  for (const [key, value] of Object.entries(colorsInput)) {
+    if (!isThemeColorKey(key)) continue;
+    if (!HEX_COLOR_RE.test(value)) {
+      throw new Error(`${key} must be a 6-digit hex color like #0a0a0a`);
+    }
+    colors[key] = value;
+  }
+  return { enabled: input.enabled, colors };
+}
+
+export async function readThemeConfig(): Promise<ServerThemeConfig> {
+  return lock(async () => {
+    try {
+      const raw = await readFile(THEME_CONFIG_FILE(), "utf8");
+      return normalizeThemeConfig(JSON.parse(raw));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return DEFAULT_THEME_CONFIG;
+      throw err;
+    }
+  });
+}
+
+export async function writeThemeConfig(input: ServerThemeConfig): Promise<ServerThemeConfig> {
+  const safe = validateThemeConfig(input);
+  await lock(async () => atomicWriteJson(THEME_CONFIG_FILE(), safe));
+  return safe;
+}
+
+export async function resetThemeConfig(): Promise<ServerThemeConfig> {
+  await lock(async () => atomicWriteJson(THEME_CONFIG_FILE(), DEFAULT_THEME_CONFIG));
+  return DEFAULT_THEME_CONFIG;
+}


### PR DESCRIPTION
## Summary

Adds global, server-managed custom color theming for broad pi-forge UI surfaces. The existing appearance picker is browser-local and limited to built-in palettes; this PR adds instance-wide color overrides persisted under `FORGE_DATA_DIR` so operators can define shared app/background/chat/text/highlight colors for everyone using the instance.

The custom theme focuses on broad semantic colors rather than per-component styling. Neutral text is standardized through three configurable text colors so surfaces like chat, Settings, Processes, and orchestration/worker status cards stay consistent across light and dark modes.

## Usage

Open Settings → Appearance:

1. Choose a base appearance if desired.
2. Enable “Global custom colors”.
3. Use “Start from appearance” + “Copy colors” to seed custom colors from a built-in theme.
4. Edit colors and click “Save custom colors”.
5. Optionally export/import a standalone `pi-forge-theme.json`.

Programmatic API:

```bash
# Read global custom theme
curl -H "Authorization: Bearer $KEY" \
  http://localhost:3000/api/v1/config/theme

# Replace global custom theme
curl -X PUT -H "Authorization: Bearer $KEY" \
  -H "Content-Type: application/json" \
  -d '{"enabled":true,"colors":{"appBackground":"#0a0a0a","panelBackground":"#171717","userBubbleBackground":"#262626","assistantBubbleBackground":"#171717","primaryText":"#f5f5f5","secondaryText":"#d4d4d4","mutedText":"#a3a3a3","highlightBackground":"#facc15","highlightText":"#111827","selectionBackground":"#525252"}}' \
  http://localhost:3000/api/v1/config/theme

# Reset and disable custom theme
curl -X DELETE -H "Authorization: Bearer $KEY" \
  http://localhost:3000/api/v1/config/theme
```

The broader Settings → Backup export/import also includes `theme.json`.

## What changed (14 files, +888/-45)

- `packages/server/src/theme-config.ts` — new atomic `FORGE_DATA_DIR/theme.json` reader/writer with color validation and defaults.
- `packages/server/src/routes/config.ts` — added authenticated `GET`/`PUT`/`DELETE /config/theme` routes and OpenAPI schemas.
- `packages/server/src/routes/health.ts` — includes theme config in public `/ui-config` so the browser can apply it on boot.
- `packages/server/src/config-export.ts` — includes `theme.json` in portable config backup/import.
- `packages/client/src/lib/api-client/{types.ts,index.ts}` — added theme wire types, validators, and API methods.
- `packages/client/src/lib/server-theme.ts` — applies/removes server theme CSS variables on `<html>`.
- `packages/client/src/store/ui-config-store.ts` — stores and applies server theme loaded from `/ui-config`.
- `packages/client/src/index.css` — adds semantic CSS variables for broad surfaces, a three-step neutral text scale, improved stock light-mode neutral contrast, and explicit `light:text-neutral-*` handling.
- `packages/client/src/components/SettingsPanel.tsx` — adds global custom color editor, base appearance copy, standalone theme JSON import/export, and reset controls.
- `packages/client/src/{App.tsx,components/ChatInput.tsx,components/ChatView.tsx}` — tags broad surfaces for server theme styling and improves light-mode Abort button contrast.
- `docs/agent/config.md` — documents `theme.json` ownership.

## Test plan

- [x] `git diff --check`
- [x] `npm run build`
- [ ] Manual: Settings → Appearance custom colors can be enabled, saved, reset, imported, and exported in a browser.
- [ ] Manual: Stock Light mode contrast looks correct for process/orchestration status cards, provider model counts, and the Abort button.
- [ ] CI green before merge
