### PR TITLE
chore: bump pi sdk to 0.80.10

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -524,14 +524,15 @@ curl -s -X PUT -H "Authorization: Bearer $KEY" -H "Content-Type: application/jso
 ### Read / write models.json (custom providers)
 
 ```bash
-# GET returns the file with `apiKey` / `apiKeyCommand` REPLACED by
-# "***REDACTED***" so the raw secret never leaves the server. The
-# persisted file is unchanged; PUT takes the actual values.
+# GET returns the file with `apiKey` REPLACED by "***REDACTED***" so the
+# raw secret never leaves the server. SDK 0.80 command-valued apiKey strings
+# such as "!op read ..." are also redacted; legacy apiKeyCommand is migrated.
+# The persisted file is otherwise unchanged; PUT takes the actual values.
 curl -s -H "Authorization: Bearer $KEY" $BASE/api/v1/config/models
 
 curl -s -X PUT -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
   $BASE/api/v1/config/models \
-  -d '{"providers":{"vllm-local":{"api":"openai-completions","url":"http://localhost:8000/v1","models":[...]}}}'
+  -d '{"providers":{"vllm-local":{"api":"openai-completions","baseUrl":"http://localhost:8000/v1","apiKey":"$VLLM_API_KEY","models":[...]}}}'
 ```
 
 ### List / toggle skills

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,7 +195,8 @@ internal proxy.
   "providers": {
     "vllm-local": {
       "api": "openai-completions",
-      "url": "http://localhost:8000/v1",
+      "baseUrl": "http://localhost:8000/v1",
+      "apiKey": "$VLLM_API_KEY",
       "models": [
         {
           "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -211,6 +212,14 @@ internal proxy.
   }
 }
 ```
+
+`apiKey` is optional when credentials come from `auth.json`, `/login`, or a
+runtime environment supported by the SDK. In SDK 0.80+, this single field also
+supports value resolution: use `$ENV_VAR` / `${ENV_VAR}` for environment
+interpolation or prefix a command with `!`, for example
+`"apiKey": "!op read 'op://vault/item/credential'"`. Older pi-forge
+`apiKeyCommand` entries are migrated automatically to this `apiKey` command
+syntax on the next config read/write or session start.
 
 **Per-model fields:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2266,12 +2266,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.10.tgz",
-      "integrity": "sha512-XKxgdjhcPuyjrthCOFSgfzT3xZ1uBrJ1IMVDxci1to6hIN6BIg9J5iY8q0pGXK1DLgATLP23da+1UyZLwA360Q==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.1.tgz",
+      "integrity": "sha512-/Y4XzinEIQekXRjMxtYy2QJt6y43Gw+7itAvsA8TNCuUrYMBI6WvZjlMMcYsjK+Oyt919noN0EsT9/Xd3D0ziw==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.10",
+        "@earendil-works/pi-ai": "^0.80.1",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -2290,9 +2290,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.10.tgz",
-      "integrity": "sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.1.tgz",
+      "integrity": "sha512-qsHmuoBRu7a6rkOis/Elwl8jEhA9T884H/mXMP3tbz1slEBI+dHaY3zJ0nlEqUl+jcTz1FJNdgOVLG4sQHOPXQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -2315,15 +2315,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.10.tgz",
-      "integrity": "sha512-YxaRhmgyDTvLDdGVbe7YzTHV80oL5mX5odg6EhGHz3w5Wu1Ix8DCw7bhtiOBLGQNFRcknia0zPmVWIj30XP1EA==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.1.tgz",
+      "integrity": "sha512-tlFNPF5cbQsVOASvgxNmC19+CkncR4DZwa8e+uNf74D0Y2Pruqgqvh8biFzHcwQVqVqagFRQ7QM1yhFX1z+lEw==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.10",
-        "@earendil-works/pi-ai": "^0.79.10",
-        "@earendil-works/pi-tui": "^0.79.10",
+        "@earendil-works/pi-agent-core": "^0.80.1",
+        "@earendil-works/pi-ai": "^0.80.1",
+        "@earendil-works/pi-tui": "^0.80.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -2786,11 +2786,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.10.tgz",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.1.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.10",
+        "@earendil-works/pi-ai": "^0.80.1",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -2800,8 +2800,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.10.tgz",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -2824,8 +2824,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.10.tgz",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.1.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -8285,7 +8285,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -10674,7 +10673,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -11303,7 +11301,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -14816,7 +14813,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17161,9 +17157,9 @@
       "name": "@pi-forge/server",
       "version": "1.4.4",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "0.79.10",
-        "@earendil-works/pi-ai": "0.79.10",
-        "@earendil-works/pi-coding-agent": "0.79.10",
+        "@earendil-works/pi-agent-core": "0.80.1",
+        "@earendil-works/pi-ai": "0.80.1",
+        "@earendil-works/pi-coding-agent": "0.80.1",
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^10.0.0",
         "@fastify/rate-limit": "^11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2266,12 +2266,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.1.tgz",
-      "integrity": "sha512-/Y4XzinEIQekXRjMxtYy2QJt6y43Gw+7itAvsA8TNCuUrYMBI6WvZjlMMcYsjK+Oyt919noN0EsT9/Xd3D0ziw==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
+      "integrity": "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.1",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -2290,9 +2290,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.1.tgz",
-      "integrity": "sha512-qsHmuoBRu7a6rkOis/Elwl8jEhA9T884H/mXMP3tbz1slEBI+dHaY3zJ0nlEqUl+jcTz1FJNdgOVLG4sQHOPXQ==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -2315,15 +2315,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.1.tgz",
-      "integrity": "sha512-tlFNPF5cbQsVOASvgxNmC19+CkncR4DZwa8e+uNf74D0Y2Pruqgqvh8biFzHcwQVqVqagFRQ7QM1yhFX1z+lEw==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.1",
-        "@earendil-works/pi-ai": "^0.80.1",
-        "@earendil-works/pi-tui": "^0.80.1",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -2786,11 +2786,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.1.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.1",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -2800,8 +2800,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.1.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -2824,8 +2824,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.1.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -17157,9 +17157,9 @@
       "name": "@pi-forge/server",
       "version": "1.4.4",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "0.80.1",
-        "@earendil-works/pi-ai": "0.80.1",
-        "@earendil-works/pi-coding-agent": "0.80.1",
+        "@earendil-works/pi-agent-core": "0.80.10",
+        "@earendil-works/pi-ai": "0.80.10",
+        "@earendil-works/pi-coding-agent": "0.80.10",
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^10.0.0",
         "@fastify/rate-limit": "^11.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,9 +9,9 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.80.1",
-    "@earendil-works/pi-ai": "0.80.1",
-    "@earendil-works/pi-coding-agent": "0.80.1",
+    "@earendil-works/pi-agent-core": "0.80.10",
+    "@earendil-works/pi-ai": "0.80.10",
+    "@earendil-works/pi-coding-agent": "0.80.10",
     "@fastify/cors": "^11.0.1",
     "@fastify/multipart": "^10.0.0",
     "@fastify/rate-limit": "^11.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,9 +9,9 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.79.10",
-    "@earendil-works/pi-ai": "0.79.10",
-    "@earendil-works/pi-coding-agent": "0.79.10",
+    "@earendil-works/pi-agent-core": "0.80.1",
+    "@earendil-works/pi-ai": "0.80.1",
+    "@earendil-works/pi-coding-agent": "0.80.1",
     "@fastify/cors": "^11.0.1",
     "@fastify/multipart": "^10.0.0",
     "@fastify/rate-limit": "^11.0.0",

--- a/packages/server/src/config-manager.ts
+++ b/packages/server/src/config-manager.ts
@@ -49,21 +49,52 @@ export interface ModelsJson {
 }
 
 export interface ProviderConfig {
+  name?: string;
   baseUrl?: string;
+  /**
+   * SDK 0.80+ resolves literal values, `$ENV` / `${ENV}` interpolation, and
+   * command values prefixed with `!` from this single field.
+   */
   apiKey?: string;
+  /**
+   * Legacy pi-forge / older pi SDK shape. SDK 0.80 no longer consumes this
+   * field, so config-manager migrates it to `apiKey: "!..."` before the SDK
+   * reads models.json.
+   */
   apiKeyCommand?: string | string[];
   api?: "messages" | "responses" | "completions" | string;
   authHeader?: boolean;
   headers?: Record<string, string>;
+  compat?: Record<string, unknown>;
+  modelOverrides?: Record<
+    string,
+    {
+      name?: string;
+      baseUrl?: string;
+      api?: string;
+      reasoning?: boolean;
+      thinkingLevelMap?: Record<string, string | null>;
+      input?: ("text" | "image")[];
+      cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+      contextWindow?: number;
+      maxTokens?: number;
+      headers?: Record<string, string>;
+      compat?: Record<string, unknown>;
+    }
+  >;
   models?: {
     id: string;
     name: string;
     api?: string;
+    baseUrl?: string;
     reasoning: boolean;
+    thinkingLevelMap?: Record<string, string | null>;
     input: ("text" | "image")[];
     cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
     contextWindow: number;
     maxTokens: number;
+    headers?: Record<string, string>;
+    compat?: Record<string, unknown>;
   }[];
 }
 
@@ -186,6 +217,53 @@ async function readJsonOr<T>(path: string, fallback: T): Promise<T> {
 // ---------------------------------------------------------------------------
 // models.json
 
+function shellQuote(arg: string): string {
+  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, `'"'"'`)}'`;
+}
+
+function apiKeyCommandToConfigValue(command: string | string[]): string {
+  const rendered = Array.isArray(command) ? command.map(shellQuote).join(" ") : command;
+  return rendered.startsWith("!") ? rendered : `!${rendered}`;
+}
+
+function normalizeLegacyProviderConfig(provider: ProviderConfig): {
+  provider: ProviderConfig;
+  changed: boolean;
+} {
+  if (provider.apiKeyCommand === undefined) return { provider, changed: false };
+  const { apiKeyCommand, ...rest } = provider;
+  const normalized: ProviderConfig = { ...rest };
+  if (normalized.apiKey === undefined) {
+    normalized.apiKey = apiKeyCommandToConfigValue(apiKeyCommand);
+  }
+  return { provider: normalized, changed: true };
+}
+
+function normalizeLegacyModelsJson(data: ModelsJson): { data: ModelsJson; changed: boolean } {
+  let changed = false;
+  const providers: Record<string, ProviderConfig> = {};
+  for (const [name, provider] of Object.entries(data.providers ?? {})) {
+    const normalized = normalizeLegacyProviderConfig(provider);
+    providers[name] = normalized.provider;
+    changed = changed || normalized.changed;
+  }
+  return { data: { providers }, changed };
+}
+
+/**
+ * SDK 0.80 removed `models.json#providers.*.apiKeyCommand`; commands now live
+ * in `apiKey` with a leading `!`. Persistently migrate the old shape before
+ * handing models.json to the SDK so existing pi-forge installs keep working.
+ */
+export async function migrateLegacyModelsJsonIfNeeded(): Promise<boolean> {
+  const current = await readModelsJson();
+  const normalized = normalizeLegacyModelsJson(current);
+  if (!normalized.changed) return false;
+  await atomicWriteJson(MODELS_FILE(), normalized.data);
+  return true;
+}
+
 export async function readModelsJson(): Promise<ModelsJson> {
   const data = await readJsonOr<unknown>(MODELS_FILE(), { providers: {} });
   if (typeof data !== "object" || data === null || !("providers" in data)) {
@@ -201,7 +279,7 @@ export async function readModelsJson(): Promise<ModelsJson> {
 /**
  * Like readModelsJson but with secret-shaped fields replaced with a literal
  * sentinel. Used by the GET /config/models route so an inline `apiKey` in
- * models.json (the pi SDK accepts both inline keys and `apiKeyCommand`) is
+ * models.json (including SDK 0.80 command values such as `!op read ...`) is
  * never echoed back to a browser or to an operator's log shipper.
  *
  * The persisted file is unchanged — writeModelsJson takes the actual
@@ -209,6 +287,7 @@ export async function readModelsJson(): Promise<ModelsJson> {
  */
 const SECRET_PLACEHOLDER = "***REDACTED***";
 export async function readModelsJsonRedacted(): Promise<ModelsJson> {
+  await migrateLegacyModelsJsonIfNeeded();
   const raw = await readModelsJson();
   const out: Record<string, ProviderConfig> = {};
   for (const [name, provider] of Object.entries(raw.providers)) {
@@ -227,7 +306,7 @@ function redactProviderConfig(p: ProviderConfig): ProviderConfig {
 
 export async function writeModelsJson(data: ModelsJson): Promise<void> {
   // Round-trip secret protection: GET /config/models redacts inline
-  // `apiKey` / `apiKeyCommand` to a sentinel string. If the editor
+  // `apiKey` / legacy `apiKeyCommand` to a sentinel string. If the editor
   // PUTs the body back unchanged, the literal sentinel would
   // overwrite the real secret on disk and the next request would go
   // out with `Authorization: Bearer ***REDACTED***`. Pre-merge here
@@ -245,9 +324,11 @@ export async function writeModelsJson(data: ModelsJson): Promise<void> {
     }
     if (cleaned.apiKeyCommand === SECRET_PLACEHOLDER) {
       if (prior?.apiKeyCommand !== undefined) cleaned.apiKeyCommand = prior.apiKeyCommand;
+      else if (prior?.apiKey !== undefined) cleaned.apiKey = prior.apiKey;
       else delete cleaned.apiKeyCommand;
     }
-    safe.providers[name] = cleaned;
+    const normalized = normalizeLegacyProviderConfig(cleaned);
+    safe.providers[name] = normalized.provider;
   }
   await atomicWriteJson(MODELS_FILE(), safe);
 }
@@ -383,6 +464,7 @@ export async function updateSettings(patch: Record<string, unknown>): Promise<Se
 // needing a restart.
 
 export async function liveProvidersListing(): Promise<ProvidersListing> {
+  await migrateLegacyModelsJsonIfNeeded();
   const store = authStorage();
   const registry = ModelRegistry.create(store, MODELS_FILE());
   const all: Model<Api>[] = registry.getAll();

--- a/packages/server/src/config-manager.ts
+++ b/packages/server/src/config-manager.ts
@@ -2,9 +2,10 @@ import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import {
-  AuthStorage,
   DefaultResourceLoader,
   ModelRegistry,
+  ModelRuntime,
+  type ModelRuntime as ModelRuntimeInstance,
   type PromptTemplate,
   type ResourceDiagnostic,
   SettingsManager,
@@ -14,6 +15,7 @@ import {
 import {
   getSupportedThinkingLevels,
   type Api,
+  type Credential,
   type Model,
   type ModelThinkingLevel,
 } from "@earendil-works/pi-ai";
@@ -334,10 +336,23 @@ export async function writeModelsJson(data: ModelsJson): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// auth.json — uses the SDK's AuthStorage for locking + presence semantics.
+// auth.json / models.json — use the SDK's async ModelRuntime facade for 0.80+.
 
-function authStorage(): AuthStorage {
-  return AuthStorage.create(AUTH_FILE());
+type AuthJson = Record<string, Credential>;
+
+async function readAuthJson(): Promise<AuthJson> {
+  const data = await readJsonOr<unknown>(AUTH_FILE(), {});
+  if (typeof data !== "object" || data === null) return {};
+  return data as AuthJson;
+}
+
+async function writeAuthJson(data: AuthJson): Promise<void> {
+  await atomicWriteJson(AUTH_FILE(), data);
+}
+
+async function liveModelRuntime(): Promise<ModelRuntime> {
+  await migrateLegacyModelsJsonIfNeeded();
+  return ModelRuntime.create({ authPath: AUTH_FILE(), modelsPath: MODELS_FILE() });
 }
 
 /**
@@ -347,32 +362,30 @@ function authStorage(): AuthStorage {
  * knows built-in providers and silently returns undefined for anything
  * defined in models.json.
  */
-export function liveModelRegistry(): ModelRegistry {
-  return ModelRegistry.create(authStorage(), MODELS_FILE());
+export async function liveModelRegistry(): Promise<ModelRegistry> {
+  const runtime = await liveModelRuntime();
+  return new ModelRegistry(runtime);
 }
 
-export function readAuthSummary(): AuthSummary {
-  const store = authStorage();
+export async function readAuthSummary(): Promise<AuthSummary> {
   const providers: Record<string, AuthEntry> = {};
-  // `list()` enumerates providers stored in auth.json. Augment each with the
-  // typed `getAuthStatus` shape so the response surface matches what the UI
-  // would render (configured + source + label, no key value).
-  for (const provider of store.list()) {
-    const status = store.getAuthStatus(provider);
+  for (const [provider, credential] of Object.entries(await readAuthJson())) {
     providers[provider] = {
-      configured: status.configured,
-      source: status.source,
-      label: status.label,
+      configured: true,
+      source: "stored",
+      label: credential.type === "oauth" ? "OAuth" : "Stored API key",
     };
   }
   return { providers };
 }
 
-export function writeApiKey(provider: string, apiKey: string): void {
+export async function writeApiKey(provider: string, apiKey: string): Promise<void> {
   if (provider.length === 0) throw new Error("provider name cannot be empty");
   if (apiKey.length === 0) throw new Error("api key cannot be empty");
-  const store = authStorage();
-  store.set(provider, { type: "api_key", key: apiKey });
+  if (DANGEROUS_KEYS.has(provider)) throw new Error("provider name cannot be reserved");
+  const auth = await readAuthJson();
+  auth[provider] = { type: "api_key", key: apiKey };
+  await writeAuthJson(auth);
 }
 
 export class AuthProviderNotFoundError extends Error {
@@ -382,10 +395,23 @@ export class AuthProviderNotFoundError extends Error {
   }
 }
 
-export function removeApiKey(provider: string): void {
-  const store = authStorage();
-  if (!store.has(provider)) throw new AuthProviderNotFoundError(provider);
-  store.remove(provider);
+export async function removeApiKey(provider: string): Promise<void> {
+  const auth = await readAuthJson();
+  if (auth[provider] === undefined) throw new AuthProviderNotFoundError(provider);
+  delete auth[provider];
+  await writeAuthJson(auth);
+}
+
+export async function syncStoredApiKeyToRuntime(
+  runtime: ModelRuntimeInstance,
+  provider: string,
+): Promise<void> {
+  const credential = (await readAuthJson())[provider];
+  if (credential?.type === "api_key" && typeof credential.key === "string") {
+    await runtime.setRuntimeApiKey(provider, credential.key);
+  } else {
+    await runtime.removeRuntimeApiKey(provider);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -465,8 +491,7 @@ export async function updateSettings(patch: Record<string, unknown>): Promise<Se
 
 export async function liveProvidersListing(): Promise<ProvidersListing> {
   await migrateLegacyModelsJsonIfNeeded();
-  const store = authStorage();
-  const registry = ModelRegistry.create(store, MODELS_FILE());
+  const registry = await liveModelRegistry();
   const all: Model<Api>[] = registry.getAll();
   // When HIDE_BUILTIN_PROVIDERS is on, restrict to providers whose
   // name appears as a key in models.json. Built-ins (anthropic,

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -544,7 +544,7 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (_req, reply) => {
       try {
-        return readAuthSummary();
+        return await readAuthSummary();
       } catch (err) {
         return internalError(reply, err);
       }
@@ -587,7 +587,7 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       try {
-        writeApiKey(req.params.provider, req.body.apiKey);
+        await writeApiKey(req.params.provider, req.body.apiKey);
         return { provider: req.params.provider, configured: true };
       } catch (err) {
         return internalError(reply, err);
@@ -611,7 +611,7 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (req, reply) => {
       try {
-        removeApiKey(req.params.provider);
+        await removeApiKey(req.params.provider);
         return reply.code(204).send();
       } catch (err) {
         if (err instanceof AuthProviderNotFoundError) {

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -293,8 +293,10 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
       schema: {
         description:
           "Read `models.json` (custom provider configurations). Inline `apiKey` " +
-          "and `apiKeyCommand` fields are returned as `***REDACTED***` so the " +
-          "raw secret never leaves the server. The persisted file is unchanged " +
+          "fields, including command values such as `!op read ...`, are returned " +
+          "as `***REDACTED***` so the raw secret never leaves the server. " +
+          "Legacy `apiKeyCommand` fields are migrated to SDK 0.80 `apiKey` command values. " +
+          "The persisted file is unchanged " +
           "— PUT /config/models takes the actual values; the redaction is on " +
           "the read path only.",
         tags: ["config"],

--- a/packages/server/src/routes/control.ts
+++ b/packages/server/src/routes/control.ts
@@ -14,6 +14,7 @@ import {
   liveModelRegistry,
   migrateLegacyModelsJsonIfNeeded,
   readSettings,
+  syncStoredApiKeyToRuntime,
   withSettingsLock,
   writeSettings,
 } from "../config-manager.js";
@@ -516,7 +517,7 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
       // collapsed to `unknown_model` and the user had no hint which side
       // was wrong.
       await migrateLegacyModelsJsonIfNeeded();
-      const registry = liveModelRegistry();
+      const registry = await liveModelRegistry();
       const providerKnown = registry.getAll().some((m) => m.provider === req.body.provider);
       if (!providerKnown) {
         return reply.code(400).send({ error: "unknown_provider" });
@@ -558,30 +559,13 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
           // undefined so we don't try to restore a phantom snapshot.
         }
         try {
-          // The live AgentSession was created with a ModelRegistry
-          // snapshot of auth.json + models.json at session-create time;
-          // the SDK never re-reads either file on its own. If the user
-          // added a provider/key AFTER this session was created, the
-          // SDK's `setModel` -> `_modelRegistry.hasConfiguredAuth(...)`
-          // check would fail against the stale snapshot even though
-          // our route-level `liveModelRegistry()` validation just
-          // passed (it reads fresh each call).
-          //
-          // TWO reloads are needed, in this order: ModelRegistry's
-          // `refresh()` re-reads models.json + resets API/OAuth
-          // provider registrations, but does NOT touch AuthStorage —
-          // the AuthStorage.data map (what `hasAuth(provider)` queries)
-          // stays frozen at session-create time. Without the explicit
-          // `authStorage.reload()`, refresh() alone closes only half
-          // the staleness gap and `set_model_failed` still fires for
-          // any provider whose key was added post-create.
-          //
-          // Both calls mutate in place, so every subsequent SDK use
-          // inside this session (turn execution, per-request auth
-          // lookup, model picker enumeration) also picks up the new
-          // keys without restarting the session.
-          live.session.modelRegistry.authStorage.reload();
-          live.session.modelRegistry.refresh();
+          // The live AgentSession was created with a ModelRuntime snapshot of
+          // auth.json + models.json at session-create time; refresh it before
+          // calling setModel so providers, models, and credentials added after
+          // session creation are visible without restarting the session.
+          await live.session.modelRuntime.reloadConfig();
+          await syncStoredApiKeyToRuntime(live.session.modelRuntime, req.body.provider);
+          await live.session.modelRuntime.refresh();
           // Wrap in withTimeout so a hung SDK setModel can't hold the
           // settings lock indefinitely. Without this, a single hung
           // setModel blocks every subsequent PUT /config/settings,

--- a/packages/server/src/routes/control.ts
+++ b/packages/server/src/routes/control.ts
@@ -12,6 +12,7 @@ import {
 } from "../session-registry.js";
 import {
   liveModelRegistry,
+  migrateLegacyModelsJsonIfNeeded,
   readSettings,
   withSettingsLock,
   writeSettings,
@@ -514,6 +515,7 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
       // diagnostic from a typo in the model id. Without this, both cases
       // collapsed to `unknown_model` and the user had no hint which side
       // was wrong.
+      await migrateLegacyModelsJsonIfNeeded();
       const registry = liveModelRegistry();
       const providerKnown = registry.getAll().some((m) => m.provider === req.body.provider);
       if (!providerKnown) {

--- a/packages/server/src/routes/prompt.ts
+++ b/packages/server/src/routes/prompt.ts
@@ -1,6 +1,7 @@
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import { ConversionError, convertAttachment, pickConverter } from "../attachment-converters.js";
 import { config } from "../config.js";
+import { syncStoredApiKeyToRuntime } from "../config-manager.js";
 import { formatErrorChain } from "../diagnostics.js";
 import { expandFileReferences, languageHintForPath } from "../file-references.js";
 import {
@@ -351,7 +352,9 @@ async function preflight(
     });
     return undefined;
   }
-  if (!live.session.modelRegistry.hasConfiguredAuth(model)) {
+  await live.session.modelRuntime.reloadConfig();
+  await syncStoredApiKeyToRuntime(live.session.modelRuntime, model.provider);
+  if (!live.session.modelRuntime.hasConfiguredAuth(model.provider)) {
     await reply.code(400).send({
       error: "no_api_key",
       message: `No API key configured for provider "${model.provider}". Add one via PUT /api/v1/config/auth/${model.provider}.`,

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -13,7 +13,11 @@ import { buildForgeResourceLoader } from "./agent-resource-loader.js";
 import { createSandboxedToolDefinitions } from "./agent-tool-overrides.js";
 import { config } from "./config.js";
 import { makeDedupe, makeLock } from "./concurrency.js";
-import { effectivePromptsForProject, effectiveSkillsForProject } from "./config-manager.js";
+import {
+  effectivePromptsForProject,
+  effectiveSkillsForProject,
+  migrateLegacyModelsJsonIfNeeded,
+} from "./config-manager.js";
 import { readProjects } from "./project-manager.js";
 import { filterEnabledTools, readToolOverrides } from "./tool-overrides.js";
 import { discoverExtensionResources } from "./extensions-discovery.js";
@@ -692,6 +696,7 @@ export async function createSession(
     settingsManager,
     projectId,
   );
+  await migrateLegacyModelsJsonIfNeeded();
   const { session } = await createAgentSession({
     cwd: workspacePath,
     sessionManager,
@@ -1029,6 +1034,7 @@ export async function resumeSession(
       settingsManager,
       projectId,
     );
+    await migrateLegacyModelsJsonIfNeeded();
     const { session } = await createAgentSession({
       cwd: workspacePath,
       sessionManager,
@@ -1708,6 +1714,7 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
     settingsManager,
     source.projectId,
   );
+  await migrateLegacyModelsJsonIfNeeded();
   const { session } = await createAgentSession({
     cwd: source.workspacePath,
     sessionManager,
@@ -1812,6 +1819,7 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
         restoredSettingsManager,
         source.projectId,
       );
+      await migrateLegacyModelsJsonIfNeeded();
       const { session: restoredSession } = await createAgentSession({
         cwd: source.workspacePath,
         sessionManager: restoredManager,
@@ -1941,6 +1949,7 @@ export async function rebuildAgentSessionForTools(
     settingsManager,
     live.projectId,
   );
+  await migrateLegacyModelsJsonIfNeeded();
   const { session: newSession } = await createAgentSession({
     cwd: live.workspacePath,
     sessionManager,

--- a/tests/test-attachments.ts
+++ b/tests/test-attachments.ts
@@ -11,10 +11,9 @@
  *   - The size limit + image-count limit return 400 BEFORE
  *     `session.prompt()` is invoked.
  *
- * The test stubs both `session.prompt`, `session.model`, and
- * `session.modelRegistry.hasConfiguredAuth` so the route's
- * pre-flight passes without configuring a real provider. No LLM
- * round-trip required.
+ * The test stubs `session.prompt`, `session.model`, and the
+ * `session.modelRuntime` auth preflight surface so the route passes without
+ * configuring a real provider. No LLM round-trip required.
  */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -75,7 +74,12 @@ async function main(): Promise<void> {
       session: {
         prompt: (text: string, opts?: unknown) => Promise<void>;
         model: unknown;
-        modelRegistry: { hasConfiguredAuth: (m: unknown) => boolean };
+        modelRuntime: {
+          reloadConfig: () => Promise<void>;
+          setRuntimeApiKey: (provider: string, apiKey: string) => Promise<void>;
+          removeRuntimeApiKey: (provider: string) => Promise<void>;
+          hasConfiguredAuth: (provider: string) => boolean;
+        };
       };
     }>;
     disposeSession: (id: string) => boolean;
@@ -108,7 +112,12 @@ async function main(): Promise<void> {
     const calls: PromptCall[] = [];
     const fakeSession = {
       model: { provider: "test", id: "test-model" },
-      modelRegistry: { hasConfiguredAuth: () => true },
+      modelRuntime: {
+        reloadConfig: async () => undefined,
+        setRuntimeApiKey: async () => undefined,
+        removeRuntimeApiKey: async () => undefined,
+        hasConfiguredAuth: () => true,
+      },
       prompt: async (text: string, opts?: unknown): Promise<void> => {
         calls.push({ text, opts: opts as PromptCall["opts"] });
       },

--- a/tests/test-config.ts
+++ b/tests/test-config.ts
@@ -158,13 +158,63 @@ async function main(): Promise<void> {
       );
     }
 
-    // 3. PUT /config/models with malformed body → 400.
+    // 3. Legacy apiKeyCommand is migrated to SDK 0.80's apiKey command syntax.
+    {
+      const legacyModels = {
+        providers: {
+          ...customProvider.providers,
+          legacy: {
+            baseUrl: "http://localhost:8001/v1",
+            apiKeyCommand: ["printf", "legacy-secret"],
+            api: "completions",
+            authHeader: true,
+            models: [
+              {
+                id: "legacy-model",
+                name: "Legacy Model",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 4096,
+                maxTokens: 1024,
+              },
+            ],
+          },
+        },
+      };
+      await writeFile(join(configDir, "models.json"), JSON.stringify(legacyModels), "utf8");
+      const r = await jget(base, "/api/v1/config/models");
+      assert("GET /config/models migrates legacy apiKeyCommand → 200", r.status === 200);
+      const redacted = r.body as {
+        providers: Record<string, { apiKey?: string; apiKeyCommand?: string }>;
+      };
+      assert(
+        "  migrated response redacts apiKey",
+        redacted.providers.legacy?.apiKey === "***REDACTED***",
+      );
+      assert(
+        "  migrated response omits apiKeyCommand",
+        redacted.providers.legacy?.apiKeyCommand === undefined,
+        JSON.stringify(redacted.providers.legacy),
+      );
+      const migrated = JSON.parse(await readFile(join(configDir, "models.json"), "utf8")) as {
+        providers: Record<string, { apiKey?: string; apiKeyCommand?: string }>;
+      };
+      assert(
+        "  on-disk legacy command became ! command apiKey",
+        migrated.providers.legacy?.apiKey === "!printf legacy-secret" &&
+          migrated.providers.legacy?.apiKeyCommand === undefined,
+        JSON.stringify(migrated.providers.legacy),
+      );
+    }
+
+    // 4. PUT /config/models with malformed body → 400.
     {
       const r = await jsend(base, "PUT", "/api/v1/config/models", { not: "right" });
       assert("PUT /config/models malformed → 400", r.status === 400);
     }
 
-    // 4. /config/auth — store, presence-only read, delete.
+    // 5. /config/auth — store, presence-only read, delete.
     {
       const empty = await jget(base, "/api/v1/config/auth");
       assert("GET /config/auth initial → 200", empty.status === 200);


### PR DESCRIPTION
## Summary

Bumps the coordinated Pi SDK packages from `0.79.10` to the latest published `0.80.10` and updates pi-forge for the SDK 0.80 auth/model runtime changes.

SDK 0.80 no longer exposes the old root `AuthStorage` / `ModelRegistry.create(...)` surface and live sessions now use `modelRuntime` instead of `modelRegistry`. This PR migrates pi-forge's provider listing, auth routes, model switching, and prompt auth preflight to the 0.80 runtime API.

It also preserves compatibility for legacy `models.json` provider configs using `apiKeyCommand` by migrating them to SDK 0.80 command-backed `apiKey` values (`!command`).

## Usage

Existing configs continue to work and are migrated automatically:

```json
{
  "providers": {
    "custom": {
      "apiKeyCommand": "op read 'op://vault/item/key'"
    }
  }
}
```

becomes:

```json
{
  "providers": {
    "custom": {
      "apiKey": "!op read 'op://vault/item/key'"
    }
  }
}
```

Existing live sessions also resync the stored provider API key into their SDK `modelRuntime` before model switching and prompt preflight, so deleting/re-adding a provider key does not require creating a new session.

## What changed (7 files)

- `packages/server/package.json`, `package-lock.json` — bump `@earendil-works/pi-ai`, `@earendil-works/pi-agent-core`, and `@earendil-works/pi-coding-agent` to `0.80.10`.
- `packages/server/src/config-manager.ts` — add legacy `apiKeyCommand` migration, expand SDK 0.80 provider config typing, use `ModelRuntime` + `new ModelRegistry(runtime)`, and keep auth writes atomic while preserving redacted reads.
- `packages/server/src/routes/control.ts` — await async model registry creation and refresh/sync live session `modelRuntime` before per-session model changes.
- `packages/server/src/routes/prompt.ts` — use `modelRuntime` for auth preflight and sync stored API keys for existing live sessions before prompt submission.
- `packages/server/src/routes/config.ts` — await async auth helpers and document SDK 0.80 command-backed `apiKey` behavior.
- `tests/test-attachments.ts` — update prompt route stubs for the new `modelRuntime` preflight surface.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run test:ci`
- [x] `npx tsx tests/test-attachments.ts`
- [x] `npx tsx tests/test-config.ts`
- [x] `npx npm@latest approve-scripts --allow-scripts-pending` → no pending scripts
- [x] Manual dev-server smoke: provider/model listing, API key save/delete, switching an existing live session to a provider whose key was deleted/re-added, simple prompt, image/text attachment prompt
- [ ] CI green before merge
