### PR TITLE
chore(release): v1.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.4.6] — 2026-06-24
+
+### Added
+
+- **Configurable MCP tool result truncation.** Settings now exposes MCP text-result truncation controls, persists them in `mcp.json`, and lets operators disable truncation or tune the character cap while preserving the existing default behavior.
+- **Login inactivity timeout.** Browser JWTs can now expire after a configurable idle period via `LOGIN_INACTIVITY_TIMEOUT_SECONDS` / `--login-inactivity-timeout-seconds`, while passive polling and SSE traffic validate tokens without extending activity.
+- **Direct logo URL mode.** Deployments can opt into `LOGO_URL_MODE=direct` to return configured logo URLs directly to the browser, with CSP image sources derived from the logo origins and optional `LOGO_IMG_SRC_ALLOWLIST` entries.
+
+### Changed
+
+- **Custom logo handling is safer by default.** Remote auth and app header logos are fetched at startup, validated, cached under `FORGE_DATA_DIR/cache/logos/`, and served from same-origin `/cache/logos/...`, with Vite dev proxy support and graceful fallback to the built-in logo.
+- **Sandbox workspace permission handoff is centralized.** File-pane and startup preparation paths now share sandbox permission repair logic that hands files to the tool UID while preserving server group access.
+
+### Fixed
+
+- **Sandbox file-pane operations keep working after ownership drift.** Creating files inside folders, moving files into folders, deleting entries, and downloading files or archives in sandbox mode now repair permissions consistently.
+- **Direct and cached custom logos respect production CSP.** Same-origin cached logos avoid blocked remote image loads by default, while direct mode explicitly adds trusted logo origins to `img-src`.
+
 ## [1.4.5] — 2026-06-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "workspaces": [
         "packages/*"
       ],
@@ -17087,7 +17087,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17159,7 +17159,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.79.10",
         "@earendil-works/pi-ai": "0.79.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepares the v1.4.6 release bump from updated `origin/main` after the v1.4.5 release. The release notes were generated from changes since `v1.4.5`, including recently merged PRs #342, #343, #344, and #345, then the repository release tooling rolled `CHANGELOG.md` and bumped all package versions in lockstep.

No tag or GitHub release is created by this PR.

## Usage

No direct runtime usage change for this release PR. After merge, cut the tag from updated `main` when ready:

```bash
git checkout main
git pull --ff-only
git tag v1.4.6
git push origin v1.4.6
```

## What changed (5 files, +25/-7)

- `CHANGELOG.md` — adds v1.4.6 release notes covering MCP truncation settings, login idle timeout, custom logo cache/direct modes, and sandbox permission fixes; rolls `## [Unreleased]` to `## [1.4.6] — 2026-06-24`.
- `package.json` — bumps the root package version to `1.4.6` via `scripts/bump-version.sh`.
- `packages/server/package.json` — bumps the server workspace package version to `1.4.6` via release tooling.
- `packages/client/package.json` — bumps the client workspace package version to `1.4.6` via release tooling.
- `package-lock.json` — refreshes lockfile package metadata for the `1.4.6` version.

## Test plan

- [x] `scripts/bump-version.sh 1.4.6`
- [x] `npx npm@latest approve-scripts --allow-scripts-pending` — reported `No packages with unreviewed install scripts.`
- [x] `npm run format:check`
- [x] `npm run check`
- [ ] CI green before merge
