### PR TITLE
fix: improve composer refs and chat autoscroll

### DIFF
--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -58,13 +58,20 @@ function parseChatFileReferences(text: string): string[] {
   // Lazy bare alternation + lookahead so trailing sentence punctuation
   // (`?`, `,`, `;`, `:`, `!`, `)`, `]`) doesn't get glued onto the
   // path — kept in sync with the server-side REF_RE in
-  // file-references.ts. See that file for the rationale.
+  // file-references.ts. See that file for the rationale. For the draft
+  // badge row, keep bare one-word mentions like `@alex` out of the UI;
+  // quoted refs and path-shaped bare refs are explicit enough to badge.
   const re = /(?:^|\s)@(?:"([^"\n]+)"|([^\s]+?))(?=[?,;:!)\]]?(?:\s|$))/g;
   const out: string[] = [];
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {
-    const p = m[1] ?? m[2];
-    if (p !== undefined) out.push(p);
+    const quoted = m[1];
+    const bare = m[2];
+    if (quoted !== undefined) {
+      out.push(quoted);
+    } else if (bare !== undefined && /[./\\]/.test(bare)) {
+      out.push(bare);
+    }
   }
   return out;
 }
@@ -255,6 +262,7 @@ export function ChatInput({ sessionId }: Props) {
   const sendPrompt = useSessionStore((s) => s.sendPrompt);
   const sendSteer = useSessionStore((s) => s.sendSteer);
   const reloadMessages = useSessionStore((s) => s.reloadMessages);
+  const requestScrollToBottom = useSessionStore((s) => s.requestScrollToBottom);
   const abortSession = useSessionStore((s) => s.abortSession);
   const error = useSessionStore((s) => s.error);
 
@@ -609,10 +617,10 @@ export function ChatInput({ sessionId }: Props) {
           setAttachmentError(
             minimalUi
               ? "/<cmd> runs a pi-forge command (compact, abort, settings, …). " +
-                  "@<path> references a project file (autocomplete from the popover)."
+                  "@<path> references a project file (autocomplete from the popover); type \\@ for a literal @."
               : "/<cmd> runs a pi-forge command (compact, abort, settings, …). " +
                   "!cmd runs bash (output → next LLM context); !!cmd runs bash local-only. " +
-                  "@<path> references a project file (autocomplete from the popover).",
+                  "@<path> references a project file (autocomplete from the popover); type \\@ for a literal @.",
           );
         },
       },
@@ -1238,6 +1246,7 @@ export function ChatInput({ sessionId }: Props) {
       }
       return;
     }
+    requestScrollToBottom(sessionId);
     setSubmitting(true);
     try {
       // Bash exec dispatch — `!cmd` includes the result in the next

--- a/packages/client/src/components/ChatMarkdown.tsx
+++ b/packages/client/src/components/ChatMarkdown.tsx
@@ -131,6 +131,13 @@ interface Props {
    * on the standard line-break semantics.
    */
   chatStyleBreaks?: boolean;
+  /**
+   * Enable TeX-style `$...$` and `$$...$$` math. Assistant output keeps
+   * this enabled so model-authored math still renders, but user chat
+   * bubbles can disable it to preserve pasted shell snippets, prices, and
+   * env vars containing dollar signs as ordinary prose.
+   */
+  enableMath?: boolean;
 }
 
 /**
@@ -276,7 +283,12 @@ const components: Components = {
   pre: ({ children }) => <>{children}</>,
 };
 
-export function ChatMarkdown({ text, size = "sm", chatStyleBreaks = false }: Props) {
+export function ChatMarkdown({
+  text,
+  size = "sm",
+  chatStyleBreaks = false,
+  enableMath = true,
+}: Props) {
   // The outer container holds the typography scale + breaks long
   // unbroken tokens (URLs, identifiers, base64 dumps) so a single
   // gigantic word can't blow out the bubble width. Tailwind's
@@ -297,11 +309,20 @@ export function ChatMarkdown({ text, size = "sm", chatStyleBreaks = false }: Pro
   // those nodes into rendered MathML+HTML using KaTeX. Order matters —
   // remark-math must run before remark-breaks so a `$\rightarrow$` token
   // lands as a math node rather than text containing a literal `\n` →
-  // `<br>` rewrite around the dollar signs.
-  const plugins = chatStyleBreaks ? [remarkGfm, remarkMath, remarkBreaks] : [remarkGfm, remarkMath];
+  // `<br>` rewrite around the dollar signs. User-authored chat bubbles
+  // disable math because pasted multiline shell/env text commonly contains
+  // literal `$` pairs that should not switch into KaTeX formatting.
+  const plugins = enableMath
+    ? chatStyleBreaks
+      ? [remarkGfm, remarkMath, remarkBreaks]
+      : [remarkGfm, remarkMath]
+    : chatStyleBreaks
+      ? [remarkGfm, remarkBreaks]
+      : [remarkGfm];
+  const rehypePlugins = enableMath ? [rehypeKatex] : [];
   return (
     <div className={`${sizeClass} break-words [overflow-wrap:anywhere]`}>
-      <ReactMarkdown remarkPlugins={plugins} rehypePlugins={[rehypeKatex]} components={components}>
+      <ReactMarkdown remarkPlugins={plugins} rehypePlugins={rehypePlugins} components={components}>
         {text}
       </ReactMarkdown>
     </div>

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useLayoutEffect,
@@ -121,6 +122,7 @@ export function ChatView({ sessionId }: Props) {
   // re-fires when the target index actually changes (selecting the
   // map and reading by key would re-run on every map mutation).
   const pendingScrollTarget = useSessionStore((s) => s.pendingScrollByMessageIndex[sessionId]);
+  const bottomPinRequest = useSessionStore((s) => s.bottomPinRequestBySession[sessionId] ?? 0);
   const consumePendingScroll = useSessionStore((s) => s.consumePendingScroll);
   // Quick-action run cards for THIS session — empty array when none.
   // The store mutation triggers a re-render which the sticky-bottom
@@ -207,6 +209,7 @@ export function ChatView({ sessionId }: Props) {
   }, [sessionId, openStream, closeStream]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
+  const messageListRef = useRef<HTMLDivElement>(null);
   // "Sticky bottom" scroll: track the user's INTENT in a ref via the
   // onScroll handler, then auto-scroll only when intent says "follow."
   //
@@ -233,12 +236,24 @@ export function ChatView({ sessionId }: Props) {
     lastScrollTopRef.current = el.scrollTop;
   };
 
+  const snapChatToBottom = useCallback((): void => {
+    const el = scrollRef.current;
+    if (el !== null) {
+      el.scrollTop = el.scrollHeight;
+      lastScrollTopRef.current = el.scrollTop;
+    }
+  }, []);
+
+  const followChatToBottom = useCallback((): void => {
+    if (isFollowingBottomRef.current) snapChatToBottom();
+  }, [snapChatToBottom]);
+
   useLayoutEffect(() => {
     const el = scrollRef.current;
     if (el === null) return;
     if (isFollowingBottomRef.current) {
-      el.scrollTop = el.scrollHeight;
-      lastScrollTopRef.current = el.scrollTop;
+      snapChatToBottom();
+      requestAnimationFrame(snapChatToBottom);
       return;
     }
 
@@ -248,19 +263,28 @@ export function ChatView({ sessionId }: Props) {
     // appearing/disappearing, etc.). Browser scroll anchoring can otherwise
     // nudge the chat a few pixels when generation finishes.
     el.scrollTop = lastScrollTopRef.current;
-  }, [messages, streamingText, isStreaming, generatingToolCall]);
+  }, [
+    messages,
+    compactions,
+    streamingText,
+    isStreaming,
+    activeTool,
+    generatingToolCall,
+    queued,
+    sessionRuns.length,
+    snapChatToBottom,
+  ]);
 
-  const snapChatToBottom = (): void => {
-    const el = scrollRef.current;
-    if (el !== null) {
-      el.scrollTop = el.scrollHeight;
-      lastScrollTopRef.current = el.scrollTop;
-    }
-  };
-
-  const followChatToBottom = (): void => {
-    if (isFollowingBottomRef.current) snapChatToBottom();
-  };
+  useEffect(() => {
+    const list = messageListRef.current;
+    if (list === null || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      followChatToBottom();
+      requestAnimationFrame(followChatToBottom);
+    });
+    observer.observe(list);
+    return () => observer.disconnect();
+  }, [followChatToBottom]);
 
   // Force scroll-to-bottom + re-engage follow mode whenever a NEW
   // user message lands at the tail. Catches both the "user typed in
@@ -277,13 +301,20 @@ export function ChatView({ sessionId }: Props) {
       requestAnimationFrame(snapChatToBottom);
     }
     lastUserMessageCountRef.current = userCount;
-  }, [messages]);
+  }, [messages, snapChatToBottom]);
 
   useEffect(() => {
     if (!isStreaming) return;
     isFollowingBottomRef.current = true;
     snapChatToBottom();
-  }, [isStreaming]);
+  }, [isStreaming, snapChatToBottom]);
+
+  useEffect(() => {
+    if (bottomPinRequest === 0) return;
+    isFollowingBottomRef.current = true;
+    snapChatToBottom();
+    requestAnimationFrame(snapChatToBottom);
+  }, [bottomPinRequest, snapChatToBottom]);
 
   // Global-search scroll-to-message: when the search bar dispatches a
   // pending target for this session, locate the matching wrapper by
@@ -420,7 +451,7 @@ export function ChatView({ sessionId }: Props) {
               No messages yet. Send a prompt to get started.
             </p>
           )}
-          <div className="chat-message-list mx-auto max-w-3xl space-y-4">
+          <div ref={messageListRef} className="chat-message-list mx-auto max-w-3xl space-y-4">
             {(() => {
               // Pair toolCall blocks (in assistant messages) with their
               // matching toolResult messages (by toolCallId) so each
@@ -1143,7 +1174,7 @@ function Message({
               // ChatMarkdown's `chatStyleBreaks` prop docstring for
               // the trade-off (tables in user input need a leading
               // blank line; this matches what most users type).
-              <ChatMarkdown text={text} chatStyleBreaks />
+              <ChatMarkdown text={text} chatStyleBreaks enableMath={false} />
             )}
           </div>
         )}

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -204,6 +204,8 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
   delete nextTurnWriteCount[sessionId];
   const nextQueued = { ...current.queuedBySession };
   delete nextQueued[sessionId];
+  const nextBottomPinRequest = { ...current.bottomPinRequestBySession };
+  delete nextBottomPinRequest[sessionId];
   const byProject: Record<string, UnifiedSession[]> = {};
   for (const [pid, list] of Object.entries(current.byProject)) {
     byProject[pid] = list.filter((u) => u.sessionId !== sessionId);
@@ -219,6 +221,7 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
     fileRefreshCountBySession: nextFileRefreshCount,
     turnWriteCountBySession: nextTurnWriteCount,
     queuedBySession: nextQueued,
+    bottomPinRequestBySession: nextBottomPinRequest,
     byProject,
     activeSessionId: current.activeSessionId === sessionId ? undefined : current.activeSessionId,
   };
@@ -320,6 +323,7 @@ interface SessionState {
    * same session doesn't re-trigger the scroll.
    */
   pendingScrollByMessageIndex: Record<string, number>;
+  bottomPinRequestBySession: Record<string, number>;
   /** Errors surfaced from API calls (sticky until next successful op). */
   error: string | undefined;
   loadingList: boolean;
@@ -360,6 +364,8 @@ interface SessionState {
   requestScrollToMessage: (sessionId: string, messageIndex: number) => void;
   /** Consume + clear the pending scroll target for `sessionId`. */
   consumePendingScroll: (sessionId: string) => number | undefined;
+  /** Force the chat viewport to pin to the bottom for a user-originated entry. */
+  requestScrollToBottom: (sessionId: string) => void;
   sendPrompt: (sessionId: string, text: string, attachments?: File[]) => Promise<void>;
   sendSteer: (sessionId: string, text: string, mode?: "steer" | "followUp") => Promise<void>;
   abortSession: (sessionId: string) => Promise<void>;
@@ -392,6 +398,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   compactionEndCountBySession: {},
   queuedBySession: {},
   pendingScrollByMessageIndex: {},
+  bottomPinRequestBySession: {},
   error: undefined,
   loadingList: false,
 
@@ -522,6 +529,15 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       return { pendingScrollByMessageIndex: next };
     });
     return value;
+  },
+
+  requestScrollToBottom: (sessionId) => {
+    set((s) => ({
+      bottomPinRequestBySession: {
+        ...s.bottomPinRequestBySession,
+        [sessionId]: (s.bottomPinRequestBySession[sessionId] ?? 0) + 1,
+      },
+    }));
   },
 
   setActiveSession: (sessionId) => {

--- a/packages/server/src/file-references.ts
+++ b/packages/server/src/file-references.ts
@@ -38,9 +38,11 @@ import { checkFileReference, readFile } from "./file-manager.js";
  *                  intentionally do NOT bulk-embed directory contents
  *                  — large dirs would blow the context window, and
  *                  the model has cheap tools to explore on demand.
- *     error     → missing / outside root / binary. Replace marker
- *                  with `[@<path> not included: <reason>]` so neither
- *                  user nor model is left guessing.
+ *     literal   → missing paths are escaped as literal text so ordinary prose
+ *                  like `thanks @alex` does not become a file reference.
+ *     error     → outside root / binary. Replace marker with
+ *                  `[@<path> not included: <reason>]` so neither user nor
+ *                  model is left guessing.
  *
  * Multiple markers in one prompt are classified independently, then
  * inline candidates compete for a shared aggregate budget. See
@@ -137,6 +139,7 @@ export async function expandFileReferences(text: string, workspacePath: string):
     | { kind: "inlineCandidate"; size: number; abs: string }
     | { kind: "deferLarge" }
     | { kind: "directory" }
+    | { kind: "literal" }
     | { kind: "error"; reason: string };
 
   // Phase 1: classify every marker in parallel. Cheap — `checkFileReference`
@@ -159,7 +162,7 @@ export async function expandFileReferences(text: string, workspacePath: string):
       } catch (err) {
         const e = err as Error & { code?: string };
         if (e.name === "NotFoundError" || e.code === "ENOENT") {
-          return { kind: "error", reason: "file not found" };
+          return { kind: "literal" };
         }
         if (e.name === "PathOutsideRootError" || e.name === "AgentToolPathDeniedError") {
           return { kind: "error", reason: "path is outside allowed roots" };
@@ -204,6 +207,7 @@ export async function expandFileReferences(text: string, workspacePath: string):
     | { kind: "inline"; text: string }
     | { kind: "defer" }
     | { kind: "directory" }
+    | { kind: "literal" }
     | { kind: "error"; reason: string };
 
   // Phase 3: read content for the budget survivors, materialise the
@@ -213,6 +217,7 @@ export async function expandFileReferences(text: string, workspacePath: string):
   const outcomes: Outcome[] = await Promise.all(
     classifications.map(async (c, i): Promise<Outcome> => {
       if (c.kind === "directory") return { kind: "directory" };
+      if (c.kind === "literal") return { kind: "literal" };
       if (c.kind === "error") return { kind: "error", reason: c.reason };
       if (c.kind === "deferLarge") return { kind: "defer" };
       // c.kind === "inlineCandidate"
@@ -270,6 +275,8 @@ export async function expandFileReferences(text: string, workspacePath: string):
       const dirPath = mm.path.endsWith("/") ? mm.path : `${mm.path}/`;
       const dirMarker = /\s/.test(dirPath) ? `@"${dirPath}"` : `@${dirPath}`;
       out = `${before}${dirMarker}${after}`;
+    } else if (outcome.kind === "literal") {
+      out = `${before}\\${marker}${after}`;
     } else {
       out = `${before}[${marker} not included: ${outcome.reason}]${after}`;
     }

--- a/tests/test-folder-references.ts
+++ b/tests/test-folder-references.ts
@@ -8,7 +8,8 @@
  *   - Directory marker preserved with trailing `/` appended
  *   - Existing trailing `/` from user input is kept (not doubled)
  *   - Quoted form `@"path with spaces"` works for directories too
- *   - Non-existent path still becomes `[@<path> not included: ...]`
+ *   - Non-existent paths are escaped so `@mentions` are not file refs
+ *   - Escaped `\\@` stays literal
  *   - File markers (small + large + binary) keep their existing
  *     behaviour — regression guard
  *   - listAllFiles output now includes directories with trailing `/`
@@ -109,12 +110,23 @@ async function main(): Promise<void> {
       );
     }
 
-    // 5. Non-existent path still errors out cleanly
+    // 5. Non-existent paths are escaped so ordinary @mentions do not
+    // get surfaced as file references in the rendered chat bubble.
     {
-      const out = await fr.expandFileReferences("missing @nope", workspace);
+      const out = await fr.expandFileReferences("thanks @alex for the notes", workspace);
       assert(
-        "missing path produces `[@nope not included: ...]`",
-        out.includes("[@nope not included") && out.includes("not found"),
+        "missing bare mention is escaped literal text",
+        out === "thanks \\@alex for the notes",
+        `got: ${JSON.stringify(out)}`,
+      );
+    }
+
+    // 5b. Backslash escapes a marker even when the path exists.
+    {
+      const out = await fr.expandFileReferences("literal \\@src please", workspace);
+      assert(
+        "escaped at-sign stays literal",
+        out === "literal \\@src please",
         `got: ${JSON.stringify(out)}`,
       );
     }


### PR DESCRIPTION
## Summary

Fixes three chat UX issues around composer references, user-message rendering, and sticky-bottom scrolling. Literal or missing `@` mentions no longer surface as file references, user-authored multiline text containing `$` no longer gets parsed as math, and chat stays pinned to bottom through user submissions, thinking blocks, and generating tool-call placeholders while still preserving intentional scroll-up behavior.

## Usage

No operator action required. In the chat composer:

- Type normal mentions such as `@alex`; nonexistent paths are stored escaped so they render as literal text rather than file-reference badges.
- Use existing file reference flows (`@src/file.ts`, `@"path with spaces"`, autocomplete, or file-browser insert) for real files/folders.
- Paste shell/env text containing `$` into a user message; it renders as normal prose.

## What changed (6 files)

- `packages/server/src/file-references.ts` — treats missing `@...` targets as escaped literal text instead of failed file references; valid files/folders and protected-path errors keep existing behavior.
- `packages/client/src/components/ChatInput.tsx` — hides bare one-word mentions from draft file-ref badges, documents literal `@` help text, and requests bottom pinning on user submission.
- `packages/client/src/components/ChatMarkdown.tsx` — adds an `enableMath` flag so user bubbles can disable math parsing while assistant output keeps KaTeX support.
- `packages/client/src/components/ChatView.tsx` — disables math for user messages and strengthens sticky-bottom behavior with explicit bottom-pin requests plus ResizeObserver-backed follow-bottom updates.
- `packages/client/src/store/session-store.ts` — adds per-session bottom-pin request state for user-originated scroll-to-bottom.
- `tests/test-folder-references.ts` — updates reference expansion coverage for missing/literal `@` behavior.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only folder-references,agent-tool-sandbox`
- [ ] Manual browser validation: submit literal `@alex`, nonexistent `@nope`, valid file refs, multiline `$` paste, and streamed thinking/tool-call placeholder autoscroll.
- [ ] CI green before merge
