### PR TITLE
chore: bump version to 1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.4.7] — 2026-07-22
+
+### Added
+
+- **High contrast theme.** A new built-in high contrast appearance option improves contrast across the app shell, editor, terminal, settings, and chat surfaces.
+
+### Changed
+
+- **Dependency updates for v1.4.7.** Updated the pinned pi SDK trio to 0.80.10 and refreshed the associated lockfile entries.
+
+### Fixed
+
+- **Async subagent completion output is preserved.** Background subagent returns now keep their completion text available in session output and discovery flows.
+- **Composer references and chat autoscroll are more reliable.** File/folder reference insertion, prompt submission, and transcript scrolling now better preserve user intent while following new output when appropriate.
+- **MCP auth and backup settings are easier to use.** Settings and backup flows now handle MCP auth data more consistently and list backup quick actions in the backup pane.
+- **Terminal rendering and copy behavior are smoother.** Terminal display updates, selection/copy interactions, and related rendering details have been tightened.
+
 ## [1.4.6] — 2026-06-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "workspaces": [
         "packages/*"
       ],
@@ -8259,6 +8259,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -10647,6 +10648,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -11275,6 +11277,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -14787,6 +14790,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17092,7 +17096,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17164,7 +17168,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.10",
         "@earendil-works/pi-ai": "0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the v1.4.7 release by rolling the changelog entries for the changes merged since v1.4.6 and bumping the project package versions in lockstep.

## Usage

No runtime behavior changes are introduced by this PR. After merge, tag the release from updated `main`:

```bash
git checkout main
git pull --ff-only
git tag v1.4.7
git push origin v1.4.7
```

## What changed (5 files, +28/-7)

- `CHANGELOG.md` — added the v1.4.7 dated release notes covering the pi SDK bump, high contrast theme, async subagent output preservation, composer/autoscroll fixes, MCP auth/backup settings fixes, and terminal UX fixes.
- `package.json` — bumped the root package version to `1.4.7`.
- `packages/client/package.json` — bumped the client package version to `1.4.7`.
- `packages/server/package.json` — bumped the server package version to `1.4.7`.
- `package-lock.json` — refreshed lockfile package metadata for `1.4.7`.

## Test plan

- [x] `npx npm@latest approve-scripts --allow-scripts-pending`
- [x] `npx prettier --write CHANGELOG.md package.json package-lock.json packages/client/package.json packages/server/package.json`
- [x] `npm run build`
- [x] `npm run check`
- [ ] CI green before merge
