### PR TITLE
fix: improve MCP auth and backup settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,8 @@ or shell environment. The most-touched ones:
 | `JWT_SECRET` | (auto-generated) | HS256 signing key. Auto-generated and persisted to `${FORGE_DATA_DIR}/jwt-secret` (mode 0600) when `UI_PASSWORD`, LDAP auth, or `password-hash` is in play. Set explicitly (`openssl rand -hex 32`) to override; delete the file to rotate. |
 | `JWT_EXPIRES_IN_SECONDS` | `604800` | Absolute browser JWT lifetime (7 days by default). Equivalent CLI: `--jwt-expires-in-seconds`. |
 | `LOGIN_INACTIVITY_TIMEOUT_SECONDS` | `0` | Optional idle timeout for browser JWTs. `0` disables inactivity expiry; a positive value logs out browser sessions after that many seconds without mutating authenticated requests. Passive GETs such as SSE reconnects and status polling do not extend the idle window. Equivalent CLI: `--login-inactivity-timeout-seconds`. |
+| `LOGIN_ATTEMPT_LIMIT_MAX` | `10` | Failed browser login attempts allowed before pi-forge temporarily locks that login identity. Equivalent CLI: `--login-attempt-limit-max`. |
+| `LOGIN_LOCKOUT_MS` | `300000` | Browser login lockout duration after too many failed attempts (5 minutes by default). Lockout state is in-memory and clears on server restart. Equivalent CLI: `--login-lockout-ms`. |
 | `LDAP_ENABLED` | `false` | Enables LDAP username/password browser login. Requires the LDAP variables below. |
 | `LDAP_URL` | (unset) | LDAP server URL, e.g. `ldap://ldap.example.com:389` or `ldaps://ldap.example.com:636`. |
 | `LDAP_BIND_DN` | (unset) | Service-account bind DN used only to search for the user entry. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15863,6 +15863,15 @@
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
+      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
@@ -17179,7 +17188,8 @@
         "mammoth": "^1.12.0",
         "node-pty": "^1.0.0",
         "pdf-parse": "^2.4.5",
-        "tar": "^7.5.15"
+        "tar": "^7.5.15",
+        "undici": "^8.7.0"
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.9",

--- a/packages/client/src/components/LoginScreen.tsx
+++ b/packages/client/src/components/LoginScreen.tsx
@@ -153,7 +153,9 @@ export function LoginScreen() {
                   : "Incorrect password."
                 : error === "username_required"
                   ? "Username is required."
-                  : `Login failed: ${error}`}
+                  : error === "login_locked" || error.startsWith("too many failed login attempts")
+                    ? error
+                    : `Login failed: ${error}`}
             </p>
           )}
           <button

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -2967,7 +2967,7 @@ function ThemeSwatch({ id }: { id: ThemeId }) {
  * Export / import the pi-forge's portable config as a `.tar.gz`.
  *
  * Export bundles `mcp.json` + `settings.json` + `models.json` +
- * `skills-overrides.json` + `tool-overrides.json`. Auth is
+ * `skills-overrides.json` + `tool-overrides.json` + `quick-actions.json`. Auth is
  * deliberately excluded (provider keys / OAuth tokens), and the
  * UI calls that out so a user planning a migration knows to re-auth
  * providers afterwards.
@@ -3112,8 +3112,9 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
           <code className="font-mono">mcp.json</code>,{" "}
           <code className="font-mono">settings.json</code>,{" "}
           <code className="font-mono">models.json</code>,{" "}
-          <code className="font-mono">skills-overrides.json</code>, and{" "}
-          <code className="font-mono">tool-overrides.json</code>. Provider auth (
+          <code className="font-mono">skills-overrides.json</code>,{" "}
+          <code className="font-mono">tool-overrides.json</code>, and{" "}
+          <code className="font-mono">quick-actions.json</code>. Provider auth (
           <code className="font-mono">auth.json</code> — API keys, OAuth tokens) is{" "}
           <strong>not</strong> included; re-authenticate providers after restoring on a new install.
         </p>

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -3313,6 +3313,8 @@ interface McpDraft {
   transport: McpTransport;
   /** Headers as a flat ordered list so the user can manage rows. */
   headers: { key: string; value: string }[];
+  /** Remote-only: allow self-signed / invalid HTTPS certs for this server. */
+  ignoreCertificateErrors: boolean;
   // Stdio fields
   command: string;
   /** Args as a single textarea-friendly string; one arg per line.
@@ -3338,6 +3340,7 @@ function emptyDraft(): McpDraft {
     url: "",
     transport: "auto",
     headers: [],
+    ignoreCertificateErrors: false,
     command: "",
     argsText: "",
     env: [],
@@ -3487,6 +3490,7 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
       url: cfg.url ?? "",
       transport: cfg.transport ?? "auto",
       headers: Object.entries(cfg.headers ?? {}).map(([k, v]) => ({ key: k, value: v })),
+      ignoreCertificateErrors: cfg.ignoreCertificateErrors === true,
       command: cfg.command ?? "",
       argsText: (cfg.args ?? []).join("\n"),
       env: Object.entries(cfg.env ?? {}).map(([k, v]) => ({ key: k, value: v })),
@@ -3517,6 +3521,7 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
     if (draft.kind === "remote") {
       body.url = draft.url;
       body.transport = draft.transport;
+      if (draft.ignoreCertificateErrors) body.ignoreCertificateErrors = true;
       const headers: Record<string, string> = {};
       for (const h of draft.headers) {
         if (h.key.trim().length === 0) continue;
@@ -3691,22 +3696,20 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
               disabled={busy || !settings.truncation.enabled}
               className="w-28 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs text-neutral-100 disabled:opacity-50"
             />
-            <button
-              onClick={() =>
-                void saveTruncation({
-                  ...settings.truncation,
-                  enabled: !settings.truncation.enabled,
-                })
-              }
-              disabled={busy}
-              className={`rounded border px-3 py-1 text-xs ${
-                settings.truncation.enabled
-                  ? "border-emerald-700/50 bg-emerald-900/20 text-emerald-300 light:border-emerald-300 light:bg-emerald-50 light:text-emerald-800"
-                  : "border-neutral-700 text-neutral-300 hover:border-neutral-500"
-              }`}
-            >
-              {settings.truncation.enabled ? "Truncating" : "Pass-through"}
-            </button>
+            <label className="flex items-center gap-2 rounded border border-neutral-700 px-3 py-1 text-xs text-neutral-300">
+              <input
+                type="checkbox"
+                checked={settings.truncation.enabled}
+                disabled={busy}
+                onChange={(e) =>
+                  void saveTruncation({
+                    ...settings.truncation,
+                    enabled: e.target.checked,
+                  })
+                }
+              />
+              <span>{settings.truncation.enabled ? "Truncating" : "Pass-through"}</span>
+            </label>
           </div>
         </div>
       </div>
@@ -4202,6 +4205,17 @@ function McpDraftForm(props: {
               <option value="streamable-http">streamable-http</option>
               <option value="sse">sse</option>
             </select>
+            <label className="text-neutral-500">HTTPS certs</label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={draft.ignoreCertificateErrors}
+                onChange={(e) => setField("ignoreCertificateErrors", e.target.checked)}
+              />
+              <span className="text-[11px] text-neutral-500">
+                Ignore certificate errors for this server (self-signed/local HTTPS only).
+              </span>
+            </label>
           </>
         ) : (
           <>

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1618,7 +1618,13 @@ async function request<T>(
     } else {
       code = "invalid_error_body";
     }
-    throw new ApiError(res.status, code, parsed.ok ? undefined : `non-JSON ${res.status} body`);
+    const message =
+      parsed.ok && isObject(parsed.value) && typeof parsed.value.message === "string"
+        ? parsed.value.message
+        : parsed.ok
+          ? undefined
+          : `non-JSON ${res.status} body`;
+    throw new ApiError(res.status, code, message);
   }
 
   if (!parsed.ok) {

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -57,6 +57,7 @@ export interface McpServerConfig {
   url?: string;
   transport?: McpTransport;
   headers?: Record<string, string>;
+  ignoreCertificateErrors?: boolean;
   // stdio-only (mutually exclusive with `url`)
   command?: string;
   args?: string[];

--- a/packages/client/src/store/auth-store.ts
+++ b/packages/client/src/store/auth-store.ts
@@ -87,7 +87,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       });
     } catch (err) {
       const code = err instanceof ApiError ? err.code : "login_failed";
-      set({ loginPending: false, loginError: code });
+      const message = err instanceof ApiError && code === "login_locked" ? err.message : code;
+      set({ loginPending: false, loginError: message });
     }
   },
   changePassword: async (currentPassword: string, newPassword: string) => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -27,7 +27,8 @@
     "mammoth": "^1.12.0",
     "node-pty": "^1.0.0",
     "pdf-parse": "^2.4.5",
-    "tar": "^7.5.15"
+    "tar": "^7.5.15",
+    "undici": "^8.7.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.9",

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -25,6 +25,7 @@ const SCRYPT_SALT_BYTES = 16;
 
 const HASH_PREFIX = "scrypt";
 const lastTokenActivityMs = new Map<string, number>();
+const loginAttempts = new Map<string, { failures: number; lockedUntilMs?: number }>();
 
 export interface JwtPayload {
   sub: "ui-user";
@@ -40,6 +41,12 @@ export interface IssuedToken {
 }
 
 export type PasswordSource = "stored" | "env" | "none";
+
+export interface LoginLockoutState {
+  locked: boolean;
+  remainingMs: number;
+  lockedUntil?: string;
+}
 
 /**
  * Constant-time string comparison. Pads the shorter buffer so timingSafeEqual
@@ -126,6 +133,46 @@ export function verifyApiKey(presented: string): boolean {
   const expected = config.auth.apiKey;
   if (expected === undefined) return false;
   return constantTimeStringEqual(presented, expected);
+}
+
+export function loginLockoutKey(username: string | undefined): string {
+  return (username ?? config.auth.localAdminUsername).trim().toLowerCase();
+}
+
+export function getLoginLockoutState(key: string, nowMs = Date.now()): LoginLockoutState {
+  const state = loginAttempts.get(key);
+  const lockedUntilMs = state?.lockedUntilMs;
+  if (lockedUntilMs === undefined) return { locked: false, remainingMs: 0 };
+  if (lockedUntilMs <= nowMs) {
+    if ((state?.failures ?? 0) <= 0) loginAttempts.delete(key);
+    else loginAttempts.set(key, { failures: 0 });
+    return { locked: false, remainingMs: 0 };
+  }
+  return {
+    locked: true,
+    remainingMs: lockedUntilMs - nowMs,
+    lockedUntil: new Date(lockedUntilMs).toISOString(),
+  };
+}
+
+export function recordLoginFailure(key: string, nowMs = Date.now()): LoginLockoutState {
+  const prior = loginAttempts.get(key);
+  const failures = (prior?.failures ?? 0) + 1;
+  if (failures >= config.auth.loginAttemptLimitMax) {
+    const lockedUntilMs = nowMs + config.auth.loginLockoutMs;
+    loginAttempts.set(key, { failures: 0, lockedUntilMs });
+    return {
+      locked: true,
+      remainingMs: config.auth.loginLockoutMs,
+      lockedUntil: new Date(lockedUntilMs).toISOString(),
+    };
+  }
+  loginAttempts.set(key, { failures });
+  return { locked: false, remainingMs: 0 };
+}
+
+export function resetLoginFailures(key: string): void {
+  loginAttempts.delete(key);
 }
 
 /**

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -178,6 +178,22 @@ const FLAGS: readonly FlagDef[] = [
     defaultText: "0 (disabled)",
   },
   {
+    name: "login-attempt-limit-max",
+    env: "LOGIN_ATTEMPT_LIMIT_MAX",
+    type: "number",
+    group: "auth",
+    desc: "Failed browser login attempts before temporary lockout",
+    defaultText: "10",
+  },
+  {
+    name: "login-lockout-ms",
+    env: "LOGIN_LOCKOUT_MS",
+    type: "number",
+    group: "auth",
+    desc: "Browser login lockout duration in milliseconds after too many failed attempts",
+    defaultText: "300000 (5m)",
+  },
+  {
     name: "require-password-change",
     env: "REQUIRE_PASSWORD_CHANGE",
     type: "boolean",

--- a/packages/server/src/config-export.ts
+++ b/packages/server/src/config-export.ts
@@ -8,8 +8,9 @@
  *   - `skills-overrides.json` — pi-forge-private per-project skill enable/disable state
  *   - `tool-overrides.json`   — pi-forge-private per-project tool enable/disable state
  *   - `theme.json`            — pi-forge-private global UI color theme
+ *   - `quick-actions.json`    — pi-forge-private chat-toolbar quick actions
  *
- * The two `*-overrides.json` files live in `${FORGE_DATA_DIR}` (not
+ * The forge-private files live in `${FORGE_DATA_DIR}` (not
  * `${PI_CONFIG_DIR}` like the other three). They're included because
  * the user's per-project tool/skill toggle decisions are part of "the
  * pi-forge config a power-user wants to carry across installations" —
@@ -66,6 +67,7 @@ const ALLOWED_FILES = [
   "skills-overrides.json",
   "tool-overrides.json",
   "theme.json",
+  "quick-actions.json",
 ] as const;
 type AllowedFile = (typeof ALLOWED_FILES)[number];
 const ALLOWED_SET: ReadonlySet<string> = new Set<string>(ALLOWED_FILES);
@@ -85,6 +87,7 @@ const TARGETS: Record<AllowedFile, () => string> = {
   "skills-overrides.json": () => config.skillOverridesFile,
   "tool-overrides.json": () => config.toolOverridesFile,
   "theme.json": () => join(config.forgeDataDir, "theme.json"),
+  "quick-actions.json": () => config.quickActionsFile,
 };
 
 export interface ExportResult {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -520,6 +520,8 @@ export const config = Object.freeze({
     }),
     jwtExpiresInSeconds: readInt("JWT_EXPIRES_IN_SECONDS", 60 * 60 * 24 * 7),
     loginInactivityTimeoutSeconds: readInt("LOGIN_INACTIVITY_TIMEOUT_SECONDS", 0),
+    loginAttemptLimitMax: readBoundedInt("LOGIN_ATTEMPT_LIMIT_MAX", 10, 1, 1000),
+    loginLockoutMs: readBoundedInt("LOGIN_LOCKOUT_MS", 5 * 60_000, 1_000, 24 * 60 * 60_000),
     loginRateLimitMax: readInt("RATE_LIMIT_LOGIN_MAX", 10),
     loginRateLimitWindowMs: readInt("RATE_LIMIT_LOGIN_WINDOW_MS", 60_000),
     /**

--- a/packages/server/src/mcp/config.ts
+++ b/packages/server/src/mcp/config.ts
@@ -58,6 +58,12 @@ export interface McpServerConfig {
    * Ignored for stdio servers.
    */
   headers?: Record<string, string>;
+  /**
+   * Remote-only escape hatch for local/self-signed HTTPS MCP endpoints.
+   * When true, TLS certificate validation is disabled for this server's
+   * connection attempts. Defaults to false; do not enable for untrusted networks.
+   */
+  ignoreCertificateErrors?: boolean;
 
   /* --------- stdio-only (mutually exclusive with `url`) --------- */
   /**
@@ -199,6 +205,9 @@ function copyServerCleaned(src: McpServerConfig): McpServerConfig {
   if (src.enabled !== undefined) out.enabled = src.enabled;
   if (src.url !== undefined) out.url = src.url;
   if (src.transport !== undefined) out.transport = src.transport;
+  if (src.ignoreCertificateErrors !== undefined) {
+    out.ignoreCertificateErrors = src.ignoreCertificateErrors;
+  }
   if (src.command !== undefined) out.command = src.command;
   if (src.args !== undefined) out.args = [...src.args];
   if (src.cwd !== undefined) out.cwd = src.cwd;
@@ -229,7 +238,11 @@ export async function readMcpJsonRedacted(): Promise<McpJson> {
     }
     out[name] = cleaned;
   }
-  return { disabled: raw.disabled === true, servers: out };
+  return {
+    disabled: raw.disabled === true,
+    ...(raw.truncation !== undefined ? { truncation: raw.truncation } : {}),
+    servers: out,
+  };
 }
 
 /**

--- a/packages/server/src/mcp/manager.ts
+++ b/packages/server/src/mcp/manager.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { Agent as UndiciAgent } from "undici";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
@@ -419,13 +420,14 @@ async function syncScope(scope: Scope, configs: Record<string, McpServerConfig>)
  * Equality across every field that affects the underlying connection
  * (excluding `enabled`, which the caller compares separately because
  * a false→true flip needs to drop into connect, not just reconnect).
- * Covers both remote (`url`, `transport`, `headers`) and stdio
- * (`command`, `args`, `env`, `cwd`) — comparing the irrelevant set
+ * Covers both remote (`url`, `transport`, `headers`, TLS settings) and
+ * stdio (`command`, `args`, `env`, `cwd`) — comparing the irrelevant set
  * for a given kind is harmless because both sides are `undefined`.
  */
 function sameConnectionConfig(a: McpServerConfig, b: McpServerConfig): boolean {
   if (a.url !== b.url) return false;
   if (a.transport !== b.transport) return false;
+  if (a.ignoreCertificateErrors !== b.ignoreCertificateErrors) return false;
   if (a.command !== b.command) return false;
   if (a.cwd !== b.cwd) return false;
   if (JSON.stringify(a.args ?? []) !== JSON.stringify(b.args ?? [])) return false;
@@ -560,17 +562,18 @@ async function openConnection(cfg: McpServerConfig, scope: Scope): Promise<Opene
   }
   const url = new URL(cfg.url);
   const requested: McpTransport = cfg.transport ?? "auto";
+  const ignoreCertificateErrors = cfg.ignoreCertificateErrors === true;
   if (requested === "streamable-http") {
-    return await openStreamableHttp(url, cfg.headers);
+    return await openStreamableHttp(url, cfg.headers, ignoreCertificateErrors);
   }
   if (requested === "sse") {
-    return await openSse(url, cfg.headers);
+    return await openSse(url, cfg.headers, ignoreCertificateErrors);
   }
   // auto: try streamable-http, fall back to sse
   try {
-    return await openStreamableHttp(url, cfg.headers);
+    return await openStreamableHttp(url, cfg.headers, ignoreCertificateErrors);
   } catch {
-    return await openSse(url, cfg.headers);
+    return await openSse(url, cfg.headers, ignoreCertificateErrors);
   }
 }
 
@@ -648,15 +651,19 @@ const cachedProjectPaths = new Map<string, string>();
 // the connect boundary so we don't propagate that union mismatch into
 // our own types — runtime behavior is unaffected.
 type SdkTransport = Parameters<Client["connect"]>[0];
+type FetchWithDispatcherInit = RequestInit & { dispatcher?: UndiciAgent };
+const insecureHttpsAgent = new UndiciAgent({ connect: { rejectUnauthorized: false } });
 
 async function openStreamableHttp(
   url: URL,
   headers: Record<string, string> | undefined,
+  ignoreCertificateErrors: boolean,
 ): Promise<OpenedConnection> {
-  const transport = new StreamableHTTPClientTransport(
-    url,
-    headers !== undefined ? { requestInit: { headers } } : undefined,
-  );
+  const fetchWithTlsPolicy = makeFetchWithTlsPolicy(ignoreCertificateErrors);
+  const transport = new StreamableHTTPClientTransport(url, {
+    ...(headers !== undefined ? { requestInit: { headers } } : {}),
+    fetch: fetchWithTlsPolicy,
+  });
   const client = new Client({ name: "pi-forge", version: "1.0.0" }, { capabilities: {} });
   await client.connect(transport as unknown as SdkTransport);
   return { client, transport, resolvedTransport: "streamable-http" };
@@ -665,31 +672,34 @@ async function openStreamableHttp(
 async function openSse(
   url: URL,
   headers: Record<string, string> | undefined,
+  ignoreCertificateErrors: boolean,
 ): Promise<OpenedConnection> {
-  // Build options inline — exactOptionalPropertyTypes refuses to
-  // accept explicit `undefined` for optional properties, so the
-  // header-bearing variant builds the full options literal in one
-  // shot rather than composing it field-by-field.
-  const transport =
-    headers !== undefined
-      ? new SSEClientTransport(url, {
-          requestInit: { headers },
-          // Custom EventSource fetch factory so the SSE GET also
-          // carries the Authorization header. Browsers' native
-          // EventSource doesn't accept headers, but the MCP SDK's
-          // bundled eventsource shim does, via this factory hook.
-          eventSourceInit: {
-            fetch: (input: string | URL, init?: RequestInit) =>
-              fetch(input, {
-                ...init,
-                headers: { ...((init?.headers as Record<string, string>) ?? {}), ...headers },
-              }),
-          } as unknown as EventSourceInit,
-        })
-      : new SSEClientTransport(url);
+  const fetchWithTlsPolicy = makeFetchWithTlsPolicy(ignoreCertificateErrors);
+  const transport = new SSEClientTransport(url, {
+    ...(headers !== undefined ? { requestInit: { headers } } : {}),
+    // Custom EventSource fetch factory so the SSE GET also carries headers and
+    // the per-server TLS policy. Browsers' native EventSource doesn't accept
+    // headers, but the MCP SDK's bundled eventsource shim does via this hook.
+    eventSourceInit: {
+      fetch: (input: string | URL, init?: RequestInit) =>
+        fetchWithTlsPolicy(input, {
+          ...init,
+          headers: { ...((init?.headers as Record<string, string>) ?? {}), ...(headers ?? {}) },
+        }),
+    } as unknown as EventSourceInit,
+  });
   const client = new Client({ name: "pi-forge", version: "1.0.0" }, { capabilities: {} });
   await client.connect(transport);
   return { client, transport, resolvedTransport: "sse" };
+}
+
+function makeFetchWithTlsPolicy(ignoreCertificateErrors: boolean): typeof fetch {
+  if (!ignoreCertificateErrors) return fetch;
+  return async (input, init) =>
+    await fetch(input, {
+      ...init,
+      dispatcher: insecureHttpsAgent,
+    } as FetchWithDispatcherInit);
 }
 
 /* -------------------------- project-scope read -------------------------- */

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -3,8 +3,12 @@ import { config, authEnabled } from "../config.js";
 import {
   extractBearer,
   generateToken,
+  getLoginLockoutState,
+  loginLockoutKey,
   passwordConfigured,
   persistPassword,
+  recordLoginFailure,
+  resetLoginFailures,
   verifyPasswordWithSource,
   verifyToken,
 } from "../auth.js";
@@ -87,12 +91,22 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
           },
           400: errorSchema,
           401: errorSchema,
+          423: errorSchema,
           503: errorSchema,
         },
       },
     },
     async (req, reply) => {
       const { username, password } = req.body;
+      const attemptKey = loginLockoutKey(username);
+      const lockout = getLoginLockoutState(attemptKey);
+      if (lockout.locked) {
+        return reply.code(423).send({
+          error: "login_locked",
+          message: `too many failed login attempts; try again in ${Math.ceil(lockout.remainingMs / 1000)} seconds`,
+          lockedUntil: lockout.lockedUntil,
+        });
+      }
       const loginAsLocalAdmin =
         username === undefined ||
         username.toLowerCase() === config.auth.localAdminUsername.toLowerCase();
@@ -108,11 +122,20 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
           });
         }
         if (!result.ok) {
+          const failed = recordLoginFailure(attemptKey);
+          if (failed.locked) {
+            return reply.code(423).send({
+              error: "login_locked",
+              message: `too many failed login attempts; try again in ${Math.ceil(failed.remainingMs / 1000)} seconds`,
+              lockedUntil: failed.lockedUntil,
+            });
+          }
           return reply.code(401).send({
             error: "invalid_password",
             message: "the username or password did not match, or the user is not authorized",
           });
         }
+        resetLoginFailures(attemptKey);
         const issued = generateToken({ mustChangePassword: false });
         return { ...issued, mustChangePassword: false };
       }
@@ -126,11 +149,20 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
       }
       const result = await verifyPasswordWithSource(password);
       if (!result.ok) {
+        const failed = recordLoginFailure(attemptKey);
+        if (failed.locked) {
+          return reply.code(423).send({
+            error: "login_locked",
+            message: `too many failed login attempts; try again in ${Math.ceil(failed.remainingMs / 1000)} seconds`,
+            lockedUntil: failed.lockedUntil,
+          });
+        }
         return reply.code(401).send({
           error: "invalid_password",
           message: "the password did not match",
         });
       }
+      resetLoginFailures(attemptKey);
       const mustChangePassword = result.source === "env" && config.auth.requirePasswordChange;
       const issued = generateToken({ mustChangePassword });
       return { ...issued, mustChangePassword };

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -29,6 +29,7 @@ interface McpServerBody {
   url?: string;
   transport?: McpTransport;
   headers?: Record<string, string>;
+  ignoreCertificateErrors?: boolean;
   // stdio
   command?: string;
   args?: string[];
@@ -51,6 +52,7 @@ const serverConfigSchema = {
       type: "object",
       additionalProperties: { type: "string" },
     },
+    ignoreCertificateErrors: { type: "boolean" },
     command: { type: "string", minLength: 1 },
     args: { type: "array", items: { type: "string" } },
     env: {
@@ -119,6 +121,9 @@ function buildServerConfigFromBody(
     cfg.url = body.url;
     if (body.transport !== undefined) cfg.transport = body.transport;
     if (body.headers !== undefined) cfg.headers = body.headers;
+    if (body.ignoreCertificateErrors !== undefined) {
+      cfg.ignoreCertificateErrors = body.ignoreCertificateErrors;
+    }
   } else if (body.command !== undefined) {
     cfg.command = body.command;
     if (body.args !== undefined) cfg.args = [...body.args];

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -594,9 +594,43 @@ async function scenarioPersistedHashOnly(): Promise<void> {
   }
 }
 
+async function scenarioLoginAttemptLockout(): Promise<void> {
+  console.log("\n[scenario A3] login attempt lockout");
+  const password = "hunter2";
+  const srv = await startServer({
+    UI_PASSWORD: password,
+    JWT_SECRET: randomBytes(32).toString("hex"),
+    API_KEY: undefined,
+    LOGIN_ATTEMPT_LIMIT_MAX: "2",
+    LOGIN_LOCKOUT_MS: "60000",
+    RATE_LIMIT_LOGIN_MAX: "100",
+    RATE_LIMIT_LOGIN_WINDOW_MS: "60000",
+    REQUIRE_PASSWORD_CHANGE: "false",
+  });
+  try {
+    const wrong1 = await jsonPost(`${srv.base}/api/v1/auth/login`, { password: "wrong" });
+    assert("lockout attempt 1 → 401", wrong1.status === 401);
+
+    const wrong2 = await jsonPost(`${srv.base}/api/v1/auth/login`, { password: "wrong" });
+    assert("lockout attempt 2 → 423 locked", wrong2.status === 423);
+    const lockedBody = (await wrong2.json()) as { error?: string; message?: string };
+    assert("lockout response uses login_locked code", lockedBody.error === "login_locked");
+    assert(
+      "lockout response includes user-visible timer",
+      typeof lockedBody.message === "string" && lockedBody.message.includes("try again"),
+    );
+
+    const rightWhileLocked = await jsonPost(`${srv.base}/api/v1/auth/login`, { password });
+    assert("correct password during lockout stays locked → 423", rightWhileLocked.status === 423);
+  } finally {
+    await srv.stop();
+  }
+}
+
 async function main(): Promise<void> {
   await scenarioPasswordAndJwt();
   await scenarioLoginInactivityTimeout();
+  await scenarioLoginAttemptLockout();
   await scenarioApiKeyOnly();
   await scenarioAuthDisabled();
   await scenarioPersistedHashOnly();

--- a/tests/test-config-export.ts
+++ b/tests/test-config-export.ts
@@ -173,6 +173,9 @@ async function main(): Promise<void> {
       },
     },
   };
+  const seedQuickActions = [
+    { id: "qa-1", name: "Say hi", kind: "prompt", prompt: "hello", enabled: true },
+  ];
   const seedAuth = { providers: { anthropic: { apiKey: "sk-ant-secret-do-not-export" } } };
   await writeFile(join(configDir, "settings.json"), JSON.stringify(seedSettings), "utf8");
   await writeFile(join(configDir, "models.json"), JSON.stringify(seedModels), "utf8");
@@ -184,6 +187,7 @@ async function main(): Promise<void> {
     "utf8",
   );
   await writeFile(join(dataDir, "tool-overrides.json"), JSON.stringify(seedToolOverrides), "utf8");
+  await writeFile(join(dataDir, "quick-actions.json"), JSON.stringify(seedQuickActions), "utf8");
 
   const buildModule = (await import(
     resolve(repoRoot, "packages/server/dist/index.js")
@@ -213,11 +217,12 @@ async function main(): Promise<void> {
         .filter((s) => s.length > 0)
         .sort();
       assert(
-        "  X-Pi-Forge-Files lists all five files",
+        "  X-Pi-Forge-Files lists all six files",
         JSON.stringify(filesList) ===
           JSON.stringify([
             "mcp.json",
             "models.json",
+            "quick-actions.json",
             "settings.json",
             "skills-overrides.json",
             "tool-overrides.json",
@@ -239,11 +244,12 @@ async function main(): Promise<void> {
 
       const entries = (await listTarEntries(exportedBuf)).sort();
       assert(
-        "  tar contents match the five exportable files",
+        "  tar contents match the six exportable files",
         JSON.stringify(entries) ===
           JSON.stringify([
             "mcp.json",
             "models.json",
+            "quick-actions.json",
             "settings.json",
             "skills-overrides.json",
             "tool-overrides.json",
@@ -265,6 +271,7 @@ async function main(): Promise<void> {
       await rm(join(dataDir, "mcp.json"));
       await rm(join(dataDir, "skills-overrides.json"));
       await rm(join(dataDir, "tool-overrides.json"));
+      await rm(join(dataDir, "quick-actions.json"));
 
       const r = await postMultipart(
         base,
@@ -277,9 +284,9 @@ async function main(): Promise<void> {
       assert("POST /config/import → 200", r.status === 200, JSON.stringify(r.body));
       const summary = r.body as { imported: string[]; skipped: string[]; errors: unknown[] };
       assert(
-        "  imported lists all five",
+        "  imported lists all six",
         summary.imported.sort().join(",") ===
-          "mcp.json,models.json,settings.json,skills-overrides.json,tool-overrides.json",
+          "mcp.json,models.json,quick-actions.json,settings.json,skills-overrides.json,tool-overrides.json",
         JSON.stringify(summary),
       );
       assert("  no skipped entries", summary.skipped.length === 0, JSON.stringify(summary.skipped));
@@ -314,6 +321,14 @@ async function main(): Promise<void> {
         "  tool-overrides.json content round-trips",
         JSON.stringify(toolOverridesBack) === JSON.stringify(seedToolOverrides),
         JSON.stringify(toolOverridesBack),
+      );
+      const quickActionsBack = JSON.parse(
+        await readFile(join(dataDir, "quick-actions.json"), "utf8"),
+      );
+      assert(
+        "  quick-actions.json content round-trips",
+        JSON.stringify(quickActionsBack) === JSON.stringify(seedQuickActions),
+        JSON.stringify(quickActionsBack),
       );
 
       // auth.json was NEVER touched by the import path.
@@ -466,14 +481,14 @@ async function main(): Promise<void> {
         .split(",")
         .filter((s) => s.length > 0)
         .sort();
-      // The two `*-overrides.json` files were re-imported in step 2
-      // and again touched by step 3, so they're still on disk and
-      // included in this missing-mcp.json export.
+      // The forge-private backup files were re-imported in step 2, so
+      // they're still on disk and included in this missing-mcp.json export.
       assert(
         "  X-Pi-Forge-Files omits missing mcp.json",
         JSON.stringify(filesList) ===
           JSON.stringify([
             "models.json",
+            "quick-actions.json",
             "settings.json",
             "skills-overrides.json",
             "tool-overrides.json",
@@ -486,6 +501,7 @@ async function main(): Promise<void> {
         JSON.stringify(entries) ===
           JSON.stringify([
             "models.json",
+            "quick-actions.json",
             "settings.json",
             "skills-overrides.json",
             "tool-overrides.json",


### PR DESCRIPTION
## Summary

Fixes a grouped set of settings regressions around MCP, auth hardening, and backups:

- MCP HTTPS certificate-ignore is now represented as a checkbox and persists through the MCP config API.
- MCP result truncation can be disabled and re-enabled immediately from Settings → MCP without refreshing the page.
- Browser login now locks out after repeated failed attempts, defaulting to 10 failures and a 5 minute lockout with a user-visible timer.
- Config backup/export/import now includes `quick-actions.json` while preserving compatibility with older backups that omit it.

## Usage

MCP remote servers can opt into local/self-signed HTTPS endpoints from Settings → MCP by checking “Ignore certificate errors”. This persists as:

```json
{
  "servers": {
    "example": {
      "url": "https://localhost:9000/mcp",
      "ignoreCertificateErrors": true
    }
  }
}
```

Login lockout defaults can be adjusted if needed:

```bash
LOGIN_ATTEMPT_LIMIT_MAX=10
LOGIN_LOCKOUT_MS=300000
# or CLI:
pi-forge --login-attempt-limit-max 10 --login-lockout-ms 300000
```

Lockout state is in-memory and clears on server restart.

## What changed (18 files)

- `packages/client/src/components/SettingsPanel.tsx` — renders MCP certificate-ignore and truncation as checkboxes; includes the new remote-server field in save/edit flows.
- `packages/server/src/mcp/config.ts`, `packages/server/src/routes/mcp.ts`, `packages/client/src/lib/api-client/types.ts` — adds `ignoreCertificateErrors` to the MCP API/on-disk contract.
- `packages/server/src/mcp/manager.ts`, `packages/server/package.json`, `package-lock.json` — applies per-server TLS certificate-ignore through an `undici` dispatcher instead of global TLS env mutation.
- `packages/server/src/auth.ts`, `packages/server/src/routes/auth.ts` — adds in-memory failed-login tracking and `423 login_locked` responses with retry timing.
- `packages/server/src/config.ts`, `packages/server/src/cli.ts`, `docs/configuration.md` — wires login lockout defaults/env/CLI/docs.
- `packages/client/src/store/auth-store.ts`, `packages/client/src/components/LoginScreen.tsx`, `packages/client/src/lib/api-client/index.ts` — surfaces server login-lockout messages to the browser login form.
- `packages/server/src/config-export.ts` — includes `quick-actions.json` in backup export/import allowlist.
- `tests/test-auth.ts`, `tests/test-config-export.ts` — covers lockout behavior and quick-actions backup round-trip.

## Test plan

- [x] `npm run format`
- [x] `npm run build`
- [x] `npm run check`
- [x] `scripts/run-tests.sh --only mcp,mcp-truncation,auth,config-export,cli-flags`
- [x] `npm run test:ci` — all 51 tests passed
- [x] Manual/user validation confirmed by requester before commit
