### PR TITLE
chore(release): v1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.4.5] — 2026-06-23
+
+### Added
+
+- **Custom login branding.** Deployments can now configure server-managed login title, subtitle, accent color, logo, and compact mark values that are surfaced to the browser without exposing secrets.
+- **Server-managed custom themes.** Administrators can define persisted light/dark theme tokens through settings/API configuration, with generated CSS variables and client-side preview behavior.
+- **OpenShift sandbox SCC guidance.** Sandbox deployment docs now include OpenShift-specific security context constraint and ownership guidance for running restricted tool surfaces.
+
+### Changed
+
+- **Sandbox startup ownership handling is more robust.** Container and Kubernetes/OpenShift startup paths now support configurable ownership repair for sandbox writable directories and document the required mount permissions.
+- **Dependency updates for v1.4.5.** Refreshed selected client build dependencies including `vite` 8.1.0 and `@vitejs/plugin-react` 6.0.3.
+
+### Fixed
+
+- **Sandbox file ownership is preserved on creates.** File-manager create paths now chown new sandbox files/directories appropriately so restricted tool users can keep working with generated files.
+- **Terminal sizing avoids early wrapping.** Terminal initialization and resize handling now prevent pasted or long input from wrapping before the terminal has a stable fit.
+- **Login no longer triggers noisy git status polling.** Git status refreshes are suppressed until an authenticated workspace context is available.
+- **Orchestration worker delete notifications ignore self-initiated cleanup.** Supervisor flows no longer report expected worker deletions caused by their own lifecycle actions.
+
 ## [1.4.4] — 2026-06-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "workspaces": [
         "packages/*"
       ],
@@ -5936,9 +5936,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5956,9 +5953,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5976,9 +5970,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5996,9 +5987,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6016,9 +6004,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6036,9 +6021,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17105,7 +17087,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17177,7 +17159,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.79.10",
         "@earendil-works/pi-ai": "0.79.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the v1.4.5 release bump. Release notes were generated from changes since the previous release tag `v1.4.4` / release commit `5cfac02`, then rolled into the dated `## [1.4.5] — 2026-06-23` changelog section using the repository release tooling.

## Usage

No direct runtime usage change is required for this release PR. When this PR is ready and merged, tag from updated `main` with:

```bash
git tag v1.4.5
git push origin v1.4.5
```

Do not tag until after the release PR merges.

## What changed (5 files)

- `CHANGELOG.md` — added v1.4.5 notes for custom login branding, server-managed custom themes, OpenShift sandbox SCC guidance, sandbox ownership fixes, terminal wrapping, login git polling, orchestration cleanup notifications, and dependency refreshes.
- `package.json` — bumped root package version from 1.4.4 to 1.4.5.
- `packages/server/package.json` — bumped server package version from 1.4.4 to 1.4.5.
- `packages/client/package.json` — bumped client package version from 1.4.4 to 1.4.5.
- `package-lock.json` — refreshed lockfile package versions through `scripts/bump-version.sh 1.4.5`.

## Test plan

- [x] `scripts/bump-version.sh 1.4.5`
- [x] `npx npm@latest approve-scripts --allow-scripts-pending` — reported no packages with unreviewed install scripts
- [x] `git diff --check`
- [ ] `npm run build` — attempted, but the environment has incomplete/missing installed dependencies and dependency installation is currently failing; client build could not resolve `@vitejs/plugin-react`
- [ ] `npm run check` — attempted, typecheck passed, but lint could not resolve `@eslint/js` from the worktree `node_modules`
- [ ] `npm run test:ci` — attempted, failed immediately due missing `glob` package from the worktree `node_modules`
- [ ] CI green before merge
