### PR TITLE
docs: add rootless Podman quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ cp docker/.env.example docker/.env       # edit auth + paths if you want
 cd docker && docker compose up -d --build
 ```
 
+### Rootless Podman (SELinux-enabled Linux)
+
+Use the Podman overlay so the container user maps to your host user and Podman
+can apply private SELinux labels to the three bind mounts:
+
+```bash
+git clone https://github.com/Devin-Marks/pi-forge.git
+cd pi-forge
+cp docker/.env.example docker/.env       # edit auth + paths if you want
+cd docker
+PUID=$(id -u) PGID=$(id -g) \
+  podman-compose -f docker-compose.yml -f docker-compose.podman.yml up -d --build
+```
+
+Do not disable SELinux. The `:Z` mount labels are private to this container;
+use a different host directory if another container must mount the same path.
+
 ### npm (no Docker, runs from your shell)
 
 ```bash

--- a/docker/docker-compose.podman.yml
+++ b/docker/docker-compose.podman.yml
@@ -1,0 +1,16 @@
+# Rootless Podman overlay for SELinux-enabled Linux hosts.
+#
+# Use with docker-compose.yml:
+#   PUID=$(id -u) PGID=$(id -g) \
+#     podman-compose -f docker-compose.yml -f docker-compose.podman.yml up -d --build
+#
+# `keep-id` maps the container's pi user to the invoking host user. `:Z`
+# applies a private SELinux label to each bind-mount source.
+
+services:
+  pi-forge:
+    userns_mode: keep-id
+    volumes:
+      - ${WORKSPACE_HOST_PATH:-../workspace}:/workspace:Z
+      - ${PI_CONFIG_HOST_PATH:-~/.pi/agent}:/home/pi/.pi/agent:Z
+      - ${FORGE_DATA_HOST_PATH:-~/.pi-forge-docker}:/home/pi/.pi-forge:Z

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -172,6 +172,27 @@ cp docker/.env.example docker/.env
 cd docker && docker compose up -d --build
 ```
 
+### Rootless Podman on SELinux-enabled Linux
+
+Keep SELinux enforcing. Use the Podman overlay to map the container's `pi`
+user to the invoking host user and to give the three bind-mount sources
+private SELinux labels:
+
+```bash
+cd docker
+PUID=$(id -u) PGID=$(id -g) \
+  podman-compose -f docker-compose.yml -f docker-compose.podman.yml up -d --build
+```
+
+`userns_mode: keep-id` is Podman-specific, so it is intentionally kept out of
+the Docker Compose base file. The overlay's `:Z` volume suffix relabels the
+workspace, Pi agent config, and forge state directories for this one
+container. Do not use the same host directories from another container unless
+you deliberately manage compatible SELinux labels.
+
+For Podman installations where `podman compose` delegates to a compose
+provider, pass the same two `-f` files.
+
 ### Operations
 
 ```bash

--- a/docs/site/docs/containers.html
+++ b/docs/site/docs/containers.html
@@ -286,6 +286,21 @@ listed as runtime defaults. Quickstart:</p>
 # deploy) UI_PASSWORD (JWT_SECRET auto-generates), or API_KEY
 cd docker &amp;&amp; docker compose up -d --build
 </code></pre>
+<h3>Rootless Podman on SELinux-enabled Linux</h3>
+<p>Keep SELinux enforcing. Use the Podman overlay to map the container&#39;s <code>pi</code>
+user to the invoking host user and to give the three bind-mount sources
+private SELinux labels:</p>
+<pre><code class="language-bash">cd docker
+PUID=$(id -u) PGID=$(id -g) \
+  podman-compose -f docker-compose.yml -f docker-compose.podman.yml up -d --build
+</code></pre>
+<p><code>userns_mode: keep-id</code> is Podman-specific, so it is intentionally kept out of
+the Docker Compose base file. The overlay&#39;s <code>:Z</code> volume suffix relabels the
+workspace, Pi agent config, and forge state directories for this one
+container. Do not use the same host directories from another container unless
+you deliberately manage compatible SELinux labels.</p>
+<p>For Podman installations where <code>podman compose</code> delegates to a compose
+provider, pass the same two <code>-f</code> files.</p>
 <h3>Operations</h3>
 <pre><code class="language-bash"># Logs (follow)
 docker compose -f docker/docker-compose.yml logs -f


### PR DESCRIPTION
## What this changes

Adds a Podman-specific Compose overlay for rootless Podman on SELinux-enabled Linux hosts. The overlay maps the container user to the invoking host user with `userns_mode: keep-id` and applies private `:Z` labels to writable bind mounts. The README, container guide, and generated Pages documentation now include a copyable rootless Podman quickstart. Docker's base Compose file remains unchanged.

## Type of change

- [ ] `fix:` bug fix (no API change)
- [x] `feat:` new feature
- [ ] `refactor:` internal change, no behavior difference
- [ ] `docs:` documentation only
- [ ] `chore:` tooling, deps, build
- [ ] `test:` adding or fixing tests
- [ ] `perf:` performance improvement

## Scope

- [ ] Server (`packages/server/`)
- [ ] Client (`packages/client/`)
- [x] Docker / deploy (`docker/`, `kubernetes/`)
- [x] Docs (`docs/`, `README.md`, root markdown)
- [ ] Tests (`tests/`)

## How to verify

On a rootless Podman host with SELinux enforcing:

```bash
cd docker
PUID=$(id -u) PGID=$(id -g) \
  podman-compose -f docker-compose.yml -f docker-compose.podman.yml config

PUID=$(id -u) PGID=$(id -g) \
  podman-compose -f docker-compose.yml -f docker-compose.podman.yml up -d --build

podman exec pi-forge sh -c 'touch /workspace/.pi-forge-write-test && rm /workspace/.pi-forge-write-test'
curl -fsS http://127.0.0.1:3000/api/v1/health
```

Validated locally with Podman 5.8.2 and podman-compose 1.5.0. The merged Compose configuration parsed successfully; the deployment was recreated; workspace and Pi agent-config mounts were accessible; the health endpoint returned HTTP 200.

## Screenshots / recordings (UI changes only)

Not applicable.

## Risk and rollback

The overlay is opt-in and does not modify the Docker Compose base file. `:Z` assigns a private SELinux label to each mounted host path, so the same paths should not be shared with a second container unless compatible labels are managed deliberately. Roll back by stopping the deployment and starting it with only `docker-compose.yml`, or by reverting this commit.

## Checklist

- [x] Atomic commit(s) — one logical change per commit, conventional-commit prefix
- [x] No `Co-Authored-By` lines or AI-attribution trailers (per [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] `npm run check` passes (`tsc` + `eslint` + `prettier --check`)
- [ ] `npm run build` passes
- [ ] Relevant `tests/test-*.ts` script run and passing
- [ ] New/changed routes have JSON Schema (`schema.body`, `schema.response`, `schema.tags`) so they show up in `/api/docs`
- [x] No `process.env.*` reads outside `packages/server/src/config.ts`
- [x] No direct `fs.*` calls in route handlers (goes through `file-manager.ts` / `git-runner.ts`)
- [x] No raw `fetch()` in components (goes through `lib/api-client.ts`)
- [x] Default exports — none added (project convention is named exports)
- [ ] If changing config files / env vars, updated [`docs/configuration.md`](../docs/configuration.md) and the env vars table in [`README.md`](../README.md)
- [ ] If changing the SSE event surface, updated [`docs/sse-events.md`](../docs/sse-events.md)
- [ ] If adding a new HTTP route, updated [`docs/api-examples.md`](../docs/api-examples.md) where useful

## Notes for reviewers

Please review the Compose merge behavior: the overlay replaces the three base bind mounts by container target and adds only Podman-specific `userns_mode: keep-id`. The generated `docs/site/docs/containers.html` is included so the GitHub Pages documentation remains in sync with `docs/containers.md`.
