### PR TITLE
fix: support sandbox startup chown permissions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -182,6 +182,9 @@ WORKDIR /app
 # manifests + built artifacts is enough; module resolution walks up
 # from packages/server/dist into /app/node_modules.
 COPY --from=builder --chown=pi:pi /app/node_modules ./node_modules
+RUN if [ -d /app/node_modules/@earendil-works/pi-coding-agent ]; then \
+      chmod -R a+rX,u+w,go-w /app/node_modules/@earendil-works/pi-coding-agent; \
+    fi
 COPY --from=builder --chown=pi:pi /app/package.json ./package.json
 COPY --from=builder --chown=pi:pi /app/packages/server/package.json ./packages/server/package.json
 COPY --from=builder --chown=pi:pi /app/packages/server/dist ./packages/server/dist
@@ -221,6 +224,7 @@ case "$(printf '%s' "${AGENT_TOOL_SANDBOX_ENABLED:-false}" | tr '[:upper:]' '[:l
     # selected. Compose starts as pi directly so regular mode does not
     # need SETUID/SETGID capabilities; the root fallback preserves
     # compatibility for `docker run` invocations without --user.
+    # Sandbox startup chown paths are skipped here because sandbox is off.
     if [ "$(id -u)" = "0" ]; then
       exec gosu pi "$@"
     fi

--- a/docker/docker-compose.sandbox.yml
+++ b/docker/docker-compose.sandbox.yml
@@ -7,7 +7,8 @@
 # regular mode does not need SETUID/SETGID. Sandbox mode must start the server
 # as root and add back SETUID/SETGID so pi-forge can spawn model/user tool
 # children as AGENT_TOOL_UID:AGENT_TOOL_GID. CHOWN lets the server hand files
-# created by browser uploads/new-file APIs to the sandbox tool identity.
+# created by browser uploads/new-file APIs to the sandbox tool identity and is
+# also required for the optional AGENT_TOOL_SANDBOX_CHOWN_PATHS startup helper.
 
 services:
   pi-forge:
@@ -17,6 +18,7 @@ services:
       AGENT_TOOL_UID: ${AGENT_TOOL_UID:-1001}
       AGENT_TOOL_GID: ${AGENT_TOOL_GID:-1001}
       AGENT_TOOL_HOME: ${AGENT_TOOL_HOME:-/home/pi-tools}
+      AGENT_TOOL_SANDBOX_CHOWN_PATHS: ${AGENT_TOOL_SANDBOX_CHOWN_PATHS:-}
     cap_add:
       - CHOWN
       - SETUID

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -20,6 +20,8 @@ AGENT_TOOL_SANDBOX_ENABLED=true
 AGENT_TOOL_UID=<numeric uid>
 AGENT_TOOL_GID=<numeric gid>
 AGENT_TOOL_HOME=<writable sandbox tool home>
+# Optional startup helper for non-secret writable mounts:
+AGENT_TOOL_SANDBOX_CHOWN_PATHS=<comma-or-space-separated paths>
 ```
 
 In the Docker image defaults, `pi-tools` is:
@@ -122,6 +124,26 @@ filesystem isolation. Sandbox tool children should still run as a different
 Switching an existing deployment between regular and sandbox mode may require
 changing volume ownership/modes.
 
+## Optional startup chown helper
+
+`AGENT_TOOL_SANDBOX_CHOWN_PATHS` can reduce deployment-specific init scripts
+for paths that should be owned by `pi-tools`. When sandbox mode is enabled and
+the server starts as root, pi-forge recursively `chown`s each configured
+existing path to `AGENT_TOOL_UID:AGENT_TOOL_GID` before the HTTP server starts.
+The helper deliberately accepts only non-secret roots: `WORKSPACE_PATH`,
+`AGENT_TOOL_HOME`, and the Pi resource subtrees
+`${PI_CONFIG_DIR}/{skills,npm,git,extensions,prompts,themes}`. It rejects
+`${FORGE_DATA_DIR}`, `${PI_CONFIG_DIR}` itself, and protected config files.
+
+Example:
+
+```txt
+AGENT_TOOL_SANDBOX_CHOWN_PATHS=/workspace,/home/pi/.pi/agent/skills
+```
+
+Keep using explicit init-container or host-side permissioning for server-only
+secret paths such as `${FORGE_DATA_DIR}` and `${PI_CONFIG_DIR}/auth.json`.
+
 ## Docker Compose: native Linux bind mounts
 
 Use this section for regular Docker Engine on Linux. You can keep the default
@@ -206,8 +228,10 @@ AGENT_TOOL_HOME=/home/pi-tools
 
 Start sandbox mode with the sandbox compose overlay. The base compose file runs
 regular mode as `pi` with no Linux capabilities; the overlay switches the server
-container to root and adds back only `SETUID` / `SETGID` for sandbox child
-processes:
+container to root and adds back `SETUID` / `SETGID` for sandbox child processes
+plus `CHOWN` for the optional `AGENT_TOOL_SANDBOX_CHOWN_PATHS` startup helper.
+If you remove `CHOWN`, leave `AGENT_TOOL_SANDBOX_CHOWN_PATHS` unset or startup
+will fail on the first ownership change:
 
 ```bash
 cd docker
@@ -274,7 +298,8 @@ The base compose file already drops all capabilities. The sandbox overlay adds
 back `CHOWN`, `SETUID`, and `SETGID` and runs the server container as root.
 `SETUID` / `SETGID` let pi-forge spawn model/user tool processes as
 `pi-tools`; `CHOWN` lets browser upload and new-file APIs hand newly created
-workspace files/directories to that same sandbox identity.
+workspace files/directories to that same sandbox identity, and is also required
+when `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is configured.
 
 If OrbStack/Docker Desktop shows `.pi-forge` as `1000:1000 0700` inside the
 pi-forge container even after the helper volume init chowns it to `root:root`,
@@ -288,8 +313,10 @@ cap_add:
   - DAC_OVERRIDE # local OrbStack/Docker Desktop workaround only
 ```
 
-Keep production/native-Linux deployments to `SETUID` and `SETGID` when mounts
-can be permissioned normally.
+Keep production/native-Linux deployments to `CHOWN`, `SETUID`, and `SETGID` for
+sandbox mode. If you build a stricter custom overlay, `SETUID`/`SETGID` are
+required for identity switching; `CHOWN` is required for browser-created
+workspace ownership handoff and for `AGENT_TOOL_SANDBOX_CHOWN_PATHS`.
 
 ### One-shot volume init commands
 
@@ -408,7 +435,9 @@ pi-forge app container starts.
 ### App container security context
 
 The app container must start as UID 0 so the server can drop tool children to
-`AGENT_TOOL_UID:GID`:
+`AGENT_TOOL_UID:GID`. `SETUID`/`SETGID` are required for that identity switch;
+`CHOWN` is additionally required only if `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is set
+(otherwise startup fails on the chown step):
 
 ```yaml
 securityContext:
@@ -417,7 +446,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["ALL"]
-    add: ["SETUID", "SETGID"]
+    add: ["SETUID", "SETGID", "CHOWN"]
   seccompProfile:
     type: RuntimeDefault
 ```
@@ -434,6 +463,9 @@ env:
     value: "1001"
   - name: AGENT_TOOL_HOME
     value: /home/pi-tools
+  # Optional; requires CHOWN in the app container capabilities above.
+  - name: AGENT_TOOL_SANDBOX_CHOWN_PATHS
+    value: ""
 ```
 
 ### Init container
@@ -547,6 +579,8 @@ identity-switch behavior pi-forge needs:
 
 - UID 0 for the server container
 - `SETUID` and `SETGID` for the app container's sandbox UID/GID switch
+- `CHOWN` for browser-created workspace ownership handoff and the optional
+  `AGENT_TOOL_SANDBOX_CHOWN_PATHS` startup helper
 - `CHOWN` and `FOWNER` for the initContainer's PVC permission bootstrap
 - no privileged mode
 - no host namespaces or host networking
@@ -660,10 +694,12 @@ Security trade-offs:
 - The SCC intentionally allows UID 0 in the container. Keep the grant scoped to
   only the pi-forge ServiceAccount.
 - `SETUID` and `SETGID` are required so the server can switch shell-like tool
-  surfaces to `AGENT_TOOL_UID:GID`; `CHOWN` and `FOWNER` are required by the
-  initContainer that fixes PVC ownership/modes before startup. Do not add
-  broader capabilities unless your own storage or platform policy requires
-  them.
+  surfaces to `AGENT_TOOL_UID:GID`; `CHOWN` lets the app hand browser-created
+  workspace files to the tool identity and is required when
+  `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is configured. `CHOWN` and `FOWNER` are also
+  required by the initContainer that fixes PVC ownership/modes before startup.
+  Do not add broader capabilities unless your own storage or platform policy
+  requires them.
 - `readOnlyRootFilesystem` is not forced by the SCC so operators can use
   overlays, but the shipped pi-forge container should keep
   `readOnlyRootFilesystem: true` and mount `/tmp` as `emptyDir`.
@@ -674,7 +710,8 @@ Security trade-offs:
 Use the Kubernetes initContainer permission commands above, plus either the
 `anyuid` RoleBinding or the custom SCC/RBAC resources. The custom SCC still
 needs UID 0 plus `SETUID`/`SETGID` for the app container and `CHOWN`/`FOWNER`
-for the initContainer; it does not need privileged mode.
+for app startup chown support and the initContainer; it does not need privileged
+mode.
 
 ## pi-subagents package disabled in sandbox mode
 

--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -31,8 +31,10 @@ users log in with the password, scripts use the API key.
 `AGENT_TOOL_SANDBOX_ENABLED` defaults false. When true, config startup requires
 numeric `AGENT_TOOL_UID` and `AGENT_TOOL_GID`, sandbox shell surfaces receive
 `HOME=${AGENT_TOOL_HOME}` (default `/home/pi-tools`), and LDAP bind-password file
-references are rejected. Keep sandbox env parsing in `config.ts` and the CLI
-surface in `cli.ts` together.
+references are rejected. `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is a comma/whitespace
+list of existing non-secret paths that startup may recursively chown to the tool
+UID/GID; keep its allowed scope narrow. Keep sandbox env parsing in `config.ts`
+and the CLI surface in `cli.ts` together.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,7 @@ or shell environment. The most-touched ones:
 | `AGENT_TOOL_UID` | (unset) | Numeric UID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled. |
 | `AGENT_TOOL_GID` | (unset) | Numeric GID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled. |
 | `AGENT_TOOL_HOME` | `/home/pi-tools` | Writable HOME injected into sandboxed bash/process/terminal/quick-action/exec children. The Docker image creates this directory owned by `pi-tools`. |
+| `AGENT_TOOL_SANDBOX_CHOWN_PATHS` | (empty) | Comma- or whitespace-separated existing paths to recursively `chown` to `AGENT_TOOL_UID:AGENT_TOOL_GID` at server startup when sandbox mode is enabled. Paths are limited to `/workspace`, `AGENT_TOOL_HOME`, and non-secret Pi resource subtrees (`skills`, `npm`, `git`, `extensions`, `prompts`, `themes`). |
 
 Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
 are documented in [`deployment.md`](./deployment.md).
@@ -94,6 +95,13 @@ When this mode is enabled, LDAP bind password file references are
 rejected (`LDAP_BIND_PASSWORD_FILE` and CLI/env `@file` forms). Use a
 literal environment value or an external secret broker instead; child
 tool processes receive the scrubbed env and do not inherit it.
+
+`AGENT_TOOL_SANDBOX_CHOWN_PATHS` is an optional startup helper for
+container or pod volume ownership. Use it only for non-secret paths that
+should belong to the tool identity (for example `/workspace` or
+`${PI_CONFIG_DIR}/skills`). Pi-forge refuses protected paths such as
+`${FORGE_DATA_DIR}`, `${PI_CONFIG_DIR}` itself, and known secret config
+files.
 
 ### LDAP browser login
 

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -150,6 +150,7 @@ when you need them.
 | `AGENT_TOOL_SANDBOX_ENABLED` | `false` by default; set `true` to run tool children as `pi-tools` |
 | `AGENT_TOOL_UID` / `AGENT_TOOL_GID` | `1001` / `1001` in compose defaults |
 | `AGENT_TOOL_HOME` | `/home/pi-tools`; writable home injected as `HOME` for sandboxed terminals/processes/model bash |
+| `AGENT_TOOL_SANDBOX_CHOWN_PATHS` | unset by default; optional comma/whitespace list of existing non-secret paths that the root sandbox server recursively chowns to `AGENT_TOOL_UID:GID` on startup |
 
 Set `UI_PASSWORD` and / or `API_KEY` in `.env` for any non-loopback
 deploy — without them, auth is disabled. `JWT_SECRET` is intentionally
@@ -251,7 +252,9 @@ SSE-buffering and WebSocket-upgrade settings live in
   only `CHOWN`, `SETUID`, and `SETGID`: `SETUID` / `SETGID` are required for
   the sandbox identity switch, and `CHOWN` is required so browser upload and
   new-file APIs can hand created workspace files/directories to `pi-tools`.
-  No privileged mode or host PID is needed.
+  `CHOWN` is also required when `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is set;
+  deployments that remove `CHOWN` must leave that env var unset or startup
+  fails on the first chown. No privileged mode or host PID is needed.
 - **Secret mounts.** Mount Pi config, forge data, LDAP/UI secret files,
   and cloud credentials so they are readable by the root server but not
   by `pi-tools` (for example mode `0600` root-owned files or `0700`

--- a/docs/site/docs/agent-tool-sandbox.html
+++ b/docs/site/docs/agent-tool-sandbox.html
@@ -79,6 +79,8 @@ data, and secret mounts cannot be owned/mode-bit split as described below.</p>
 AGENT_TOOL_UID=&lt;numeric uid&gt;
 AGENT_TOOL_GID=&lt;numeric gid&gt;
 AGENT_TOOL_HOME=&lt;writable sandbox tool home&gt;
+# Optional startup helper for non-secret writable mounts:
+AGENT_TOOL_SANDBOX_CHOWN_PATHS=&lt;comma-or-space-separated paths&gt;
 </code></pre>
 <p>In the Docker image defaults, <code>pi-tools</code> is:</p>
 <pre><code class="language-txt">AGENT_TOOL_UID=1001
@@ -209,6 +211,20 @@ filesystem isolation. Sandbox tool children should still run as a different
 <code>AGENT_TOOL_UID:GID</code> so they cannot write the <code>pi</code> user&#39;s home by default.
 Switching an existing deployment between regular and sandbox mode may require
 changing volume ownership/modes.</p>
+<h2>Optional startup chown helper</h2>
+<p><code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> can reduce deployment-specific init scripts
+for paths that should be owned by <code>pi-tools</code>. When sandbox mode is enabled and
+the server starts as root, pi-forge recursively <code>chown</code>s each configured
+existing path to <code>AGENT_TOOL_UID:AGENT_TOOL_GID</code> before the HTTP server starts.
+The helper deliberately accepts only non-secret roots: <code>WORKSPACE_PATH</code>,
+<code>AGENT_TOOL_HOME</code>, and the Pi resource subtrees
+<code>${PI_CONFIG_DIR}/{skills,npm,git,extensions,prompts,themes}</code>. It rejects
+<code>${FORGE_DATA_DIR}</code>, <code>${PI_CONFIG_DIR}</code> itself, and protected config files.</p>
+<p>Example:</p>
+<pre><code class="language-txt">AGENT_TOOL_SANDBOX_CHOWN_PATHS=/workspace,/home/pi/.pi/agent/skills
+</code></pre>
+<p>Keep using explicit init-container or host-side permissioning for server-only
+secret paths such as <code>${FORGE_DATA_DIR}</code> and <code>${PI_CONFIG_DIR}/auth.json</code>.</p>
 <h2>Docker Compose: native Linux bind mounts</h2>
 <p>Use this section for regular Docker Engine on Linux. You can keep the default
 bind mounts from <code>docker/docker-compose.yml</code>:</p>
@@ -283,8 +299,10 @@ AGENT_TOOL_HOME=/home/pi-tools
 </code></pre>
 <p>Start sandbox mode with the sandbox compose overlay. The base compose file runs
 regular mode as <code>pi</code> with no Linux capabilities; the overlay switches the server
-container to root and adds back only <code>SETUID</code> / <code>SETGID</code> for sandbox child
-processes:</p>
+container to root and adds back <code>SETUID</code> / <code>SETGID</code> for sandbox child processes
+plus <code>CHOWN</code> for the optional <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> startup helper.
+If you remove <code>CHOWN</code>, leave <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> unset or startup
+will fail on the first ownership change:</p>
 <pre><code class="language-bash">cd docker
 docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
 </code></pre>
@@ -329,17 +347,24 @@ volumes:
 <pre><code class="language-bash">docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
 </code></pre>
 <p>The base compose file already drops all capabilities. The sandbox overlay adds
-back <code>SETUID</code> / <code>SETGID</code> and runs the server container as root.</p>
+back <code>CHOWN</code>, <code>SETUID</code>, and <code>SETGID</code> and runs the server container as root.
+<code>SETUID</code> / <code>SETGID</code> let pi-forge spawn model/user tool processes as
+<code>pi-tools</code>; <code>CHOWN</code> lets browser upload and new-file APIs hand newly created
+workspace files/directories to that same sandbox identity, and is also required
+when <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is configured.</p>
 <p>If OrbStack/Docker Desktop shows <code>.pi-forge</code> as <code>1000:1000 0700</code> inside the
 pi-forge container even after the helper volume init chowns it to <code>root:root</code>,
 add <code>DAC_OVERRIDE</code> for local testing:</p>
 <pre><code class="language-yaml">cap_add:
+  - CHOWN
   - SETUID
   - SETGID
   - DAC_OVERRIDE # local OrbStack/Docker Desktop workaround only
 </code></pre>
-<p>Keep production/native-Linux deployments to <code>SETUID</code> and <code>SETGID</code> when mounts
-can be permissioned normally.</p>
+<p>Keep production/native-Linux deployments to <code>CHOWN</code>, <code>SETUID</code>, and <code>SETGID</code> for
+sandbox mode. If you build a stricter custom overlay, <code>SETUID</code>/<code>SETGID</code> are
+required for identity switching; <code>CHOWN</code> is required for browser-created
+workspace ownership handoff and for <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code>.</p>
 <h3>One-shot volume init commands</h3>
 <p>This example assumes the named volumes are <code>docker_pi-config</code> and
 <code>docker_forge-data</code>, and the sandbox UID/GID is <code>1001:1001</code>:</p>
@@ -437,14 +462,16 @@ volumes. Use PVCs and an initContainer to set the ownership/modes before the
 pi-forge app container starts.</p>
 <h3>App container security context</h3>
 <p>The app container must start as UID 0 so the server can drop tool children to
-<code>AGENT_TOOL_UID:GID</code>:</p>
+<code>AGENT_TOOL_UID:GID</code>. <code>SETUID</code>/<code>SETGID</code> are required for that identity switch;
+<code>CHOWN</code> is additionally required only if <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is set
+(otherwise startup fails on the chown step):</p>
 <pre><code class="language-yaml">securityContext:
   runAsUser: 0
   runAsGroup: 0
   allowPrivilegeEscalation: false
   capabilities:
     drop: [&quot;ALL&quot;]
-    add: [&quot;SETUID&quot;, &quot;SETGID&quot;]
+    add: [&quot;SETUID&quot;, &quot;SETGID&quot;, &quot;CHOWN&quot;]
   seccompProfile:
     type: RuntimeDefault
 </code></pre>
@@ -458,6 +485,9 @@ pi-forge app container starts.</p>
     value: &quot;1001&quot;
   - name: AGENT_TOOL_HOME
     value: /home/pi-tools
+  # Optional; requires CHOWN in the app container capabilities above.
+  - name: AGENT_TOOL_SANDBOX_CHOWN_PATHS
+    value: &quot;&quot;
 </code></pre>
 <h3>Init container</h3>
 <p>This example assumes default IDs (<code>pi=1000</code>, <code>pi-tools=1001</code>) and the shipped
@@ -564,6 +594,8 @@ identity-switch behavior pi-forge needs:</p>
 <ul>
 <li>UID 0 for the server container</li>
 <li><code>SETUID</code> and <code>SETGID</code> for the app container&#39;s sandbox UID/GID switch</li>
+<li><code>CHOWN</code> for browser-created workspace ownership handoff and the optional
+<code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> startup helper</li>
 <li><code>CHOWN</code> and <code>FOWNER</code> for the initContainer&#39;s PVC permission bootstrap</li>
 <li>no privileged mode</li>
 <li>no host namespaces or host networking</li>
@@ -667,10 +699,12 @@ subjects:
 <li>The SCC intentionally allows UID 0 in the container. Keep the grant scoped to
 only the pi-forge ServiceAccount.</li>
 <li><code>SETUID</code> and <code>SETGID</code> are required so the server can switch shell-like tool
-surfaces to <code>AGENT_TOOL_UID:GID</code>; <code>CHOWN</code> and <code>FOWNER</code> are required by the
-initContainer that fixes PVC ownership/modes before startup. Do not add
-broader capabilities unless your own storage or platform policy requires
-them.</li>
+surfaces to <code>AGENT_TOOL_UID:GID</code>; <code>CHOWN</code> lets the app hand browser-created
+workspace files to the tool identity and is required when
+<code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is configured. <code>CHOWN</code> and <code>FOWNER</code> are also
+required by the initContainer that fixes PVC ownership/modes before startup.
+Do not add broader capabilities unless your own storage or platform policy
+requires them.</li>
 <li><code>readOnlyRootFilesystem</code> is not forced by the SCC so operators can use
 overlays, but the shipped pi-forge container should keep
 <code>readOnlyRootFilesystem: true</code> and mount <code>/tmp</code> as <code>emptyDir</code>.</li>
@@ -681,7 +715,8 @@ relies on <code>.pi-forge</code> and protected Pi config files staying unreadabl
 <p>Use the Kubernetes initContainer permission commands above, plus either the
 <code>anyuid</code> RoleBinding or the custom SCC/RBAC resources. The custom SCC still
 needs UID 0 plus <code>SETUID</code>/<code>SETGID</code> for the app container and <code>CHOWN</code>/<code>FOWNER</code>
-for the initContainer; it does not need privileged mode.</p>
+for app startup chown support and the initContainer; it does not need privileged
+mode.</p>
 <h2>pi-subagents package disabled in sandbox mode</h2>
 <p>The <code>pi-subagents</code> package/extension is disabled while
 <code>AGENT_TOOL_SANDBOX_ENABLED=true</code>. The package shells out to the <code>pi</code> CLI and

--- a/docs/site/docs/configuration.html
+++ b/docs/site/docs/configuration.html
@@ -95,7 +95,10 @@ single source of truth — adding a new env var means adding one row to
 the <code>FLAGS</code> table there.</p>
 <h2>Environment variables</h2>
 <p>The exhaustive list lives in <code>pi-forge --help</code> (and the <code>FLAGS</code> table
-in <code>cli.ts</code>). The most-touched ones:</p>
+in <code>cli.ts</code>). Docker&#39;s <code>.env.example</code> intentionally mirrors only a
+small common subset; use this section when adding advanced values to a
+compose override (or compose <code>environment:</code> block), Kubernetes manifest,
+or shell environment. The most-touched ones:</p>
 <table>
 <thead>
 <tr>
@@ -138,6 +141,11 @@ in <code>cli.ts</code>). The most-touched ones:</p>
 <td><code>UI_PASSWORD_FILE</code></td>
 <td>(unset)</td>
 <td>File containing the browser login password (for Kubernetes/OpenShift mounted Secrets). Takes precedence over <code>UI_PASSWORD</code>. Equivalent CLI: <code>--ui-password-file</code>; CLI <code>--ui-password @/path</code> is also supported.</td>
+</tr>
+<tr>
+<td><code>FORGE_LOCAL_ADMIN_USERNAME</code></td>
+<td><code>admin</code></td>
+<td>Username that selects the local admin password when LDAP login is enabled. Equivalent CLI: <code>--local-admin-username</code>. Must be 1-256 characters using only letters, numbers, <code>.</code>, <code>_</code>, <code>@</code>, or <code>-</code>.</td>
 </tr>
 <tr>
 <td><code>API_KEY</code></td>
@@ -210,6 +218,26 @@ in <code>cli.ts</code>). The most-touched ones:</p>
 <td>Hide terminal / git / last-turn / providers / agent-settings panels. Frontend gate; server routes unchanged. ALSO hard-disables webhook configuration, session orchestration, and the quick-actions runner.</td>
 </tr>
 <tr>
+<td><code>AUTH_BANNER_TEXT</code></td>
+<td>(unset)</td>
+<td>Optional public banner shown below the login prompt. Literal newlines/carriage returns are preserved; <code>\\n</code> and <code>\\r</code> escapes are decoded for single-line env/CLI surfaces. Do not put secrets here: it is exposed by public <code>/api/v1/ui-config</code>.</td>
+</tr>
+<tr>
+<td><code>AUTH_BANNER_HTML</code></td>
+<td><code>false</code></td>
+<td>When true, renders <code>AUTH_BANNER_TEXT</code> as sanitized HTML instead of plain text. Scripts, styles, event handlers, and unsafe links are stripped client-side. Leave false unless you need links or simple formatting.</td>
+</tr>
+<tr>
+<td><code>AUTH_LOGO_URL</code></td>
+<td>(unset)</td>
+<td>Optional absolute <code>http://</code> or <code>https://</code> URL for the login/auth logo (and app header logo). Exposed as public UI config.</td>
+</tr>
+<tr>
+<td><code>AUTH_COLOR_SCHEME</code></td>
+<td>(unset)</td>
+<td>Optional comma-separated list of exactly 8 hex colors for login/auth pages only: page background, card background, border, text, muted text, button background, button text, button hover background. Example: <code>#ffffff,#2563eb,#1d4ed8,#ffffff,#dbeafe,#2563eb,#ffffff,#1d4ed8</code>. Only <code>#rgb</code> and <code>#rrggbb</code> forms are accepted; invalid values fail startup rather than becoming CSS.</td>
+</tr>
+<tr>
 <td><code>TRUST_PROXY</code></td>
 <td><code>false</code></td>
 <td>Set when behind a reverse proxy so <code>req.ip</code> is the real client (required for per-user login rate limits).</td>
@@ -244,6 +272,16 @@ in <code>cli.ts</code>). The most-touched ones:</p>
 <td>(unset)</td>
 <td>Numeric GID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled.</td>
 </tr>
+<tr>
+<td><code>AGENT_TOOL_HOME</code></td>
+<td><code>/home/pi-tools</code></td>
+<td>Writable HOME injected into sandboxed bash/process/terminal/quick-action/exec children. The Docker image creates this directory owned by <code>pi-tools</code>.</td>
+</tr>
+<tr>
+<td><code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code></td>
+<td>(empty)</td>
+<td>Comma- or whitespace-separated existing paths to recursively <code>chown</code> to <code>AGENT_TOOL_UID:AGENT_TOOL_GID</code> at server startup when sandbox mode is enabled. Paths are limited to <code>/workspace</code>, <code>AGENT_TOOL_HOME</code>, and non-secret Pi resource subtrees (<code>skills</code>, <code>npm</code>, <code>git</code>, <code>extensions</code>, <code>prompts</code>, <code>themes</code>).</td>
+</tr>
 </tbody></table>
 <p>Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
 are documented in <a href="./deployment.md"><code>deployment.md</code></a>.</p>
@@ -251,19 +289,26 @@ are documented in <a href="./deployment.md"><code>deployment.md</code></a>.</p>
 <p>The identity sandbox is off by default and has a strict mount-permission
 contract. Read <a href="./agent-tool-sandbox.md"><code>agent-tool-sandbox.md</code></a> before
 enabling it. In short: pi-forge runs the server as root, drops
-model/user shell surfaces to <code>AGENT_TOOL_UID:GID</code>, scopes model file
-access, and requires workspace / Pi config / forge data mounts to have
-specific ownership and mode bits.</p>
+model/user shell surfaces to <code>AGENT_TOOL_UID:GID</code>, points their <code>HOME</code>
+at <code>AGENT_TOOL_HOME</code>, scopes model file access, and requires workspace /
+Pi config / forge data mounts to have specific ownership and mode bits.</p>
 <p>When this mode is enabled, LDAP bind password file references are
 rejected (<code>LDAP_BIND_PASSWORD_FILE</code> and CLI/env <code>@file</code> forms). Use a
 literal environment value or an external secret broker instead; child
 tool processes receive the scrubbed env and do not inherit it.</p>
+<p><code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is an optional startup helper for
+container or pod volume ownership. Use it only for non-secret paths that
+should belong to the tool identity (for example <code>/workspace</code> or
+<code>${PI_CONFIG_DIR}/skills</code>). Pi-forge refuses protected paths such as
+<code>${FORGE_DATA_DIR}</code>, <code>${PI_CONFIG_DIR}</code> itself, and known secret config
+files.</p>
 <h3>LDAP browser login</h3>
 <p>LDAP is opt-in and off by default. When <code>LDAP_ENABLED=true</code>, pi-forge&#39;s
-login form asks for a username and password. Username <code>admin</code> (and
-password-only API calls) always use the local pi-forge admin password
-from <code>UI_PASSWORD</code>, <code>UI_PASSWORD_FILE</code>, or the persisted password hash;
-all other usernames use LDAP. The server binds with the
+login form asks for a username and password. The configured local admin
+username (default <code>admin</code>, set with <code>FORGE_LOCAL_ADMIN_USERNAME</code> or
+<code>--local-admin-username</code>) and password-only API calls always use the
+local pi-forge admin password from <code>UI_PASSWORD</code>, <code>UI_PASSWORD_FILE</code>, or
+the persisted password hash; all other usernames use LDAP. The server binds with the
 configured service account, searches under <code>LDAP_BASE_DN</code> using
 <code>LDAP_USER_FILTER</code>, optionally checks the returned user&#39;s <code>memberOf</code>
 (or <code>LDAP_GROUP_ATTRIBUTE</code>) against <code>LDAP_REQUIRED_GROUP_DN</code>, and then
@@ -290,12 +335,13 @@ service-account passwords in container images or command-line history;
 use a mounted secret file or the CLI <code>--ldap-bind-password @/path/to/file</code>
 form instead.</p>
 <p>If both LDAP and local <code>UI_PASSWORD</code> / <code>UI_PASSWORD_FILE</code> / stored-password
-auth are present, username <code>admin</code> and password-only login use the local
-pi-forge password. Other usernames use LDAP. The username <code>admin</code> is
-reserved for local pi-forge admin auth while LDAP is enabled; an LDAP
-account named <code>admin</code> cannot be used unless this policy changes later.
-This preserves existing single-tenant admin access while allowing LDAP
-to be enabled during migration. LDAP login attempts write sanitized
+auth are present, the configured local admin username and password-only
+login use the local pi-forge password. Other usernames use LDAP. The
+local admin username is reserved for local pi-forge admin auth while
+LDAP is enabled; an LDAP account with that name cannot be used unless
+you choose a different <code>FORGE_LOCAL_ADMIN_USERNAME</code>. This preserves
+existing single-tenant admin access while allowing LDAP to be enabled
+during migration. LDAP login attempts write sanitized
 <code>[ldap]</code> lines to the server logs with the URL, base DN, username, TLS
 validation mode, and failure category; passwords are not logged.</p>
 <h2>Pi SDK config files</h2>
@@ -525,8 +571,18 @@ or render path).</p>
 <td>User code; sessions under <code>.pi/sessions/</code> here</td>
 </tr>
 </tbody></table>
-<p>See <a href="./containers.md"><code>containers.md</code></a> for UID/GID handling, image
-internals, and override env vars.</p>
+<p><code>docker/.env.example</code> intentionally keeps to common values (host port,
+UID/GID, bind mounts, auth, logging/proxy hints). Less-used values such
+as <code>JWT_SECRET</code>, <code>CORS_ORIGIN</code>, <code>MINIMAL_UI</code>, LDAP settings,
+orchestration toggles, rate limits, terminal tuning, and sandbox mode
+remain supported; add them to your own compose override or compose
+<code>environment:</code> block using the reference above when needed.</p>
+<p>In regular/non-sandbox containers, <code>$HOME</code> is <code>/home/pi</code> and is writable by the
+<code>pi</code> user so terminal/tool CLIs can create per-user files (<code>~/.config/gh</code>,
+<code>~/.gitconfig</code>, caches, and similar). In sandbox mode, tool/terminal children
+instead receive <code>HOME=${AGENT_TOOL_HOME}</code> (<code>/home/pi-tools</code> in the Docker image).
+See <a href="./containers.md"><code>containers.md</code></a> for UID/GID handling, image internals,
+sandbox-mode differences, and override env vars.</p>
 <h2>See also</h2>
 <ul>
 <li><a href="./deployment.md"><code>deployment.md</code></a> — production deploy with TLS at a

--- a/docs/site/docs/containers.html
+++ b/docs/site/docs/containers.html
@@ -102,7 +102,7 @@ runtime (Node + native bindings), and makes deploys reproducible.</p>
 <tr>
 <td><code>runtime</code></td>
 <td><code>node-python-base</code></td>
-<td>Production deps + built artifacts only. Adds <code>git</code>, <code>ripgrep</code>, <code>bash</code>, <code>curl</code>, <code>less</code>, <code>procps</code>, <code>gosu</code>, and the C++ toolchain needed for native-module rebuilds during in-container development. Default mode drops the server to <code>pi</code>; sandbox mode keeps the server as root so it can drop model/user tool processes to <code>pi-tools</code>; <code>SHELL=/bin/bash</code> so xterm sessions land in bash, not dash</td>
+<td>Production deps + built artifacts only. Adds <code>git</code>, <code>gh</code>, <code>tea</code>, <code>ripgrep</code>, <code>bash</code>, <code>curl</code>, <code>less</code>, <code>procps</code>, <code>vim</code>, <code>gosu</code>, and the C++ toolchain needed for native-module rebuilds during in-container development. Default mode drops the server to <code>pi</code>; sandbox mode keeps the server as root so it can drop model/user tool processes to <code>pi-tools</code>; <code>SHELL=/bin/bash</code> so xterm sessions land in bash, not dash</td>
 </tr>
 </tbody></table>
 <p>Final image size varies by architecture and cache state. Debian-based
@@ -114,8 +114,11 @@ prebuilds; on musl, those packages fall back to source builds.</p>
 <li><strong>Python 3.12 + pip</strong> — callable as <code>python3</code>, <code>python</code>, or <code>py</code></li>
 <li><strong><code>tini</code></strong> — init for signal forwarding + zombie reaping</li>
 <li><strong><code>git</code></strong> — required by the agent&#39;s <code>bash</code> tool and the GitPanel routes</li>
+<li><strong><code>gh</code></strong> — GitHub CLI for working with GitHub and GitHub Enterprise</li>
+<li><strong><code>tea</code></strong> — Gitea/Forgejo CLI, pinned from the upstream Gitea release</li>
 <li><strong><code>ripgrep</code></strong> — pi&#39;s <code>grep</code> tool delegates to <code>rg</code> when present;
 silently degrades to a Node walker without it</li>
+<li><strong><code>vim</code></strong> — familiar in-terminal editor for the integrated terminal</li>
 <li><strong><code>make</code>, <code>g++</code></strong> — keeps <code>npm install</code> / <code>npm rebuild</code> working
 inside the running container when native modules such as <code>node-pty</code>
 need to compile against the container&#39;s Node ABI</li>
@@ -127,7 +130,8 @@ need to compile against the container&#39;s Node ABI</li>
 preserves legacy path/env expectations.</li>
 <li><code>pi-tools</code> (<code>AGENT_TOOL_UID</code> / <code>AGENT_TOOL_GID</code> in compose, default
 <code>1001:1001</code>) is the restricted identity used when
-<code>AGENT_TOOL_SANDBOX_ENABLED=true</code>.</li>
+<code>AGENT_TOOL_SANDBOX_ENABLED=true</code>. It has its own writable home at
+<code>/home/pi-tools</code>, exposed to sandboxed shells as <code>AGENT_TOOL_HOME</code>.</li>
 </ul>
 <p>By default (<code>AGENT_TOOL_SANDBOX_ENABLED=false</code>), compose starts the
 server as the legacy <code>pi</code> user directly and drops all Linux
@@ -209,8 +213,12 @@ bind mount.</p>
 <h2>Environment variables</h2>
 <p>The full env-var reference lives in
 <a href="./configuration.md#environment-variables"><code>configuration.md</code></a>. The
-container fixes the path-related vars; everything else is yours to set
-in <code>docker/.env</code>:</p>
+container fixes the path-related vars; the shipped <code>docker/.env.example</code>
+only includes the settings most Docker users edit on day one. Add
+less-used server knobs (LDAP, CORS pinning, minimal UI, orchestration,
+rate limits, terminal tuning, explicit JWT rotation, etc.) in your own
+compose override (or by adding them to the compose <code>environment:</code> block)
+when you need them.</p>
 <table>
 <thead>
 <tr>
@@ -243,6 +251,10 @@ in <code>docker/.env</code>:</p>
 <td><code>/home/pi/.local</code></td>
 </tr>
 <tr>
+<td><code>HOME</code></td>
+<td><code>/home/pi</code>; writable by the <code>pi</code> user in regular/non-sandbox mode so CLIs such as <code>gh</code> can create <code>~/.config</code>, <code>~/.gitconfig</code>, and similar per-user files</td>
+</tr>
+<tr>
 <td><code>AGENT_TOOL_SANDBOX_ENABLED</code></td>
 <td><code>false</code> by default; set <code>true</code> to run tool children as <code>pi-tools</code></td>
 </tr>
@@ -250,12 +262,25 @@ in <code>docker/.env</code>:</p>
 <td><code>AGENT_TOOL_UID</code> / <code>AGENT_TOOL_GID</code></td>
 <td><code>1001</code> / <code>1001</code> in compose defaults</td>
 </tr>
+<tr>
+<td><code>AGENT_TOOL_HOME</code></td>
+<td><code>/home/pi-tools</code>; writable home injected as <code>HOME</code> for sandboxed terminals/processes/model bash</td>
+</tr>
+<tr>
+<td><code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code></td>
+<td>unset by default; optional comma/whitespace list of existing non-secret paths that the root sandbox server recursively chowns to <code>AGENT_TOOL_UID:GID</code> on startup</td>
+</tr>
 </tbody></table>
 <p>Set <code>UI_PASSWORD</code> and / or <code>API_KEY</code> in <code>.env</code> for any non-loopback
-deploy — without them, auth is disabled.</p>
+deploy — without them, auth is disabled. <code>JWT_SECRET</code> is intentionally
+not in the sample <code>.env</code>; when auth is enabled, pi-forge auto-generates
+and persists it under <code>${FORGE_DATA_DIR}/jwt-secret</code> unless you choose
+to manage rotation yourself.</p>
 <h2>Compose recipe</h2>
 <p>The shipped compose file (<code>docker/docker-compose.yml</code>) covers a typical
-single-host deploy. Quickstart:</p>
+single-host deploy. Its <code>.env.example</code> is deliberately concise; advanced
+server env vars remain supported but are documented instead of being
+listed as runtime defaults. Quickstart:</p>
 <pre><code class="language-bash">cp docker/.env.example docker/.env
 # edit docker/.env — at minimum set HOST_PORT and (for any non-loopback
 # deploy) UI_PASSWORD (JWT_SECRET auto-generates), or API_KEY
@@ -323,19 +348,25 @@ as <code>pi-tools</code> and file tools / <code>@file</code> references are path
 Keep secrets out of <code>/workspace</code>; workspace content is intentionally
 readable by the agent.</li>
 <li><strong>Minimal capabilities.</strong> Regular compose starts as <code>pi</code>, drops all
-capabilities, and does not need <code>SETUID</code> / <code>SETGID</code>. The optional
+capabilities, and does not need <code>CHOWN</code>, <code>SETUID</code>, or <code>SETGID</code>. The optional
 <code>docker-compose.sandbox.yml</code> overlay starts as root and adds back
-only <code>SETUID</code> / <code>SETGID</code>, which are required for the sandbox identity
-switch. No privileged mode or host PID is needed.</li>
+only <code>CHOWN</code>, <code>SETUID</code>, and <code>SETGID</code>: <code>SETUID</code> / <code>SETGID</code> are required for
+the sandbox identity switch, and <code>CHOWN</code> is required so browser upload and
+new-file APIs can hand created workspace files/directories to <code>pi-tools</code>.
+<code>CHOWN</code> is also required when <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is set;
+deployments that remove <code>CHOWN</code> must leave that env var unset or startup
+fails on the first chown. No privileged mode or host PID is needed.</li>
 <li><strong>Secret mounts.</strong> Mount Pi config, forge data, LDAP/UI secret files,
 and cloud credentials so they are readable by the root server but not
 by <code>pi-tools</code> (for example mode <code>0600</code> root-owned files or <code>0700</code>
 directories). The sandbox also blocks <code>/run/secrets</code> and
 <code>/var/run/secrets</code> from model file tools.</li>
 <li><strong>Read-only root filesystem (optional).</strong> Add <code>read_only: true</code> to
-compose with <code>tmpfs</code> mounts for <code>/tmp</code> and <code>/home/pi/.npm</code> if you
-want a hardened deploy. Native modules + node_modules live in the
-image, so they&#39;re already read-only.</li>
+compose with <code>tmpfs</code> mounts for <code>/tmp</code>, <code>/home/pi/.npm</code>, and any other
+regular-mode home/config paths you expect tools to write (for example
+<code>/home/pi/.config</code> for GitHub CLI auth) if you want a hardened deploy.
+Native modules + node_modules live in the image, so they&#39;re already
+read-only.</li>
 </ul>
 <h2>Updating</h2>
 <p>The image is <strong>not</strong> auto-updating. To pull a new release:</p>

--- a/docs/site/docs/orchestration.html
+++ b/docs/site/docs/orchestration.html
@@ -213,7 +213,11 @@ types:</p>
 </tr>
 <tr>
 <td><code>worker.deleted</code></td>
-<td>Worker&#39;s session was deleted (cold or live)</td>
+<td>Worker&#39;s session was deleted externally (cold or live); kills initiated through orchestration tools/UI controls update worker state but do not notify the supervisor about its own action.</td>
+</tr>
+<tr>
+<td><code>worker.detached</code></td>
+<td>Worker&#39;s supervisor link was detached by a human Web UI/API action; <code>orchestrate_detach_worker</code> remains a self-action and does not notify the supervisor.</td>
 </tr>
 </tbody></table>
 <p>When an event lands, the bridge enqueues it AND tries to wake the
@@ -225,6 +229,7 @@ The wake-up only fires when:</p>
 <li>There isn&#39;t already an in-flight wake-up for the current idle
 window (per-supervisor dedupe flag).</li>
 </ol>
+<p>Orchestration-initiated kills are filtered before they reach the inbox, so the supervisor is not woken for its own worker-deletion tool/UI action.</p>
 <p>If the supervisor is mid-turn, the items wait on the queue.
 Recovery fires another wake-up when the supervisor&#39;s own
 <code>agent_end</code> lands — closing the &quot;supervisor finished a turn
@@ -321,11 +326,11 @@ MINIMAL_UI hard gate — they return <code>403 orchestration_disabled</code> or
 </tr>
 <tr>
 <td><code>POST /api/v1/orchestration/sessions/:id/workers/:wid/detach</code></td>
-<td>UI detach.</td>
+<td>Web UI/API detach. Notifies the supervisor before unlinking because a human detached the worker externally.</td>
 </tr>
 <tr>
 <td><code>POST /api/v1/orchestration/sessions/:id/workers/:wid/kill</code></td>
-<td>UI kill (transcript stays on disk; use <code>DELETE /sessions/:id</code> to remove it).</td>
+<td>Programmatic orchestration kill that suppresses self-notification to the supervisor. The Web UI worker Kill button uses generic <code>DELETE /sessions/:id</code> instead so a human-initiated deletion notifies the supervisor.</td>
 </tr>
 <tr>
 <td><code>POST /api/v1/orchestration/sessions/:id/workers/:wid/resume</code></td>

--- a/docs/site/docs/processes.html
+++ b/docs/site/docs/processes.html
@@ -119,12 +119,17 @@ conversation continues.</p>
 <p>Per-<code>start</code> flags control whether the agent gets a turn to react
 on lifecycle events:</p>
 <ul>
-<li><code>alertOnSuccess</code> (default: <code>false</code>) — non-zero exit gates this off</li>
+<li><code>alertOnSuccess</code> (default: <code>false</code>) — records an informational clean-exit card, but does not wake the agent</li>
 <li><code>alertOnFailure</code> (default: <code>true</code>) — fires on crash / non-zero exit</li>
 <li><code>alertOnKill</code> (default: <code>false</code>) — fires only on external signal; killing via the tool never triggers a turn</li>
 </ul>
+<p>When one of these enabled lifecycle alerts fires, pi-forge appends a
+<code>process-notify</code> status card. Clean success is informational and does
+not wake the agent; failure and external-kill alerts start/steer an
+agent turn because they usually require intervention.</p>
 <p><code>logWatches</code> adds runtime regex matchers per process. On match, the
-manager emits a watch event the UI surfaces as an alert badge.
+manager emits a watch event the UI surfaces as an alert badge and a
+<code>process-watch</code> status card that starts/steers an agent turn.
 <code>stream: &quot;stdout&quot; | &quot;stderr&quot; | &quot;both&quot;</code>; <code>repeat: false</code> is the
 default (single-fire) — set <code>true</code> for repeat alerts.</p>
 <h2>UI</h2>

--- a/docs/site/docs/quick-actions.html
+++ b/docs/site/docs/quick-actions.html
@@ -252,7 +252,7 @@ turns).</li>
 PATH. Pi-forge launches commands with the same PATH as the
 parent process; for chips that need <code>gh</code>, <code>kubectl</code>, etc.,
 ensure they&#39;re installed in the container (the shipped image
-already has <code>git</code>, <code>gh</code>, <code>ripgrep</code>, <code>bash</code>, <code>curl</code>, <code>less</code>,
+already has <code>git</code>, <code>gh</code>, <code>tea</code>, <code>ripgrep</code>, <code>bash</code>, <code>curl</code>, <code>less</code>,
 <code>procps</code>).</p>
 <p><strong>Chip ran successfully but the output looks cut off.</strong> Stream
 output caps at 1 MB per stream; <code>truncated: true</code> on the result

--- a/docs/site/docs/sse-events.html
+++ b/docs/site/docs/sse-events.html
@@ -212,27 +212,33 @@ subscribe to this counter rather than the raw event.</p>
 </thead>
 <tbody><tr>
 <td><code>text_delta</code></td>
-<td><code>{ type: &quot;text_delta&quot;, delta: &quot;...&quot; }</code> — append to streaming text</td>
+<td><code>{ type: &quot;text_delta&quot;, contentIndex, delta: &quot;...&quot;, partial }</code> — append to streaming text</td>
 </tr>
 <tr>
 <td><code>thinking_delta</code></td>
-<td><code>{ type: &quot;thinking_delta&quot;, delta: &quot;...&quot; }</code> — thinking-block token</td>
+<td><code>{ type: &quot;thinking_delta&quot;, contentIndex, delta: &quot;...&quot;, partial }</code> — thinking-block token</td>
 </tr>
 <tr>
-<td><code>tool_use_start</code></td>
-<td><code>{ type: &quot;tool_use_start&quot;, toolCallId, name, input: {} }</code> — tool call begins</td>
+<td><code>toolcall_start</code></td>
+<td><code>{ type: &quot;toolcall_start&quot;, contentIndex, partial }</code> — tool-call block began</td>
 </tr>
 <tr>
-<td><code>tool_use_input_delta</code></td>
-<td><code>{ type: &quot;tool_use_input_delta&quot;, toolCallId, partialInput: &quot;...&quot; }</code> — JSON args streaming</td>
+<td><code>toolcall_delta</code></td>
+<td><code>{ type: &quot;toolcall_delta&quot;, contentIndex, delta: &quot;...&quot;, partial }</code> — JSON args streaming, when the provider exposes them</td>
 </tr>
 <tr>
-<td><code>usage</code></td>
-<td><code>{ type: &quot;usage&quot;, usage: { input, output, cacheRead, cacheWrite, ... } }</code> — token + cost update</td>
+<td><code>toolcall_end</code></td>
+<td><code>{ type: &quot;toolcall_end&quot;, contentIndex, toolCall, partial }</code> — tool-call block complete</td>
 </tr>
 </tbody></table>
 <p>The UI renders streaming text by accumulating <code>text_delta</code> deltas into
-<code>streamingTextBySession[id]</code> (see <code>session-store.ts</code>).</p>
+<code>streamingTextBySession[id]</code> (see <code>session-store.ts</code>). It also reads the
+<code>partial</code> assistant message on <code>toolcall_*</code> updates to show an explicit
+&quot;generating tool call&quot; indicator and any partial JSON args the SDK/provider
+has exposed. Providers differ: Anthropic streams input JSON deltas, Google
+currently emits the function-call args as a complete payload, and other
+adapters may do either. pi-forge forwards what the SDK emits and does not
+invent argument text before it exists.</p>
 <h3><code>message_end</code></h3>
 <pre><code class="language-json">{ &quot;type&quot;: &quot;message_end&quot;, &quot;sessionId&quot;: &quot;01J7...&quot; }
 </code></pre>

--- a/kubernetes/DEPLOY.md
+++ b/kubernetes/DEPLOY.md
@@ -98,7 +98,8 @@ oc apply -f kubernetes/openshift/deployment.yaml
 #    OpenShift restricted-v2 assigns a random non-root UID and cannot
 #    support pi-forge's UID/GID-switching identity sandbox. For quick
 #    testing, bind anyuid. For tighter deployments, apply the custom SCC,
-#    ClusterRole, and ClusterRoleBinding shown below instead.
+#    ClusterRole, and ClusterRoleBinding shown below instead. The custom
+#    SCC must include CHOWN if AGENT_TOOL_SANDBOX_CHOWN_PATHS is configured.
 oc adm policy add-scc-to-user anyuid -z pi-forge -n pi-forge
 
 # 5. Verify
@@ -145,8 +146,11 @@ in [`docs/configuration.md`](../docs/configuration.md) and
   env value; it does not expand `@/path`. See `docs/configuration.md#ldap-browser-login`.
 - **Agent tool identity sandbox.** `AGENT_TOOL_SANDBOX_ENABLED=false`
   by default. To enable it on vanilla Kubernetes, the container security
-  context must run the server as root and permit only the identity-switch
-  capabilities:
+  context must run the server as root and permit the sandbox capabilities.
+  `SETUID`/`SETGID` are required for the identity switch. `CHOWN` is required
+  for browser-created workspace ownership handoff and when using
+  `AGENT_TOOL_SANDBOX_CHOWN_PATHS`; without it, startup fails on the first
+  ownership change.
 
   ```yaml
   securityContext:
@@ -155,7 +159,7 @@ in [`docs/configuration.md`](../docs/configuration.md) and
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
-      add: ["SETUID", "SETGID"]
+      add: ["SETUID", "SETGID", "CHOWN"]
   ```
 
   The workspace PVC must be writable by `AGENT_TOOL_UID:GID`; Pi config,
@@ -168,9 +172,10 @@ in [`docs/configuration.md`](../docs/configuration.md) and
 - **OpenShift SCC.** restricted-v2 random UID will not support identity
   sandbox. Use `anyuid` for a simple deployment, or a custom SCC that
   allows UID 0 plus `SETUID`/`SETGID` for the app container and
-  `CHOWN`/`FOWNER` for the initContainer; privileged mode is not required.
-  Keep SCC grants with namespace/security bootstrap, not inside the
-  `DeploymentConfig`. Replace `pi-forge` with your namespace and
+  `CHOWN`/`FOWNER` for the initContainer. `CHOWN` is also required by the app
+  container when `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is configured; privileged
+  mode is not required. Keep SCC grants with namespace/security bootstrap, not
+  inside the `DeploymentConfig`. Replace `pi-forge` with your namespace and
   ServiceAccount names if they differ.
 
   Declarative example for the built-in `anyuid` SCC:
@@ -269,9 +274,11 @@ in [`docs/configuration.md`](../docs/configuration.md) and
   ```
 
   Security trade-offs: the custom SCC intentionally allows UID 0,
-  `SETUID`/`SETGID`, and the initContainer's `CHOWN`/`FOWNER`, so bind it
-  only to pi-forge's ServiceAccount. Do not add broader capabilities unless
-  your storage or platform policy requires them. Keep
+  `SETUID`/`SETGID`, and `CHOWN`/`FOWNER`, so bind it only to pi-forge's
+  ServiceAccount. `CHOWN` is needed by the initContainer, by browser-created
+  workspace ownership handoff, and by `AGENT_TOOL_SANDBOX_CHOWN_PATHS` when
+  configured. Do not add broader capabilities unless your storage or platform
+  policy requires them. Keep
   `readOnlyRootFilesystem: true` in the pi-forge container and
   mount `/tmp` as `emptyDir`; the SCC above does not force it so operators
   can use overlays. Do not use `fsGroup` to make sensitive volumes broadly

--- a/kubernetes/kube/deployment.yaml
+++ b/kubernetes/kube/deployment.yaml
@@ -74,7 +74,10 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["SETUID", "SETGID"]
+              # SETUID/SETGID are required for sandbox user switching.
+              # CHOWN is required only when AGENT_TOOL_SANDBOX_CHOWN_PATHS
+              # is set; without CHOWN, startup fails on the chown step.
+              add: ["SETUID", "SETGID", "CHOWN"]
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
@@ -104,6 +107,11 @@ spec:
               value: "1001"
             - name: AGENT_TOOL_GID
               value: "1001"
+            # Optional: comma/space-separated existing non-secret paths
+            # to chown to AGENT_TOOL_UID:GID at startup. Requires CHOWN
+            # in the container capabilities above.
+            - name: AGENT_TOOL_SANDBOX_CHOWN_PATHS
+              value: ""
             - name: LOG_LEVEL
               value: info
             - name: TRUST_PROXY

--- a/kubernetes/openshift/deployment.yaml
+++ b/kubernetes/openshift/deployment.yaml
@@ -62,7 +62,10 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["SETUID", "SETGID"]
+              # SETUID/SETGID are required for sandbox user switching.
+              # CHOWN is required only when AGENT_TOOL_SANDBOX_CHOWN_PATHS
+              # is set; without CHOWN, startup fails on the chown step.
+              add: ["SETUID", "SETGID", "CHOWN"]
             readOnlyRootFilesystem: true
           ports:
             - containerPort: 3000
@@ -92,6 +95,11 @@ spec:
               value: "1001"
             - name: AGENT_TOOL_GID
               value: "1001"
+            # Optional: comma/space-separated existing non-secret paths
+            # to chown to AGENT_TOOL_UID:GID at startup. Requires CHOWN
+            # in the container capabilities above.
+            - name: AGENT_TOOL_SANDBOX_CHOWN_PATHS
+              value: ""
             - name: LOG_LEVEL
               value: info
             - name: TRUST_PROXY

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -404,6 +404,14 @@ const FLAGS: readonly FlagDef[] = [
     desc: "Writable HOME for sandboxed model/user shell processes",
     defaultText: "/home/pi-tools",
   },
+  {
+    name: "agent-tool-sandbox-chown-paths",
+    env: "AGENT_TOOL_SANDBOX_CHOWN_PATHS",
+    type: "list",
+    group: "sandbox",
+    desc: "Existing paths to recursively chown to the sandbox UID:GID at startup",
+    defaultText: "(empty)",
+  },
   // rate limits
   {
     name: "rate-limit-login-max",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -245,6 +245,9 @@ const AGENT_TOOL_SANDBOX_ENABLED = readBool("AGENT_TOOL_SANDBOX_ENABLED", false)
 const AGENT_TOOL_UID = readOptionalInt("AGENT_TOOL_UID");
 const AGENT_TOOL_GID = readOptionalInt("AGENT_TOOL_GID");
 const AGENT_TOOL_HOME = resolve(readEnv("AGENT_TOOL_HOME") ?? "/home/pi-tools");
+const AGENT_TOOL_SANDBOX_CHOWN_PATHS = readStringList("AGENT_TOOL_SANDBOX_CHOWN_PATHS").map(
+  (path) => resolve(path),
+);
 if (AGENT_TOOL_SANDBOX_ENABLED && (AGENT_TOOL_UID === undefined || AGENT_TOOL_GID === undefined)) {
   throw new Error(
     "config: AGENT_TOOL_SANDBOX_ENABLED=true requires numeric AGENT_TOOL_UID and AGENT_TOOL_GID",
@@ -570,6 +573,7 @@ export const config = Object.freeze({
     uid: AGENT_TOOL_UID,
     gid: AGENT_TOOL_GID,
     home: AGENT_TOOL_HOME,
+    chownPaths: Object.freeze(AGENT_TOOL_SANDBOX_CHOWN_PATHS),
   }),
   /**
    * How long a detached PTY (its WebSocket closed but no replacement

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -45,6 +45,7 @@ import { disposeAllSessions } from "./session-registry.js";
 import { cleanupArchivedSessions } from "./session-archive.js";
 import { disposeAllPtys, installPtyExitHandler } from "./pty-manager.js";
 import { logSecretHygieneState } from "./agent-resource-loader.js";
+import { applySandboxStartupChowns } from "./sandbox-startup-permissions.js";
 
 /**
  * Per-route auth metadata. Routes that should skip the auth preHandler set
@@ -542,6 +543,13 @@ export async function start(): Promise<void> {
       process.exit(1);
     }
   }
+  try {
+    await applySandboxStartupChowns();
+  } catch (err) {
+    console.error("[pi-forge] failed to apply sandbox startup chowns:", (err as Error).message);
+    process.exit(1);
+  }
+
   const fastify = await buildServer();
   // One-line confirmation of optional security knobs that are easy to
   // typo or forget to wire through. If you add another opt-in

--- a/packages/server/src/sandbox-startup-permissions.ts
+++ b/packages/server/src/sandbox-startup-permissions.ts
@@ -1,0 +1,67 @@
+import { lchown, lstat, readdir } from "node:fs/promises";
+import { relative, resolve, sep } from "node:path";
+import { config } from "./config.js";
+
+const PI_CONFIG_RESOURCE_DIRS = ["skills", "npm", "git", "extensions", "prompts", "themes"];
+
+function isSameOrInside(parent: string, candidate: string): boolean {
+  const rel = relative(parent, candidate);
+  return rel === "" || (rel.length > 0 && !rel.startsWith("..") && !rel.includes(`..${sep}`));
+}
+
+function describeAllowedSandboxChownPaths(): string {
+  const resourcePaths = PI_CONFIG_RESOURCE_DIRS.map((dir) => resolve(config.piConfigDir, dir));
+  return [config.workspacePath, config.agentToolSandbox.home, ...resourcePaths].join(", ");
+}
+
+function assertAllowedSandboxChownPath(path: string): void {
+  const abs = resolve(path);
+  const allowedRoots = [
+    config.workspacePath,
+    config.agentToolSandbox.home,
+    ...PI_CONFIG_RESOURCE_DIRS.map((dir) => resolve(config.piConfigDir, dir)),
+  ];
+  if (allowedRoots.some((root) => isSameOrInside(root, abs))) return;
+  throw new Error(
+    `sandbox startup chown path ${abs} is outside allowed roots. ` +
+      `Allowed roots: ${describeAllowedSandboxChownPaths()}`,
+  );
+}
+
+async function chownRecursiveNoFollow(path: string, uid: number, gid: number): Promise<void> {
+  const st = await lstat(path);
+  if (st.isDirectory()) {
+    const entries = await readdir(path);
+    for (const entry of entries) {
+      await chownRecursiveNoFollow(resolve(path, entry), uid, gid);
+    }
+  }
+  if (st.uid === uid && st.gid === gid) return;
+  await lchown(path, uid, gid);
+}
+
+export async function applySandboxStartupChowns(): Promise<void> {
+  const paths = config.agentToolSandbox.chownPaths;
+  if (paths.length === 0) return;
+  if (!config.agentToolSandbox.enabled) {
+    console.warn(
+      "[sandbox-startup] AGENT_TOOL_SANDBOX_CHOWN_PATHS is set but sandbox mode is disabled; skipping chown",
+    );
+    return;
+  }
+
+  const uid = config.agentToolSandbox.uid!;
+  const gid = config.agentToolSandbox.gid!;
+  for (const path of paths) {
+    const abs = resolve(path);
+    assertAllowedSandboxChownPath(abs);
+    await chownRecursiveNoFollow(abs, uid, gid);
+    console.log(`[sandbox-startup] chowned ${abs} to ${uid}:${gid}`);
+  }
+}
+
+export const sandboxStartupPermissionsInternals = Object.freeze({
+  PI_CONFIG_RESOURCE_DIRS,
+  isSameOrInside,
+  assertAllowedSandboxChownPath,
+});

--- a/tests/test-agent-tool-sandbox.ts
+++ b/tests/test-agent-tool-sandbox.ts
@@ -31,6 +31,9 @@ const piConfig = resolve(workspace, ".pi", "agent");
 const forgeData = resolve(tmp, "forge-data");
 const toolHome = resolve(tmp, "pi-tools-home");
 const outside = resolve(tmp, "outside");
+const chownWorkspaceTarget = resolve(workspace, "chown-me");
+const chownAttemptTarget = resolve(workspace, "chown-attempt");
+const chownSkillsTarget = resolve(piConfig, "skills", "startup-owned");
 mkdirSync(workspace, { recursive: true });
 mkdirSync(project, { recursive: true });
 mkdirSync(shared, { recursive: true });
@@ -38,6 +41,11 @@ mkdirSync(piConfig, { recursive: true });
 mkdirSync(forgeData, { recursive: true });
 mkdirSync(toolHome, { recursive: true });
 mkdirSync(outside, { recursive: true });
+mkdirSync(chownWorkspaceTarget, { recursive: true });
+mkdirSync(chownAttemptTarget, { recursive: true });
+mkdirSync(chownSkillsTarget, { recursive: true });
+writeFileSync(resolve(chownWorkspaceTarget, "nested.txt"), "startup chown workspace\n");
+writeFileSync(resolve(chownSkillsTarget, "skill.txt"), "startup chown skill\n");
 writeFileSync(resolve(project, "hello.txt"), "hello workspace\n");
 writeFileSync(resolve(shared, "shared.txt"), "hello shared workspace\n");
 writeFileSync(resolve(outside, "secret.txt"), "outside secret\n");
@@ -55,6 +63,7 @@ process.env.AGENT_TOOL_SANDBOX_ENABLED = "true";
 process.env.AGENT_TOOL_UID = String(process.getuid?.() ?? 1000);
 process.env.AGENT_TOOL_GID = String(process.getgid?.() ?? 1000);
 process.env.AGENT_TOOL_HOME = toolHome;
+process.env.AGENT_TOOL_SANDBOX_CHOWN_PATHS = `${chownWorkspaceTarget},${chownSkillsTarget}`;
 process.env.SERVE_CLIENT = "false";
 
 try {
@@ -114,6 +123,82 @@ try {
       },
     );
     assert("LDAP file refs rejected", ldapFile.status !== 0, ldapFile.stderr);
+
+    const badChown = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+          const { applySandboxStartupChowns } = await import(${JSON.stringify(
+            resolve(repoRoot, "packages/server/dist/sandbox-startup-permissions.js"),
+          )});
+          await applySandboxStartupChowns();
+        `,
+      ],
+      {
+        env: {
+          ...baseEnv,
+          AGENT_TOOL_UID: String(process.getuid?.() ?? 1000),
+          AGENT_TOOL_GID: String(process.getgid?.() ?? 1000),
+          AGENT_TOOL_HOME: toolHome,
+          AGENT_TOOL_SANDBOX_CHOWN_PATHS: outside,
+        },
+        encoding: "utf8",
+      },
+    );
+    assert(
+      "startup chown outside allowed roots is rejected",
+      badChown.status !== 0,
+      badChown.stderr,
+    );
+
+    const currentUid = process.getuid?.() ?? 1000;
+    const currentGid = process.getgid?.() ?? 1000;
+    const targetUid = currentUid === 1 ? 2 : 1;
+    const targetGid = currentGid === 1 ? 2 : 1;
+    const chownAttempt = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+          import { statSync } from "node:fs";
+          const { applySandboxStartupChowns } = await import(${JSON.stringify(
+            resolve(repoRoot, "packages/server/dist/sandbox-startup-permissions.js"),
+          )});
+          await applySandboxStartupChowns();
+          const st = statSync(${JSON.stringify(chownAttemptTarget)});
+          console.log(JSON.stringify({ uid: st.uid, gid: st.gid }));
+        `,
+      ],
+      {
+        env: {
+          ...baseEnv,
+          AGENT_TOOL_UID: String(targetUid),
+          AGENT_TOOL_GID: String(targetGid),
+          AGENT_TOOL_HOME: toolHome,
+          AGENT_TOOL_SANDBOX_CHOWN_PATHS: chownAttemptTarget,
+        },
+        encoding: "utf8",
+      },
+    );
+    if (currentUid === 0) {
+      const statJson = chownAttempt.stdout.trim().split(/\r?\n/).at(-1) ?? "{}";
+      const changed = JSON.parse(statJson) as { uid?: number; gid?: number };
+      assert("startup chown changes ownership when privileged", chownAttempt.status === 0);
+      assert(
+        "startup chown target has requested owner/group",
+        changed.uid === targetUid && changed.gid === targetGid,
+        chownAttempt.stdout,
+      );
+    } else {
+      assert(
+        "startup chown attempts ownership change and fails without privilege",
+        chownAttempt.status !== 0 && /EPERM|operation not permitted/i.test(chownAttempt.stderr),
+        chownAttempt.stderr || chownAttempt.stdout,
+      );
+    }
   }
 
   const { resolveAgentToolPath } = (await import(
@@ -150,6 +235,21 @@ try {
       opts?: { expectedSha256?: string; overwrite?: boolean },
     ) => Promise<{ path: string; size: number; sha256: string }>;
   };
+  const { applySandboxStartupChowns } = (await import(
+    resolve(repoRoot, "packages/server/dist/sandbox-startup-permissions.js")
+  )) as { applySandboxStartupChowns: () => Promise<void> };
+
+  console.log("\nsandbox startup chown");
+  await applySandboxStartupChowns();
+  assert(
+    "startup chown workspace target still exists",
+    statSync(chownWorkspaceTarget).isDirectory(),
+  );
+  assert(
+    "startup chown nested file still exists",
+    statSync(resolve(chownWorkspaceTarget, "nested.txt")).isFile(),
+  );
+  assert("startup chown skills target still exists", statSync(chownSkillsTarget).isDirectory());
 
   console.log("\nsandbox shell env");
   const shellEnv = toolShellEnv({ ...process.env, HOME: "/home/pi", USER: "pi", LOGNAME: "pi" });


### PR DESCRIPTION
## Summary

Sandboxed tool processes run as the restricted `pi-tools` identity, but the container image did not guarantee builtin pi SDK documentation under `/app/node_modules/@earendil-works/pi-coding-agent/` was readable by that user. Operators also needed a controlled way to hand ownership of selected non-secret writable mounts to `pi-tools` at startup when running the server as root in sandbox mode.

This PR makes the builtin pi SDK documentation world-readable in the Docker image without adding broad write permissions, and adds an opt-in sandbox startup chown helper for existing non-secret paths. The helper is scoped to workspace, tool home, and known non-secret Pi resource subtrees so protected forge data and Pi auth/model/settings files are not accidentally exposed.

## Usage

```bash
# Docker sandbox mode
AGENT_TOOL_SANDBOX_ENABLED=true
AGENT_TOOL_UID=1001
AGENT_TOOL_GID=1001
AGENT_TOOL_HOME=/home/pi-tools

# Optional: only for existing non-secret paths that should belong to pi-tools.
# Requires CHOWN capability in addition to SETUID/SETGID.
AGENT_TOOL_SANDBOX_CHOWN_PATHS=/workspace,/home/pi/.pi/agent/skills
```

`SETUID` and `SETGID` are required for sandbox identity switching. `CHOWN` is additionally required only when `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is set; without it, startup fails on the first ownership change. The helper rejects paths outside the allowed non-secret roots.

## What changed

- `docker/Dockerfile` — makes `/app/node_modules/@earendil-works/pi-coding-agent/` readable/searchable by anyone while removing group/other write bits.
- `packages/server/src/config.ts` / `packages/server/src/cli.ts` — adds `AGENT_TOOL_SANDBOX_CHOWN_PATHS` and `--agent-tool-sandbox-chown-paths` using the existing env/CLI patterns.
- `packages/server/src/sandbox-startup-permissions.ts` / `packages/server/src/index.ts` — applies scoped recursive startup chowns before the HTTP server starts in sandbox mode.
- `docker/docker-compose.sandbox.yml`, `kubernetes/*` — documents/adds `CHOWN` capability where startup chown support is expected to work.
- `docs/agent-tool-sandbox.md`, `docs/configuration.md`, `docs/containers.md`, `docs/site/docs/*.html`, `docs/agent/config.md` — documents the new env var, allowed scope, capability requirements, and failure mode.
- `tests/test-agent-tool-sandbox.ts` — covers allowed/rejected startup chown paths and exercises real ownership-change behavior when privileged, with explicit unprivileged fallback expectations.

## Test plan

- [x] `npm run format`
- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only agent-tool-sandbox,cli-flags`
- [x] `git diff --check`
- [ ] CI green before merge
