### PR TITLE
feat: add MCP truncation settings and login idle timeout

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -26,7 +26,11 @@ For the full list with defaults and grouping, point users at:
 
 If both `UI_PASSWORD` and `API_KEY` are unset, auth is disabled entirely.
 Production deploys should set at least one. Setting both is common — browser
-users log in with the password, scripts use the API key.
+users log in with the password, scripts use the API key. Browser JWTs have an
+absolute lifetime (`JWT_EXPIRES_IN_SECONDS`) and can also enforce an idle timeout
+with `LOGIN_INACTIVITY_TIMEOUT_SECONDS` (0 disables idle expiry). Passive GETs
+such as SSE reconnects and polling must not refresh this idle timer; otherwise a
+reverse proxy that drops/reopens streams can keep a browser login alive forever.
 
 `AGENT_TOOL_SANDBOX_ENABLED` defaults false. When true, config startup requires
 numeric `AGENT_TOOL_UID` and `AGENT_TOOL_GID`, sandbox shell surfaces receive

--- a/docs/agent/mcp.md
+++ b/docs/agent/mcp.md
@@ -18,3 +18,8 @@ Relevant scripts include:
 - `tests/test-mcp.ts`
 - `tests/test-mcp-truncation.ts`
 - `tests/test-tool-overrides.ts`
+
+MCP result truncation is a global MCP setting persisted in `FORGE_DATA_DIR/mcp.json`
+under `truncation`. The bridge defaults to enabled at 30,000 text characters and
+can be disabled or retuned from Settings → MCP; keep this contract in sync with
+`tests/test-mcp-truncation.ts`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,8 @@ or shell environment. The most-touched ones:
 | `FORGE_LOCAL_ADMIN_USERNAME` | `admin` | Username that selects the local admin password when LDAP login is enabled. Equivalent CLI: `--local-admin-username`. Must be 1-256 characters using only letters, numbers, `.`, `_`, `@`, or `-`. |
 | `API_KEY` | (unset) | Static bearer token for programmatic access. |
 | `JWT_SECRET` | (auto-generated) | HS256 signing key. Auto-generated and persisted to `${FORGE_DATA_DIR}/jwt-secret` (mode 0600) when `UI_PASSWORD`, LDAP auth, or `password-hash` is in play. Set explicitly (`openssl rand -hex 32`) to override; delete the file to rotate. |
+| `JWT_EXPIRES_IN_SECONDS` | `604800` | Absolute browser JWT lifetime (7 days by default). Equivalent CLI: `--jwt-expires-in-seconds`. |
+| `LOGIN_INACTIVITY_TIMEOUT_SECONDS` | `0` | Optional idle timeout for browser JWTs. `0` disables inactivity expiry; a positive value logs out browser sessions after that many seconds without mutating authenticated requests. Passive GETs such as SSE reconnects and status polling do not extend the idle window. Equivalent CLI: `--login-inactivity-timeout-seconds`. |
 | `LDAP_ENABLED` | `false` | Enables LDAP username/password browser login. Requires the LDAP variables below. |
 | `LDAP_URL` | (unset) | LDAP server URL, e.g. `ldap://ldap.example.com:389` or `ldaps://ldap.example.com:636`. |
 | `LDAP_BIND_DN` | (unset) | Service-account bind DN used only to search for the user entry. |
@@ -292,10 +294,12 @@ include them so a restore preserves per-project preferences.
 
 ## MCP servers
 
-MCP server definitions live in `${FORGE_DATA_DIR}/mcp.json` (global)
-and `<project>/.mcp.json` (project-scoped). Manage via **Settings →
-MCP** or edit the files directly. See [`mcp.md`](./mcp.md) for the
-field reference, transport options, auth model, and troubleshooting.
+MCP server definitions and global MCP behavior settings live in
+`${FORGE_DATA_DIR}/mcp.json` (global). Project-scoped server definitions
+live in `<project>/.mcp.json`. Manage global entries and MCP result
+truncation via **Settings → MCP** or edit the files directly. See
+[`mcp.md`](./mcp.md) for the field reference, transport options, auth
+model, truncation semantics, and troubleshooting.
 
 ## Pi plugins
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -168,6 +168,7 @@ pi-forge:
 | `TRUST_PROXY` | `true` | Required when behind a reverse proxy so the login rate-limit sees real client IPs |
 | `CORS_ORIGIN` | the URL you reach pi-forge at, e.g. `http://pi-forge.local:3000` | Pinning stops other LAN origins from making cross-origin requests with the user's credentials |
 | `JWT_EXPIRES_IN_SECONDS` | `86400` (24 h) for shared-LAN deploys; default `604800` (7 d) for single-user | Shorter = smaller blast radius if a token leaks |
+| `LOGIN_INACTIVITY_TIMEOUT_SECONDS` | `3600` (1 h) for shared/kiosk browsers; default `0` disables idle expiry | Logs out browser JWTs after no mutating authenticated requests for the configured interval; passive GET polling / SSE reconnects do not extend it |
 | `RATE_LIMIT_LOGIN_MAX` | default `10` is fine | Per-IP login attempts per minute |
 | `LOG_LEVEL` | `info` (default) or `warn` if noisy | `debug` / `trace` are useful during incidents |
 | `MINIMAL_UI` | `true` to hide terminal / git / settings from non-admin users | Frontend gate; server routes unchanged |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -49,6 +49,10 @@ to swap a global server for a project-specific one).
 ```json
 {
   "disabled": false,
+  "truncation": {
+    "enabled": true,
+    "maxChars": 30000
+  },
   "servers": {
     "weather": {
       "url": "https://mcp.example.com/sse",
@@ -99,6 +103,8 @@ shape, so existing files don't need rewriting:
 | `env` | `Record<string, string>` | stdio | (none) | Subprocess env. Pi-forge env is **not** inherited by default (see "Stdio env" below). Treated as secret on read. |
 | `cwd` | string | stdio | project path (project scope) / pi-forge cwd (global) | Subprocess working directory. |
 | `disabled` | boolean (top-level) | — | `false` | Master kill-switch. When `true`, NO MCP tools reach the agent regardless of per-server `enabled`. |
+| `truncation.enabled` | boolean (top-level) | — | `true` | When true, text MCP results are capped before they enter agent context. |
+| `truncation.maxChars` | integer (top-level) | — | `30000` | Total text-character cap across all text blocks in one MCP result. Images pass through unchanged. |
 
 ## Stdio env passthrough
 
@@ -218,11 +224,16 @@ payloads keep their existing UI state to avoid unnecessary churn.
 ## Tool result truncation
 
 Very large text results from MCP tools are capped before they enter the agent
-context. When truncation happens, the returned text starts with a concise
+context. The default cap is 30,000 characters across all text blocks in a single
+MCP result; Settings → MCP lets you disable this or choose a different cap, and
+stores the choice in `${FORGE_DATA_DIR}/mcp.json` as `truncation.enabled` /
+`truncation.maxChars`.
+
+When truncation happens, the returned text starts with a concise
 `MCP_RESULT_TRUNCATED` warning that includes the omitted size and tells the model
 to retry with a smaller scope, narrower filter, or pagination. The visible payload
 then keeps the start and end of the original result with a marker where the middle
-was omitted.
+was omitted. Image blocks pass through unchanged.
 
 ## Troubleshooting
 

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -3373,6 +3373,7 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
   const stdioTrust = useMcpStore((s) => s.byProject[project?.id ?? "__no_project__"]?.stdioTrust);
   const refreshProject = useMcpStore((s) => s.refreshProject);
   const setMcpEnabled = useMcpStore((s) => s.setMcpEnabled);
+  const setMcpTruncation = useMcpStore((s) => s.setMcpTruncation);
   const upsertServer = useMcpStore((s) => s.upsertServer);
   const deleteServer = useMcpStore((s) => s.deleteServer);
   const probeServerStore = useMcpStore((s) => s.probeServer);
@@ -3384,6 +3385,7 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
   const [editingName, setEditingName] = useState<string | undefined>(undefined);
   const [busy, setBusy] = useState(false);
   const [probing, setProbing] = useState<string | undefined>(undefined);
+  const [truncationMaxDraft, setTruncationMaxDraft] = useState<string | undefined>(undefined);
 
   // Per-tool listing fetched alongside the server config so each
   // server row can cascade its tools (each tool gets its own
@@ -3441,6 +3443,19 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
       await refreshProject(project?.id);
     } catch (err) {
       onError(`Failed to toggle MCP: ${errorCode(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveTruncation = async (next: { enabled: boolean; maxChars: number }): Promise<void> => {
+    setBusy(true);
+    try {
+      await setMcpTruncation(next);
+      setTruncationMaxDraft(undefined);
+      onError(undefined);
+    } catch (err) {
+      onError(`Failed to update MCP truncation: ${errorCode(err)}`);
     } finally {
       setBusy(false);
     }
@@ -3619,24 +3634,81 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
         on name collision).
       </p>
 
-      <div className="flex items-center justify-between rounded border border-neutral-800 bg-neutral-900/40 p-3">
-        <div>
-          <div className="text-sm font-medium text-neutral-100">MCP tools</div>
-          <div className="text-[11px] text-neutral-500">
-            Master switch. When off, no MCP tools reach the agent regardless of per-server state.
+      <div className="space-y-3 rounded border border-neutral-800 bg-neutral-900/40 p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className="text-sm font-medium text-neutral-100">MCP tools</div>
+            <div className="text-[11px] text-neutral-500">
+              Master switch. When off, no MCP tools reach the agent regardless of per-server state.
+            </div>
+          </div>
+          <button
+            onClick={() => void toggleMaster(!enabled)}
+            disabled={busy}
+            className={`rounded border px-3 py-1 text-xs ${
+              enabled
+                ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800"
+                : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
+            }`}
+          >
+            {enabled ? "Enabled" : "Disabled"}
+          </button>
+        </div>
+        <div className="flex flex-wrap items-end justify-between gap-3 border-t border-neutral-800 pt-3">
+          <div className="min-w-[240px] flex-1">
+            <div className="text-sm font-medium text-neutral-100">Result truncation</div>
+            <div className="text-[11px] text-neutral-500">
+              Caps total text returned by each MCP tool before it enters agent context. Images pass
+              through unchanged. Disable only for trusted, bounded tools.
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-[11px] text-neutral-500" htmlFor="mcp-truncation-max">
+              Max chars
+            </label>
+            <input
+              id="mcp-truncation-max"
+              type="number"
+              min={1}
+              max={1000000}
+              value={truncationMaxDraft ?? String(settings.truncation.maxChars)}
+              onChange={(e) => setTruncationMaxDraft(e.target.value)}
+              onBlur={() => {
+                const parsed = Number.parseInt(
+                  truncationMaxDraft ?? String(settings.truncation.maxChars),
+                  10,
+                );
+                if (
+                  Number.isFinite(parsed) &&
+                  parsed >= 1 &&
+                  parsed !== settings.truncation.maxChars
+                ) {
+                  void saveTruncation({ ...settings.truncation, maxChars: parsed });
+                } else {
+                  setTruncationMaxDraft(undefined);
+                }
+              }}
+              disabled={busy || !settings.truncation.enabled}
+              className="w-28 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs text-neutral-100 disabled:opacity-50"
+            />
+            <button
+              onClick={() =>
+                void saveTruncation({
+                  ...settings.truncation,
+                  enabled: !settings.truncation.enabled,
+                })
+              }
+              disabled={busy}
+              className={`rounded border px-3 py-1 text-xs ${
+                settings.truncation.enabled
+                  ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800"
+                  : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
+              }`}
+            >
+              {settings.truncation.enabled ? "Truncating" : "Pass-through"}
+            </button>
           </div>
         </div>
-        <button
-          onClick={() => void toggleMaster(!enabled)}
-          disabled={busy}
-          className={`rounded border px-3 py-1 text-xs ${
-            enabled
-              ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800"
-              : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
-          }`}
-        >
-          {enabled ? "Enabled" : "Disabled"}
-        </button>
       </div>
 
       {project !== undefined && (

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -620,14 +620,21 @@ function vMcpSettings(value: unknown, status: number): McpSettingsResponse {
     !isObject(value) ||
     typeof value.enabled !== "boolean" ||
     typeof value.connected !== "number" ||
-    typeof value.total !== "number"
+    typeof value.total !== "number" ||
+    !isObject(value.truncation) ||
+    typeof value.truncation.enabled !== "boolean" ||
+    typeof value.truncation.maxChars !== "number"
   ) {
-    fail(status, "expected { enabled, connected, total }");
+    fail(status, "expected { enabled, connected, total, truncation }");
   }
   return {
     enabled: value.enabled,
     connected: value.connected,
     total: value.total,
+    truncation: {
+      enabled: value.truncation.enabled,
+      maxChars: value.truncation.maxChars,
+    },
   };
 }
 
@@ -1988,6 +1995,11 @@ export const api = {
     request("/api/v1/mcp/settings", vMcpSettings, {
       method: "PUT",
       body: { enabled },
+    }),
+  setMcpTruncation: (truncation: { enabled: boolean; maxChars: number }) =>
+    request("/api/v1/mcp/settings", vMcpSettings, {
+      method: "PUT",
+      body: { truncation },
     }),
   /** GLOBAL servers (config + status). Pass projectId to also include
    *  status entries for the project's `.mcp.json` servers. */

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -103,6 +103,8 @@ export interface McpSettingsResponse {
   connected: number;
   /** Total GLOBAL servers configured. */
   total: number;
+  /** MCP text-result truncation applied before MCP results enter agent context. */
+  truncation: { enabled: boolean; maxChars: number };
 }
 
 // ---------------- processes ----------------

--- a/packages/client/src/store/mcp-store.ts
+++ b/packages/client/src/store/mcp-store.ts
@@ -14,7 +14,13 @@ function stableJson(value: unknown): string {
 }
 
 function sameSettings(a: McpSettingsResponse | undefined, b: McpSettingsResponse): boolean {
-  return a?.enabled === b.enabled && a.connected === b.connected && a.total === b.total;
+  return (
+    a?.enabled === b.enabled &&
+    a.connected === b.connected &&
+    a.total === b.total &&
+    a.truncation.enabled === b.truncation.enabled &&
+    a.truncation.maxChars === b.truncation.maxChars
+  );
 }
 
 function sameProjectData(a: ProjectScopeData | undefined, b: ProjectScopeData): boolean {
@@ -95,6 +101,7 @@ interface McpState {
   /** Pulls global config + per-project status. Idempotent. */
   refreshProject: (projectId: string | undefined) => Promise<void>;
   setMcpEnabled: (enabled: boolean) => Promise<void>;
+  setMcpTruncation: (truncation: { enabled: boolean; maxChars: number }) => Promise<void>;
   upsertServer: (name: string, body: McpServerConfig) => Promise<void>;
   deleteServer: (name: string) => Promise<void>;
   probeServer: (name: string, projectId: string | undefined) => Promise<void>;
@@ -220,6 +227,21 @@ export const useMcpStore = create<McpState>((set, get) => ({
       set({ settings: r, error: undefined });
     } catch (err) {
       // Revert on failure so the UI doesn't drift from the server.
+      if (prior !== undefined) set({ settings: prior });
+      set({ error: describeError(err) });
+      throw err;
+    }
+  },
+
+  setMcpTruncation: async (truncation) => {
+    const prior = get().settings;
+    if (prior !== undefined) {
+      set({ settings: { ...prior, truncation } });
+    }
+    try {
+      const r = await api.setMcpTruncation(truncation);
+      set({ settings: r, error: undefined });
+    } catch (err) {
       if (prior !== undefined) set({ settings: prior });
       set({ error: describeError(err) });
       throw err;

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -24,6 +24,7 @@ const SCRYPT_KEYLEN = 64;
 const SCRYPT_SALT_BYTES = 16;
 
 const HASH_PREFIX = "scrypt";
+const lastTokenActivityMs = new Map<string, number>();
 
 export interface JwtPayload {
   sub: "ui-user";
@@ -73,6 +74,7 @@ export function generateToken(opts: { mustChangePassword: boolean }): IssuedToke
     },
   );
   const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+  lastTokenActivityMs.set(token, Date.now());
   return { token, expiresAt };
 }
 
@@ -80,7 +82,7 @@ export function generateToken(opts: { mustChangePassword: boolean }): IssuedToke
  * Verify a JWT and return the typed payload, or undefined on any failure
  * (bad signature, expired, missing JWT_SECRET, wrong subject).
  */
-export function verifyToken(token: string): JwtPayload | undefined {
+export function verifyToken(token: string, opts: { touch?: boolean } = {}): JwtPayload | undefined {
   if (config.auth.jwtSecret === undefined) return undefined;
   try {
     const decoded = jwt.verify(token, config.auth.jwtSecret, {
@@ -92,6 +94,7 @@ export function verifyToken(token: string): JwtPayload | undefined {
     // mustChangePassword may be absent on tokens issued before this
     // field existed; treat absence as `false` so existing sessions
     // don't get force-rerouted to the change-password screen.
+    if (!tokenIsActive(token, decoded.iat, opts.touch !== false)) return undefined;
     const mustChangePassword =
       typeof (decoded as { mustChangePassword?: unknown }).mustChangePassword === "boolean"
         ? (decoded as { mustChangePassword: boolean }).mustChangePassword
@@ -104,6 +107,19 @@ export function verifyToken(token: string): JwtPayload | undefined {
     // (and we don't want to leak which case applies to a brute-forcer).
     return undefined;
   }
+}
+
+function tokenIsActive(token: string, issuedAtSeconds: number, touch: boolean): boolean {
+  const timeoutSeconds = config.auth.loginInactivityTimeoutSeconds;
+  if (timeoutSeconds <= 0) return true;
+  const now = Date.now();
+  const lastSeen = lastTokenActivityMs.get(token) ?? issuedAtSeconds * 1000;
+  if (now - lastSeen > timeoutSeconds * 1000) {
+    lastTokenActivityMs.delete(token);
+    return false;
+  }
+  if (touch) lastTokenActivityMs.set(token, now);
+  return true;
 }
 
 export function verifyApiKey(presented: string): boolean {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -170,6 +170,14 @@ const FLAGS: readonly FlagDef[] = [
     defaultText: "604800 (7d)",
   },
   {
+    name: "login-inactivity-timeout-seconds",
+    env: "LOGIN_INACTIVITY_TIMEOUT_SECONDS",
+    type: "number",
+    group: "auth",
+    desc: "Expire browser JWTs after this many seconds without activity (0 disables)",
+    defaultText: "0 (disabled)",
+  },
+  {
     name: "require-password-change",
     env: "REQUIRE_PASSWORD_CHANGE",
     type: "boolean",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -479,6 +479,7 @@ export const config = Object.freeze({
       tlsRejectUnauthorized: readBool("LDAP_TLS_REJECT_UNAUTHORIZED", true),
     }),
     jwtExpiresInSeconds: readInt("JWT_EXPIRES_IN_SECONDS", 60 * 60 * 24 * 7),
+    loginInactivityTimeoutSeconds: readInt("LOGIN_INACTIVITY_TIMEOUT_SECONDS", 0),
     loginRateLimitMax: readInt("RATE_LIMIT_LOGIN_MAX", 10),
     loginRateLimitWindowMs: readInt("RATE_LIMIT_LOGIN_WINDOW_MS", 60_000),
     /**

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -59,6 +59,17 @@ declare module "fastify" {
   }
 }
 
+function shouldRefreshJwtActivity(method: string): boolean {
+  const upper = method.toUpperCase();
+  // Browser background work is mostly GET (SSE connects/reconnects,
+  // status polling, git polling, static-ish diagnostics). If those
+  // refresh the idle clock, a reverse proxy that periodically drops
+  // and reopens SSE can keep a login alive forever without user
+  // activity. Mutating requests are deliberate user/app actions and
+  // extend the browser session.
+  return upper !== "GET" && upper !== "HEAD" && upper !== "OPTIONS";
+}
+
 export async function buildServer(): Promise<FastifyInstance> {
   // Install before Fastify so unhandledRejection handlers from this
   // module are first in line — they print full cause chains for
@@ -368,7 +379,7 @@ export async function buildServer(): Promise<FastifyInstance> {
       reply.code(401).send({ error: "missing_token" });
       return;
     }
-    const tokenPayload = verifyToken(presented);
+    const tokenPayload = verifyToken(presented, { touch: shouldRefreshJwtActivity(req.method) });
     if (tokenPayload !== undefined) {
       // Initial-login tokens (issued because the user authenticated
       // with the env-supplied UI_PASSWORD and REQUIRE_PASSWORD_CHANGE

--- a/packages/server/src/mcp/config.ts
+++ b/packages/server/src/mcp/config.ts
@@ -87,6 +87,13 @@ export interface McpServerConfig {
   cwd?: string;
 }
 
+export interface McpTruncationConfig {
+  /** Default true. When false, MCP text results pass through without truncation. */
+  enabled?: boolean;
+  /** Total text-character cap across all MCP result text blocks. Default 30000. */
+  maxChars?: number;
+}
+
 export interface McpJson {
   /**
    * Master kill-switch surfaced as a toggle in Settings → MCP. When
@@ -96,6 +103,8 @@ export interface McpJson {
    * skipped. Defaults to false (MCP tools available).
    */
   disabled?: boolean;
+  /** MCP result truncation settings. Defaults to enabled with a 30k character cap. */
+  truncation?: McpTruncationConfig;
   servers: Record<string, McpServerConfig>;
 }
 
@@ -111,6 +120,19 @@ export function isStdioConfig(cfg: McpServerConfig): boolean {
 }
 
 const SECRET_PLACEHOLDER = "***REDACTED***";
+export const DEFAULT_MCP_TRUNCATION_MAX_CHARS = 30_000;
+
+export function normalizeMcpTruncationConfig(
+  input: McpTruncationConfig | undefined,
+): Required<McpTruncationConfig> {
+  const enabled = input?.enabled !== false;
+  const rawMax = input?.maxChars;
+  const maxChars =
+    typeof rawMax === "number" && Number.isFinite(rawMax) && rawMax >= 1
+      ? Math.floor(rawMax)
+      : DEFAULT_MCP_TRUNCATION_MAX_CHARS;
+  return { enabled, maxChars };
+}
 
 async function ensureDir(): Promise<void> {
   await mkdir(dirname(config.mcpConfigFile), { recursive: true });
@@ -148,10 +170,19 @@ export async function readMcpJson(): Promise<McpJson> {
     }
     const servers = (parsed as { servers?: unknown }).servers;
     const disabled = (parsed as { disabled?: unknown }).disabled === true;
+    const rawTruncation = (parsed as { truncation?: unknown }).truncation;
+    const truncation =
+      typeof rawTruncation === "object" && rawTruncation !== null
+        ? normalizeMcpTruncationConfig(rawTruncation)
+        : undefined;
     if (typeof servers !== "object" || servers === null) {
-      return { disabled, servers: {} };
+      return { disabled, ...(truncation !== undefined ? { truncation } : {}), servers: {} };
     }
-    return { disabled, servers: servers as Record<string, McpServerConfig> };
+    return {
+      disabled,
+      ...(truncation !== undefined ? { truncation } : {}),
+      servers: servers as Record<string, McpServerConfig>,
+    };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return { servers: {} };
     throw err;
@@ -234,6 +265,10 @@ export async function writeMcpJson(next: McpJson): Promise<void> {
   const existing: McpJson = await readMcpJson().catch(() => ({ servers: {} }));
   const safe: McpJson = { servers: {} };
   if (next.disabled === true) safe.disabled = true;
+  const truncation = normalizeMcpTruncationConfig(next.truncation);
+  if (truncation.enabled !== true || truncation.maxChars !== DEFAULT_MCP_TRUNCATION_MAX_CHARS) {
+    safe.truncation = truncation;
+  }
   for (const [name, server] of Object.entries(next.servers ?? {})) {
     const merged = copyServerCleaned(server);
     if (server.headers !== undefined) {
@@ -256,6 +291,15 @@ export async function upsertMcpServer(name: string, server: McpServerConfig): Pr
 export async function setMcpDisabled(disabled: boolean): Promise<void> {
   const cur = await readMcpJson();
   cur.disabled = disabled;
+  await writeMcpJson(cur);
+}
+
+export async function setMcpTruncationConfig(truncation: McpTruncationConfig): Promise<void> {
+  const cur = await readMcpJson();
+  cur.truncation = normalizeMcpTruncationConfig({
+    ...normalizeMcpTruncationConfig(cur.truncation),
+    ...truncation,
+  });
   await writeMcpJson(cur);
 }
 

--- a/packages/server/src/mcp/manager.ts
+++ b/packages/server/src/mcp/manager.ts
@@ -8,9 +8,15 @@ import {
   StdioClientTransport,
 } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { isStdioConfig, readMcpJson, type McpServerConfig, type McpTransport } from "./config.js";
+import {
+  isStdioConfig,
+  normalizeMcpTruncationConfig,
+  readMcpJson,
+  type McpServerConfig,
+  type McpTransport,
+} from "./config.js";
 import { isStdioTrustedForProject } from "./stdio-trust.js";
-import { bridgeMcpTool } from "./tool-bridge.js";
+import { bridgeMcpTool, setMcpResultTruncationSettings } from "./tool-bridge.js";
 
 /** Looser-than-the-SDK transport handle — we only need close().
  *  The SDK's `Transport` interface declares `sessionId: string` (not
@@ -126,6 +132,7 @@ export async function ensureGlobalLoaded(): Promise<void> {
 async function loadGlobalNow(): Promise<void> {
   const cfg = await readMcpJson();
   globallyEnabled = cfg.disabled !== true;
+  setMcpResultTruncationSettings(normalizeMcpTruncationConfig(cfg.truncation));
   await syncScope("global", cfg.servers);
   globalLoaded = true;
 }

--- a/packages/server/src/mcp/tool-bridge.ts
+++ b/packages/server/src/mcp/tool-bridge.ts
@@ -3,6 +3,11 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 
+export interface McpResultTruncationSettings {
+  enabled: boolean;
+  maxChars: number;
+}
+
 /**
  * Translate a single MCP tool advertised by a connected MCP server
  * into a pi `ToolDefinition` the agent can call.
@@ -225,16 +230,35 @@ export function mcpResultToAgentResult(res: unknown): AgentToolResult<unknown> {
 export const MCP_TEXT_CAP_CHARS = 30_000;
 export const MCP_TEXT_HEAD_RATIO = 0.6;
 
+let runtimeTruncationSettings: McpResultTruncationSettings = {
+  enabled: true,
+  maxChars: MCP_TEXT_CAP_CHARS,
+};
+
+export function setMcpResultTruncationSettings(settings: McpResultTruncationSettings): void {
+  runtimeTruncationSettings = {
+    enabled: settings.enabled,
+    maxChars: Math.max(1, Math.floor(settings.maxChars)),
+  };
+}
+
+export function getMcpResultTruncationSettings(): McpResultTruncationSettings {
+  return { ...runtimeTruncationSettings };
+}
+
 export type ContentBlock =
   | { type: "text"; text: string }
   | { type: "image"; data: string; mimeType: string };
 
 export function capTextContent(blocks: ContentBlock[]): ContentBlock[] {
+  const settings = runtimeTruncationSettings;
+  if (!settings.enabled) return blocks;
+  const capChars = settings.maxChars;
   let totalText = 0;
   for (const b of blocks) {
     if (b.type === "text") totalText += b.text.length;
   }
-  if (totalText <= MCP_TEXT_CAP_CHARS) return blocks;
+  if (totalText <= capChars) return blocks;
   // Flatten all text blocks into one head+tail string. Preserves
   // image blocks in their original positions; drops in-between text
   // separators in exchange for staying under the cap.
@@ -242,8 +266,8 @@ export function capTextContent(blocks: ContentBlock[]): ContentBlock[] {
     .filter((b): b is { type: "text"; text: string } => b.type === "text")
     .map((b) => b.text)
     .join("\n\n");
-  const headLen = Math.floor(MCP_TEXT_CAP_CHARS * MCP_TEXT_HEAD_RATIO);
-  const tailLen = MCP_TEXT_CAP_CHARS - headLen;
+  const headLen = Math.floor(capChars * MCP_TEXT_HEAD_RATIO);
+  const tailLen = capChars - headLen;
   const head = flat.slice(0, headLen);
   const tail = flat.slice(flat.length - tailLen);
   const omitted = flat.length - headLen - tailLen;

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -3,6 +3,7 @@ import {
   deleteMcpServer,
   readMcpJsonRedacted,
   setMcpDisabled,
+  setMcpTruncationConfig,
   upsertMcpServer,
   type McpServerConfig,
   type McpTransport,
@@ -18,6 +19,7 @@ import {
   unloadProject,
 } from "../mcp/manager.js";
 import { grantStdioTrust, isStdioTrustedForProject, revokeStdioTrust } from "../mcp/stdio-trust.js";
+import { getMcpResultTruncationSettings } from "../mcp/tool-bridge.js";
 import { getProject } from "../project-manager.js";
 import { errorSchema } from "./_schemas.js";
 
@@ -136,16 +138,25 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
           "Master MCP toggle + a compact connection summary the header " +
           "badge consumes. `enabled` mirrors `mcp.json#disabled === false`. " +
           "`connected` / `total` count GLOBAL servers only (project-scope " +
-          "counts come from /mcp/servers?projectId=...).",
+          "counts come from /mcp/servers?projectId=...). `truncation` controls " +
+          "the MCP text-result cap applied before results enter agent context.",
         tags: ["config"],
         response: {
           200: {
             type: "object",
-            required: ["enabled", "connected", "total"],
+            required: ["enabled", "connected", "total", "truncation"],
             properties: {
               enabled: { type: "boolean" },
               connected: { type: "integer", minimum: 0 },
               total: { type: "integer", minimum: 0 },
+              truncation: {
+                type: "object",
+                required: ["enabled", "maxChars"],
+                properties: {
+                  enabled: { type: "boolean" },
+                  maxChars: { type: "integer", minimum: 1 },
+                },
+              },
             },
           },
         },
@@ -156,33 +167,53 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
       const enabled = isGloballyEnabled();
       const total = status.length;
       const connected = status.filter((s) => s.state === "connected").length;
-      return { enabled, connected, total };
+      return { enabled, connected, total, truncation: getMcpResultTruncationSettings() };
     },
   );
 
-  fastify.put<{ Body: { enabled: boolean } }>(
+  fastify.put<{
+    Body: { enabled?: boolean; truncation?: { enabled?: boolean; maxChars?: number } };
+  }>(
     "/mcp/settings",
     {
       schema: {
         description:
-          "Toggle the master MCP enable/disable flag. When disabled, no " +
-          "MCP tools are passed into createAgentSession (existing live " +
-          "sessions are unaffected — start a new session to apply).",
+          "Update MCP settings. The master enabled flag controls whether MCP tools are passed " +
+          "into createAgentSession (existing live sessions are unaffected). The truncation " +
+          "setting controls whether MCP text results are capped before they enter agent context.",
         tags: ["config"],
         body: {
           type: "object",
-          required: ["enabled"],
+          minProperties: 1,
           additionalProperties: false,
-          properties: { enabled: { type: "boolean" } },
+          properties: {
+            enabled: { type: "boolean" },
+            truncation: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                enabled: { type: "boolean" },
+                maxChars: { type: "integer", minimum: 1, maximum: 1000000 },
+              },
+            },
+          },
         },
         response: {
           200: {
             type: "object",
-            required: ["enabled", "connected", "total"],
+            required: ["enabled", "connected", "total", "truncation"],
             properties: {
               enabled: { type: "boolean" },
               connected: { type: "integer", minimum: 0 },
               total: { type: "integer", minimum: 0 },
+              truncation: {
+                type: "object",
+                required: ["enabled", "maxChars"],
+                properties: {
+                  enabled: { type: "boolean" },
+                  maxChars: { type: "integer", minimum: 1 },
+                },
+              },
             },
           },
           400: errorSchema,
@@ -190,13 +221,19 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req) => {
-      await setMcpDisabled(!req.body.enabled);
+      if (req.body.enabled !== undefined) {
+        await setMcpDisabled(!req.body.enabled);
+      }
+      if (req.body.truncation !== undefined) {
+        await setMcpTruncationConfig(req.body.truncation);
+      }
       await reloadGlobal();
       const status = getStatus();
       return {
         enabled: isGloballyEnabled(),
         total: status.length,
         connected: status.filter((s) => s.state === "connected").length,
+        truncation: getMcpResultTruncationSettings(),
       };
     },
   );

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -223,6 +223,66 @@ async function scenarioPasswordAndJwt(): Promise<void> {
   }
 }
 
+async function scenarioLoginInactivityTimeout(): Promise<void> {
+  console.log("\n[scenario A2] login inactivity timeout");
+  const password = "hunter2";
+  const srv = await startServer({
+    UI_PASSWORD: password,
+    JWT_SECRET: randomBytes(32).toString("hex"),
+    API_KEY: undefined,
+    LOGIN_INACTIVITY_TIMEOUT_SECONDS: "1",
+    REQUIRE_PASSWORD_CHANGE: "false",
+  });
+  try {
+    const login = await jsonPost(`${srv.base}/api/v1/auth/login`, { password });
+    assert("login with inactivity timeout → 200", login.status === 200);
+    const issued = (await login.json()) as { token: string };
+
+    const activeProbe = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: { Authorization: `Bearer ${issued.token}` },
+    });
+    assert("fresh JWT passes before inactivity timeout", activeProbe.status === 404);
+
+    await new Promise((r) => setTimeout(r, 650));
+    const passiveGet = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: { Authorization: `Bearer ${issued.token}` },
+    });
+    assert("passive GET before timeout still passes", passiveGet.status === 404);
+
+    await new Promise((r) => setTimeout(r, 550));
+    const expiredAfterPassiveGet = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: { Authorization: `Bearer ${issued.token}` },
+    });
+    assert(
+      "passive GET polling does not refresh inactivity timeout → 401",
+      expiredAfterPassiveGet.status === 401,
+    );
+
+    const login2 = await jsonPost(`${srv.base}/api/v1/auth/login`, { password });
+    assert("second login for mutation refresh check → 200", login2.status === 200);
+    const issued2 = (await login2.json()) as { token: string };
+    await new Promise((r) => setTimeout(r, 650));
+    const mutatingProbe = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${issued2.token}` },
+    });
+    assert("mutating request before timeout passes", mutatingProbe.status === 404);
+    await new Promise((r) => setTimeout(r, 550));
+    const activeAfterMutation = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: { Authorization: `Bearer ${issued2.token}` },
+    });
+    assert("mutating request refreshes inactivity timeout", activeAfterMutation.status === 404);
+
+    await new Promise((r) => setTimeout(r, 1050));
+    const expiredProbe = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: { Authorization: `Bearer ${issued2.token}` },
+    });
+    assert("idle JWT after inactivity timeout → 401", expiredProbe.status === 401);
+  } finally {
+    await srv.stop();
+  }
+}
+
 async function scenarioApiKeyOnly(): Promise<void> {
   console.log("\n[scenario B] API_KEY only (no UI_PASSWORD)");
   const apiKey = "test-api-key-" + randomBytes(8).toString("hex");
@@ -529,6 +589,7 @@ async function scenarioPersistedHashOnly(): Promise<void> {
 
 async function main(): Promise<void> {
   await scenarioPasswordAndJwt();
+  await scenarioLoginInactivityTimeout();
   await scenarioApiKeyOnly();
   await scenarioAuthDisabled();
   await scenarioPersistedHashOnly();

--- a/tests/test-mcp-truncation.ts
+++ b/tests/test-mcp-truncation.ts
@@ -57,13 +57,22 @@ interface ToolBridgeModule {
   };
   MCP_TEXT_CAP_CHARS: number;
   MCP_TEXT_HEAD_RATIO: number;
+  getMcpResultTruncationSettings: () => { enabled: boolean; maxChars: number };
+  setMcpResultTruncationSettings: (settings: { enabled: boolean; maxChars: number }) => void;
 }
 
 async function main(): Promise<void> {
   const mod = (await import(
     resolve(repoRoot, "packages/server/dist/mcp/tool-bridge.js")
   )) as unknown as ToolBridgeModule;
-  const { capTextContent, mcpResultToAgentResult, MCP_TEXT_CAP_CHARS, MCP_TEXT_HEAD_RATIO } = mod;
+  const {
+    capTextContent,
+    mcpResultToAgentResult,
+    MCP_TEXT_CAP_CHARS,
+    MCP_TEXT_HEAD_RATIO,
+    getMcpResultTruncationSettings,
+    setMcpResultTruncationSettings,
+  } = mod;
 
   const headLen = Math.floor(MCP_TEXT_CAP_CHARS * MCP_TEXT_HEAD_RATIO);
   const tailLen = MCP_TEXT_CAP_CHARS - headLen;
@@ -235,6 +244,36 @@ async function main(): Promise<void> {
         out.content[0].text.includes("[error]"),
     );
   }
+
+  // ---------- settings: disable truncation ----------
+  {
+    setMcpResultTruncationSettings({ enabled: false, maxChars: MCP_TEXT_CAP_CHARS });
+    const blocks: ContentBlock[] = [{ type: "text", text: "N".repeat(MCP_TEXT_CAP_CHARS + 1) }];
+    const out = capTextContent(blocks);
+    assert("settings disabled: pass-through", out === blocks);
+  }
+
+  // ---------- settings: custom cap ----------
+  {
+    const customCap = 120;
+    setMcpResultTruncationSettings({ enabled: true, maxChars: customCap });
+    const settings = getMcpResultTruncationSettings();
+    assert(
+      "settings custom cap: persisted in runtime",
+      settings.enabled === true && settings.maxChars === customCap,
+      JSON.stringify(settings),
+    );
+    const out = capTextContent([{ type: "text", text: "C".repeat(500) }]);
+    assert("settings custom cap: truncates", out[0]?.type === "text");
+    if (out[0]?.type === "text") {
+      assert(
+        "settings custom cap: under cap+marker overhead",
+        out[0].text.length > customCap && out[0].text.length < customCap + 1000,
+        `len=${out[0].text.length}`,
+      );
+    }
+  }
+  setMcpResultTruncationSettings({ enabled: true, maxChars: MCP_TEXT_CAP_CHARS });
 
   // ---------- 60/40 head/tail ratio honored ----------
   {

--- a/tests/test-mcp.ts
+++ b/tests/test-mcp.ts
@@ -201,6 +201,9 @@ async function main(): Promise<void> {
   const config = (await import(
     resolve(repoRoot, "packages/server/dist/mcp/config.js")
   )) as typeof import("../packages/server/src/mcp/config.js");
+  const toolBridge = (await import(
+    resolve(repoRoot, "packages/server/dist/mcp/tool-bridge.js")
+  )) as typeof import("../packages/server/src/mcp/tool-bridge.js");
 
   // Eager connect inside `syncScope` is fire-and-forget (`void
   // connectEntry(entry)`), so loadGlobal returns before the WS
@@ -238,6 +241,12 @@ async function main(): Promise<void> {
     });
     await manager.loadGlobal();
     await waitForState("test", {}, "connected");
+    assert(
+      "truncation default: enabled at 30k chars",
+      JSON.stringify(toolBridge.getMcpResultTruncationSettings()) ===
+        JSON.stringify({ enabled: true, maxChars: 30000 }),
+      JSON.stringify(toolBridge.getMcpResultTruncationSettings()),
+    );
     const status1 = manager.getStatus();
     assert("global load: 1 server in pool", status1.length === 1);
     assert(
@@ -312,6 +321,18 @@ async function main(): Promise<void> {
         manager.getStatus()[0]?.state === "connected",
       );
     }
+
+    // ---- Case C3: persisted truncation settings update runtime behavior ----
+    await config.setMcpTruncationConfig({ enabled: false, maxChars: 1234 });
+    await manager.reloadGlobal();
+    assert(
+      "truncation settings: persisted disable + custom cap reach tool bridge",
+      JSON.stringify(toolBridge.getMcpResultTruncationSettings()) ===
+        JSON.stringify({ enabled: false, maxChars: 1234 }),
+      JSON.stringify(toolBridge.getMcpResultTruncationSettings()),
+    );
+    await config.setMcpTruncationConfig({ enabled: true, maxChars: 30000 });
+    await manager.reloadGlobal();
 
     // ---- Case D: per-server enabled:false → server moves to disabled ----
     await config.writeMcpJson({


### PR DESCRIPTION
## Summary

Adds operator-controlled MCP tool result truncation and a browser login inactivity timeout. MCP text results were previously always capped at a hard-coded 30,000 characters; this PR makes that behavior visible and configurable from Settings → MCP while preserving the default. Browser JWTs now also support an optional idle timeout. A follow-up fix ensures passive GET traffic such as SSE reconnects, status polling, and proxy-induced stream reconnects validates tokens without refreshing idle activity, so a reverse proxy cannot keep a browser login alive indefinitely.

## Usage

```bash
# Optional browser JWT idle timeout; 0 disables idle expiry (default)
LOGIN_INACTIVITY_TIMEOUT_SECONDS=3600 pi-forge

# Equivalent CLI flag
pi-forge --login-inactivity-timeout-seconds 3600
```

MCP truncation is configured in Settings → MCP. It persists in `${FORGE_DATA_DIR}/mcp.json`:

```json
{
  "truncation": {
    "enabled": true,
    "maxChars": 30000
  },
  "servers": {}
}
```

`truncation.enabled=false` passes MCP text results through unchanged. `truncation.maxChars` caps total text characters across all text blocks in one MCP result; images pass through unchanged.

## What changed (20 files, +449/-47)

- `packages/server/src/mcp/tool-bridge.ts` — adds runtime MCP truncation settings and keeps the existing head/tail truncation behavior as the default.
- `packages/server/src/mcp/config.ts`, `packages/server/src/mcp/manager.ts`, `packages/server/src/routes/mcp.ts` — persists `truncation` in `mcp.json`, normalizes defaults, applies settings on reload, and exposes the setting through `/api/v1/mcp/settings`.
- `packages/client/src/components/SettingsPanel.tsx`, `packages/client/src/store/mcp-store.ts`, `packages/client/src/lib/api-client/*` — adds the Settings → MCP truncation controls and client API typing/validation.
- `packages/server/src/config.ts`, `packages/server/src/cli.ts`, `packages/server/src/auth.ts`, `packages/server/src/index.ts` — adds `LOGIN_INACTIVITY_TIMEOUT_SECONDS` / `--login-inactivity-timeout-seconds` and enforces idle expiry without refreshing activity for passive GET/HEAD/OPTIONS traffic.
- `tests/test-auth.ts`, `tests/test-mcp-truncation.ts`, `tests/test-mcp.ts` — covers idle expiry, passive polling behavior, mutating refresh behavior, configurable truncation, and persisted MCP truncation settings.
- `docs/mcp.md`, `docs/configuration.md`, `docs/deployment.md`, `docs/agent/config.md`, `docs/agent/mcp.md` — documents MCP truncation settings and login inactivity timeout/proxy guidance.

## Test plan

- [x] `npm run format`
- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only mcp,mcp-truncation,auth,cli-flags,config`
- [x] Follow-up validation: `npm run build && npm run check && scripts/run-tests.sh --only auth`
- [ ] CI green before merge
