### PR TITLE
feat: add direct logo URL mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,10 +69,12 @@ or shell environment. The most-touched ones:
 | `MINIMAL_UI` | `false` | Hide terminal / git / last-turn / providers / agent-settings panels. Frontend gate; server routes unchanged. ALSO hard-disables webhook configuration, session orchestration, and the quick-actions runner. |
 | `AUTH_BANNER_TEXT` | (unset) | Optional public banner shown below the login prompt. Literal newlines/carriage returns are preserved; `\\n` and `\\r` escapes are decoded for single-line env/CLI surfaces. Do not put secrets here: it is exposed by public `/api/v1/ui-config`. |
 | `AUTH_BANNER_HTML` | `false` | When true, renders `AUTH_BANNER_TEXT` as sanitized HTML instead of plain text. Scripts, styles, event handlers, and unsafe links are stripped client-side. Leave false unless you need links or simple formatting. |
-| `AUTH_URL_LOGO` | (unset) | Optional absolute `http://` or `https://` URL for the login/auth logo. Pulled at server startup into `FORGE_DATA_DIR/cache/logos/` and exposed to the app as a same-origin `/cache/logos/...` URL so CSP stays strict. If fetch/validation fails, the built-in logo is used. |
+| `LOGO_URL_MODE` | `cache` | Logo URL handling mode. `cache` fetches configured logo URLs at server startup into `FORGE_DATA_DIR/cache/logos/` and returns same-origin `/cache/logos/...` URLs. `direct` returns configured raw URLs so the browser loads them directly. Accepted values: `cache`, `direct`. |
+| `LOGO_IMG_SRC_ALLOWLIST` | (unset) | Extra Content-Security-Policy `img-src` sources for `LOGO_URL_MODE=direct`, comma- or whitespace-separated. Entries must be exact `http(s)` origins such as `https://cdn.example.com`, scheme sources such as `https:`, or explicit `*`. The configured logo URL origins are added automatically; use this only for known redirect/CDN origins. |
+| `AUTH_URL_LOGO` | (unset) | Optional absolute `http://` or `https://` URL for the login/auth logo. In `cache` mode, failed fetch/validation falls back to the built-in logo. In `direct` mode, the raw URL is returned without server fetch validation and browser/CSP/network behavior applies. |
 | `AUTH_LOGO_URL` | (unset) | Legacy alias for `AUTH_URL_LOGO`. |
-| `APP_LOGO_DARK_URL` | (unset) | Optional absolute `http://` or `https://` URL for the app header logo in dark-mode themes. Cached/served same-origin; invalid or unreachable URLs fall back to the built-in logo. |
-| `APP_LOGO_LIGHT_URL` | (unset) | Optional absolute `http://` or `https://` URL for the app header logo in light-mode themes. Cached/served same-origin; invalid or unreachable URLs fall back to the built-in logo. |
+| `APP_LOGO_DARK_URL` | (unset) | Optional absolute `http://` or `https://` URL for the app header logo in dark-mode themes. Follows `LOGO_URL_MODE`; invalid or unreachable URLs fall back only in `cache` mode. |
+| `APP_LOGO_LIGHT_URL` | (unset) | Optional absolute `http://` or `https://` URL for the app header logo in light-mode themes. Follows `LOGO_URL_MODE`; invalid or unreachable URLs fall back only in `cache` mode. |
 | `AUTH_COLOR_SCHEME` | (unset) | Optional comma-separated list of exactly 8 hex colors for login/auth pages only: page background, card background, border, text, muted text, button background, button text, button hover background. Example: `#ffffff,#2563eb,#1d4ed8,#ffffff,#dbeafe,#2563eb,#ffffff,#1d4ed8`. Only `#rgb` and `#rrggbb` forms are accepted; invalid values fail startup rather than becoming CSS. |
 | `TRUST_PROXY` | `false` | Set when behind a reverse proxy so `req.ip` is the real client (required for per-user login rate limits). |
 | `ORCHESTRATION_DISABLED` | `false` | Disable the chat-view `Orch` toggle and orchestration REST/tool surface. Orchestration is enabled by default; hard-disabled under `MINIMAL_UI` regardless. See [`orchestration.md`](./orchestration.md). |
@@ -83,6 +85,27 @@ or shell environment. The most-touched ones:
 | `AGENT_TOOL_GID` | (unset) | Numeric GID used for sandboxed bash/process/terminal/quick-action/exec children. Required only when sandbox is enabled. |
 | `AGENT_TOOL_HOME` | `/home/pi-tools` | Writable HOME injected into sandboxed bash/process/terminal/quick-action/exec children. The Docker image creates this directory owned by `pi-tools`. |
 | `AGENT_TOOL_SANDBOX_CHOWN_PATHS` | (empty) | Comma- or whitespace-separated existing paths to recursively `chown` to `AGENT_TOOL_UID:AGENT_TOOL_GID` at server startup when sandbox mode is enabled. Paths are limited to `/workspace`, `AGENT_TOOL_HOME`, and non-secret Pi resource subtrees (`skills`, `npm`, `git`, `extensions`, `prompts`, `themes`). |
+
+Logo URL mode examples:
+
+```bash
+# Default: server fetches logos once at startup and serves /cache/logos/... same-origin.
+AUTH_URL_LOGO=https://assets.example.com/pi-forge-auth.svg \
+APP_LOGO_DARK_URL=https://assets.example.com/pi-forge-dark.svg \
+pi-forge
+
+# Direct: browser loads the raw configured URLs. Their origins are added to img-src automatically.
+LOGO_URL_MODE=direct \
+AUTH_URL_LOGO=https://assets.example.com/pi-forge-auth.svg \
+APP_LOGO_DARK_URL=https://assets.example.com/pi-forge-dark.svg \
+pi-forge
+
+# If a direct logo URL redirects to another trusted CDN origin, allow it explicitly.
+LOGO_URL_MODE=direct \
+LOGO_IMG_SRC_ALLOWLIST=https://cdn.example.net \
+AUTH_URL_LOGO=https://assets.example.com/pi-forge-auth.svg \
+pi-forge
+```
 
 Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
 are documented in [`deployment.md`](./deployment.md).

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -209,6 +209,7 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
   const authBannerText =
     typeof value.authBannerText === "string" ? value.authBannerText : undefined;
   const authBannerHtml = typeof value.authBannerHtml === "boolean" ? value.authBannerHtml : false;
+  const logoUrlMode = value.logoUrlMode === "direct" ? "direct" : "cache";
   const authLogoUrl = typeof value.authLogoUrl === "string" ? value.authLogoUrl : undefined;
   const appLogoDarkUrl =
     typeof value.appLogoDarkUrl === "string" ? value.appLogoDarkUrl : undefined;
@@ -225,6 +226,7 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
       value.serverTheme === undefined ? undefined : vServerThemeConfig(value.serverTheme, status),
     authBannerText,
     authBannerHtml,
+    logoUrlMode,
     authColorScheme,
     authLogoUrl,
     appLogoDarkUrl,

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -328,13 +328,15 @@ export interface UiConfigResponse {
   authBannerText: string | undefined;
   /** True when the banner should render as sanitized HTML. */
   authBannerHtml: boolean;
+  /** Logo URL handling mode selected by the server. */
+  logoUrlMode: "cache" | "direct";
   /** Optional login/auth page color scheme. */
   authColorScheme: AuthColorScheme | undefined;
-  /** Optional same-origin URL for the login/auth logo. */
+  /** Optional URL for the login/auth logo (same-origin cache URL unless direct mode is enabled). */
   authLogoUrl: string | undefined;
-  /** Optional same-origin URL for the app header logo in dark-mode themes. */
+  /** Optional URL for the app header logo in dark-mode themes. */
   appLogoDarkUrl: string | undefined;
-  /** Optional same-origin URL for the app header logo in light-mode themes. */
+  /** Optional URL for the app header logo in light-mode themes. */
   appLogoLightUrl: string | undefined;
 }
 

--- a/packages/client/src/store/ui-config-store.ts
+++ b/packages/client/src/store/ui-config-store.ts
@@ -44,13 +44,15 @@ interface UiConfigState {
   authBannerText: string | undefined;
   /** True when the banner should render as sanitized HTML. */
   authBannerHtml: boolean;
+  /** Logo URL handling mode selected by the server. */
+  logoUrlMode: "cache" | "direct";
   /** Optional login/auth page color scheme. */
   authColorScheme: AuthColorScheme | undefined;
-  /** Optional same-origin URL for the login/auth logo. */
+  /** Optional URL for the login/auth logo (same-origin cache URL unless direct mode is enabled). */
   authLogoUrl: string | undefined;
-  /** Optional same-origin URL for the app header logo in dark-mode themes. */
+  /** Optional URL for the app header logo in dark-mode themes. */
   appLogoDarkUrl: string | undefined;
-  /** Optional same-origin URL for the app header logo in light-mode themes. */
+  /** Optional URL for the app header logo in light-mode themes. */
   appLogoLightUrl: string | undefined;
   /** Last load error (sticky until a retry succeeds), for diagnostics. */
   error: string | undefined;
@@ -68,6 +70,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
   serverTheme: undefined,
   authBannerText: undefined,
   authBannerHtml: false,
+  logoUrlMode: "cache",
   authColorScheme: undefined,
   authLogoUrl: undefined,
   appLogoDarkUrl: undefined,
@@ -91,6 +94,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
         serverTheme: cfg.serverTheme,
         authBannerText: cfg.authBannerText,
         authBannerHtml: cfg.authBannerHtml,
+        logoUrlMode: cfg.logoUrlMode,
         authColorScheme: cfg.authColorScheme,
         authLogoUrl: cfg.authLogoUrl,
         appLogoDarkUrl: cfg.appLogoDarkUrl,

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -316,11 +316,27 @@ const FLAGS: readonly FlagDef[] = [
     defaultText: "false",
   },
   {
+    name: "logo-url-mode",
+    env: "LOGO_URL_MODE",
+    type: "string",
+    group: "features",
+    desc: "Logo URL handling: cache (server caches same-origin) or direct (browser loads raw URLs)",
+    defaultText: "cache",
+  },
+  {
+    name: "logo-img-src-allowlist",
+    env: "LOGO_IMG_SRC_ALLOWLIST",
+    type: "list",
+    group: "features",
+    desc: "Extra CSP img-src sources for direct logo mode (origins, schemes, or explicit *)",
+    defaultText: "(unset)",
+  },
+  {
     name: "auth-url-logo",
     env: "AUTH_URL_LOGO",
     type: "string",
     group: "features",
-    desc: "Absolute http(s) URL for the login/auth logo; cached and served same-origin",
+    desc: "Absolute http(s) URL for the login/auth logo; cached same-origin unless LOGO_URL_MODE=direct",
     defaultText: "(unset)",
   },
   {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -101,6 +101,42 @@ function readHttpUrl(key: string): string | undefined {
   return url.toString();
 }
 
+export type LogoUrlMode = "cache" | "direct";
+
+function readLogoUrlMode(key: string): LogoUrlMode {
+  const value = readEnv(key) ?? "cache";
+  if (value === "cache" || value === "direct") return value;
+  throw new Error(`config: ${key} must be one of: cache, direct (got ${value})`);
+}
+
+function readLogoImgSrcAllowlist(key: string): string[] {
+  return readStringList(key).map((source) => {
+    if (source === "*") return source;
+    if (/^[a-z][a-z0-9+.-]*:$/i.test(source)) return source;
+    let url: URL;
+    try {
+      url = new URL(source);
+    } catch {
+      throw new Error(
+        `config: ${key} entries must be absolute origins like https://cdn.example.com, scheme sources like https:, or explicit * (got ${source})`,
+      );
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error(`config: ${key} origins must use http: or https: (got ${url.protocol})`);
+    }
+    if (
+      url.username.length > 0 ||
+      url.password.length > 0 ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash
+    ) {
+      throw new Error(`config: ${key} entries must be origins only, not full URLs (got ${source})`);
+    }
+    return url.origin;
+  });
+}
+
 const HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
 function normalizeHexColor(key: string, value: string, index: number): string {
@@ -348,6 +384,8 @@ export const config = Object.freeze({
    */
   authBannerText: readUiText("AUTH_BANNER_TEXT"),
   authBannerHtml: readBool("AUTH_BANNER_HTML", false),
+  logoUrlMode: readLogoUrlMode("LOGO_URL_MODE"),
+  logoImgSrcAllowlist: readLogoImgSrcAllowlist("LOGO_IMG_SRC_ALLOWLIST"),
   authLogoUrl: readHttpUrl("AUTH_URL_LOGO") ?? readHttpUrl("AUTH_LOGO_URL"),
   appLogoDarkUrl: readHttpUrl("APP_LOGO_DARK_URL"),
   appLogoLightUrl: readHttpUrl("APP_LOGO_LIGHT_URL"),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -71,6 +71,26 @@ function shouldRefreshJwtActivity(method: string): boolean {
   return upper !== "GET" && upper !== "HEAD" && upper !== "OPTIONS";
 }
 
+function originForLogo(url: string | undefined): string | undefined {
+  if (url === undefined) return undefined;
+  return new URL(url).origin;
+}
+
+function imgSrcCsp(): string {
+  const sources = new Set(["'self'", "data:", "blob:"]);
+  if (config.logoUrlMode === "direct") {
+    for (const source of [
+      originForLogo(config.authLogoUrl),
+      originForLogo(config.appLogoDarkUrl),
+      originForLogo(config.appLogoLightUrl),
+      ...config.logoImgSrcAllowlist,
+    ]) {
+      if (source !== undefined) sources.add(source);
+    }
+  }
+  return `img-src ${[...sources].join(" ")}`;
+}
+
 export async function buildServer(): Promise<FastifyInstance> {
   // Install before Fastify so unhandledRejection handlers from this
   // module are first in line — they print full cause chains for
@@ -168,11 +188,13 @@ export async function buildServer(): Promise<FastifyInstance> {
   await fastify.register(rateLimit, { global: false });
 
   await initializeLogoCache(fastify.log);
-  await fastify.register(fastifyStatic, {
-    root: logoCacheDir(),
-    prefix: LOGO_CACHE_PREFIX,
-    decorateReply: false,
-  });
+  if (config.logoUrlMode === "cache") {
+    await fastify.register(fastifyStatic, {
+      root: logoCacheDir(),
+      prefix: LOGO_CACHE_PREFIX,
+      decorateReply: false,
+    });
+  }
 
   // Security headers — set on every response, both API and static.
   // Done as an onSend hook rather than via @fastify/helmet to avoid the
@@ -194,7 +216,8 @@ export async function buildServer(): Promise<FastifyInstance> {
   //     in RootErrorBoundary + CodeMirror's inline cursor/selection
   //     styles compile to style="..." attributes. Keep also on
   //     style-src for Safari < 15.4 which falls back to it.
-  //   - img-src 'self' data: blob: — chat attachments + diff inline icons.
+  //   - img-src 'self' data: blob: (+ direct logo origins when enabled) —
+  //     chat attachments, diff inline icons, and optional raw browser-loaded logos.
   //   - connect-src 'self' — same-origin only. Browsers normalize
   //     ws://same-host to the page origin, so 'self' covers the
   //     integrated terminal WS without granting open-to-any-host
@@ -221,7 +244,7 @@ export async function buildServer(): Promise<FastifyInstance> {
         // honor the tighter style-src-attr below.
         "style-src 'self' 'unsafe-inline'",
         "style-src-attr 'unsafe-inline'",
-        "img-src 'self' data: blob:",
+        imgSrcCsp(),
         "font-src 'self' data:",
         "connect-src 'self'",
         "worker-src 'self' blob:",

--- a/packages/server/src/logo-cache.ts
+++ b/packages/server/src/logo-cache.ts
@@ -22,13 +22,13 @@ const PATH_EXTENSIONS = new Set([".svg", ".png", ".jpg", ".jpeg", ".gif", ".webp
 
 type LogoKey = "auth" | "appDark" | "appLight";
 
-interface CachedLogoState {
+export interface LogoUrlState {
   authLogoUrl: string | undefined;
   appLogoDarkUrl: string | undefined;
   appLogoLightUrl: string | undefined;
 }
 
-let cachedLogoState: CachedLogoState = {
+let cachedLogoState: LogoUrlState = {
   authLogoUrl: undefined,
   appLogoDarkUrl: undefined,
   appLogoLightUrl: undefined,
@@ -38,7 +38,14 @@ export function logoCacheDir(): string {
   return join(config.forgeDataDir, "cache", "logos");
 }
 
-export function cachedLogoUrls(): CachedLogoState {
+export function logoUrls(): LogoUrlState {
+  if (config.logoUrlMode === "direct") {
+    return {
+      authLogoUrl: config.authLogoUrl,
+      appLogoDarkUrl: config.appLogoDarkUrl,
+      appLogoLightUrl: config.appLogoLightUrl,
+    };
+  }
   return cachedLogoState;
 }
 
@@ -46,6 +53,10 @@ export async function initializeLogoCache(log: {
   warn: (obj: unknown, msg?: string) => void;
   info: (obj: unknown, msg?: string) => void;
 }): Promise<void> {
+  if (config.logoUrlMode === "direct") {
+    log.info("logo URL mode is direct; skipping server-side logo cache refresh");
+    return;
+  }
   await mkdir(logoCacheDir(), { recursive: true });
   const entries: [LogoKey, string | undefined][] = [
     ["auth", config.authLogoUrl],

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -5,7 +5,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { sessionCount } from "../session-registry.js";
 import { ptyCount } from "../pty-manager.js";
 import { config, passwordAuthEnabled } from "../config.js";
-import { cachedLogoUrls } from "../logo-cache.js";
+import { logoUrls } from "../logo-cache.js";
 import { isOrchestrationEnabled } from "../orchestration/config.js";
 import { DEFAULT_THEME_COLORS, readThemeConfig, THEME_COLOR_KEYS } from "../theme-config.js";
 
@@ -159,6 +159,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
               // client-sanitized.
               authBannerText: { type: "string" },
               authBannerHtml: { type: "boolean" },
+              logoUrlMode: { type: "string", enum: ["cache", "direct"] },
               authLogoUrl: { type: "string" },
               appLogoDarkUrl: { type: "string" },
               appLogoLightUrl: { type: "string" },
@@ -192,7 +193,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async () => {
       const serverTheme = await readThemeConfig();
-      const logos = cachedLogoUrls();
+      const logos = logoUrls();
       return {
         minimal: config.minimalUi,
         workspaceRoot: config.workspacePath,
@@ -202,6 +203,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
         serverTheme: { ...serverTheme, defaults: DEFAULT_THEME_COLORS },
         authBannerText: config.authBannerText,
         authBannerHtml: config.authBannerHtml,
+        logoUrlMode: config.logoUrlMode,
         authLogoUrl: logos.authLogoUrl,
         appLogoDarkUrl: logos.appLogoDarkUrl,
         appLogoLightUrl: logos.appLogoLightUrl,

--- a/tests/test-api.ts
+++ b/tests/test-api.ts
@@ -163,6 +163,7 @@ async function main(): Promise<void> {
       const uiBody = uiConfig.body as {
         authBannerText?: string;
         authBannerHtml?: boolean;
+        logoUrlMode?: string;
         authLogoUrl?: string;
         authColorScheme?: {
           pageBackground: string;
@@ -180,6 +181,7 @@ async function main(): Promise<void> {
         uiBody.authBannerText === "Welcome\nRead <b>the policy</b>",
       );
       assert("ui-config reports banner HTML opt-in", uiBody.authBannerHtml === true);
+      assert("ui-config reports default logo cache mode", uiBody.logoUrlMode === "cache");
       assert(
         "ui-config omits invalid logo URL for built-in fallback",
         uiBody.authLogoUrl === undefined,

--- a/tests/test-logo-cache.ts
+++ b/tests/test-logo-cache.ts
@@ -1,12 +1,14 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const repoRoot = resolve(__dirname, "..");
+const serverEntry = resolve(repoRoot, "packages/server/dist/index.js");
 
 let failures = 0;
 function assert(label: string, ok: boolean, detail?: string): void {
@@ -15,6 +17,38 @@ function assert(label: string, ok: boolean, detail?: string): void {
     failures += 1;
     console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
   }
+}
+
+async function waitFor(url: string, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.status < 500) return;
+    } catch {
+      // keep trying until the server is ready
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`timed out waiting for ${url}`);
+}
+
+async function pickFreePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const address = server.address();
+  await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+  if (address === null || typeof address === "string") throw new Error("unexpected listen address");
+  return address.port;
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolveStop) => {
+    child.once("exit", () => resolveStop());
+    child.kill("SIGTERM");
+    setTimeout(() => child.kill("SIGKILL"), 1500).unref();
+  });
 }
 
 function serveLogo(req: IncomingMessage, res: ServerResponse): void {
@@ -74,10 +108,16 @@ async function main(): Promise<void> {
   try {
     const cfgRes = await fetch(`${base}/api/v1/ui-config`);
     const cfg = (await cfgRes.json()) as {
+      logoUrlMode?: string;
       authLogoUrl?: string;
       appLogoDarkUrl?: string;
       appLogoLightUrl?: string;
     };
+    assert(
+      "ui-config reports default cache mode",
+      cfg.logoUrlMode === "cache",
+      JSON.stringify(cfg),
+    );
     assert(
       "ui-config returns cached auth logo",
       cfg.authLogoUrl?.startsWith("/cache/logos/auth-") === true,
@@ -94,6 +134,13 @@ async function main(): Promise<void> {
       JSON.stringify(cfg),
     );
 
+    const defaultCsp = cfgRes.headers.get("content-security-policy") ?? "";
+    assert(
+      "cache mode CSP keeps img-src same-origin",
+      defaultCsp.includes("img-src 'self' data: blob:"),
+    );
+    assert("cache mode CSP does not allow remote logo origin", !defaultCsp.includes(remoteBase));
+
     const cachedRes = await fetch(`${base}${cfg.authLogoUrl}`);
     const cachedText = await cachedRes.text();
     assert("cached logo is served same-origin", cachedRes.status === 200, String(cachedRes.status));
@@ -107,6 +154,112 @@ async function main(): Promise<void> {
       rm(dataDir, { recursive: true, force: true }),
     ]);
   }
+
+  const directWorkspace = await mkdtemp(join(tmpdir(), "pi-forge-logo-direct-ws-"));
+  const directConfigDir = await mkdtemp(join(tmpdir(), "pi-forge-logo-direct-cfg-"));
+  const directDataDir = await mkdtemp(join(tmpdir(), "pi-forge-logo-direct-data-"));
+  const directPort = await pickFreePort();
+  const directChild = spawn(process.execPath, [serverEntry], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PORT: String(directPort),
+      LOG_LEVEL: "warn",
+      NODE_ENV: "test",
+      WORKSPACE_PATH: directWorkspace,
+      PI_CONFIG_DIR: directConfigDir,
+      FORGE_DATA_DIR: directDataDir,
+      SESSION_DIR: join(directWorkspace, ".pi", "sessions"),
+      LOGO_URL_MODE: "direct",
+      LOGO_IMG_SRC_ALLOWLIST: "https://cdn.example.org",
+      AUTH_URL_LOGO: `${remoteBase}/logo.svg`,
+      APP_LOGO_DARK_URL: `${remoteBase}/not-an-image`,
+      APP_LOGO_LIGHT_URL: `${remoteBase}/missing.svg`,
+      AUTH_LOGO_URL: undefined,
+      UI_PASSWORD: undefined,
+      JWT_SECRET: undefined,
+      API_KEY: undefined,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  directChild.stderr?.on("data", (b) =>
+    process.stderr.write(`[direct server stderr] ${String(b)}`),
+  );
+  const directBase = `http://127.0.0.1:${directPort}`;
+
+  try {
+    await waitFor(`${directBase}/api/v1/health`);
+    const cfgRes = await fetch(`${directBase}/api/v1/ui-config`);
+    const cfg = (await cfgRes.json()) as {
+      logoUrlMode?: string;
+      authLogoUrl?: string;
+      appLogoDarkUrl?: string;
+      appLogoLightUrl?: string;
+    };
+    assert("direct mode is reported", cfg.logoUrlMode === "direct", JSON.stringify(cfg));
+    assert("direct mode returns raw auth URL", cfg.authLogoUrl === `${remoteBase}/logo.svg`);
+    assert(
+      "direct mode returns raw dark URL without server validation",
+      cfg.appLogoDarkUrl === `${remoteBase}/not-an-image`,
+    );
+    assert(
+      "direct mode returns raw light URL without server validation",
+      cfg.appLogoLightUrl === `${remoteBase}/missing.svg`,
+    );
+
+    const csp = cfgRes.headers.get("content-security-policy") ?? "";
+    assert("direct mode CSP allows configured logo origin", csp.includes(remoteBase), csp);
+    assert(
+      "direct mode CSP includes extra allowlist origin",
+      csp.includes("https://cdn.example.org"),
+      csp,
+    );
+    assert(
+      "direct mode does not register cache route",
+      (await fetch(`${directBase}/cache/logos/nope.svg`)).status === 404,
+    );
+  } finally {
+    await stopChild(directChild);
+    await Promise.all([
+      rm(directWorkspace, { recursive: true, force: true }),
+      rm(directConfigDir, { recursive: true, force: true }),
+      rm(directDataDir, { recursive: true, force: true }),
+    ]);
+  }
+
+  const invalidMode = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `import ${JSON.stringify(pathToFileURL(resolve(repoRoot, "packages/server/dist/config.js")).href)}`,
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        WORKSPACE_PATH: await mkdtemp(join(tmpdir(), "pi-forge-logo-invalid-ws-")),
+        PI_CONFIG_DIR: await mkdtemp(join(tmpdir(), "pi-forge-logo-invalid-cfg-")),
+        FORGE_DATA_DIR: await mkdtemp(join(tmpdir(), "pi-forge-logo-invalid-data-")),
+        NODE_ENV: "test",
+        LOGO_URL_MODE: "bogus",
+        UI_PASSWORD: undefined,
+        JWT_SECRET: undefined,
+        API_KEY: undefined,
+      },
+      encoding: "utf8",
+    },
+  );
+  assert(
+    "invalid LOGO_URL_MODE fails config parsing",
+    invalidMode.status !== 0,
+    invalidMode.stderr,
+  );
+  assert(
+    "invalid LOGO_URL_MODE error names accepted values",
+    invalidMode.stderr.includes("cache, direct"),
+    invalidMode.stderr,
+  );
 
   if (failures > 0) process.exit(1);
   console.log("\nPASS  test-logo-cache");


### PR DESCRIPTION
## Summary

PR #344 made configured logo URLs safer by fetching them at server startup, caching them under `FORGE_DATA_DIR/cache/logos/`, and returning same-origin `/cache/logos/...` URLs to the browser. That remains the default behavior.

This PR adds an explicit operator-selected direct mode for deployments that want the browser to resolve raw configured logo URLs itself. Direct mode returns the configured auth, dark app, and light app logo URLs through `/api/v1/ui-config` without server-side logo fetch validation. To keep production CSP strict, direct mode derives `img-src` entries from configured logo URL origins and supports an additional explicit allowlist for redirect/CDN origins.

## Usage

```bash
# Default: server caches logos and returns same-origin /cache/logos/... URLs.
LOGO_URL_MODE=cache \
AUTH_URL_LOGO=https://assets.example.com/pi-forge-auth.svg \
APP_LOGO_DARK_URL=https://assets.example.com/pi-forge-dark.svg \
pi-forge

# Direct: browser loads raw configured URLs; configured origins are added to CSP img-src.
LOGO_URL_MODE=direct \
AUTH_URL_LOGO=https://assets.example.com/pi-forge-auth.svg \
APP_LOGO_DARK_URL=https://assets.example.com/pi-forge-dark.svg \
pi-forge

# If a direct URL redirects to another trusted CDN origin, allow it explicitly.
LOGO_URL_MODE=direct \
LOGO_IMG_SRC_ALLOWLIST=https://cdn.example.net \
AUTH_URL_LOGO=https://assets.example.com/pi-forge-auth.svg \
pi-forge
```

Accepted `LOGO_URL_MODE` values are `cache` and `direct`; invalid values fail config parsing. `LOGO_IMG_SRC_ALLOWLIST` accepts exact `http(s)` origins, scheme sources such as `https:`, or explicit `*`.

## What changed (11 files, +299/-23)

- `packages/server/src/config.ts` — parses and validates `LOGO_URL_MODE` and `LOGO_IMG_SRC_ALLOWLIST` alongside existing logo URLs.
- `packages/server/src/cli.ts` — adds `--logo-url-mode` and `--logo-img-src-allowlist` CLI flags.
- `packages/server/src/logo-cache.ts` — centralizes logo URL resolution so cache mode returns cached URLs and direct mode returns raw configured URLs.
- `packages/server/src/index.ts` — skips cache static registration in direct mode and builds `img-src` CSP from configured direct logo origins plus allowlist entries.
- `packages/server/src/routes/health.ts` — exposes `logoUrlMode` on public `/api/v1/ui-config` and uses the selected logo resolver.
- `packages/client/src/lib/api-client/index.ts`, `packages/client/src/lib/api-client/types.ts`, `packages/client/src/store/ui-config-store.ts` — carries `logoUrlMode` through the typed client/store surface while existing logo consumers continue using the returned URLs.
- `docs/configuration.md` — documents the new env vars, defaults, CSP caveats, and examples.
- `tests/test-logo-cache.ts` — covers default cache mode, direct raw URL behavior, derived/allowlisted CSP entries, skipped cache route in direct mode, and invalid mode parsing.
- `tests/test-api.ts` — asserts public ui-config reports the default cache mode.

## Test plan

- [x] `npm run format`
- [x] `npm run build`
- [x] `npm run check`
- [x] `npx tsx tests/test-logo-cache.ts`
- [x] `npx tsx tests/test-api.ts`
- [x] `npx tsx tests/test-cli-flags.ts`
- [x] `scripts/run-tests.sh --only auth,config,scaffold`
- [ ] CI green before merge
