### PR TITLE
fix: preserve async subagent completion output

### DIFF
--- a/packages/server/src/subagents-external.ts
+++ b/packages/server/src/subagents-external.ts
@@ -39,6 +39,7 @@ interface AsyncResultFile {
   results?: {
     agent?: string;
     output?: string;
+    finalOutput?: string;
     success?: boolean;
     error?: string;
     sessionFile?: string;
@@ -225,6 +226,7 @@ function formatCompletionContent(
   const agent = result?.agent ?? result?.results?.[0]?.agent ?? "subagent";
   const summary =
     result?.summary ??
+    result?.results?.[0]?.finalOutput ??
     result?.results?.[0]?.output ??
     result?.results?.[0]?.error ??
     `(background run ${status.rootRunId} ${state})`;
@@ -286,7 +288,14 @@ export async function deliverExternalSubagentCompletionForRun(root: string): Pro
   if (status === undefined || !TERMINAL_STATES.has(status.state)) return;
   const resultPath = join(SUBAGENTS_RESULTS_DIR, `${root}.json`);
   const result = await readJson<AsyncResultFile>(resultPath);
-  const parentId = await sessionIdFromSessionReference(result?.sessionId ?? status.parentSessionId);
+  if (result === undefined) {
+    // pi-subagents can write the terminal status before it writes the async
+    // result file. Defer the parent notification until the result exists so
+    // the durable chat message contains the child output instead of an early
+    // placeholder that would then be deduped forever.
+    return;
+  }
+  const parentId = await sessionIdFromSessionReference(result.sessionId ?? status.parentSessionId);
   if (parentId === undefined) return;
   const live = getSession(parentId);
   if (live === undefined) return;

--- a/tests/test-subagent-discovery.ts
+++ b/tests/test-subagent-discovery.ts
@@ -309,6 +309,19 @@ async function main(): Promise<void> {
       }),
       "utf8",
     );
+    await subagentsExternal.deliverExternalSubagentCompletionForRun(runId);
+    const notifyBeforeResult = parent.session.messages?.find(
+      (m) =>
+        typeof m === "object" &&
+        m !== null &&
+        (m as { customType?: unknown }).customType === "subagent-notify",
+    );
+    assert(
+      "terminal status waits for async result before notifying parent",
+      notifyBeforeResult === undefined,
+      `message=${JSON.stringify(notifyBeforeResult)}`,
+    );
+
     await mkdir(subagentsExternal.SUBAGENTS_RESULTS_DIR, { recursive: true });
     await writeFile(
       join(subagentsExternal.SUBAGENTS_RESULTS_DIR, `${runId}.json`),
@@ -317,8 +330,7 @@ async function main(): Promise<void> {
         sessionId: parent.sessionId,
         agent: "reviewer",
         success: true,
-        summary: "done",
-        sessionFile: childAPath,
+        results: [{ agent: "reviewer", finalOutput: "done", sessionFile: childAPath }],
       }),
       "utf8",
     );
@@ -332,7 +344,8 @@ async function main(): Promise<void> {
     assert(
       "explicit async completion path appends renderable subagent-notify to parent",
       typeof notifyMessage?.content === "string" &&
-        notifyMessage.content.includes("Background task completed"),
+        notifyMessage.content.includes("Background task completed") &&
+        notifyMessage.content.includes("done"),
       `message=${JSON.stringify(notifyMessage)}`,
     );
 


### PR DESCRIPTION
## Summary

Async `pi-subagents` runs can finish after the parent session turn has already ended. In that path, `pi-forge` watches the external status/result files and appends a `subagent-notify` custom message back to the parent session so the completion is visible in chat/SSE snapshots.

The bug was a race: pi-subagents may write terminal `status.json` before writing the async result JSON. pi-forge could deliver an early placeholder notification, then dedupe the later real result forever. This PR defers parent completion notification until the result file exists, and reads `results[].finalOutput` so the actual async child output is preserved.

## Usage

No direct user-facing usage change. Run an async subagent as before; when the background child completes after the parent turn is idle, its completion/output is reported back to the parent session via the existing `subagent-notify` message path.

## What changed (2 files, +26/-4)

- `packages/server/src/subagents-external.ts` — waits for the async result JSON before delivering terminal subagent completion to the parent session, avoiding permanent placeholder dedupe; also supports `results[].finalOutput` in async result summaries.
- `tests/test-subagent-discovery.ts` — adds regression coverage for terminal status arriving before the result file and verifies the final output is included once the result is written.

## Test plan

- [x] `npx prettier --write packages/server/src/subagents-external.ts tests/test-subagent-discovery.ts`
- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only session,subagent-discovery`
- [x] `npm run test:ci` — all 51 tests passed
