### PR TITLE
fix(orchestration): suppress self-initiated worker delete notifications

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -198,7 +198,7 @@ MINIMAL_UI hard gate — they return `403 orchestration_disabled` or
 | `GET /api/v1/orchestration/sessions/:id/inbox` | Full inbox history (delivered + pending), newest first. |
 | `POST /api/v1/orchestration/sessions/:id/inbox/clear` | Wipe inbox. |
 | `POST /api/v1/orchestration/sessions/:id/workers/:wid/detach` | UI detach. |
-| `POST /api/v1/orchestration/sessions/:id/workers/:wid/kill` | UI kill (transcript stays on disk; use `DELETE /sessions/:id` to remove it). |
+| `POST /api/v1/orchestration/sessions/:id/workers/:wid/kill` | Programmatic orchestration kill that suppresses self-notification to the supervisor. The Web UI worker Kill button uses generic `DELETE /sessions/:id` instead so a human-initiated deletion notifies the supervisor. |
 | `POST /api/v1/orchestration/sessions/:id/workers/:wid/resume` | Force-resume a cold worker into the registry. |
 
 Full schemas: open `/api/docs` in your deploy.

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -123,7 +123,7 @@ types:
 | `worker.ask_user` | Worker called `ask_user_question` |
 | `worker.auto_retry_failed` | Worker's SDK auto-retry exhausted on a provider error |
 | `worker.process_alert` | Not enqueued for worker process alerts; process success/failure/kill notifications stay in the worker session and do not wake the supervisor |
-| `worker.deleted` | Worker's session was deleted (cold or live) |
+| `worker.deleted` | Worker's session was deleted externally (cold or live); kills initiated through orchestration tools/UI controls update worker state but do not notify the supervisor about its own action. |
 
 When an event lands, the bridge enqueues it AND tries to wake the
 supervisor with a small `[orchestration] N pending events…` prompt.
@@ -133,6 +133,8 @@ The wake-up only fires when:
 2. The supervisor is **idle** (not currently mid-turn), AND
 3. There isn't already an in-flight wake-up for the current idle
    window (per-supervisor dedupe flag).
+
+Orchestration-initiated kills are filtered before they reach the inbox, so the supervisor is not woken for its own worker-deletion tool/UI action.
 
 If the supervisor is mid-turn, the items wait on the queue.
 Recovery fires another wake-up when the supervisor's own

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -124,6 +124,7 @@ types:
 | `worker.auto_retry_failed` | Worker's SDK auto-retry exhausted on a provider error |
 | `worker.process_alert` | Not enqueued for worker process alerts; process success/failure/kill notifications stay in the worker session and do not wake the supervisor |
 | `worker.deleted` | Worker's session was deleted externally (cold or live); kills initiated through orchestration tools/UI controls update worker state but do not notify the supervisor about its own action. |
+| `worker.detached` | Worker's supervisor link was detached by a human Web UI/API action; `orchestrate_detach_worker` remains a self-action and does not notify the supervisor. |
 
 When an event lands, the bridge enqueues it AND tries to wake the
 supervisor with a small `[orchestration] N pending events…` prompt.
@@ -197,7 +198,7 @@ MINIMAL_UI hard gate — they return `403 orchestration_disabled` or
 | `GET /api/v1/orchestration/sessions/:id/workers` | Live worker list for a supervisor (drives the Workers panel). |
 | `GET /api/v1/orchestration/sessions/:id/inbox` | Full inbox history (delivered + pending), newest first. |
 | `POST /api/v1/orchestration/sessions/:id/inbox/clear` | Wipe inbox. |
-| `POST /api/v1/orchestration/sessions/:id/workers/:wid/detach` | UI detach. |
+| `POST /api/v1/orchestration/sessions/:id/workers/:wid/detach` | Web UI/API detach. Notifies the supervisor before unlinking because a human detached the worker externally. |
 | `POST /api/v1/orchestration/sessions/:id/workers/:wid/kill` | Programmatic orchestration kill that suppresses self-notification to the supervisor. The Web UI worker Kill button uses generic `DELETE /sessions/:id` instead so a human-initiated deletion notifies the supervisor. |
 | `POST /api/v1/orchestration/sessions/:id/workers/:wid/resume` | Force-resume a cold worker into the registry. |
 

--- a/packages/client/src/components/OrchestrationPanel.tsx
+++ b/packages/client/src/components/OrchestrationPanel.tsx
@@ -275,7 +275,12 @@ function SupervisorControls({
     setBusy(true);
     setError(undefined);
     try {
-      await api.killWorker(link.sessionId, workerId);
+      // Human-initiated worker deletion from the Web UI is an external
+      // session delete from the supervisor agent's perspective, so use the
+      // generic session DELETE route. The orchestration kill endpoint stays
+      // reserved for supervisor/tool-initiated self-actions and suppresses
+      // redundant notifications back to that same supervisor.
+      await api.disposeSession(workerId);
       await onAfter();
     } catch (err) {
       setError(err instanceof ApiError ? err.code : (err as Error).message);

--- a/packages/client/src/components/OrchestrationPanel.tsx
+++ b/packages/client/src/components/OrchestrationPanel.tsx
@@ -460,6 +460,8 @@ function inboxTypeLabel(t: InboxItemType): string {
       return "process";
     case "worker.deleted":
       return "deleted";
+    case "worker.detached":
+      return "detached";
   }
 }
 

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -839,7 +839,8 @@ export type InboxItemType =
   | "worker.ask_user"
   | "worker.auto_retry_failed"
   | "worker.process_alert"
-  | "worker.deleted";
+  | "worker.deleted"
+  | "worker.detached";
 
 export interface InboxItemWire {
   id: string;

--- a/packages/server/src/orchestration/event-bridge.ts
+++ b/packages/server/src/orchestration/event-bridge.ts
@@ -182,17 +182,25 @@ export async function bridgeWorkerExecutionStopped(
 
 export async function bridgeWorkerDeleted(
   sessionId: string,
-  meta: { wasLive: boolean; reason?: "deleted" | "killed" | "disposed" | "aborted" },
+  meta: {
+    wasLive: boolean;
+    reason?: "deleted" | "killed" | "disposed" | "aborted";
+    notifySupervisor?: boolean;
+  },
 ): Promise<void> {
   const reason = meta.reason ?? "deleted";
-  await bridgeWorkerExecutionStopped(sessionId, { wasLive: meta.wasLive, reason });
+  if (meta.notifySupervisor !== false) {
+    await bridgeWorkerExecutionStopped(sessionId, { wasLive: meta.wasLive, reason });
+  }
   await updateWorkerLifecycle(sessionId, {
     state: "deleted",
     turnOpen: false,
     lastStateAt: new Date().toISOString(),
     stopReason: reason,
   });
-  await bridgeWorkerEvent(sessionId, "worker.deleted", {
-    wasLive: meta.wasLive,
-  });
+  if (meta.notifySupervisor !== false) {
+    await bridgeWorkerEvent(sessionId, "worker.deleted", {
+      wasLive: meta.wasLive,
+    });
+  }
 }

--- a/packages/server/src/orchestration/inbox.ts
+++ b/packages/server/src/orchestration/inbox.ts
@@ -8,8 +8,9 @@
  * Delivery policy:
  *   - If the supervisor is active, every worker update is delivered as
  *     `steer` so it can enter the current run at the next model step.
- *   - If the supervisor is idle, every update except delete/unregister
- *     starts a new turn; delete/unregister only appends a visible card.
+ *   - If the supervisor is idle, every external worker update starts a
+ *     new turn. Orchestration-initiated worker deletion is filtered before
+ *     it reaches this bridge.
  */
 import { sendCustomLifecycleMessage } from "../lifecycle-notifications.js";
 import { getSession } from "../session-registry.js";
@@ -43,8 +44,8 @@ function logInbox(level: "info" | "warn", payload: Record<string, unknown>): voi
 export const ORCHESTRATION_WAKE_PREFIX = "[orchestration]";
 export const ORCHESTRATION_NOTIFY_TYPE = "orchestration-notify";
 
-export function shouldTriggerWorkerTurn(type: InboxEventType): boolean {
-  return type !== "worker.deleted";
+export function shouldTriggerWorkerTurn(_type: InboxEventType): boolean {
+  return true;
 }
 
 function workerStateForInboxType(type: InboxEventType): string {

--- a/packages/server/src/orchestration/inbox.ts
+++ b/packages/server/src/orchestration/inbox.ts
@@ -52,6 +52,7 @@ function workerStateForInboxType(type: InboxEventType): string {
   if (type === "worker.ended") return "ended";
   if (type === "worker.execution_stopped_without_agent_end") return "failed";
   if (type === "worker.deleted") return "deleted";
+  if (type === "worker.detached") return "detached";
   if (type === "worker.ask_user") return "awaiting_question";
   if (type === "worker.process_alert") return "process_alert";
   return type.replace(/^worker\./, "");
@@ -102,7 +103,7 @@ function summarizeWorkerEventData(type: InboxEventType, data: Record<string, unk
     const lastStart = typeof data.lastAgentStartAt === "string" ? data.lastAgentStartAt : "";
     return `reason: ${reason}${lastStart !== "" ? `\nlastAgentStartAt: ${lastStart}` : ""}`;
   }
-  if (type === "worker.deleted") {
+  if (type === "worker.deleted" || type === "worker.detached") {
     return `wasLive: ${data.wasLive === true ? "true" : "false"}`;
   }
   try {

--- a/packages/server/src/orchestration/tools.ts
+++ b/packages/server/src/orchestration/tools.ts
@@ -739,7 +739,11 @@ function createKillWorker(supervisorId: string): ToolDefinition {
       const p = params as { workerId: string; deleteOnDisk?: boolean };
       const guard = await assertOwns(supervisorId, p.workerId);
       if (guard !== undefined) return guard;
-      const result = await killWorkerAndArchive({ supervisorId, workerId: p.workerId });
+      const result = await killWorkerAndArchive({
+        supervisorId,
+        workerId: p.workerId,
+        notifySupervisor: false,
+      });
       return ok(
         {
           workerId: p.workerId,

--- a/packages/server/src/orchestration/types.ts
+++ b/packages/server/src/orchestration/types.ts
@@ -34,6 +34,7 @@ export const INBOX_EVENT_TYPES = [
   "worker.auto_retry_failed",
   "worker.process_alert",
   "worker.deleted",
+  "worker.detached",
 ] as const;
 
 export type InboxEventType = (typeof INBOX_EVENT_TYPES)[number];

--- a/packages/server/src/orchestration/worker-lifecycle.ts
+++ b/packages/server/src/orchestration/worker-lifecycle.ts
@@ -53,6 +53,7 @@ function notifySupervisorSessionListChanged(args: {
 export async function killWorkerAndArchive(args: {
   supervisorId: string;
   workerId: string;
+  notifySupervisor?: boolean;
 }): Promise<KillWorkerResult> {
   const projectId =
     (await findProjectIdForSession(args.workerId)) ??
@@ -66,7 +67,11 @@ export async function killWorkerAndArchive(args: {
   }
 
   // Fire before unregistering so the bridge can still resolve the supervisor.
-  await bridgeWorkerDeleted(args.workerId, { wasLive, reason: "killed" }).catch(() => undefined);
+  await bridgeWorkerDeleted(args.workerId, {
+    wasLive,
+    reason: "killed",
+    ...(args.notifySupervisor !== undefined ? { notifySupervisor: args.notifySupervisor } : {}),
+  }).catch(() => undefined);
   await unregisterWorker(args.workerId);
   notifySupervisorSessionListChanged({
     supervisorId: args.supervisorId,
@@ -92,7 +97,11 @@ export async function cleanupWorkersForDeletedSupervisor(
   const workerIds = await getWorkerIds(supervisorId);
   const results: Record<string, KillWorkerResult> = {};
   for (const workerId of workerIds) {
-    results[workerId] = await killWorkerAndArchive({ supervisorId, workerId });
+    results[workerId] = await killWorkerAndArchive({
+      supervisorId,
+      workerId,
+      notifySupervisor: false,
+    });
   }
   await disableSupervisor(supervisorId);
   return { workerIds, results };

--- a/packages/server/src/routes/orchestration.ts
+++ b/packages/server/src/routes/orchestration.ts
@@ -41,6 +41,7 @@ import {
   OrchestrationError,
   unregisterWorker,
 } from "../orchestration/store.js";
+import { bridgeWorkerEvent } from "../orchestration/inbox.js";
 import { clearInbox, pendingInboxCount, readAllInbox } from "../orchestration/store.js";
 import { MAX_DEPTH } from "../orchestration/types.js";
 import { killWorkerAndArchive } from "../orchestration/worker-lifecycle.js";
@@ -489,6 +490,9 @@ export const orchestrationRoutes: FastifyPluginAsync = async (fastify) => {
       if (rec === undefined || rec.supervisorId !== req.params.id) {
         return reply.code(404).send({ error: "worker_not_linked" });
       }
+      await bridgeWorkerEvent(req.params.wid, "worker.detached", {
+        wasLive: getSession(req.params.wid) !== undefined,
+      });
       await unregisterWorker(req.params.wid);
       return reply.code(204).send();
     },

--- a/packages/server/src/routes/orchestration.ts
+++ b/packages/server/src/routes/orchestration.ts
@@ -529,7 +529,11 @@ export const orchestrationRoutes: FastifyPluginAsync = async (fastify) => {
       if (rec === undefined || rec.supervisorId !== req.params.id) {
         return reply.code(404).send({ error: "worker_not_linked" });
       }
-      return killWorkerAndArchive({ supervisorId: req.params.id, workerId: req.params.wid });
+      return killWorkerAndArchive({
+        supervisorId: req.params.id,
+        workerId: req.params.wid,
+        notifySupervisor: false,
+      });
     },
   );
 

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -127,7 +127,11 @@ interface EventBridgeModule {
   ) => Promise<void>;
   bridgeWorkerDeleted: (
     sessionId: string,
-    meta: { wasLive: boolean; reason?: "deleted" | "killed" | "disposed" | "aborted" },
+    meta: {
+      wasLive: boolean;
+      reason?: "deleted" | "killed" | "disposed" | "aborted";
+      notifySupervisor?: boolean;
+    },
   ) => Promise<void>;
 }
 
@@ -432,8 +436,8 @@ async function main(): Promise<void> {
     inbox.shouldTriggerWorkerTurn("worker.ended"),
   );
   assert(
-    "worker deletion does NOT trigger supervisor turn",
-    !inbox.shouldTriggerWorkerTurn("worker.deleted"),
+    "external worker deletion triggers supervisor turn",
+    inbox.shouldTriggerWorkerTurn("worker.deleted"),
   );
   assert(
     "worker ask_user triggers supervisor turn",
@@ -593,6 +597,25 @@ async function main(): Promise<void> {
     "explicit stop clears open turn and records deleted state",
     (await store.getWorkerRecord("w-state"))?.turnOpen === false &&
       (await store.getWorkerRecord("w-state"))?.state === "deleted",
+  );
+
+  await store.clearInbox("sup-1");
+  await eventBridge.bridgeWorkerAgentEvent(
+    { sessionId: "w-state", session: fakeSession },
+    { type: "agent_start" },
+  );
+  await eventBridge.bridgeWorkerDeleted("w-state", {
+    wasLive: true,
+    reason: "killed",
+    notifySupervisor: false,
+  });
+  lifecycleItems = await store.readAllInbox("sup-1");
+  assert(
+    "orchestrator-initiated delete updates state without notifying supervisor",
+    lifecycleItems.length === 0 &&
+      (await store.getWorkerRecord("w-state"))?.turnOpen === false &&
+      (await store.getWorkerRecord("w-state"))?.state === "deleted",
+    JSON.stringify(lifecycleItems),
   );
 
   // Clear worker-event history
@@ -969,28 +992,9 @@ async function main(): Promise<void> {
       JSON.stringify(killRes.body),
     );
     const killInboxItems = await store.readAllInbox(realSid);
-    const killStopItem = killInboxItems.find(
-      (item) =>
-        item.workerId === realWorkerId &&
-        item.type === "worker.execution_stopped_without_agent_end",
-    );
     assert(
-      "kill worker records stopped-without-agent_end reason=killed",
-      killStopItem?.data.reason === "killed",
-      JSON.stringify(killInboxItems),
-    );
-    const killNotify = await waitForMessage(onSrv.base, realSid, (message) => {
-      const details = message.details as { workerId?: unknown; state?: unknown } | undefined;
-      return (
-        message.role === "custom" &&
-        message.customType === "orchestration-notify" &&
-        details?.workerId === realWorkerId &&
-        details.state === "failed"
-      );
-    });
-    assert(
-      "worker failure posts orchestration-notify custom card",
-      killNotify !== undefined,
+      "orchestration kill does not notify supervisor about its own deletion",
+      !killInboxItems.some((item) => item.workerId === realWorkerId),
       JSON.stringify(killInboxItems),
     );
     const afterKillList = await jsend(
@@ -1096,6 +1100,23 @@ async function main(): Promise<void> {
     );
     const deleteWorkerRes = await jsend(onSrv.base, "DELETE", `/api/v1/sessions/${deleteWorkerId}`);
     assert("DELETE /sessions/:id for worker returns 204", deleteWorkerRes.status === 204);
+    const deleteNotify = await waitForMessage(onSrv.base, realSid, (message) => {
+      const details = message.details as
+        | { workerId?: unknown; state?: unknown; eventType?: unknown }
+        | undefined;
+      return (
+        message.role === "custom" &&
+        message.customType === "orchestration-notify" &&
+        details?.workerId === deleteWorkerId &&
+        details.state === "deleted" &&
+        details.eventType === "worker.deleted"
+      );
+    });
+    assert(
+      "direct web UI/session delete notifies supervisor",
+      deleteNotify !== undefined,
+      `workerId=${deleteWorkerId}`,
+    );
     const afterDeleteWorkerList = await jsend(
       onSrv.base,
       "GET",

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -25,7 +25,7 @@
 import { randomUUID } from "node:crypto";
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer, type Server } from "node:net";
-import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -317,6 +317,16 @@ async function jsend(
 }
 
 async function main(): Promise<void> {
+  const orchestrationPanelSource = await readFile(
+    resolve(repoRoot, "packages/client/src/components/OrchestrationPanel.tsx"),
+    "utf8",
+  );
+  assert(
+    "Web UI worker kill uses session DELETE route so supervisor is notified",
+    orchestrationPanelSource.includes("await api.disposeSession(workerId)") &&
+      !orchestrationPanelSource.includes("await api.killWorker(link.sessionId, workerId)"),
+  );
+
   // The store + inbox modules read `FORGE_DATA_DIR` from `config.ts`
   // at module-import time. Plant the env BEFORE the first dynamic
   // import so the in-test calls share a data dir with the spawned

--- a/tests/test-orchestration.ts
+++ b/tests/test-orchestration.ts
@@ -326,6 +326,10 @@ async function main(): Promise<void> {
     orchestrationPanelSource.includes("await api.disposeSession(workerId)") &&
       !orchestrationPanelSource.includes("await api.killWorker(link.sessionId, workerId)"),
   );
+  assert(
+    "Web UI worker detach uses orchestration detach route",
+    orchestrationPanelSource.includes("await api.detachWorker(link.sessionId, workerId)"),
+  );
 
   // The store + inbox modules read `FORGE_DATA_DIR` from `config.ts`
   // at module-import time. Plant the env BEFORE the first dynamic
@@ -1187,6 +1191,50 @@ async function main(): Promise<void> {
     } catch {
       // ignore — body cancel after abort can throw
     }
+
+    const detachWorker = await jsend(onSrv.base, "POST", "/api/v1/sessions", {
+      projectId: realProjectId,
+    });
+    assert(
+      "create detach-route worker session → 201",
+      detachWorker.status === 201 &&
+        typeof (detachWorker.body as { sessionId: string }).sessionId === "string",
+    );
+    const detachWorkerId = (detachWorker.body as { sessionId: string }).sessionId;
+    await store.registerWorker({ supervisorId: realSid, workerId: detachWorkerId });
+    const detachRes = await jsend(
+      onSrv.base,
+      "POST",
+      `/api/v1/orchestration/sessions/${realSid}/workers/${detachWorkerId}/detach`,
+    );
+    assert("Web UI/API detach route returns 204", detachRes.status === 204);
+    const detachNotify = await waitForMessage(onSrv.base, realSid, (message) => {
+      const details = message.details as
+        | { workerId?: unknown; state?: unknown; eventType?: unknown }
+        | undefined;
+      return (
+        message.role === "custom" &&
+        message.customType === "orchestration-notify" &&
+        details?.workerId === detachWorkerId &&
+        details.state === "detached" &&
+        details.eventType === "worker.detached"
+      );
+    });
+    assert(
+      "Web UI/API detach notifies supervisor before unlinking",
+      detachNotify !== undefined,
+      `workerId=${detachWorkerId}`,
+    );
+    const detachLink = await jsend(
+      onSrv.base,
+      "GET",
+      `/api/v1/orchestration/sessions/${detachWorkerId}`,
+    );
+    assert(
+      "detached worker becomes standalone after notifying",
+      detachLink.status === 200 && (detachLink.body as { role?: string }).role === "standalone",
+      JSON.stringify(detachLink.body),
+    );
 
     // Deleting the supervisor itself should cascade through the same worker
     // cleanup path: registered workers (and their subagent children) are


### PR DESCRIPTION
## Summary

Orchestration worker lifecycle notifications had different semantics depending on how the action was initiated. Supervisor/tool-owned worker kills should not notify the same supervisor about its own action, but human Web UI actions should. The Web UI worker Kill button previously used the suppressing orchestration kill endpoint, and the Web UI/API detach route unlinked the worker without first creating any supervisor-visible event.

This PR separates those paths: supervisor/tool-owned worker kills remain suppressed, while human Web UI/session deletion and Web UI/API detaches deliver orchestration notifications that wake the supervisor turn before the worker is removed or unlinked.

## Usage

No new user-facing commands or configuration. Existing flows now behave as intended:

```text
orchestrate_kill_worker / programmatic orchestration kill -> no self-notification
Web UI worker Kill button / DELETE /api/v1/sessions/:id -> supervisor is notified
Web UI/API worker Detach button / POST /orchestration/.../detach -> supervisor is notified before unlink
orchestrate_detach_worker -> no self-notification
```

## What changed (9 files)

- `packages/client/src/components/OrchestrationPanel.tsx` — routes human Web UI worker Kill through generic `api.disposeSession(workerId)` and keeps the human Detach button on the orchestration detach route.
- `packages/client/src/lib/api-client/index.ts` — adds `worker.detached` to inbox event typing.
- `packages/server/src/orchestration/event-bridge.ts` — added an explicit `notifySupervisor` option for worker deletion bridging while preserving lifecycle state updates.
- `packages/server/src/orchestration/worker-lifecycle.ts` — threaded notification suppression through orchestration-owned worker archive/kill paths and supervisor-delete cleanup.
- `packages/server/src/orchestration/tools.ts` — suppresses supervisor self-notification for `orchestrate_kill_worker`; `orchestrate_detach_worker` remains a self-action and does not enqueue an event.
- `packages/server/src/routes/orchestration.ts` — the Web UI/API detach route now enqueues `worker.detached` before unlinking; the REST orchestration kill endpoint still suppresses self-notification.
- `packages/server/src/orchestration/inbox.ts` — external `worker.deleted` and `worker.detached` notifications trigger supervisor turns and render visible `orchestration-notify` cards.
- `packages/server/src/orchestration/types.ts` — adds the `worker.detached` inbox event type.
- `tests/test-orchestration.ts` — covers Web UI route choices, suppressed orchestration kills, direct/web UI-style worker session deletion notifications, and Web UI/API detach notifications before unlinking.
- `docs/orchestration.md` — documents the distinction between external/human worker deletion/detach notifications and orchestration-initiated self-actions.

## Test plan

- [x] `npm run build`
- [x] `NODE_OPTIONS=--max-old-space-size=4096 npm run check`
- [x] `npx tsx tests/test-orchestration.ts`
- [x] `npx tsx tests/test-session.ts`
- [x] `npx tsx tests/test-api.ts`
- [ ] CI green before merge
