### PR TITLE
feat: add high contrast theme

### DIFF
--- a/packages/client/src/components/CodeMirrorEditor.tsx
+++ b/packages/client/src/components/CodeMirrorEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { EditorView, basicSetup } from "codemirror";
 import { Compartment, EditorState, type Extension } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
@@ -70,6 +70,56 @@ const editorFillContainerTheme = EditorView.theme({
   "&": { height: "100%" },
 });
 
+const highContrastEditorTheme = EditorView.theme(
+  {
+    "&": {
+      backgroundColor: "#000000",
+      color: "#ffffff",
+    },
+    ".cm-content": {
+      caretColor: "#ffffff",
+    },
+    ".cm-cursor, .cm-dropCursor": {
+      borderLeftColor: "#ffffff",
+    },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+      backgroundColor: "#264f78",
+    },
+    ".cm-activeLine": {
+      backgroundColor: "#111111",
+    },
+    ".cm-activeLineGutter": {
+      backgroundColor: "#111111",
+      color: "#ffffff",
+    },
+    ".cm-gutters": {
+      backgroundColor: "#000000",
+      borderRightColor: "#6a6a6a",
+      color: "#c6c6c6",
+    },
+    ".cm-lineNumbers .cm-gutterElement": {
+      color: "#c6c6c6",
+    },
+    ".cm-panels": {
+      backgroundColor: "#0c0c0c",
+      color: "#ffffff",
+    },
+    ".cm-searchMatch": {
+      backgroundColor: "#ffff0055",
+      outline: "1px solid #ffff00",
+    },
+    ".cm-searchMatch.cm-searchMatch-selected": {
+      backgroundColor: "#ff990080",
+    },
+    ".cm-tooltip": {
+      backgroundColor: "#0c0c0c",
+      borderColor: "#ffffff",
+      color: "#ffffff",
+    },
+  },
+  { dark: true },
+);
+
 /**
  * CodeMirror host. Lives in its own module so EditorPanel can pull it
  * in via `React.lazy()` — the CM bundle is ~700 KB minified and the
@@ -123,6 +173,15 @@ export function CodeMirrorEditor({
   const themeCompartmentRef = useRef<Compartment>(new Compartment());
   const activeTheme = useThemeStore((s) => s.theme);
   const editorMode = themeDef(activeTheme).mode;
+  const editorThemeExtension = useMemo<Extension>(
+    () =>
+      activeTheme === "high-contrast"
+        ? highContrastEditorTheme
+        : editorMode === "dark"
+          ? oneDark
+          : [],
+    [activeTheme, editorMode],
+  );
 
   // Latest `onChange` / `onSaveShortcut` in refs so the EditorView
   // listener doesn't capture stale closures across renders.
@@ -154,7 +213,7 @@ export function CodeMirrorEditor({
       // light-themed CodeMirror pack is bundled, so light mode
       // falls back to CodeMirror's default light styling (which
       // reads cleanly on white backgrounds).
-      themeCompartmentRef.current.of(editorMode === "dark" ? oneDark : []),
+      themeCompartmentRef.current.of(editorThemeExtension),
       wrapCompartmentRef.current.of(wrap ? EditorView.lineWrapping : []),
       // Git diff gutter + scrollbar overview. The extension itself
       // doesn't need a compartment — the StateField it ships with
@@ -204,16 +263,16 @@ export function CodeMirrorEditor({
   }, [wrap]);
 
   // Reconfigure the theme compartment when the user changes the
-  // app theme. dark→light flips oneDark off; light→dark flips it
-  // back on. Same compartment trick as wrap — preserves editor
-  // state.
+  // app theme. dark→light flips oneDark off; high contrast swaps in
+  // its dedicated black/white editor chrome. Same compartment trick
+  // as wrap — preserves editor state.
   useEffect(() => {
     const view = viewRef.current;
     if (view === null) return;
     view.dispatch({
-      effects: themeCompartmentRef.current.reconfigure(editorMode === "dark" ? oneDark : []),
+      effects: themeCompartmentRef.current.reconfigure(editorThemeExtension),
     });
-  }, [editorMode]);
+  }, [editorThemeExtension]);
 
   // External draft change (e.g. reloadFile bringing fresh disk content)
   // — sync into the editor without firing onChange.

--- a/packages/client/src/components/EditorPanel.tsx
+++ b/packages/client/src/components/EditorPanel.tsx
@@ -104,7 +104,7 @@ export function EditorPanel() {
   }, [activeExt]);
 
   return (
-    <div className="flex h-full flex-col bg-neutral-950 text-sm text-neutral-200">
+    <div className="forge-editor-panel flex h-full flex-col bg-neutral-950 text-sm text-neutral-200">
       <Tabs
         files={openFiles}
         activePath={activePath}
@@ -203,7 +203,7 @@ function Tabs({
     onCloseAll();
   };
   return (
-    <div className="flex border-b border-neutral-800 bg-neutral-900/40">
+    <div className="forge-editor-tabs flex border-b border-neutral-800 bg-neutral-900/40">
       {/* Close-all sits before the tab strip so its position is
           stable regardless of how many tabs are open. Confirmation
           prompt only when there are unsaved changes. */}
@@ -348,7 +348,7 @@ function StatusBar({
   // disabled while a save is in flight to avoid double-fire.
   const canSave = (dirty || saveError !== undefined) && !saving && !file.binary;
   return (
-    <div className="flex items-center justify-between gap-3 border-t border-neutral-800 bg-neutral-900/40 px-3 py-1 text-[11px]">
+    <div className="forge-editor-status flex items-center justify-between gap-3 border-t border-neutral-800 bg-neutral-900/40 px-3 py-1 text-[11px]">
       <div className="flex items-center gap-2">
         <span className="font-mono text-neutral-500">{file.language}</span>
         <button

--- a/packages/client/src/components/FileBrowserPanel.tsx
+++ b/packages/client/src/components/FileBrowserPanel.tsx
@@ -401,7 +401,7 @@ export function FileBrowserPanel() {
   };
 
   return (
-    <div className="flex h-full flex-col text-xs text-neutral-300">
+    <div className="forge-file-browser flex h-full flex-col bg-neutral-950 text-xs text-neutral-300">
       <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
         <span className="truncate font-medium text-neutral-200" title={project.path}>
           {project.name}
@@ -690,7 +690,7 @@ function FileContextMenu(props: {
 
   return (
     <div
-      className="fixed z-50 min-w-[200px] overflow-hidden rounded-md border border-neutral-700 bg-neutral-900 shadow-lg"
+      className="forge-file-context-menu fixed z-50 min-w-[200px] overflow-hidden rounded-md border border-neutral-700 bg-neutral-900 shadow-lg"
       style={{ left: props.x, top: props.y }}
       onMouseDown={(e) => e.stopPropagation()}
     >

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -303,7 +303,7 @@ export function SessionList({ projectId }: Props) {
     // `mt-1` separates the first session row from the project row
     // above; without it, the active-row highlight backgrounds (both
     // are `bg-neutral-800`) touch and read as one continuous block.
-    <div className="ml-6 mt-1 space-y-0.5">
+    <div className="forge-session-list ml-6 mt-1 space-y-0.5">
       {/* "New session" lives on the parent project row in
           ProjectSidebar (the + button on hover). Avoids stacking
           a second action button per project. */}
@@ -409,7 +409,7 @@ function SessionRow(props: SessionRowProps) {
       // by 2 px. Blue, not emerald, to disambiguate from any future
       // success / drop affordances on these rows.
       style={depth > 0 ? { marginLeft: `${Math.min(depth, 3) * 8}px` } : undefined}
-      className={`group flex items-center gap-1 rounded border-l-2 border-t border-t-neutral-800/40 px-2 py-0.5 text-xs light:border-t-neutral-200 ${
+      className={`forge-session-row group flex items-center gap-1 rounded border-l-2 border-t border-t-neutral-800/40 px-2 py-0.5 text-xs light:border-t-neutral-200 ${
         isSelected
           ? "border-l-blue-400 bg-blue-500/15 text-neutral-100 hover:bg-blue-500/25"
           : isActive

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -2877,6 +2877,18 @@ const SERVER_THEME_BASE_COLORS: Record<ThemeId, ServerThemeColors> = {
     highlightText: "#11111b",
     selectionBackground: "#585b70",
   },
+  "high-contrast": {
+    appBackground: "#000000",
+    panelBackground: "#0c0c0c",
+    userBubbleBackground: "#1f1f1f",
+    assistantBubbleBackground: "#0c0c0c",
+    primaryText: "#ffffff",
+    secondaryText: "#dcdcdc",
+    mutedText: "#a0a0a0",
+    highlightBackground: "#ffff00",
+    highlightText: "#000000",
+    selectionBackground: "#7a7a7a",
+  },
 };
 
 function isObject(v: unknown): v is Record<string, unknown> {

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -120,6 +120,28 @@
   --pi-terminal-fg: #cdd6f4;
 }
 
+[data-theme="high-contrast"] {
+  color-scheme: dark;
+  /* VS Code High Contrast-inspired: near-black surfaces,
+     white primary text, and intentionally separated grays so
+     borders, muted labels, panels, and selections remain visible
+     without remapping the app's semantic/accent Tailwind colors. */
+  --color-neutral-50: #ffffff;
+  --color-neutral-100: #ffffff;
+  --color-neutral-200: #f2f2f2;
+  --color-neutral-300: #dcdcdc;
+  --color-neutral-400: #c6c6c6;
+  --color-neutral-500: #a0a0a0;
+  --color-neutral-600: #7a7a7a;
+  --color-neutral-700: #5a5a5a;
+  --color-neutral-800: #1f1f1f;
+  --color-neutral-900: #0c0c0c;
+  --color-neutral-950: #000000;
+  --pi-editor-bg: #000000;
+  --pi-terminal-bg: #000000;
+  --pi-terminal-fg: #ffffff;
+}
+
 :root {
   --forge-app-bg: var(--color-neutral-950);
   --forge-panel-bg: var(--color-neutral-900);
@@ -182,6 +204,52 @@
 [data-server-theme="on"] mark {
   background: var(--forge-highlight-bg) !important;
   color: var(--forge-highlight-text) !important;
+}
+
+[data-theme="high-contrast"] .message-bubble[data-message-role="user"] {
+  background: #171717;
+  border: 1px solid #8a8a8a;
+  border-left-width: 2px;
+  color: #ffffff;
+}
+
+[data-theme="high-contrast"] .message-bubble[data-message-role="assistant"] {
+  background: #000000;
+  border: 1px solid #dcdcdc;
+  border-left: 2px solid #f2f2f2;
+  color: #ffffff;
+}
+
+[data-theme="high-contrast"] .message-bubble ::selection {
+  background: #264f78;
+  color: #ffffff;
+}
+
+[data-theme="high-contrast"] .forge-file-browser,
+[data-theme="high-contrast"] .forge-editor-panel {
+  background: #000000;
+  color: #ffffff;
+}
+
+[data-theme="high-contrast"] .forge-file-browser > div:first-child,
+[data-theme="high-contrast"] .forge-editor-tabs,
+[data-theme="high-contrast"] .forge-editor-status {
+  background: #0c0c0c;
+  border-color: #6a6a6a;
+}
+
+[data-theme="high-contrast"] .forge-file-context-menu {
+  background: #0c0c0c;
+  border-color: #ffffff;
+  color: #ffffff;
+}
+
+[data-theme="high-contrast"] .forge-session-row {
+  border-top-color: #444444;
+}
+
+[data-theme="high-contrast"] .forge-session-row:first-of-type {
+  border-top-color: #5a5a5a;
 }
 
 /* `light:text-neutral-*` classes are separate escaped class names,

--- a/packages/client/src/lib/theme.ts
+++ b/packages/client/src/lib/theme.ts
@@ -6,7 +6,13 @@ import { create } from "zustand";
  * three-step change: add an id here, add a CSS rule in index.css,
  * and (optionally) tag it light vs dark in {@link THEME_DEFS}.
  */
-export type ThemeId = "dark" | "light" | "dracula" | "solarized-dark" | "catppuccin-mocha";
+export type ThemeId =
+  | "dark"
+  | "light"
+  | "dracula"
+  | "solarized-dark"
+  | "catppuccin-mocha"
+  | "high-contrast";
 
 export interface ThemeDef {
   id: ThemeId;
@@ -22,6 +28,7 @@ export const THEME_DEFS: ThemeDef[] = [
   { id: "dracula", label: "Dracula", mode: "dark" },
   { id: "solarized-dark", label: "Solarized Dark", mode: "dark" },
   { id: "catppuccin-mocha", label: "Catppuccin Mocha", mode: "dark" },
+  { id: "high-contrast", label: "High Contrast", mode: "dark" },
 ];
 
 const STORAGE_KEY = "forge.theme";
@@ -74,6 +81,7 @@ const THEME_CHROME: Record<ThemeId, string> = {
   dracula: "#191a21",
   "solarized-dark": "#002b36",
   "catppuccin-mocha": "#11111b",
+  "high-contrast": "#000000",
 };
 
 function syncThemeColorMeta(id: ThemeId): void {


### PR DESCRIPTION
## Summary

Adds a selectable High Contrast appearance theme inspired by VS Code High Contrast. The theme keeps existing semantic/accent colors available for status and tool states, while improving contrast for core chrome, chat bubbles, file browsing/editor surfaces, and session-list dividers.

## Usage

Select **High Contrast** from Settings → Appearance → Theme. The setting is browser-local like the existing base themes.

## What changed (7 files)

- `packages/client/src/lib/theme.ts` — registers the `high-contrast` theme id, picker label, dark-mode classification, and browser chrome color.
- `packages/client/src/index.css` — adds the high contrast neutral palette plus scoped overrides for chat bubbles, file/editor surfaces, file context menus, and session row dividers.
- `packages/client/src/components/SettingsPanel.tsx` — adds High Contrast defaults to the “Copy colors” global custom colors flow.
- `packages/client/src/components/FileBrowserPanel.tsx` — adds stable class hooks so file browser and context menu surfaces can receive high contrast overrides.
- `packages/client/src/components/EditorPanel.tsx` — adds stable class hooks for editor shell, tabs, and status bar high contrast styling.
- `packages/client/src/components/CodeMirrorEditor.tsx` — adds a dedicated high contrast CodeMirror theme for editor content, gutters, cursor, selection, search matches, panels, and tooltips.
- `packages/client/src/components/SessionList.tsx` — adds stable class hooks for high contrast session row divider overrides.

## Test plan

- [x] `./node_modules/.bin/prettier --write` on changed files
- [x] `npm run build`
- [x] `npm run check`
- [ ] Manual browser visual check: High Contrast theme in chat bubbles, file browser/editor, context menu, and session pane dividers
- [ ] CI green before merge
