### PR TITLE
fix: hide password settings when LDAP is enabled

### DIFF
--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -4376,7 +4376,7 @@ function GeneralTab() {
   const version = useUiConfigStore((s) => s.version);
   const loaded = useUiConfigStore((s) => s.loaded);
   const passwordAuthEnabled = useUiConfigStore((s) => s.passwordAuthEnabled);
-  const ldapEnabled = useAuthStore((s) => s.ldapEnabled);
+  const ldapEnabled = useUiConfigStore((s) => s.ldapEnabled);
   return (
     <div className="space-y-6 text-sm text-neutral-300">
       <header className="space-y-1">

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -4376,7 +4376,10 @@ function GeneralTab() {
   const version = useUiConfigStore((s) => s.version);
   const loaded = useUiConfigStore((s) => s.loaded);
   const passwordAuthEnabled = useUiConfigStore((s) => s.passwordAuthEnabled);
-  const ldapEnabled = useUiConfigStore((s) => s.ldapEnabled);
+  const uiConfigLdapEnabled = useUiConfigStore((s) => s.ldapEnabled);
+  const authLdapEnabled = useAuthStore((s) => s.ldapEnabled);
+  const showChangePassword =
+    loaded && passwordAuthEnabled && !uiConfigLdapEnabled && !authLdapEnabled;
   return (
     <div className="space-y-6 text-sm text-neutral-300">
       <header className="space-y-1">
@@ -4446,7 +4449,7 @@ function GeneralTab() {
         </ul>
       </section>
 
-      {passwordAuthEnabled && !ldapEnabled && <ChangePasswordSection />}
+      {showChangePassword && <ChangePasswordSection />}
     </div>
   );
 }

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -4368,13 +4368,15 @@ const MIN_PASSWORD_LENGTH = 8;
  * Catch-all "what am I running + account" pane. Combines the previous
  * About pane (version + links) with an in-place password-change form
  * for deployments that use UI_PASSWORD auth. The password section
- * hides on API-key-only deployments — there's nothing to change in
- * that case.
+ * hides on API-key-only deployments and LDAP-enabled deployments —
+ * in those cases there is no local password to change or password
+ * changes should be managed by LDAP.
  */
 function GeneralTab() {
   const version = useUiConfigStore((s) => s.version);
   const loaded = useUiConfigStore((s) => s.loaded);
   const passwordAuthEnabled = useUiConfigStore((s) => s.passwordAuthEnabled);
+  const ldapEnabled = useAuthStore((s) => s.ldapEnabled);
   return (
     <div className="space-y-6 text-sm text-neutral-300">
       <header className="space-y-1">
@@ -4444,7 +4446,7 @@ function GeneralTab() {
         </ul>
       </section>
 
-      {passwordAuthEnabled && <ChangePasswordSection />}
+      {passwordAuthEnabled && !ldapEnabled && <ChangePasswordSection />}
     </div>
   );
 }

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -202,6 +202,10 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
   const version = typeof value.version === "string" ? value.version : "unknown";
   const passwordAuthEnabled =
     typeof value.passwordAuthEnabled === "boolean" ? value.passwordAuthEnabled : true;
+  // Default to false on older servers that predate the field. When
+  // absent, the Settings General tab falls back to the historical local
+  // password UI behavior instead of hiding the section unexpectedly.
+  const ldapEnabled = typeof value.ldapEnabled === "boolean" ? value.ldapEnabled : false;
   // Default to false on older servers that predate the field — those
   // builds kept orchestration behind an explicit opt-in flag.
   const orchestrationEnabled =
@@ -221,6 +225,7 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
     workspaceRoot: value.workspaceRoot,
     version,
     passwordAuthEnabled,
+    ldapEnabled,
     orchestrationEnabled,
     serverTheme:
       value.serverTheme === undefined ? undefined : vServerThemeConfig(value.serverTheme, status),

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -316,6 +316,11 @@ export interface UiConfigResponse {
    */
   passwordAuthEnabled: boolean;
   /**
+   * True when LDAP username/password login is enabled. Public,
+   * non-secret auth-mode metadata used to hide local password-change UI.
+   */
+  ldapEnabled: boolean;
+  /**
    * True when the server has orchestration available (enabled by
    * default unless disabled by config) AND is NOT in MINIMAL_UI mode.
    * Controls whether the supervisor-mode toggle and Workers panel

--- a/packages/client/src/store/ui-config-store.ts
+++ b/packages/client/src/store/ui-config-store.ts
@@ -32,6 +32,11 @@ interface UiConfigState {
    */
   passwordAuthEnabled: boolean;
   /**
+   * True when LDAP username/password login is enabled. Defaults false
+   * until /ui-config loads so local password deployments keep the form.
+   */
+  ldapEnabled: boolean;
+  /**
    * True when the server has session orchestration available
    * (enabled by default unless disabled by config, and not MINIMAL_UI).
    * Default false until /ui-config loads so older servers that do not
@@ -66,6 +71,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
   workspaceRoot: "",
   version: "",
   passwordAuthEnabled: true,
+  ldapEnabled: false,
   orchestrationEnabled: false,
   serverTheme: undefined,
   authBannerText: undefined,
@@ -90,6 +96,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
         workspaceRoot: cfg.workspaceRoot,
         version: cfg.version,
         passwordAuthEnabled: cfg.passwordAuthEnabled,
+        ldapEnabled: cfg.ldapEnabled,
         orchestrationEnabled: cfg.orchestrationEnabled,
         serverTheme: cfg.serverTheme,
         authBannerText: cfg.authBannerText,

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -124,6 +124,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
               "workspaceRoot",
               "version",
               "passwordAuthEnabled",
+              "ldapEnabled",
               "orchestrationEnabled",
               "serverTheme",
               "authBannerHtml",
@@ -148,6 +149,11 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
               // deployments report false; the Settings → General
               // password change section hides in that case.
               passwordAuthEnabled: { type: "boolean" },
+              // True when LDAP username/password login is enabled.
+              // This is non-secret public auth mode metadata used to
+              // hide local password-change UI; LDAP-managed passwords
+              // must be rotated outside pi-forge.
+              ldapEnabled: { type: "boolean" },
               // True iff session orchestration is reachable. Enabled
               // by default, but false when disabled by instance config
               // OR when MINIMAL_UI is true (MINIMAL_UI is a hard gate).
@@ -199,6 +205,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
         workspaceRoot: config.workspacePath,
         version: SERVER_VERSION,
         passwordAuthEnabled: passwordAuthEnabled(),
+        ldapEnabled: config.auth.ldap.enabled,
         orchestrationEnabled: isOrchestrationEnabled(),
         serverTheme: { ...serverTheme, defaults: DEFAULT_THEME_COLORS },
         authBannerText: config.authBannerText,

--- a/tests/test-api.ts
+++ b/tests/test-api.ts
@@ -163,6 +163,7 @@ async function main(): Promise<void> {
       const uiBody = uiConfig.body as {
         authBannerText?: string;
         authBannerHtml?: boolean;
+        ldapEnabled?: boolean;
         logoUrlMode?: string;
         authLogoUrl?: string;
         authColorScheme?: {
@@ -181,6 +182,7 @@ async function main(): Promise<void> {
         uiBody.authBannerText === "Welcome\nRead <b>the policy</b>",
       );
       assert("ui-config reports banner HTML opt-in", uiBody.authBannerHtml === true);
+      assert("ui-config reports ldapEnabled=false by default", uiBody.ldapEnabled === false);
       assert("ui-config reports default logo cache mode", uiBody.logoUrlMode === "cache");
       assert(
         "ui-config omits invalid logo URL for built-in fallback",

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -400,6 +400,13 @@ async function scenarioLdapAdminUsesLocalPassword(): Promise<void> {
     REQUIRE_PASSWORD_CHANGE: "false",
   });
   try {
+    const uiConfig = (await (await fetch(`${srv.base}/api/v1/ui-config`)).json()) as {
+      ldapEnabled?: boolean;
+      passwordAuthEnabled?: boolean;
+    };
+    assert("ui-config reports ldapEnabled=true", uiConfig.ldapEnabled === true);
+    assert("ui-config keeps local passwordAuthEnabled=true", uiConfig.passwordAuthEnabled === true);
+
     const passwordOnly = await jsonPost(`${srv.base}/api/v1/auth/login`, {
       password: localPassword,
     });


### PR DESCRIPTION
## Summary

Settings > General currently shows the local Change Password form whenever password auth is available, even if LDAP login is enabled. In LDAP deployments, password rotation should be managed by LDAP instead of pi-forge. This PR hides the Change Password section whenever the existing auth bootstrap state reports LDAP authentication is enabled, while keeping it visible for non-LDAP password-auth deployments.

## Usage

No operator action required. With LDAP enabled (`LDAP_ENABLED=true`), open Settings > General and the Change Password section is omitted. With LDAP disabled and local password auth available, the section remains available.

## What changed (1 file, +5/-3)

- `packages/client/src/components/SettingsPanel.tsx` — reads the existing non-secret `ldapEnabled` flag from `useAuthStore` and gates the General tab's `ChangePasswordSection` on `passwordAuthEnabled && !ldapEnabled`; updated the section comment to document LDAP-managed passwords.

## Test plan

- [x] `npm run format -- packages/client/src/components/SettingsPanel.tsx`
- [x] `npm run build`
- [x] `scripts/run-tests.sh --only auth,config,api`
- [x] `npx eslint packages/client/src/components/SettingsPanel.tsx && npm run format:check -- packages/client/src/components/SettingsPanel.tsx`
- [ ] `npm run check` — attempted twice; typecheck completed, but full-repo ESLint was killed by the local container OOM/limits (`FATAL ERROR: Reached heap limit` then exit 137 with `NODE_OPTIONS=--max-old-space-size=4096`). Targeted lint and format checks for the changed file passed.
- [ ] CI green before merge
