### PR TITLE
fix: chown sandbox file creates

### DIFF
--- a/docker/docker-compose.sandbox.yml
+++ b/docker/docker-compose.sandbox.yml
@@ -5,8 +5,9 @@
 #
 # The base compose file starts as the pi user and drops all capabilities so
 # regular mode does not need SETUID/SETGID. Sandbox mode must start the server
-# as root and add back only SETUID/SETGID so pi-forge can spawn model/user tool
-# children as AGENT_TOOL_UID:AGENT_TOOL_GID.
+# as root and add back SETUID/SETGID so pi-forge can spawn model/user tool
+# children as AGENT_TOOL_UID:AGENT_TOOL_GID. CHOWN lets the server hand files
+# created by browser uploads/new-file APIs to the sandbox tool identity.
 
 services:
   pi-forge:
@@ -17,5 +18,6 @@ services:
       AGENT_TOOL_GID: ${AGENT_TOOL_GID:-1001}
       AGENT_TOOL_HOME: ${AGENT_TOOL_HOME:-/home/pi-tools}
     cap_add:
+      - CHOWN
       - SETUID
       - SETGID

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -271,7 +271,10 @@ docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
 ```
 
 The base compose file already drops all capabilities. The sandbox overlay adds
-back `SETUID` / `SETGID` and runs the server container as root.
+back `CHOWN`, `SETUID`, and `SETGID` and runs the server container as root.
+`SETUID` / `SETGID` let pi-forge spawn model/user tool processes as
+`pi-tools`; `CHOWN` lets browser upload and new-file APIs hand newly created
+workspace files/directories to that same sandbox identity.
 
 If OrbStack/Docker Desktop shows `.pi-forge` as `1000:1000 0700` inside the
 pi-forge container even after the helper volume init chowns it to `root:root`,
@@ -279,6 +282,7 @@ add `DAC_OVERRIDE` for local testing:
 
 ```yaml
 cap_add:
+  - CHOWN
   - SETUID
   - SETGID
   - DAC_OVERRIDE # local OrbStack/Docker Desktop workaround only

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -246,10 +246,12 @@ SSE-buffering and WebSocket-upgrade settings live in
   Keep secrets out of `/workspace`; workspace content is intentionally
   readable by the agent.
 - **Minimal capabilities.** Regular compose starts as `pi`, drops all
-  capabilities, and does not need `SETUID` / `SETGID`. The optional
+  capabilities, and does not need `CHOWN`, `SETUID`, or `SETGID`. The optional
   `docker-compose.sandbox.yml` overlay starts as root and adds back
-  only `SETUID` / `SETGID`, which are required for the sandbox identity
-  switch. No privileged mode or host PID is needed.
+  only `CHOWN`, `SETUID`, and `SETGID`: `SETUID` / `SETGID` are required for
+  the sandbox identity switch, and `CHOWN` is required so browser upload and
+  new-file APIs can hand created workspace files/directories to `pi-tools`.
+  No privileged mode or host PID is needed.
 - **Secret mounts.** Mount Pi config, forge data, LDAP/UI secret files,
   and cloud credentials so they are readable by the root server but not
   by `pi-tools` (for example mode `0600` root-owned files or `0700`

--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -1,4 +1,6 @@
 import {
+  lchown,
+  lstat,
   mkdir,
   open as fsOpen,
   readFile as fsReadFile,
@@ -17,6 +19,7 @@ import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } 
 import { createHash, randomUUID } from "node:crypto";
 import { create as tarCreate } from "tar";
 import type { Readable } from "node:stream";
+import { config } from "./config.js";
 
 /**
  * Filesystem operations bounded by a per-call project root.
@@ -221,6 +224,57 @@ async function verifyPathSafe(target: string, root: string): Promise<string> {
       }
       cursor = parent;
     }
+  }
+}
+
+function sandboxOwnershipEnabled(): boolean {
+  return config.agentToolSandbox.enabled;
+}
+
+async function applySandboxOwnership(path: string): Promise<void> {
+  if (!sandboxOwnershipEnabled()) return;
+  const uid = config.agentToolSandbox.uid!;
+  const gid = config.agentToolSandbox.gid!;
+  const currentUid = typeof process.getuid === "function" ? process.getuid() : undefined;
+  const currentGid = typeof process.getgid === "function" ? process.getgid() : undefined;
+  if (currentUid === uid && currentGid === gid) return;
+  // lchown deliberately avoids following a malicious symlink if a path is
+  // swapped between creation and ownership fix-up. File writes chown their
+  // private temp file before the atomic rename, so the final visible file is
+  // never server-owned in sandbox mode.
+  await lchown(path, uid, gid);
+}
+
+async function missingDirectoryChain(dir: string, root: string): Promise<string[]> {
+  const resolvedDir = assertInsideRoot(dir, root);
+  const missing: string[] = [];
+  let cursor = resolvedDir;
+  while (true) {
+    try {
+      await lstat(cursor);
+      return missing.reverse();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      missing.push(cursor);
+      const parent = dirname(cursor);
+      if (parent === cursor) throw new PathOutsideRootError(dir, root);
+      cursor = parent;
+    }
+  }
+}
+
+async function mkdirWithSandboxOwnership(dir: string, root: string): Promise<void> {
+  const missing = sandboxOwnershipEnabled() ? await missingDirectoryChain(dir, root) : [];
+  await mkdir(dir, { recursive: true });
+  try {
+    for (const created of missing) {
+      await applySandboxOwnership(created);
+    }
+  } catch (err) {
+    for (const created of [...missing].reverse()) {
+      await rmdir(created).catch(() => undefined);
+    }
+    throw err;
   }
 }
 
@@ -505,13 +559,19 @@ export async function writeFile(absPath: string, root: string, content: string):
   // succeed (`/foo/bar/baz.ts` works even if `/foo/bar` doesn't exist).
   // Safe AFTER verifyPathSafe: the deepest existing ancestor was
   // proven inside `root`, so any dirs we create are under it.
-  await mkdir(dirname(resolved), { recursive: true });
+  await mkdirWithSandboxOwnership(dirname(resolved), root);
   // Atomic-ish write. tmp + rename keeps a partially-written file from
   // ever existing under the target name; same pattern config-manager and
   // project-manager use.
   const tmp = `${resolved}.${randomUUID()}.tmp`;
-  await fsWriteFile(tmp, content, "utf8");
-  await fsRename(tmp, resolved);
+  try {
+    await fsWriteFile(tmp, content, "utf8");
+    await applySandboxOwnership(tmp);
+    await fsRename(tmp, resolved);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
 }
 
 /**
@@ -638,7 +698,7 @@ async function writeFileBytesAtPath(
     if (opts?.overwrite !== true) throw new TargetExistsError(target);
     if (!existing.isFile()) throw new InvalidNameError("target is a directory");
   }
-  await mkdir(dirname(target), { recursive: true });
+  await mkdirWithSandboxOwnership(dirname(target), root);
   const tmp = `${target}.${randomUUID()}.upload.tmp`;
   const hash = createHash("sha256");
   let size = 0;
@@ -663,7 +723,13 @@ async function writeFileBytesAtPath(
     await unlink(tmp).catch(() => undefined);
     throw new ChecksumMismatchError(target, expected, actual);
   }
-  await fsRename(tmp, target);
+  try {
+    await applySandboxOwnership(tmp);
+    await fsRename(tmp, target);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
   return { path: target, size, sha256: actual };
 }
 
@@ -682,6 +748,12 @@ export async function makeDirectory(
   const exists = await stat(target).catch(() => undefined);
   if (exists !== undefined) throw new TargetExistsError(target);
   await mkdir(target, { recursive: false });
+  try {
+    await applySandboxOwnership(target);
+  } catch (err) {
+    await rmdir(target).catch(() => undefined);
+    throw err;
+  }
   return target;
 }
 

--- a/tests/test-agent-tool-sandbox.ts
+++ b/tests/test-agent-tool-sandbox.ts
@@ -137,11 +137,129 @@ try {
       files: { filename: string; buffer: Buffer }[],
     ) => Promise<{ imported: string[]; skipped: { name: string; reason: string }[] }>;
   };
+  const { makeDirectory, writeFile, writeFileBytesRelative } = (await import(
+    resolve(repoRoot, "packages/server/dist/file-manager.js")
+  )) as {
+    makeDirectory: (parentAbsPath: string, root: string, name: string) => Promise<string>;
+    writeFile: (absPath: string, root: string, content: string) => Promise<void>;
+    writeFileBytesRelative: (
+      parentAbsPath: string,
+      relativePath: string,
+      root: string,
+      source: AsyncIterable<Buffer | Uint8Array>,
+      opts?: { expectedSha256?: string; overwrite?: boolean },
+    ) => Promise<{ path: string; size: number; sha256: string }>;
+  };
 
   console.log("\nsandbox shell env");
   const shellEnv = toolShellEnv({ ...process.env, HOME: "/home/pi", USER: "pi", LOGNAME: "pi" });
   assert("sandbox shell HOME uses AGENT_TOOL_HOME", shellEnv.HOME === toolHome, shellEnv.HOME);
   assert("sandbox shell USER uses tool identity", shellEnv.USER === "pi-tools", shellEnv.USER);
+
+  async function* bufferSource(content: string): AsyncIterable<Buffer> {
+    yield Buffer.from(content);
+  }
+
+  console.log("\nsandbox file-manager ownership");
+  await writeFile(resolve(project, "created", "from-write.txt"), project, "created\n");
+  const uploadResult = await writeFileBytesRelative(
+    project,
+    "uploaded/nested/from-upload.txt",
+    project,
+    bufferSource("uploaded\n"),
+  );
+  const mkdirResult = await makeDirectory(project, project, "browser-dir");
+  const expectedUid = Number(process.env.AGENT_TOOL_UID);
+  const expectedGid = Number(process.env.AGENT_TOOL_GID);
+  for (const ownedPath of [
+    resolve(project, "created"),
+    resolve(project, "created", "from-write.txt"),
+    resolve(project, "uploaded"),
+    resolve(project, "uploaded", "nested"),
+    uploadResult.path,
+    mkdirResult,
+  ]) {
+    const st = statSync(ownedPath);
+    assert(
+      `sandbox-created path owned by tool identity: ${ownedPath.slice(project.length + 1)}`,
+      st.uid === expectedUid && st.gid === expectedGid,
+      `${st.uid}:${st.gid}`,
+    );
+  }
+
+  if ((process.getuid?.() ?? 0) === 0) {
+    const ownershipProject = resolve(tmp, "ownership-root-project");
+    const ownershipWorkspace = resolve(tmp, "ownership-root-workspace");
+    const ownershipPiConfig = resolve(tmp, "ownership-root-pi");
+    const ownershipData = resolve(tmp, "ownership-root-data");
+    mkdirSync(ownershipProject, { recursive: true });
+    mkdirSync(ownershipWorkspace, { recursive: true });
+    mkdirSync(ownershipPiConfig, { recursive: true });
+    mkdirSync(ownershipData, { recursive: true });
+    const ownership = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+          import { statSync } from "node:fs";
+          import { resolve } from "node:path";
+          const { writeFile, writeFileBytesRelative } = await import(${JSON.stringify(
+            resolve(repoRoot, "packages/server/dist/file-manager.js"),
+          )});
+          const project = ${JSON.stringify(ownershipProject)};
+          async function* bufferSource(content) { yield Buffer.from(content); }
+          await writeFile(resolve(project, "new", "file.txt"), project, "x");
+          const uploaded = await writeFileBytesRelative(project, "drop/inner/upload.txt", project, bufferSource("y"));
+          const statOwner = (path) => {
+            const st = statSync(path);
+            return { uid: st.uid, gid: st.gid };
+          };
+          console.log(JSON.stringify({
+            writeDir: statOwner(resolve(project, "new")),
+            writeFile: statOwner(resolve(project, "new", "file.txt")),
+            uploadDir: statOwner(resolve(project, "drop", "inner")),
+            uploadFile: statOwner(uploaded.path),
+          }));
+        `,
+      ],
+      {
+        env: {
+          ...process.env,
+          NODE_ENV: "test",
+          WORKSPACE_PATH: ownershipWorkspace,
+          PI_CONFIG_DIR: ownershipPiConfig,
+          FORGE_DATA_DIR: ownershipData,
+          SESSION_DIR: resolve(ownershipWorkspace, ".pi", "sessions"),
+          AGENT_TOOL_SANDBOX_ENABLED: "true",
+          AGENT_TOOL_UID: "1",
+          AGENT_TOOL_GID: "1",
+          AGENT_TOOL_HOME: toolHome,
+          SERVE_CLIENT: "false",
+        },
+        encoding: "utf8",
+      },
+    );
+    assert(
+      "root can chown file-manager creates to configured UID/GID",
+      ownership.status === 0,
+      ownership.stderr,
+    );
+    const ownershipJson = ownership.stdout.trim().split(/\r?\n/).at(-1) ?? "{}";
+    const ownershipStats = JSON.parse(ownershipJson) as Record<
+      string,
+      { uid: number; gid: number }
+    >;
+    for (const [label, st] of Object.entries(ownershipStats)) {
+      assert(
+        `root-created ${label} owned by 1:1`,
+        st.uid === 1 && st.gid === 1,
+        `${st.uid}:${st.gid}`,
+      );
+    }
+  } else {
+    assert("root-only ownership coverage skipped as non-root", true);
+  }
 
   console.log("\nskills import permissions");
   const skillsImport = await importSkillsFromFiles([


### PR DESCRIPTION
## Summary

In sandbox mode, browser-driven file creates and uploads were performed by the root/server process, so new workspace files could remain owned by the server instead of the restricted `pi-tools` identity that runs terminals and model/user tool surfaces. That left sandbox tool processes unable to edit files created through the file browser or upload APIs.

This PR centralizes sandbox ownership handling in the file-manager layer so new file writes, uploads, and created directories are handed to `AGENT_TOOL_UID:GID` when `AGENT_TOOL_SANDBOX_ENABLED=true`, while preserving existing path validation and atomic write behavior.

## Usage

No API changes are required. In sandbox deployments, keep sandbox mode enabled and provide the configured tool identity:

```bash
AGENT_TOOL_SANDBOX_ENABLED=true
AGENT_TOOL_UID=1001
AGENT_TOOL_GID=1001
AGENT_TOOL_HOME=/home/pi-tools
```

The sandbox Docker Compose overlay now also adds `CHOWN`, because the root server needs that capability to transfer browser-created workspace files/directories to `pi-tools`.

## What changed (5 files, +209/-11)

- `packages/server/src/file-manager.ts` — adds centralized sandbox ownership helpers using `lchown`; applies them to editor writes, streamed uploads, nested upload directories, and explicit directory creates; cleans up temp files/directories if ownership transfer fails.
- `tests/test-agent-tool-sandbox.ts` — adds coverage for sandbox ownership of file-manager creates and uploads, including root-only verification when available and non-root fallback coverage.
- `docker/docker-compose.sandbox.yml` — adds the `CHOWN` capability alongside `SETUID` / `SETGID` for sandbox mode.
- `docs/agent-tool-sandbox.md` — documents why sandbox mode needs `CHOWN` and updates capability examples.
- `docs/containers.md` — updates container security notes to include the new `CHOWN` capability requirement.

## Test plan

- [x] `npx prettier --write packages/server/src/file-manager.ts tests/test-agent-tool-sandbox.ts docker/docker-compose.sandbox.yml docs/agent-tool-sandbox.md docs/containers.md`
- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only files,agent-tool-sandbox`
- [x] `git diff --check`
- [ ] CI green before merge
