### PR TITLE
fix: repair file pane sandbox permissions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -197,10 +197,10 @@ COPY --from=builder --chown=pi:pi /app/packages/client/dist ./packages/client/di
 # Sandbox deployments must explicitly permission their mounts; see
 # docs/agent-tool-sandbox.md.
 RUN mkdir -p /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm /home/pi-tools/.config \
- && chown -R pi-tools:pi-tools /workspace /home/pi-tools \
+ && chown -R pi:pi /workspace /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm \
+ && chown -R pi-tools:pi-tools /home/pi-tools \
  && chown pi:pi /home/pi \
- && chown root:pi-tools /home/pi/.pi \
- && chown -R pi:pi /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm \
+ && chown pi:pi-tools /home/pi/.pi \
  && chmod 0775 /workspace \
  && chmod 0755 /home/pi /home/pi/.pi \
  && chmod 0700 /home/pi/.pi/agent /home/pi/.pi-forge /home/pi/.local /home/pi/.npm /home/pi-tools
@@ -211,12 +211,42 @@ set -eu
 case "$(printf '%s' "${AGENT_TOOL_SANDBOX_ENABLED:-false}" | tr '[:upper:]' '[:lower:]')" in
   1|true|yes|on)
     # Sandbox mode: keep the server as root so it can setuid/setgid
-    # model/user tool children to AGENT_TOOL_UID:GID. Mount ownership is
-    # an operator contract; see docs/agent-tool-sandbox.md.
+    # model/user tool children to AGENT_TOOL_UID:GID. Prepare the standard
+    # writable mounts here, before Node imports config.ts and tries to create
+    # server-private files such as /home/pi/.pi-forge/jwt-secret.
     if [ "$(id -u)" != "0" ]; then
       echo "AGENT_TOOL_SANDBOX_ENABLED=true requires the container to run as root" >&2
       exit 1
     fi
+    tool_uid="${AGENT_TOOL_UID:?AGENT_TOOL_UID is required when sandbox is enabled}"
+    tool_gid="${AGENT_TOOL_GID:?AGENT_TOOL_GID is required when sandbox is enabled}"
+    workspace_path="${WORKSPACE_PATH:-/workspace}"
+    forge_data_dir="${FORGE_DATA_DIR:-/home/pi/.pi-forge}"
+    pi_config_dir="${PI_CONFIG_DIR:-/home/pi/.pi/agent}"
+    tool_home="${AGENT_TOOL_HOME:-/home/pi-tools}"
+
+    mkdir -p "$workspace_path" "$forge_data_dir" "$pi_config_dir" "$tool_home"
+
+    chown root:root "$forge_data_dir"
+    chmod u+rwx "$forge_data_dir"
+    chown -R root:root "$forge_data_dir"
+    chmod -R u+rwX,go-rwx "$forge_data_dir"
+
+    chown root:0 "$workspace_path"
+    chmod u+rwx,g+rwx "$workspace_path"
+    chown -R root:0 "$workspace_path"
+    chmod -R u+rwX,g+rwX,o-rwx "$workspace_path"
+    chown -R "$tool_uid:0" "$workspace_path"
+
+    chown root:"$tool_gid" "$pi_config_dir"
+    chmod 0750 "$pi_config_dir"
+
+    chown root:"$tool_gid" "$tool_home"
+    chmod u+rwx "$tool_home"
+    chown -R root:"$tool_gid" "$tool_home"
+    chmod -R u+rwX,go-rwx "$tool_home"
+    chown -R "$tool_uid:$tool_gid" "$tool_home"
+
     exec "$@"
     ;;
   *)

--- a/docker/docker-compose.sandbox.yml
+++ b/docker/docker-compose.sandbox.yml
@@ -6,9 +6,9 @@
 # The base compose file starts as the pi user and drops all capabilities so
 # regular mode does not need SETUID/SETGID. Sandbox mode must start the server
 # as root and add back SETUID/SETGID so pi-forge can spawn model/user tool
-# children as AGENT_TOOL_UID:AGENT_TOOL_GID. CHOWN lets the server hand files
-# created by browser uploads/new-file APIs to the sandbox tool identity and is
-# also required for the optional AGENT_TOOL_SANDBOX_CHOWN_PATHS startup helper.
+# children as AGENT_TOOL_UID:GID. CHOWN lets startup prepare standard writable
+# mounts and lets browser uploads/new-file APIs hand workspace paths to the
+# sandbox tool identity.
 
 services:
   pi-forge:

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -115,8 +115,11 @@ resources loadable and the selected agent resource directories writable by
 `pi-tools`.
 
 The Docker image's built-in directory ownership remains optimized for regular
-mode (`pi` owns `/home/pi` plus `/home/pi/.pi/agent` and `/home/pi/.pi-forge`) so
-non-sandbox tools can create ordinary per-user config such as `~/.config/gh`.
+mode (`pi` owns `/home/pi`, `/home/pi/.pi`, `/home/pi/.pi/agent`, and
+`/home/pi/.pi-forge`) so non-sandbox tools can create ordinary per-user config
+such as `~/.config/gh` and `~/.pi/...` files. The `/home/pi/.pi` group remains
+`pi-tools` without group write so sandbox tools can traverse non-secret resource
+parents without being able to create arbitrary entries there.
 Enabling sandbox with bind mounts or persistent volumes is an explicit operator
 step: adjust the mount permissions to the table above before relying on
 filesystem isolation. Sandbox tool children should still run as a different
@@ -126,10 +129,16 @@ changing volume ownership/modes.
 
 ## Optional startup chown helper
 
-`AGENT_TOOL_SANDBOX_CHOWN_PATHS` can reduce deployment-specific init scripts
-for paths that should be owned by `pi-tools`. When sandbox mode is enabled and
-the server starts as root, pi-forge recursively `chown`s each configured
-existing path to `AGENT_TOOL_UID:AGENT_TOOL_GID` before the HTTP server starts.
+When sandbox mode is enabled and the server starts as root, pi-forge always
+prepares `WORKSPACE_PATH` for sharing between `pi-tools` and the root server
+before the HTTP server starts: owner is `AGENT_TOOL_UID`, group is the server's
+group (root group in the Docker overlay), and mode bits include group rwX. This
+lets the sandbox tool identity write as owner while the root server can still
+create, move, read, delete, and download files without `DAC_OVERRIDE`.
+
+`AGENT_TOOL_SANDBOX_CHOWN_PATHS` can reduce deployment-specific init scripts for
+additional existing paths that should use the same shared sandbox/server
+permissions.
 The helper deliberately accepts only non-secret roots: `WORKSPACE_PATH`,
 `AGENT_TOOL_HOME`, and the Pi resource subtrees
 `${PI_CONFIG_DIR}/{skills,npm,git,extensions,prompts,themes}`. It rejects
@@ -138,7 +147,7 @@ The helper deliberately accepts only non-secret roots: `WORKSPACE_PATH`,
 Example:
 
 ```txt
-AGENT_TOOL_SANDBOX_CHOWN_PATHS=/workspace,/home/pi/.pi/agent/skills
+AGENT_TOOL_SANDBOX_CHOWN_PATHS=/home/pi/.pi/agent/skills
 ```
 
 Keep using explicit init-container or host-side permissioning for server-only
@@ -229,9 +238,12 @@ AGENT_TOOL_HOME=/home/pi-tools
 Start sandbox mode with the sandbox compose overlay. The base compose file runs
 regular mode as `pi` with no Linux capabilities; the overlay switches the server
 container to root and adds back `SETUID` / `SETGID` for sandbox child processes
-plus `CHOWN` for the optional `AGENT_TOOL_SANDBOX_CHOWN_PATHS` startup helper.
-If you remove `CHOWN`, leave `AGENT_TOOL_SANDBOX_CHOWN_PATHS` unset or startup
-will fail on the first ownership change:
+plus `CHOWN` for entrypoint mount preparation and browser-created workspace
+ownership handoff. The image entrypoint prepares `/workspace`,
+`/home/pi/.pi-forge`, `/home/pi/.pi/agent`, and `AGENT_TOOL_HOME` before Node
+starts so server-private files such as `jwt-secret` can be created without
+`DAC_OVERRIDE`. If you remove `CHOWN`, sandbox startup will fail on the first
+ownership change:
 
 ```bash
 cd docker
@@ -297,26 +309,17 @@ docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
 The base compose file already drops all capabilities. The sandbox overlay adds
 back `CHOWN`, `SETUID`, and `SETGID` and runs the server container as root.
 `SETUID` / `SETGID` let pi-forge spawn model/user tool processes as
-`pi-tools`; `CHOWN` lets browser upload and new-file APIs hand newly created
-workspace files/directories to that same sandbox identity, and is also required
-when `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is configured.
-
-If OrbStack/Docker Desktop shows `.pi-forge` as `1000:1000 0700` inside the
-pi-forge container even after the helper volume init chowns it to `root:root`,
-add `DAC_OVERRIDE` for local testing:
-
-```yaml
-cap_add:
-  - CHOWN
-  - SETUID
-  - SETGID
-  - DAC_OVERRIDE # local OrbStack/Docker Desktop workaround only
-```
+`pi-tools`; `CHOWN` lets the entrypoint prepare standard mounts before Node
+starts and lets browser upload/new-file APIs hand newly created workspace
+files/directories to that same sandbox identity (with the server group kept for
+root-server access). It is also required when `AGENT_TOOL_SANDBOX_CHOWN_PATHS`
+is configured.
 
 Keep production/native-Linux deployments to `CHOWN`, `SETUID`, and `SETGID` for
 sandbox mode. If you build a stricter custom overlay, `SETUID`/`SETGID` are
-required for identity switching; `CHOWN` is required for browser-created
-workspace ownership handoff and for `AGENT_TOOL_SANDBOX_CHOWN_PATHS`.
+required for identity switching; `CHOWN` is required for entrypoint mount
+preparation, browser-created workspace ownership handoff, and
+`AGENT_TOOL_SANDBOX_CHOWN_PATHS`.
 
 ### One-shot volume init commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ or shell environment. The most-touched ones:
 | `AGENT_TOOL_UID` | (unset) | Numeric UID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled. |
 | `AGENT_TOOL_GID` | (unset) | Numeric GID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled. |
 | `AGENT_TOOL_HOME` | `/home/pi-tools` | Writable HOME injected into sandboxed bash/process/terminal/quick-action/exec children. The Docker image creates this directory owned by `pi-tools`. |
-| `AGENT_TOOL_SANDBOX_CHOWN_PATHS` | (empty) | Comma- or whitespace-separated existing paths to recursively `chown` to `AGENT_TOOL_UID:AGENT_TOOL_GID` at server startup when sandbox mode is enabled. Paths are limited to `/workspace`, `AGENT_TOOL_HOME`, and non-secret Pi resource subtrees (`skills`, `npm`, `git`, `extensions`, `prompts`, `themes`). |
+| `AGENT_TOOL_SANDBOX_CHOWN_PATHS` | (empty) | Optional comma- or whitespace-separated existing extra paths to recursively prepare for sandbox sharing at server startup when sandbox mode is enabled. `WORKSPACE_PATH` is always prepared automatically. Prepared paths are owned by `AGENT_TOOL_UID` with the server's group and group rwX bits so both the sandbox tool identity and root server without `DAC_OVERRIDE` can access them. Extra paths are limited to `WORKSPACE_PATH`, `AGENT_TOOL_HOME`, and non-secret Pi resource subtrees (`skills`, `npm`, `git`, `extensions`, `prompts`, `themes`). |
 
 Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
 are documented in [`deployment.md`](./deployment.md).

--- a/packages/server/src/agent-tool-overrides.ts
+++ b/packages/server/src/agent-tool-overrides.ts
@@ -19,6 +19,11 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { createForgeBashOperations } from "./agent-bash-operations.js";
 import { assertAgentToolPathAllowed, resolveAgentToolPath } from "./agent-tool-policy.js";
+import {
+  applySandboxParentChainHandoff,
+  applySandboxPathHandoff,
+  applySandboxTreeHandoff,
+} from "./sandbox-permissions.js";
 
 function guard(workspacePath: string, absolutePath: string): string {
   return resolveAgentToolPath(workspacePath, absolutePath);
@@ -88,17 +93,26 @@ export function createSandboxedToolDefinitions(
   const editOps: EditOperations = {
     readFile: async (absolutePath) => readFile(guard(workspacePath, absolutePath)),
     writeFile: async (absolutePath, content) => {
-      await writeFile(guard(workspacePath, absolutePath), content);
+      const safePath = guard(workspacePath, absolutePath);
+      await applySandboxParentChainHandoff(workspacePath, safePath);
+      await writeFile(safePath, content);
+      await applySandboxPathHandoff(safePath);
     },
     access: async (absolutePath) => access(guard(workspacePath, absolutePath)),
   };
 
   const writeOps: WriteOperations = {
     writeFile: async (absolutePath, content) => {
-      await writeFile(guard(workspacePath, absolutePath), content);
+      const safePath = guard(workspacePath, absolutePath);
+      await applySandboxParentChainHandoff(workspacePath, safePath);
+      await writeFile(safePath, content);
+      await applySandboxPathHandoff(safePath);
     },
     mkdir: async (dir) => {
-      await mkdir(guard(workspacePath, dir), { recursive: true });
+      const safeDir = guard(workspacePath, dir);
+      await applySandboxParentChainHandoff(workspacePath, safeDir);
+      await mkdir(safeDir, { recursive: true });
+      await applySandboxTreeHandoff(safeDir);
     },
   };
 

--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -1,5 +1,4 @@
 import {
-  lchown,
   lstat,
   mkdir,
   open as fsOpen,
@@ -19,7 +18,11 @@ import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } 
 import { createHash, randomUUID } from "node:crypto";
 import { create as tarCreate } from "tar";
 import type { Readable } from "node:stream";
-import { config } from "./config.js";
+import {
+  applySandboxPathHandoff,
+  applySandboxTreeHandoff,
+  sandboxPermissionsEnabled,
+} from "./sandbox-permissions.js";
 
 /**
  * Filesystem operations bounded by a per-call project root.
@@ -227,52 +230,46 @@ async function verifyPathSafe(target: string, root: string): Promise<string> {
   }
 }
 
-function sandboxOwnershipEnabled(): boolean {
-  return config.agentToolSandbox.enabled;
-}
-
-async function applySandboxOwnership(path: string): Promise<void> {
-  if (!sandboxOwnershipEnabled()) return;
-  const uid = config.agentToolSandbox.uid!;
-  const gid = config.agentToolSandbox.gid!;
-  const currentUid = typeof process.getuid === "function" ? process.getuid() : undefined;
-  const currentGid = typeof process.getgid === "function" ? process.getgid() : undefined;
-  if (currentUid === uid && currentGid === gid) return;
-  // lchown deliberately avoids following a malicious symlink if a path is
-  // swapped between creation and ownership fix-up. File writes chown their
-  // private temp file before the atomic rename, so the final visible file is
-  // never server-owned in sandbox mode.
-  await lchown(path, uid, gid);
-}
-
-async function missingDirectoryChain(dir: string, root: string): Promise<string[]> {
+function directoryChain(dir: string, root: string): string[] {
   const resolvedDir = assertInsideRoot(dir, root);
-  const missing: string[] = [];
-  let cursor = resolvedDir;
-  while (true) {
-    try {
-      await lstat(cursor);
-      return missing.reverse();
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-      missing.push(cursor);
-      const parent = dirname(cursor);
-      if (parent === cursor) throw new PathOutsideRootError(dir, root);
-      cursor = parent;
-    }
+  const resolvedRoot = assertInsideRoot(root, root);
+  const rel = relative(resolvedRoot, resolvedDir);
+  if (rel === "") return [resolvedRoot];
+  const parts = rel.split(sep).filter(Boolean);
+  const dirs = [resolvedRoot];
+  let cursor = resolvedRoot;
+  for (const part of parts) {
+    cursor = join(cursor, part);
+    dirs.push(cursor);
   }
+  return dirs;
 }
 
-async function mkdirWithSandboxOwnership(dir: string, root: string): Promise<void> {
-  const missing = sandboxOwnershipEnabled() ? await missingDirectoryChain(dir, root) : [];
-  await mkdir(dir, { recursive: true });
+async function ensureDirectoryForWrite(dir: string, root: string): Promise<void> {
+  if (!sandboxPermissionsEnabled()) {
+    await mkdir(dir, { recursive: true });
+    return;
+  }
+
+  const dirs = directoryChain(dir, root);
+  const created: string[] = [];
   try {
-    for (const created of missing) {
-      await applySandboxOwnership(created);
+    for (const current of dirs) {
+      const existing = await lstat(current).catch((err: NodeJS.ErrnoException) => {
+        if (err.code === "ENOENT") return undefined;
+        throw err;
+      });
+      if (existing === undefined) {
+        await mkdir(current, { recursive: false });
+        created.push(current);
+      } else if (!existing.isDirectory()) {
+        throw new InvalidNameError("path parent is not a directory");
+      }
+      await applySandboxPathHandoff(current);
     }
   } catch (err) {
-    for (const created of [...missing].reverse()) {
-      await rmdir(created).catch(() => undefined);
+    for (const current of [...created].reverse()) {
+      await rmdir(current).catch(() => undefined);
     }
     throw err;
   }
@@ -469,6 +466,7 @@ async function walkFlat(dir: string, root: string, relPath: string, out: string[
 
 export async function readFile(absPath: string, root: string): Promise<ReadResult> {
   const resolved = await verifyPathSafe(absPath, root);
+  await applySandboxPathHandoff(resolved);
   const st = await stat(resolved).catch(() => undefined);
   if (st === undefined) throw new NotFoundError(resolved);
   if (!st.isFile()) throw new NotAFileError(resolved);
@@ -559,14 +557,14 @@ export async function writeFile(absPath: string, root: string, content: string):
   // succeed (`/foo/bar/baz.ts` works even if `/foo/bar` doesn't exist).
   // Safe AFTER verifyPathSafe: the deepest existing ancestor was
   // proven inside `root`, so any dirs we create are under it.
-  await mkdirWithSandboxOwnership(dirname(resolved), root);
+  await ensureDirectoryForWrite(dirname(resolved), root);
   // Atomic-ish write. tmp + rename keeps a partially-written file from
   // ever existing under the target name; same pattern config-manager and
   // project-manager use.
   const tmp = `${resolved}.${randomUUID()}.tmp`;
   try {
     await fsWriteFile(tmp, content, "utf8");
-    await applySandboxOwnership(tmp);
+    await applySandboxPathHandoff(tmp);
     await fsRename(tmp, resolved);
   } catch (err) {
     await unlink(tmp).catch(() => undefined);
@@ -595,6 +593,7 @@ export async function downloadStream(
   const st = await stat(resolved).catch(() => undefined);
   if (st === undefined) throw new NotFoundError(resolved);
   if (st.isFile()) {
+    await applySandboxPathHandoff(resolved);
     return {
       kind: "file",
       filename: basename(resolved),
@@ -603,6 +602,7 @@ export async function downloadStream(
     };
   }
   if (st.isDirectory()) {
+    await applySandboxTreeHandoff(resolved);
     const dirName = basename(resolved).length > 0 ? basename(resolved) : "project";
     // tar's `cwd` is the parent — entries inside the archive are
     // prefixed with `<dirName>/...` so unpacking creates a real
@@ -698,7 +698,7 @@ async function writeFileBytesAtPath(
     if (opts?.overwrite !== true) throw new TargetExistsError(target);
     if (!existing.isFile()) throw new InvalidNameError("target is a directory");
   }
-  await mkdirWithSandboxOwnership(dirname(target), root);
+  await ensureDirectoryForWrite(dirname(target), root);
   const tmp = `${target}.${randomUUID()}.upload.tmp`;
   const hash = createHash("sha256");
   let size = 0;
@@ -724,7 +724,7 @@ async function writeFileBytesAtPath(
     throw new ChecksumMismatchError(target, expected, actual);
   }
   try {
-    await applySandboxOwnership(tmp);
+    await applySandboxPathHandoff(tmp);
     await fsRename(tmp, target);
   } catch (err) {
     await unlink(tmp).catch(() => undefined);
@@ -747,9 +747,10 @@ export async function makeDirectory(
   // UI can prompt the user instead of silently no-op'ing.
   const exists = await stat(target).catch(() => undefined);
   if (exists !== undefined) throw new TargetExistsError(target);
+  await ensureDirectoryForWrite(parent, root);
   await mkdir(target, { recursive: false });
   try {
-    await applySandboxOwnership(target);
+    await applySandboxPathHandoff(target);
   } catch (err) {
     await rmdir(target).catch(() => undefined);
     throw err;
@@ -781,6 +782,7 @@ export async function renameEntry(absPath: string, root: string, newName: string
   // attacker = user, but we still stat the target right before the
   // second rename and bail with TargetExistsError if a squatter
   // appeared.
+  await ensureDirectoryForWrite(dirname(resolved), root);
   if (resolved.toLowerCase() === target.toLowerCase()) {
     const tmp = `${resolved}.casefix-${randomUUID()}`;
     await fsRename(resolved, tmp);
@@ -792,6 +794,7 @@ export async function renameEntry(absPath: string, root: string, newName: string
       const squatter = await stat(target).catch(() => undefined);
       if (squatter !== undefined) throw new TargetExistsError(target);
       await fsRename(tmp, target);
+      await applySandboxPathHandoff(target);
     } catch (err) {
       // Best-effort rollback: if the second rename fails (or the
       // squatter check trips), put the file back under its original
@@ -806,6 +809,7 @@ export async function renameEntry(absPath: string, root: string, newName: string
   const exists = await stat(target).catch(() => undefined);
   if (exists !== undefined) throw new TargetExistsError(target);
   await fsRename(resolved, target);
+  await applySandboxPathHandoff(target);
   return target;
 }
 
@@ -827,8 +831,10 @@ export async function moveEntry(
   }
   const exists = await stat(dest).catch(() => undefined);
   if (exists !== undefined) throw new TargetExistsError(dest);
-  await mkdir(dirname(dest), { recursive: true });
+  await ensureDirectoryForWrite(dirname(src), root);
+  await ensureDirectoryForWrite(dirname(dest), root);
   await fsRename(src, dest);
+  await applySandboxPathHandoff(dest);
   return dest;
 }
 
@@ -847,6 +853,7 @@ export async function deleteEntry(
   }
   const st = await stat(resolved).catch(() => undefined);
   if (st === undefined) throw new NotFoundError(resolved);
+  await ensureDirectoryForWrite(dirname(resolved), root);
   if (st.isDirectory()) {
     // Empty dirs are always safe to remove. Non-empty dirs require an
     // explicit `recursive: true` from the caller — the route plumbs

--- a/packages/server/src/git-clone.ts
+++ b/packages/server/src/git-clone.ts
@@ -36,6 +36,8 @@ import { rm, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { scrubbedEnv } from "./pty-manager.js";
 import { applySandboxTreeHandoff } from "./sandbox-permissions.js";
+import { config } from "./config.js";
+import { sandboxSpawnIdentity } from "./agent-bash-operations.js";
 
 const MAX_PROGRESS_BUFFER_BYTES = 64 * 1024;
 const CLONE_TIMEOUT_MS = 30 * 60 * 1000;
@@ -255,13 +257,7 @@ export function cloneRepository(opts: CloneOptions): SpawnedClone {
 
   push({ type: "started", cloneUrlForDisplay: displayUrl });
 
-  const env: Record<string, string> = {
-    ...scrubbedEnv(),
-    // Prevent git from prompting on stdin when credentials are
-    // wrong / missing — without this, git can hang indefinitely
-    // waiting for a username/password.
-    GIT_TERMINAL_PROMPT: "0",
-  };
+  const env = gitCloneEnv();
 
   if (opts.insecureTls === true) {
     // git's standard "skip cert validation" knob. Equivalent to
@@ -287,6 +283,7 @@ export function cloneRepository(opts: CloneOptions): SpawnedClone {
     cwd: dirname(target),
     env,
     stdio: ["ignore", "pipe", "pipe"],
+    ...sandboxSpawnIdentity(),
   });
 
   let stderrBuffer = "";
@@ -414,11 +411,24 @@ async function persistInsecureTlsForOrigin(target: string, cleanUrl: string): Pr
   await runGitQuiet(target, ["config", "--local", `http.${cleanUrl}.sslVerify`, "false"]);
 }
 
+function gitCloneEnv(): Record<string, string> {
+  const env = scrubbedEnv();
+  return {
+    ...env,
+    ...(config.agentToolSandbox.enabled ? { HOME: config.agentToolSandbox.home } : {}),
+    // Prevent git from prompting on stdin when credentials are
+    // wrong / missing — without this, git can hang indefinitely
+    // waiting for a username/password.
+    GIT_TERMINAL_PROMPT: "0",
+  };
+}
+
 async function runGitQuiet(cwd: string, args: string[]): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const child = spawn("git", ["-C", cwd, ...args], {
-      env: scrubbedEnv(),
+      env: gitCloneEnv(),
       stdio: "ignore",
+      ...sandboxSpawnIdentity(),
     });
     child.on("error", reject);
     child.on("close", (code) => {

--- a/packages/server/src/git-clone.ts
+++ b/packages/server/src/git-clone.ts
@@ -35,6 +35,7 @@ import { spawn } from "node:child_process";
 import { rm, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { scrubbedEnv } from "./pty-manager.js";
+import { applySandboxTreeHandoff } from "./sandbox-permissions.js";
 
 const MAX_PROGRESS_BUFFER_BYTES = 64 * 1024;
 const CLONE_TIMEOUT_MS = 30 * 60 * 1000;
@@ -361,6 +362,17 @@ export function cloneRepository(opts: CloneOptions): SpawnedClone {
           }
           if (opts.insecureTls === true) {
             await persistInsecureTlsForOrigin(target, displayUrl).catch(() => undefined);
+          }
+          try {
+            await applySandboxTreeHandoff(target);
+          } catch (err) {
+            await rm(target, { recursive: true, force: true }).catch(() => undefined);
+            finish({
+              type: "error",
+              message: `git clone completed but sandbox permission handoff failed: ${err instanceof Error ? err.message : String(err)}`,
+            });
+            resolveOuter();
+            return;
           }
           finish({ type: "done", target });
           resolveOuter();

--- a/packages/server/src/git-runner.ts
+++ b/packages/server/src/git-runner.ts
@@ -4,6 +4,8 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { assertInsideRoot } from "./file-manager.js";
+import { config } from "./config.js";
+import { sandboxSpawnIdentity } from "./agent-bash-operations.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -191,6 +193,7 @@ async function runGit(cwd: string, args: string[]): Promise<RunResult> {
       cwd,
       maxBuffer: MAX_BUFFER,
       env: gitEnv(),
+      ...sandboxSpawnIdentity(),
     });
     return { stdout, stderr, exitCode: 0 };
   } catch (err) {
@@ -229,7 +232,9 @@ async function runGit(cwd: string, args: string[]): Promise<RunResult> {
 function gitEnv(): NodeJS.ProcessEnv {
   return {
     ...process.env,
-    HOME: process.env.HOME ?? homedir(),
+    HOME: config.agentToolSandbox.enabled
+      ? config.agentToolSandbox.home
+      : (process.env.HOME ?? homedir()),
     GIT_TERMINAL_PROMPT: "0",
     GIT_ASKPASS: "true",
     LC_ALL: "C",
@@ -257,6 +262,7 @@ export async function runGitRaw(
       cwd,
       maxBuffer: opts.maxBuffer ?? MAX_BUFFER,
       env: gitEnv(),
+      ...sandboxSpawnIdentity(),
     });
     return { stdout, stderr };
   } catch (err) {

--- a/packages/server/src/project-manager.ts
+++ b/packages/server/src/project-manager.ts
@@ -12,6 +12,7 @@ import {
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { randomUUID } from "node:crypto";
 import { config } from "./config.js";
+import { applySandboxPathHandoff } from "./sandbox-permissions.js";
 import { clearProjectOverrides as clearProjectSkillOverrides } from "./skill-overrides.js";
 import { clearProjectPromptOverrides } from "./prompt-overrides.js";
 import { clearProjectSystemPromptAddendum } from "./system-prompt-overrides.js";
@@ -410,6 +411,13 @@ export async function createDirectory(parentPath: string, name: string): Promise
   if (!isInsideWorkspace(target)) {
     throw new PathOutsideWorkspaceError(target);
   }
+  await applySandboxPathHandoff(parent);
   await mkdir(target, { recursive: false });
+  try {
+    await applySandboxPathHandoff(target);
+  } catch (err) {
+    await rm(target, { recursive: true, force: true }).catch(() => undefined);
+    throw err;
+  }
   return target;
 }

--- a/packages/server/src/sandbox-permissions.ts
+++ b/packages/server/src/sandbox-permissions.ts
@@ -23,16 +23,36 @@ export async function applySandboxPathHandoff(path: string): Promise<void> {
   const st = await lstat(path);
   const uid = config.agentToolSandbox.uid!;
   const gid = sandboxSharedGid();
-  if (st.uid !== uid || st.gid !== gid) {
-    await lchown(path, uid, gid);
+  if (st.isSymbolicLink()) {
+    if (st.uid !== uid || st.gid !== gid) {
+      await lchown(path, uid, gid);
+    }
+    return;
   }
-  if (st.isSymbolicLink()) return;
+
   const currentMode = st.mode & 0o777;
   const desiredMode = st.isDirectory()
     ? currentMode | SANDBOX_GROUP_RWX
     : currentMode | SANDBOX_GROUP_RW | ((currentMode & 0o111) !== 0 ? SANDBOX_GROUP_X : 0);
+
+  // Sandbox containers keep CHOWN but intentionally do not need FOWNER or
+  // DAC_OVERRIDE. On Linux, UID 0 without FOWNER cannot chmod a path after
+  // it has been chowned to the tool UID. Temporarily make the running server
+  // identity the owner, apply mode bits, then hand ownership to the tool UID.
+  const serverUid = typeof process.getuid === "function" ? process.getuid() : undefined;
+  if (serverUid !== undefined && st.uid !== serverUid) {
+    await lchown(path, serverUid, gid);
+  } else if (st.gid !== gid) {
+    await lchown(path, st.uid, gid);
+  }
+
   if (desiredMode !== currentMode) {
     await chmod(path, desiredMode);
+  }
+
+  const afterModeOwner = await lstat(path);
+  if (afterModeOwner.uid !== uid || afterModeOwner.gid !== gid) {
+    await lchown(path, uid, gid);
   }
 }
 

--- a/packages/server/src/sandbox-permissions.ts
+++ b/packages/server/src/sandbox-permissions.ts
@@ -1,5 +1,5 @@
 import { chmod, lchown, lstat, readdir } from "node:fs/promises";
-import { resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { config } from "./config.js";
 
 const SANDBOX_GROUP_RW = 0o060;
@@ -66,4 +66,32 @@ export async function applySandboxTreeHandoff(path: string): Promise<void> {
     }
   }
   await applySandboxPathHandoff(path);
+}
+
+export async function applySandboxDirectoryChainHandoff(root: string, dir: string): Promise<void> {
+  if (!sandboxPermissionsEnabled()) return;
+  const resolvedRoot = resolve(root);
+  const resolvedDir = resolve(dir);
+  const rel = relative(resolvedRoot, resolvedDir);
+  if (rel.startsWith("..") || rel.includes(`..${sep}`)) {
+    await applySandboxPathHandoff(resolvedDir);
+    return;
+  }
+  const parts = rel.split(sep).filter(Boolean);
+  let current = resolvedRoot;
+  await applyExistingSandboxPathHandoff(current);
+  for (const part of parts) {
+    current = join(current, part);
+    await applyExistingSandboxPathHandoff(current);
+  }
+}
+
+async function applyExistingSandboxPathHandoff(path: string): Promise<void> {
+  await applySandboxPathHandoff(path).catch((err: NodeJS.ErrnoException) => {
+    if (err.code !== "ENOENT") throw err;
+  });
+}
+
+export async function applySandboxParentChainHandoff(root: string, path: string): Promise<void> {
+  await applySandboxDirectoryChainHandoff(root, dirname(path));
 }

--- a/packages/server/src/sandbox-permissions.ts
+++ b/packages/server/src/sandbox-permissions.ts
@@ -1,0 +1,49 @@
+import { chmod, lchown, lstat, readdir } from "node:fs/promises";
+import { resolve } from "node:path";
+import { config } from "./config.js";
+
+const SANDBOX_GROUP_RW = 0o060;
+const SANDBOX_GROUP_RWX = 0o070;
+const SANDBOX_GROUP_X = 0o010;
+
+export function sandboxPermissionsEnabled(): boolean {
+  return config.agentToolSandbox.enabled;
+}
+
+export function sandboxSharedGid(): number {
+  return typeof process.getgid === "function" ? process.getgid() : 0;
+}
+
+export function sandboxHandoffDescription(): string {
+  return `${config.agentToolSandbox.uid}:${sandboxSharedGid()}`;
+}
+
+export async function applySandboxPathHandoff(path: string): Promise<void> {
+  if (!sandboxPermissionsEnabled()) return;
+  const st = await lstat(path);
+  const uid = config.agentToolSandbox.uid!;
+  const gid = sandboxSharedGid();
+  if (st.uid !== uid || st.gid !== gid) {
+    await lchown(path, uid, gid);
+  }
+  if (st.isSymbolicLink()) return;
+  const currentMode = st.mode & 0o777;
+  const desiredMode = st.isDirectory()
+    ? currentMode | SANDBOX_GROUP_RWX
+    : currentMode | SANDBOX_GROUP_RW | ((currentMode & 0o111) !== 0 ? SANDBOX_GROUP_X : 0);
+  if (desiredMode !== currentMode) {
+    await chmod(path, desiredMode);
+  }
+}
+
+export async function applySandboxTreeHandoff(path: string): Promise<void> {
+  if (!sandboxPermissionsEnabled()) return;
+  const st = await lstat(path);
+  if (st.isDirectory()) {
+    const entries = await readdir(path);
+    for (const entry of entries) {
+      await applySandboxTreeHandoff(resolve(path, entry));
+    }
+  }
+  await applySandboxPathHandoff(path);
+}

--- a/packages/server/src/sandbox-startup-permissions.ts
+++ b/packages/server/src/sandbox-startup-permissions.ts
@@ -1,6 +1,7 @@
-import { lchown, lstat, readdir } from "node:fs/promises";
+import { lstat, readdir } from "node:fs/promises";
 import { relative, resolve, sep } from "node:path";
 import { config } from "./config.js";
+import { applySandboxPathHandoff, sandboxHandoffDescription } from "./sandbox-permissions.js";
 
 const PI_CONFIG_RESOURCE_DIRS = ["skills", "npm", "git", "extensions", "prompts", "themes"];
 
@@ -28,35 +29,35 @@ function assertAllowedSandboxChownPath(path: string): void {
   );
 }
 
-async function chownRecursiveNoFollow(path: string, uid: number, gid: number): Promise<void> {
+async function chownRecursiveNoFollow(path: string): Promise<void> {
   const st = await lstat(path);
   if (st.isDirectory()) {
     const entries = await readdir(path);
     for (const entry of entries) {
-      await chownRecursiveNoFollow(resolve(path, entry), uid, gid);
+      await chownRecursiveNoFollow(resolve(path, entry));
     }
   }
-  if (st.uid === uid && st.gid === gid) return;
-  await lchown(path, uid, gid);
+  await applySandboxPathHandoff(path);
 }
 
 export async function applySandboxStartupChowns(): Promise<void> {
-  const paths = config.agentToolSandbox.chownPaths;
-  if (paths.length === 0) return;
   if (!config.agentToolSandbox.enabled) {
-    console.warn(
-      "[sandbox-startup] AGENT_TOOL_SANDBOX_CHOWN_PATHS is set but sandbox mode is disabled; skipping chown",
-    );
+    if (config.agentToolSandbox.chownPaths.length > 0) {
+      console.warn(
+        "[sandbox-startup] AGENT_TOOL_SANDBOX_CHOWN_PATHS is set but sandbox mode is disabled; skipping chown",
+      );
+    }
     return;
   }
 
-  const uid = config.agentToolSandbox.uid!;
-  const gid = config.agentToolSandbox.gid!;
+  const paths = [...new Set([config.workspacePath, ...config.agentToolSandbox.chownPaths])];
   for (const path of paths) {
     const abs = resolve(path);
     assertAllowedSandboxChownPath(abs);
-    await chownRecursiveNoFollow(abs, uid, gid);
-    console.log(`[sandbox-startup] chowned ${abs} to ${uid}:${gid}`);
+    await chownRecursiveNoFollow(abs);
+    console.log(
+      `[sandbox-startup] prepared ${abs} for sandbox handoff ${sandboxHandoffDescription()}`,
+    );
   }
 }
 

--- a/tests/test-agent-tool-sandbox.ts
+++ b/tests/test-agent-tool-sandbox.ts
@@ -188,8 +188,8 @@ try {
       const changed = JSON.parse(statJson) as { uid?: number; gid?: number };
       assert("startup chown changes ownership when privileged", chownAttempt.status === 0);
       assert(
-        "startup chown target has requested owner/group",
-        changed.uid === targetUid && changed.gid === targetGid,
+        "startup chown target has requested owner and server group",
+        changed.uid === targetUid && changed.gid === currentGid,
         chownAttempt.stdout,
       );
     } else {
@@ -235,6 +235,17 @@ try {
       opts?: { expectedSha256?: string; overwrite?: boolean },
     ) => Promise<{ path: string; size: number; sha256: string }>;
   };
+  const { createDirectory: createWorkspaceDirectory } = (await import(
+    resolve(repoRoot, "packages/server/dist/project-manager.js")
+  )) as { createDirectory: (parentPath: string, name: string) => Promise<string> };
+  const { cloneRepository } = (await import(
+    resolve(repoRoot, "packages/server/dist/git-clone.js")
+  )) as {
+    cloneRepository: (opts: { url: string; target: string }) => {
+      promise: Promise<void>;
+      events: AsyncIterable<{ type: string; target?: string; message?: string }>;
+    };
+  };
   const { applySandboxStartupChowns } = (await import(
     resolve(repoRoot, "packages/server/dist/sandbox-startup-permissions.js")
   )) as { applySandboxStartupChowns: () => Promise<void> };
@@ -269,8 +280,9 @@ try {
     bufferSource("uploaded\n"),
   );
   const mkdirResult = await makeDirectory(project, project, "browser-dir");
+  const workspaceDirResult = await createWorkspaceDirectory(workspace, "browser-project");
   const expectedUid = Number(process.env.AGENT_TOOL_UID);
-  const expectedGid = Number(process.env.AGENT_TOOL_GID);
+  const expectedGid = process.getgid?.() ?? Number(process.env.AGENT_TOOL_GID);
   for (const ownedPath of [
     resolve(project, "created"),
     resolve(project, "created", "from-write.txt"),
@@ -278,13 +290,62 @@ try {
     resolve(project, "uploaded", "nested"),
     uploadResult.path,
     mkdirResult,
+    workspaceDirResult,
   ]) {
     const st = statSync(ownedPath);
+    const mode = st.mode & 0o777;
     assert(
-      `sandbox-created path owned by tool identity: ${ownedPath.slice(project.length + 1)}`,
+      `sandbox-created path owned by tool identity and server group: ${ownedPath.slice(project.length + 1)}`,
       st.uid === expectedUid && st.gid === expectedGid,
       `${st.uid}:${st.gid}`,
     );
+    assert(
+      `sandbox-created path is group accessible: ${ownedPath.slice(project.length + 1)}`,
+      st.isDirectory() ? (mode & 0o070) === 0o070 : (mode & 0o060) === 0o060,
+      mode.toString(8),
+    );
+  }
+
+  if (spawnSync("git", ["--version"], { encoding: "utf8" }).status === 0) {
+    const sourceRepo = resolve(tmp, "source-repo");
+    mkdirSync(sourceRepo, { recursive: true });
+    spawnSync("git", ["init"], { cwd: sourceRepo, encoding: "utf8" });
+    writeFileSync(resolve(sourceRepo, "README.md"), "# sandbox clone\n", "utf8");
+    spawnSync("git", ["add", "README.md"], { cwd: sourceRepo, encoding: "utf8" });
+    spawnSync(
+      "git",
+      ["-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "init"],
+      {
+        cwd: sourceRepo,
+        encoding: "utf8",
+      },
+    );
+    const cloneTarget = resolve(workspace, "cloned-project");
+    const cloned = cloneRepository({ url: `file://${sourceRepo}`, target: cloneTarget });
+    let cloneDone = false;
+    let cloneError = "";
+    for await (const event of cloned.events) {
+      if (event.type === "done") cloneDone = true;
+      if (event.type === "error") cloneError = event.message ?? "clone error";
+    }
+    await cloned.promise;
+    assert("sandbox git clone completes", cloneDone, cloneError);
+    for (const clonedPath of [cloneTarget, resolve(cloneTarget, "README.md")]) {
+      const st = statSync(clonedPath);
+      const mode = st.mode & 0o777;
+      assert(
+        `sandbox-cloned path owned by tool identity and server group: ${clonedPath.slice(workspace.length + 1)}`,
+        st.uid === expectedUid && st.gid === expectedGid,
+        `${st.uid}:${st.gid}`,
+      );
+      assert(
+        `sandbox-cloned path is group accessible: ${clonedPath.slice(workspace.length + 1)}`,
+        st.isDirectory() ? (mode & 0o070) === 0o070 : (mode & 0o060) === 0o060,
+        mode.toString(8),
+      );
+    }
+  } else {
+    assert("git clone sandbox handoff coverage skipped because git is unavailable", true);
   }
 
   if ((process.getuid?.() ?? 0) === 0) {
@@ -341,7 +402,7 @@ try {
       },
     );
     assert(
-      "root can chown file-manager creates to configured UID/GID",
+      "root can prepare file-manager creates for sandbox handoff",
       ownership.status === 0,
       ownership.stderr,
     );
@@ -352,8 +413,8 @@ try {
     >;
     for (const [label, st] of Object.entries(ownershipStats)) {
       assert(
-        `root-created ${label} owned by 1:1`,
-        st.uid === 1 && st.gid === 1,
+        `root-created ${label} owned by tool uid and server group`,
+        st.uid === 1 && st.gid === 0,
         `${st.uid}:${st.gid}`,
       );
     }

--- a/tests/test-files.ts
+++ b/tests/test-files.ts
@@ -10,7 +10,8 @@
  *   - PUT /files/write creates a file (with parent dirs); content reads back
  *     verbatim via GET /files/read; language detected from extension
  *   - POST /files/rename moves a file to a new basename in the same dir
- *   - POST /files/move relocates across directories
+ *   - POST /files/move relocates across directories and into folders in sandbox mode
+ *   - GET /files/download streams files and directory archives
  *   - DELETE /files/delete removes a file
  *   - POST /files/mkdir creates a directory; second call → 409 (target_exists)
  *   - DELETE /files/delete on a non-empty dir → 409 (directory_not_empty)
@@ -27,6 +28,7 @@ import {
   mkdtemp,
   readFile as fsRead,
   rm,
+  stat,
   symlink,
   writeFile as fsWrite,
 } from "node:fs/promises";
@@ -179,6 +181,9 @@ async function main(): Promise<void> {
       UI_PASSWORD: undefined,
       JWT_SECRET: undefined,
       SERVE_CLIENT: "false",
+      AGENT_TOOL_SANDBOX_ENABLED: "true",
+      AGENT_TOOL_UID: String(typeof process.getuid === "function" ? process.getuid() : 0),
+      AGENT_TOOL_GID: String(typeof process.getgid === "function" ? process.getgid() : 0),
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -330,6 +335,74 @@ async function main(): Promise<void> {
       const qs = new URLSearchParams({ projectId, path: movedDest }).toString();
       const read = await jget(`${base}/api/v1/files/read?${qs}`, auth);
       assert("file readable at new dest", read.status === 200);
+    }
+
+    // ---- sandbox handoff: create and move inside folders ----
+    {
+      const folder = await jsend(
+        "POST",
+        `${base}/api/v1/files/mkdir`,
+        { projectId, parentPath: canonicalProjectPath, name: "sandbox-folder" },
+        auth,
+      );
+      assert("sandbox mkdir folder → 200", folder.status === 200, JSON.stringify(folder.body));
+      const folderPath = (folder.body as { path: string }).path;
+      const folderMode = (await stat(folderPath)).mode & 0o777;
+      assert(
+        "sandbox folder is group-writable",
+        (folderMode & 0o070) === 0o070,
+        folderMode.toString(8),
+      );
+
+      const childPath = join(folderPath, "child.txt");
+      const created = await jsend(
+        "PUT",
+        `${base}/api/v1/files/write`,
+        { projectId, path: childPath, content: "child\n" },
+        auth,
+      );
+      assert(
+        "sandbox write inside folder → 200",
+        created.status === 200,
+        JSON.stringify(created.body),
+      );
+      const childMode = (await stat(childPath)).mode & 0o777;
+      assert(
+        "sandbox file is group-readable/writable",
+        (childMode & 0o060) === 0o060,
+        childMode.toString(8),
+      );
+
+      const movedIntoFolder = join(folderPath, "moved.ts");
+      const moved = await jsend(
+        "POST",
+        `${base}/api/v1/files/move`,
+        { projectId, src: movedDest, dest: movedIntoFolder },
+        auth,
+      );
+      assert(
+        "sandbox move file into folder → 200",
+        moved.status === 200,
+        JSON.stringify(moved.body),
+      );
+      movedDest = (moved.body as { path: string }).path;
+    }
+
+    // ---- download file and directory ----
+    {
+      const fileQs = new URLSearchParams({ projectId, path: movedDest }).toString();
+      const fileRes = await fetch(`${base}/api/v1/files/download?${fileQs}`, { headers: auth });
+      assert("GET /files/download file → 200", fileRes.status === 200);
+      assert("download file content matches", (await fileRes.text()) === "export const y = 2;\n");
+
+      const dirQs = new URLSearchParams({
+        projectId,
+        path: join(canonicalProjectPath, "sandbox-folder"),
+      }).toString();
+      const dirRes = await fetch(`${base}/api/v1/files/download?${dirQs}`, { headers: auth });
+      const dirBytes = await dirRes.arrayBuffer();
+      assert("GET /files/download directory → 200", dirRes.status === 200);
+      assert("download directory returns bytes", dirBytes.byteLength > 0);
     }
 
     // ---- delete file ----


### PR DESCRIPTION
## Summary

File-pane operations in sandbox mode could leave browser-created or browser-moved workspace entries owned in a way that either the sandbox tool user or the root server could not access. This showed up as permission denied when creating a file inside a folder, moving a file into a folder, and downloading trees after ownership drift. Separately, the Docker image's default ownership made regular/non-sandbox deployments less friendly to the `pi` user writing normal home/config paths.

This PR centralizes sandbox workspace handoff permissions, keeps the root server's group access while handing ownership to the sandbox tool UID, and restores non-sandbox image-layer ownership for `pi` home/config directories.

## Usage

No new user-facing API is required. Existing file-pane operations continue to use the same routes.

For sandbox Docker Compose deployments, the sandbox overlay now prepares `/workspace` by default:

```yaml
AGENT_TOOL_SANDBOX_CHOWN_PATHS: /workspace
```

Operators can still override `AGENT_TOOL_SANDBOX_CHOWN_PATHS` with a comma/whitespace list of allowed non-secret roots when they need to prepare additional sandbox-writable resource directories.

## What changed (9 files)

- `packages/server/src/sandbox-permissions.ts` — adds a shared helper for sandbox path/tree handoff that sets owner to the sandbox tool UID, group to the server group, and preserves existing mode bits while adding needed group access.
- `packages/server/src/file-manager.ts` — applies sandbox handoff centrally across file-pane read, write, mkdir, upload, rename/move, delete, and download/archive flows.
- `packages/server/src/sandbox-startup-permissions.ts` — reuses the shared handoff helper for startup chown paths while keeping allowed-root validation narrow.
- `docker/Dockerfile` — restores regular-mode image ownership so `pi` owns `/workspace`, `/home/pi`, `/home/pi/.pi`, Pi config/data, and cache dirs; keeps `/home/pi/.pi` group-traversable for `pi-tools`.
- `docker/docker-compose.sandbox.yml` — defaults sandbox startup preparation to `/workspace`.
- `docs/agent-tool-sandbox.md` and `docs/configuration.md` — document the shared sandbox/server permission model and regular-mode home ownership.
- `tests/test-files.ts` — covers sandbox create-inside-folder, move-into-folder, and file/directory download behavior through HTTP routes.
- `tests/test-agent-tool-sandbox.ts` — updates startup/file-manager ownership assertions for sandbox UID + server-group handoff and group accessibility.

## Test plan

- [x] `npm run format`
- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only files,agent-tool-sandbox`
- [ ] CI green before merge
