### PR TITLE
Feature: Add skill and extension slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ For source builds and a development setup see
 - **Quick actions** — operator-defined chips in the chat toolbar
   that either run a shell command in the active project's cwd or
   insert/send a templated prompt to the active session.
+- **Skill and extension slash commands** — discover enabled skills and
+  registered local or external extension commands from the chat input's `/`
+  palette. Skills use the validated skill flow; extensions use their registered
+  prompt handlers and can leave dismissible Markdown feedback in the timeline.
 - **Provider management** — Anthropic / OpenAI / Google / OpenRouter built-in,
   plus custom OpenAI-compatible endpoints (vLLM, LiteLLM, Ollama, internal
   gateways) via `models.json`.
@@ -172,7 +176,7 @@ The full feature grid (with categories and screenshots) is on the
 - [Security model](./SECURITY.md) — threat model + vulnerability reporting
 
 **Configure & extend**
-- [Configuration & env vars](./docs/configuration.md) — every flag, env var, and pi config file
+- [Configuration & env vars](./docs/configuration.md) — every flag, env var, pi config file, and slash-command behavior
 - [MCP servers](./docs/mcp.md) — remote + stdio servers, per-project trust gate, per-tool toggles
 - [Webhooks](./docs/webhooks.md) — HTTPS POSTs on agent/session events, HMAC signing, retry
 - [Session orchestration](./docs/orchestration.md) — supervisor sessions that spawn and coordinate workers

--- a/docs/agent-tool-sandbox.md
+++ b/docs/agent-tool-sandbox.md
@@ -439,8 +439,8 @@ pi-forge app container starts.
 
 The app container must start as UID 0 so the server can drop tool children to
 `AGENT_TOOL_UID:GID`. `SETUID`/`SETGID` are required for that identity switch;
-`CHOWN` is additionally required only if `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is set
-(otherwise startup fails on the chown step):
+`CHOWN` is also required because container startup performs mount-preparation
+`chown` operations even when `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is unset:
 
 ```yaml
 securityContext:
@@ -466,7 +466,7 @@ env:
     value: "1001"
   - name: AGENT_TOOL_HOME
     value: /home/pi-tools
-  # Optional; requires CHOWN in the app container capabilities above.
+  # Optional; CHOWN remains required for standard mount preparation.
   - name: AGENT_TOOL_SANDBOX_CHOWN_PATHS
     value: ""
 ```
@@ -582,8 +582,9 @@ identity-switch behavior pi-forge needs:
 
 - UID 0 for the server container
 - `SETUID` and `SETGID` for the app container's sandbox UID/GID switch
-- `CHOWN` for browser-created workspace ownership handoff and the optional
-  `AGENT_TOOL_SANDBOX_CHOWN_PATHS` startup helper
+- `CHOWN` for container startup mount preparation, browser-created workspace
+  ownership handoff, and the optional `AGENT_TOOL_SANDBOX_CHOWN_PATHS` startup
+  helper
 - `CHOWN` and `FOWNER` for the initContainer's PVC permission bootstrap
 - no privileged mode
 - no host namespaces or host networking
@@ -697,10 +698,11 @@ Security trade-offs:
 - The SCC intentionally allows UID 0 in the container. Keep the grant scoped to
   only the pi-forge ServiceAccount.
 - `SETUID` and `SETGID` are required so the server can switch shell-like tool
-  surfaces to `AGENT_TOOL_UID:GID`; `CHOWN` lets the app hand browser-created
-  workspace files to the tool identity and is required when
-  `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is configured. `CHOWN` and `FOWNER` are also
-  required by the initContainer that fixes PVC ownership/modes before startup.
+  surfaces to `AGENT_TOOL_UID:GID`; `CHOWN` lets the app prepare standard mounts
+  at container startup and hand browser-created workspace files to the tool
+  identity, even when `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is unset. `CHOWN` and
+  `FOWNER` are also required by the initContainer that fixes PVC ownership/modes
+  before startup.
   Do not add broader capabilities unless your own storage or platform policy
   requires them.
 - `readOnlyRootFilesystem` is not forced by the SCC so operators can use
@@ -712,9 +714,9 @@ Security trade-offs:
 
 Use the Kubernetes initContainer permission commands above, plus either the
 `anyuid` RoleBinding or the custom SCC/RBAC resources. The custom SCC still
-needs UID 0 plus `SETUID`/`SETGID` for the app container and `CHOWN`/`FOWNER`
-for app startup chown support and the initContainer; it does not need privileged
-mode.
+needs UID 0 plus `SETUID`/`SETGID` for the app container, `CHOWN` for its
+startup mount preparation, and `CHOWN`/`FOWNER` for the initContainer; it does
+not need privileged mode.
 
 ## pi-subagents package disabled in sandbox mode
 

--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -36,9 +36,10 @@ reverse proxy that drops/reopens streams can keep a browser login alive forever.
 numeric `AGENT_TOOL_UID` and `AGENT_TOOL_GID`, sandbox shell surfaces receive
 `HOME=${AGENT_TOOL_HOME}` (default `/home/pi-tools`), and LDAP bind-password file
 references are rejected. `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is a comma/whitespace
-list of existing non-secret paths that startup may recursively chown to the tool
-UID/GID; keep its allowed scope narrow. Keep sandbox env parsing in `config.ts`
-and the CLI surface in `cli.ts` together.
+list of existing non-secret paths that startup may recursively prepare with
+`AGENT_TOOL_UID` and the server process group (the root group in the documented
+container overlay), with group rwX bits; keep its allowed scope narrow. Keep
+sandbox env parsing in `config.ts` and the CLI surface in `cli.ts` together.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -329,6 +329,54 @@ These files are **forge-private**, not pi-side state — pi has no native
 concept of per-project skill/tool toggles. Backups via Settings → Backup
 include them so a restore preserves per-project preferences.
 
+## Slash commands
+
+Start a chat-input draft with `/` to open the slash-command palette. It lists
+pi-forge commands, enabled prompt templates and skills for the active project,
+and commands registered by extensions on the active session. Type after `/` to
+filter; use the arrow keys or click to choose an entry. Selecting a pi-forge
+UI command executes it immediately and clears the input. Selecting a prompt
+template, skill, or extension command inserts its exact invocation and a
+trailing space, ready for arguments and Enter to submit.
+
+A registered extension command takes precedence over a pi-forge UI command
+with the same `/name`; submitting that name runs the extension handler. The
+exception is an exact invocation of an enabled skill (`/skill:<name>`): it
+always uses the validated skill flow, even if an extension registers the same
+name. A disabled or unknown skill name is not a skill invocation and follows
+the normal slash-command dispatch rules.
+
+### Skills
+
+Skills use the syntax `/skill:<name> [instructions]`. The palette exposes only
+effective skills, but invocation is validated again against the active project's
+configuration and the live session's loaded skills. It also runs the normal
+model/auth preflight before the SDK receives the native skill command.
+
+`[instructions]` is optional, free-form text; it may span multiple lines after
+the skill has been selected. Skills start a fresh agent run, not a mid-turn
+steer, and cannot run while the session is streaming. Wait for the active run
+to finish before submitting one.
+
+### Extension commands
+
+Local extensions and externally installed extension packages can register
+commands. Their session-specific entries appear in the same palette as
+`/<name>`. Submit `/name` or `/name <arguments>` to send the exact text through
+the normal session prompt flow. A literal space separates the name from
+arguments, following the SDK's space-delimited command grammar. A registered
+extension command bypasses model/auth preflight, may run while the agent is
+streaming, and is not converted into a steer message. This bypass applies only
+to a command that is registered on the live session; other prompt submissions
+use the normal prompt flow.
+
+An extension command may call `ctx.ui.notify()` to emit Markdown feedback in
+the chat timeline. Each notification remains there until dismissed during the
+current browser session; it is not persisted through reload. Multiple info,
+warning, and error messages remain independently visible. See
+[`sse-events.md`](./sse-events.md#extension-ui-notifications) for the event
+payload.
+
 ## MCP servers
 
 MCP server definitions and global MCP behavior settings live in

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -150,7 +150,7 @@ when you need them.
 | `AGENT_TOOL_SANDBOX_ENABLED` | `false` by default; set `true` to run tool children as `pi-tools` |
 | `AGENT_TOOL_UID` / `AGENT_TOOL_GID` | `1001` / `1001` in compose defaults |
 | `AGENT_TOOL_HOME` | `/home/pi-tools`; writable home injected as `HOME` for sandboxed terminals/processes/model bash |
-| `AGENT_TOOL_SANDBOX_CHOWN_PATHS` | unset by default; optional comma/whitespace list of existing non-secret paths that the root sandbox server recursively chowns to `AGENT_TOOL_UID:GID` on startup |
+| `AGENT_TOOL_SANDBOX_CHOWN_PATHS` | unset by default; optional comma/whitespace list of existing non-secret paths that the root sandbox server recursively prepares at startup: each path is owned by `AGENT_TOOL_UID` with the server process group (root group in this sandbox overlay) and group rwX bits |
 
 Set `UI_PASSWORD` and / or `API_KEY` in `.env` for any non-loopback
 deploy — without them, auth is disabled. `JWT_SECRET` is intentionally
@@ -271,11 +271,13 @@ SSE-buffering and WebSocket-upgrade settings live in
   capabilities, and does not need `CHOWN`, `SETUID`, or `SETGID`. The optional
   `docker-compose.sandbox.yml` overlay starts as root and adds back
   only `CHOWN`, `SETUID`, and `SETGID`: `SETUID` / `SETGID` are required for
-  the sandbox identity switch, and `CHOWN` is required so browser upload and
-  new-file APIs can hand created workspace files/directories to `pi-tools`.
-  `CHOWN` is also required when `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is set;
-  deployments that remove `CHOWN` must leave that env var unset or startup
-  fails on the first chown. No privileged mode or host PID is needed.
+  the sandbox identity switch, and `CHOWN` is required for sandbox startup
+  mount/workspace ownership preparation even when
+  `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is unset, and so browser upload and new-file
+  APIs can hand created workspace files/directories to `pi-tools`. Setting that
+  option adds further permitted paths to prepare at startup, so sandbox
+  deployments that remove `CHOWN` fail on the first ownership change. No
+  privileged mode or host PID is needed.
 - **Secret mounts.** Mount Pi config, forge data, LDAP/UI secret files,
   and cloud credentials so they are readable by the root server but not
   by `pi-tools` (for example mode `0600` root-owned files or `0700`

--- a/docs/site/docs/agent-tool-sandbox.html
+++ b/docs/site/docs/agent-tool-sandbox.html
@@ -203,8 +203,11 @@ secret Pi config files by policy and filesystem mode, while leaving non-secret
 resources loadable and the selected agent resource directories writable by
 <code>pi-tools</code>.</p>
 <p>The Docker image&#39;s built-in directory ownership remains optimized for regular
-mode (<code>pi</code> owns <code>/home/pi</code> plus <code>/home/pi/.pi/agent</code> and <code>/home/pi/.pi-forge</code>) so
-non-sandbox tools can create ordinary per-user config such as <code>~/.config/gh</code>.
+mode (<code>pi</code> owns <code>/home/pi</code>, <code>/home/pi/.pi</code>, <code>/home/pi/.pi/agent</code>, and
+<code>/home/pi/.pi-forge</code>) so non-sandbox tools can create ordinary per-user config
+such as <code>~/.config/gh</code> and <code>~/.pi/...</code> files. The <code>/home/pi/.pi</code> group remains
+<code>pi-tools</code> without group write so sandbox tools can traverse non-secret resource
+parents without being able to create arbitrary entries there.
 Enabling sandbox with bind mounts or persistent volumes is an explicit operator
 step: adjust the mount permissions to the table above before relying on
 filesystem isolation. Sandbox tool children should still run as a different
@@ -212,16 +215,21 @@ filesystem isolation. Sandbox tool children should still run as a different
 Switching an existing deployment between regular and sandbox mode may require
 changing volume ownership/modes.</p>
 <h2>Optional startup chown helper</h2>
-<p><code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> can reduce deployment-specific init scripts
-for paths that should be owned by <code>pi-tools</code>. When sandbox mode is enabled and
-the server starts as root, pi-forge recursively <code>chown</code>s each configured
-existing path to <code>AGENT_TOOL_UID:AGENT_TOOL_GID</code> before the HTTP server starts.
+<p>When sandbox mode is enabled and the server starts as root, pi-forge always
+prepares <code>WORKSPACE_PATH</code> for sharing between <code>pi-tools</code> and the root server
+before the HTTP server starts: owner is <code>AGENT_TOOL_UID</code>, group is the server&#39;s
+group (root group in the Docker overlay), and mode bits include group rwX. This
+lets the sandbox tool identity write as owner while the root server can still
+create, move, read, delete, and download files without <code>DAC_OVERRIDE</code>.</p>
+<p><code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> can reduce deployment-specific init scripts for
+additional existing paths that should use the same shared sandbox/server
+permissions.
 The helper deliberately accepts only non-secret roots: <code>WORKSPACE_PATH</code>,
 <code>AGENT_TOOL_HOME</code>, and the Pi resource subtrees
 <code>${PI_CONFIG_DIR}/{skills,npm,git,extensions,prompts,themes}</code>. It rejects
 <code>${FORGE_DATA_DIR}</code>, <code>${PI_CONFIG_DIR}</code> itself, and protected config files.</p>
 <p>Example:</p>
-<pre><code class="language-txt">AGENT_TOOL_SANDBOX_CHOWN_PATHS=/workspace,/home/pi/.pi/agent/skills
+<pre><code class="language-txt">AGENT_TOOL_SANDBOX_CHOWN_PATHS=/home/pi/.pi/agent/skills
 </code></pre>
 <p>Keep using explicit init-container or host-side permissioning for server-only
 secret paths such as <code>${FORGE_DATA_DIR}</code> and <code>${PI_CONFIG_DIR}/auth.json</code>.</p>
@@ -300,9 +308,12 @@ AGENT_TOOL_HOME=/home/pi-tools
 <p>Start sandbox mode with the sandbox compose overlay. The base compose file runs
 regular mode as <code>pi</code> with no Linux capabilities; the overlay switches the server
 container to root and adds back <code>SETUID</code> / <code>SETGID</code> for sandbox child processes
-plus <code>CHOWN</code> for the optional <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> startup helper.
-If you remove <code>CHOWN</code>, leave <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> unset or startup
-will fail on the first ownership change:</p>
+plus <code>CHOWN</code> for entrypoint mount preparation and browser-created workspace
+ownership handoff. The image entrypoint prepares <code>/workspace</code>,
+<code>/home/pi/.pi-forge</code>, <code>/home/pi/.pi/agent</code>, and <code>AGENT_TOOL_HOME</code> before Node
+starts so server-private files such as <code>jwt-secret</code> can be created without
+<code>DAC_OVERRIDE</code>. If you remove <code>CHOWN</code>, sandbox startup will fail on the first
+ownership change:</p>
 <pre><code class="language-bash">cd docker
 docker compose -f docker-compose.yml -f docker-compose.sandbox.yml up -d --build
 </code></pre>
@@ -349,22 +360,16 @@ volumes:
 <p>The base compose file already drops all capabilities. The sandbox overlay adds
 back <code>CHOWN</code>, <code>SETUID</code>, and <code>SETGID</code> and runs the server container as root.
 <code>SETUID</code> / <code>SETGID</code> let pi-forge spawn model/user tool processes as
-<code>pi-tools</code>; <code>CHOWN</code> lets browser upload and new-file APIs hand newly created
-workspace files/directories to that same sandbox identity, and is also required
-when <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is configured.</p>
-<p>If OrbStack/Docker Desktop shows <code>.pi-forge</code> as <code>1000:1000 0700</code> inside the
-pi-forge container even after the helper volume init chowns it to <code>root:root</code>,
-add <code>DAC_OVERRIDE</code> for local testing:</p>
-<pre><code class="language-yaml">cap_add:
-  - CHOWN
-  - SETUID
-  - SETGID
-  - DAC_OVERRIDE # local OrbStack/Docker Desktop workaround only
-</code></pre>
+<code>pi-tools</code>; <code>CHOWN</code> lets the entrypoint prepare standard mounts before Node
+starts and lets browser upload/new-file APIs hand newly created workspace
+files/directories to that same sandbox identity (with the server group kept for
+root-server access). It is also required when <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code>
+is configured.</p>
 <p>Keep production/native-Linux deployments to <code>CHOWN</code>, <code>SETUID</code>, and <code>SETGID</code> for
 sandbox mode. If you build a stricter custom overlay, <code>SETUID</code>/<code>SETGID</code> are
-required for identity switching; <code>CHOWN</code> is required for browser-created
-workspace ownership handoff and for <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code>.</p>
+required for identity switching; <code>CHOWN</code> is required for entrypoint mount
+preparation, browser-created workspace ownership handoff, and
+<code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code>.</p>
 <h3>One-shot volume init commands</h3>
 <p>This example assumes the named volumes are <code>docker_pi-config</code> and
 <code>docker_forge-data</code>, and the sandbox UID/GID is <code>1001:1001</code>:</p>
@@ -463,8 +468,8 @@ pi-forge app container starts.</p>
 <h3>App container security context</h3>
 <p>The app container must start as UID 0 so the server can drop tool children to
 <code>AGENT_TOOL_UID:GID</code>. <code>SETUID</code>/<code>SETGID</code> are required for that identity switch;
-<code>CHOWN</code> is additionally required only if <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is set
-(otherwise startup fails on the chown step):</p>
+<code>CHOWN</code> is also required because container startup performs mount-preparation
+<code>chown</code> operations even when <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is unset:</p>
 <pre><code class="language-yaml">securityContext:
   runAsUser: 0
   runAsGroup: 0
@@ -485,7 +490,7 @@ pi-forge app container starts.</p>
     value: &quot;1001&quot;
   - name: AGENT_TOOL_HOME
     value: /home/pi-tools
-  # Optional; requires CHOWN in the app container capabilities above.
+  # Optional; CHOWN remains required for standard mount preparation.
   - name: AGENT_TOOL_SANDBOX_CHOWN_PATHS
     value: &quot;&quot;
 </code></pre>
@@ -594,8 +599,9 @@ identity-switch behavior pi-forge needs:</p>
 <ul>
 <li>UID 0 for the server container</li>
 <li><code>SETUID</code> and <code>SETGID</code> for the app container&#39;s sandbox UID/GID switch</li>
-<li><code>CHOWN</code> for browser-created workspace ownership handoff and the optional
-<code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> startup helper</li>
+<li><code>CHOWN</code> for container startup mount preparation, browser-created workspace
+ownership handoff, and the optional <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> startup
+helper</li>
 <li><code>CHOWN</code> and <code>FOWNER</code> for the initContainer&#39;s PVC permission bootstrap</li>
 <li>no privileged mode</li>
 <li>no host namespaces or host networking</li>
@@ -699,10 +705,11 @@ subjects:
 <li>The SCC intentionally allows UID 0 in the container. Keep the grant scoped to
 only the pi-forge ServiceAccount.</li>
 <li><code>SETUID</code> and <code>SETGID</code> are required so the server can switch shell-like tool
-surfaces to <code>AGENT_TOOL_UID:GID</code>; <code>CHOWN</code> lets the app hand browser-created
-workspace files to the tool identity and is required when
-<code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is configured. <code>CHOWN</code> and <code>FOWNER</code> are also
-required by the initContainer that fixes PVC ownership/modes before startup.
+surfaces to <code>AGENT_TOOL_UID:GID</code>; <code>CHOWN</code> lets the app prepare standard mounts
+at container startup and hand browser-created workspace files to the tool
+identity, even when <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is unset. <code>CHOWN</code> and
+<code>FOWNER</code> are also required by the initContainer that fixes PVC ownership/modes
+before startup.
 Do not add broader capabilities unless your own storage or platform policy
 requires them.</li>
 <li><code>readOnlyRootFilesystem</code> is not forced by the SCC so operators can use
@@ -714,9 +721,9 @@ relies on <code>.pi-forge</code> and protected Pi config files staying unreadabl
 </ul>
 <p>Use the Kubernetes initContainer permission commands above, plus either the
 <code>anyuid</code> RoleBinding or the custom SCC/RBAC resources. The custom SCC still
-needs UID 0 plus <code>SETUID</code>/<code>SETGID</code> for the app container and <code>CHOWN</code>/<code>FOWNER</code>
-for app startup chown support and the initContainer; it does not need privileged
-mode.</p>
+needs UID 0 plus <code>SETUID</code>/<code>SETGID</code> for the app container, <code>CHOWN</code> for its
+startup mount preparation, and <code>CHOWN</code>/<code>FOWNER</code> for the initContainer; it does
+not need privileged mode.</p>
 <h2>pi-subagents package disabled in sandbox mode</h2>
 <p>The <code>pi-subagents</code> package/extension is disabled while
 <code>AGENT_TOOL_SANDBOX_ENABLED=true</code>. The package shells out to the <code>pi</code> CLI and

--- a/docs/site/docs/api.html
+++ b/docs/site/docs/api.html
@@ -472,14 +472,15 @@ curl -s -X PUT -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: 
 # Patch is shallow-merged; pass null to delete a key.
 </code></pre>
 <h3>Read / write models.json (custom providers)</h3>
-<pre><code class="language-bash"># GET returns the file with `apiKey` / `apiKeyCommand` REPLACED by
-# &quot;***REDACTED***&quot; so the raw secret never leaves the server. The
-# persisted file is unchanged; PUT takes the actual values.
+<pre><code class="language-bash"># GET returns the file with `apiKey` REPLACED by &quot;***REDACTED***&quot; so the
+# raw secret never leaves the server. SDK 0.80 command-valued apiKey strings
+# such as &quot;!op read ...&quot; are also redacted; legacy apiKeyCommand is migrated.
+# The persisted file is otherwise unchanged; PUT takes the actual values.
 curl -s -H &quot;Authorization: Bearer $KEY&quot; $BASE/api/v1/config/models
 
 curl -s -X PUT -H &quot;Authorization: Bearer $KEY&quot; -H &quot;Content-Type: application/json&quot; \
   $BASE/api/v1/config/models \
-  -d &#39;{&quot;providers&quot;:{&quot;vllm-local&quot;:{&quot;api&quot;:&quot;openai-completions&quot;,&quot;url&quot;:&quot;http://localhost:8000/v1&quot;,&quot;models&quot;:[...]}}}&#39;
+  -d &#39;{&quot;providers&quot;:{&quot;vllm-local&quot;:{&quot;api&quot;:&quot;openai-completions&quot;,&quot;baseUrl&quot;:&quot;http://localhost:8000/v1&quot;,&quot;apiKey&quot;:&quot;$VLLM_API_KEY&quot;,&quot;models&quot;:[...]}}}&#39;
 </code></pre>
 <h3>List / toggle skills</h3>
 <pre><code class="language-bash"># Merged skills (global from ~/.pi/agent/skills/ + project-local from

--- a/docs/site/docs/configuration.html
+++ b/docs/site/docs/configuration.html
@@ -158,6 +158,26 @@ or shell environment. The most-touched ones:</p>
 <td>HS256 signing key. Auto-generated and persisted to <code>${FORGE_DATA_DIR}/jwt-secret</code> (mode 0600) when <code>UI_PASSWORD</code>, LDAP auth, or <code>password-hash</code> is in play. Set explicitly (<code>openssl rand -hex 32</code>) to override; delete the file to rotate.</td>
 </tr>
 <tr>
+<td><code>JWT_EXPIRES_IN_SECONDS</code></td>
+<td><code>604800</code></td>
+<td>Absolute browser JWT lifetime (7 days by default). Equivalent CLI: <code>--jwt-expires-in-seconds</code>.</td>
+</tr>
+<tr>
+<td><code>LOGIN_INACTIVITY_TIMEOUT_SECONDS</code></td>
+<td><code>0</code></td>
+<td>Optional idle timeout for browser JWTs. <code>0</code> disables inactivity expiry; a positive value logs out browser sessions after that many seconds without mutating authenticated requests. Passive GETs such as SSE reconnects and status polling do not extend the idle window. Equivalent CLI: <code>--login-inactivity-timeout-seconds</code>.</td>
+</tr>
+<tr>
+<td><code>LOGIN_ATTEMPT_LIMIT_MAX</code></td>
+<td><code>10</code></td>
+<td>Failed browser login attempts allowed before pi-forge temporarily locks that login identity. Equivalent CLI: <code>--login-attempt-limit-max</code>.</td>
+</tr>
+<tr>
+<td><code>LOGIN_LOCKOUT_MS</code></td>
+<td><code>300000</code></td>
+<td>Browser login lockout duration after too many failed attempts (5 minutes by default). Lockout state is in-memory and clears on server restart. Equivalent CLI: <code>--login-lockout-ms</code>.</td>
+</tr>
+<tr>
 <td><code>LDAP_ENABLED</code></td>
 <td><code>false</code></td>
 <td>Enables LDAP username/password browser login. Requires the LDAP variables below.</td>
@@ -228,9 +248,34 @@ or shell environment. The most-touched ones:</p>
 <td>When true, renders <code>AUTH_BANNER_TEXT</code> as sanitized HTML instead of plain text. Scripts, styles, event handlers, and unsafe links are stripped client-side. Leave false unless you need links or simple formatting.</td>
 </tr>
 <tr>
+<td><code>LOGO_URL_MODE</code></td>
+<td><code>cache</code></td>
+<td>Logo URL handling mode. <code>cache</code> fetches configured logo URLs at server startup into <code>FORGE_DATA_DIR/cache/logos/</code> and returns same-origin <code>/cache/logos/...</code> URLs. <code>direct</code> returns configured raw URLs so the browser loads them directly. Accepted values: <code>cache</code>, <code>direct</code>.</td>
+</tr>
+<tr>
+<td><code>LOGO_IMG_SRC_ALLOWLIST</code></td>
+<td>(unset)</td>
+<td>Extra Content-Security-Policy <code>img-src</code> sources for <code>LOGO_URL_MODE=direct</code>, comma- or whitespace-separated. Entries must be exact <code>http(s)</code> origins such as <code>https://cdn.example.com</code>, scheme sources such as <code>https:</code>, or explicit <code>*</code>. The configured logo URL origins are added automatically; use this only for known redirect/CDN origins.</td>
+</tr>
+<tr>
+<td><code>AUTH_URL_LOGO</code></td>
+<td>(unset)</td>
+<td>Optional absolute <code>http://</code> or <code>https://</code> URL for the login/auth logo. In <code>cache</code> mode, failed fetch/validation falls back to the built-in logo. In <code>direct</code> mode, the raw URL is returned without server fetch validation and browser/CSP/network behavior applies.</td>
+</tr>
+<tr>
 <td><code>AUTH_LOGO_URL</code></td>
 <td>(unset)</td>
-<td>Optional absolute <code>http://</code> or <code>https://</code> URL for the login/auth logo (and app header logo). Exposed as public UI config.</td>
+<td>Legacy alias for <code>AUTH_URL_LOGO</code>.</td>
+</tr>
+<tr>
+<td><code>APP_LOGO_DARK_URL</code></td>
+<td>(unset)</td>
+<td>Optional absolute <code>http://</code> or <code>https://</code> URL for the app header logo in dark-mode themes. Follows <code>LOGO_URL_MODE</code>; invalid or unreachable URLs fall back only in <code>cache</code> mode.</td>
+</tr>
+<tr>
+<td><code>APP_LOGO_LIGHT_URL</code></td>
+<td>(unset)</td>
+<td>Optional absolute <code>http://</code> or <code>https://</code> URL for the app header logo in light-mode themes. Follows <code>LOGO_URL_MODE</code>; invalid or unreachable URLs fall back only in <code>cache</code> mode.</td>
 </tr>
 <tr>
 <td><code>AUTH_COLOR_SCHEME</code></td>
@@ -280,9 +325,27 @@ or shell environment. The most-touched ones:</p>
 <tr>
 <td><code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code></td>
 <td>(empty)</td>
-<td>Comma- or whitespace-separated existing paths to recursively <code>chown</code> to <code>AGENT_TOOL_UID:AGENT_TOOL_GID</code> at server startup when sandbox mode is enabled. Paths are limited to <code>/workspace</code>, <code>AGENT_TOOL_HOME</code>, and non-secret Pi resource subtrees (<code>skills</code>, <code>npm</code>, <code>git</code>, <code>extensions</code>, <code>prompts</code>, <code>themes</code>).</td>
+<td>Optional comma- or whitespace-separated existing extra paths to recursively prepare for sandbox sharing at server startup when sandbox mode is enabled. <code>WORKSPACE_PATH</code> is always prepared automatically. Prepared paths are owned by <code>AGENT_TOOL_UID</code> with the server&#39;s group and group rwX bits so both the sandbox tool identity and root server without <code>DAC_OVERRIDE</code> can access them. Extra paths are limited to <code>WORKSPACE_PATH</code>, <code>AGENT_TOOL_HOME</code>, and non-secret Pi resource subtrees (<code>skills</code>, <code>npm</code>, <code>git</code>, <code>extensions</code>, <code>prompts</code>, <code>themes</code>).</td>
 </tr>
 </tbody></table>
+<p>Logo URL mode examples:</p>
+<pre><code class="language-bash"># Default: server fetches logos once at startup and serves /cache/logos/... same-origin.
+AUTH_URL_LOGO=https://assets.example.com/pi-forge-auth.svg \
+APP_LOGO_DARK_URL=https://assets.example.com/pi-forge-dark.svg \
+pi-forge
+
+# Direct: browser loads the raw configured URLs. Their origins are added to img-src automatically.
+LOGO_URL_MODE=direct \
+AUTH_URL_LOGO=https://assets.example.com/pi-forge-auth.svg \
+APP_LOGO_DARK_URL=https://assets.example.com/pi-forge-dark.svg \
+pi-forge
+
+# If a direct logo URL redirects to another trusted CDN origin, allow it explicitly.
+LOGO_URL_MODE=direct \
+LOGO_IMG_SRC_ALLOWLIST=https://cdn.example.net \
+AUTH_URL_LOGO=https://assets.example.com/pi-forge-auth.svg \
+pi-forge
+</code></pre>
 <p>Production-tuning knobs (rate limits, JWT lifetime, TLS / proxy posture)
 are documented in <a href="./deployment.md"><code>deployment.md</code></a>.</p>
 <h3>Agent tool identity sandbox</h3>
@@ -375,7 +438,8 @@ internal proxy.</p>
   &quot;providers&quot;: {
     &quot;vllm-local&quot;: {
       &quot;api&quot;: &quot;openai-completions&quot;,
-      &quot;url&quot;: &quot;http://localhost:8000/v1&quot;,
+      &quot;baseUrl&quot;: &quot;http://localhost:8000/v1&quot;,
+      &quot;apiKey&quot;: &quot;$VLLM_API_KEY&quot;,
       &quot;models&quot;: [
         {
           &quot;id&quot;: &quot;Qwen/Qwen2.5-Coder-32B-Instruct&quot;,
@@ -391,6 +455,13 @@ internal proxy.</p>
   }
 }
 </code></pre>
+<p><code>apiKey</code> is optional when credentials come from <code>auth.json</code>, <code>/login</code>, or a
+runtime environment supported by the SDK. In SDK 0.80+, this single field also
+supports value resolution: use <code>$ENV_VAR</code> / <code>${ENV_VAR}</code> for environment
+interpolation or prefix a command with <code>!</code>, for example
+<code>&quot;apiKey&quot;: &quot;!op read &#39;op://vault/item/credential&#39;&quot;</code>. Older pi-forge
+<code>apiKeyCommand</code> entries are migrated automatically to this <code>apiKey</code> command
+syntax on the next config read/write or session start.</p>
 <p><strong>Per-model fields:</strong></p>
 <table>
 <thead>
@@ -527,11 +598,52 @@ input&#39;s slash palette without a project switch (cross-tab signal via
 <p>These files are <strong>forge-private</strong>, not pi-side state — pi has no native
 concept of per-project skill/tool toggles. Backups via Settings → Backup
 include them so a restore preserves per-project preferences.</p>
+<h2>Slash commands</h2>
+<p>Start a chat-input draft with <code>/</code> to open the slash-command palette. It lists
+pi-forge commands, enabled prompt templates and skills for the active project,
+and commands registered by extensions on the active session. Type after <code>/</code> to
+filter; use the arrow keys or click to choose an entry. Selecting a pi-forge
+UI command executes it immediately and clears the input. Selecting a prompt
+template, skill, or extension command inserts its exact invocation and a
+trailing space, ready for arguments and Enter to submit.</p>
+<p>A registered extension command takes precedence over a pi-forge UI command
+with the same <code>/name</code>; submitting that name runs the extension handler. The
+exception is an exact invocation of an enabled skill (<code>/skill:&lt;name&gt;</code>): it
+always uses the validated skill flow, even if an extension registers the same
+name. A disabled or unknown skill name is not a skill invocation and follows
+the normal slash-command dispatch rules.</p>
+<h3>Skills</h3>
+<p>Skills use the syntax <code>/skill:&lt;name&gt; [instructions]</code>. The palette exposes only
+effective skills, but invocation is validated again against the active project&#39;s
+configuration and the live session&#39;s loaded skills. It also runs the normal
+model/auth preflight before the SDK receives the native skill command.</p>
+<p><code>[instructions]</code> is optional, free-form text; it may span multiple lines after
+the skill has been selected. Skills start a fresh agent run, not a mid-turn
+steer, and cannot run while the session is streaming. Wait for the active run
+to finish before submitting one.</p>
+<h3>Extension commands</h3>
+<p>Local extensions and externally installed extension packages can register
+commands. Their session-specific entries appear in the same palette as
+<code>/&lt;name&gt;</code>. Submit <code>/name</code> or <code>/name &lt;arguments&gt;</code> to send the exact text through
+the normal session prompt flow. A literal space separates the name from
+arguments, following the SDK&#39;s space-delimited command grammar. A registered
+extension command bypasses model/auth preflight, may run while the agent is
+streaming, and is not converted into a steer message. This bypass applies only
+to a command that is registered on the live session; other prompt submissions
+use the normal prompt flow.</p>
+<p>An extension command may call <code>ctx.ui.notify()</code> to emit Markdown feedback in
+the chat timeline. Each notification remains there until dismissed during the
+current browser session; it is not persisted through reload. Multiple info,
+warning, and error messages remain independently visible. See
+<a href="./sse-events.html#extension-ui-notifications"><code>sse-events.md</code></a> for the event
+payload.</p>
 <h2>MCP servers</h2>
-<p>MCP server definitions live in <code>${FORGE_DATA_DIR}/mcp.json</code> (global)
-and <code>&lt;project&gt;/.mcp.json</code> (project-scoped). Manage via <strong>Settings →
-MCP</strong> or edit the files directly. See <a href="./mcp.md"><code>mcp.md</code></a> for the
-field reference, transport options, auth model, and troubleshooting.</p>
+<p>MCP server definitions and global MCP behavior settings live in
+<code>${FORGE_DATA_DIR}/mcp.json</code> (global). Project-scoped server definitions
+live in <code>&lt;project&gt;/.mcp.json</code>. Manage global entries and MCP result
+truncation via <strong>Settings → MCP</strong> or edit the files directly. See
+<a href="./mcp.md"><code>mcp.md</code></a> for the field reference, transport options, auth
+model, truncation semantics, and troubleshooting.</p>
 <h2>Pi plugins</h2>
 <p>The pi CLI installs community plugins with <code>pi install npm:&lt;package&gt;</code>.
 Plugin sources land under <code>${PI_CONFIG_DIR}/packages/&lt;name&gt;</code> and

--- a/docs/site/docs/containers.html
+++ b/docs/site/docs/containers.html
@@ -268,7 +268,7 @@ when you need them.</p>
 </tr>
 <tr>
 <td><code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code></td>
-<td>unset by default; optional comma/whitespace list of existing non-secret paths that the root sandbox server recursively chowns to <code>AGENT_TOOL_UID:GID</code> on startup</td>
+<td>unset by default; optional comma/whitespace list of existing non-secret paths that the root sandbox server recursively prepares at startup: each path is owned by <code>AGENT_TOOL_UID</code> with the server process group (root group in this sandbox overlay) and group rwX bits</td>
 </tr>
 </tbody></table>
 <p>Set <code>UI_PASSWORD</code> and / or <code>API_KEY</code> in <code>.env</code> for any non-loopback
@@ -366,11 +366,13 @@ readable by the agent.</li>
 capabilities, and does not need <code>CHOWN</code>, <code>SETUID</code>, or <code>SETGID</code>. The optional
 <code>docker-compose.sandbox.yml</code> overlay starts as root and adds back
 only <code>CHOWN</code>, <code>SETUID</code>, and <code>SETGID</code>: <code>SETUID</code> / <code>SETGID</code> are required for
-the sandbox identity switch, and <code>CHOWN</code> is required so browser upload and
-new-file APIs can hand created workspace files/directories to <code>pi-tools</code>.
-<code>CHOWN</code> is also required when <code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is set;
-deployments that remove <code>CHOWN</code> must leave that env var unset or startup
-fails on the first chown. No privileged mode or host PID is needed.</li>
+the sandbox identity switch, and <code>CHOWN</code> is required for sandbox startup
+mount/workspace ownership preparation even when
+<code>AGENT_TOOL_SANDBOX_CHOWN_PATHS</code> is unset, and so browser upload and new-file
+APIs can hand created workspace files/directories to <code>pi-tools</code>. Setting that
+option adds further permitted paths to prepare at startup, so sandbox
+deployments that remove <code>CHOWN</code> fail on the first ownership change. No
+privileged mode or host PID is needed.</li>
 <li><strong>Secret mounts.</strong> Mount Pi config, forge data, LDAP/UI secret files,
 and cloud credentials so they are readable by the root server but not
 by <code>pi-tools</code> (for example mode <code>0600</code> root-owned files or <code>0700</code>

--- a/docs/site/docs/deployment.html
+++ b/docs/site/docs/deployment.html
@@ -225,6 +225,11 @@ pi-forge:</p>
 <td>Shorter = smaller blast radius if a token leaks</td>
 </tr>
 <tr>
+<td><code>LOGIN_INACTIVITY_TIMEOUT_SECONDS</code></td>
+<td><code>3600</code> (1 h) for shared/kiosk browsers; default <code>0</code> disables idle expiry</td>
+<td>Logs out browser JWTs after no mutating authenticated requests for the configured interval; passive GET polling / SSE reconnects do not extend it</td>
+</tr>
+<tr>
 <td><code>RATE_LIMIT_LOGIN_MAX</code></td>
 <td>default <code>10</code> is fine</td>
 <td>Per-IP login attempts per minute</td>

--- a/docs/site/docs/mcp.html
+++ b/docs/site/docs/mcp.html
@@ -131,6 +131,10 @@ to swap a global server for a project-specific one).</p>
 <p><code>mcp.json</code> (pi-forge-native shape, written by the UI):</p>
 <pre><code class="language-json">{
   &quot;disabled&quot;: false,
+  &quot;truncation&quot;: {
+    &quot;enabled&quot;: true,
+    &quot;maxChars&quot;: 30000
+  },
   &quot;servers&quot;: {
     &quot;weather&quot;: {
       &quot;url&quot;: &quot;https://mcp.example.com/sse&quot;,
@@ -237,6 +241,20 @@ shape, so existing files don&#39;t need rewriting:</p>
 <td>—</td>
 <td><code>false</code></td>
 <td>Master kill-switch. When <code>true</code>, NO MCP tools reach the agent regardless of per-server <code>enabled</code>.</td>
+</tr>
+<tr>
+<td><code>truncation.enabled</code></td>
+<td>boolean (top-level)</td>
+<td>—</td>
+<td><code>true</code></td>
+<td>When true, text MCP results are capped before they enter agent context.</td>
+</tr>
+<tr>
+<td><code>truncation.maxChars</code></td>
+<td>integer (top-level)</td>
+<td>—</td>
+<td><code>30000</code></td>
+<td>Total text-character cap across all text blocks in one MCP result. Images pass through unchanged.</td>
 </tr>
 </tbody></table>
 <h2>Stdio env passthrough</h2>
@@ -363,11 +381,15 @@ this browser tab refresh automatically on the shared MCP ticker. Unchanged statu
 payloads keep their existing UI state to avoid unnecessary churn.</p>
 <h2>Tool result truncation</h2>
 <p>Very large text results from MCP tools are capped before they enter the agent
-context. When truncation happens, the returned text starts with a concise
+context. The default cap is 30,000 characters across all text blocks in a single
+MCP result; Settings → MCP lets you disable this or choose a different cap, and
+stores the choice in <code>${FORGE_DATA_DIR}/mcp.json</code> as <code>truncation.enabled</code> /
+<code>truncation.maxChars</code>.</p>
+<p>When truncation happens, the returned text starts with a concise
 <code>MCP_RESULT_TRUNCATED</code> warning that includes the omitted size and tells the model
 to retry with a smaller scope, narrower filter, or pagination. The visible payload
 then keeps the start and end of the original result with a marker where the middle
-was omitted.</p>
+was omitted. Image blocks pass through unchanged.</p>
 <h2>Troubleshooting</h2>
 <p><strong>Status stuck in <code>error</code></strong> — Settings → MCP, expand the row, read
 <code>lastError</code>. Common causes:</p>

--- a/docs/site/docs/sse-events.html
+++ b/docs/site/docs/sse-events.html
@@ -342,6 +342,42 @@ message at the position of the compaction; UI should refresh.</p>
 <pre><code class="language-json">{ &quot;type&quot;: &quot;auto_retry_end&quot;, &quot;sessionId&quot;: &quot;01J7...&quot; }
 </code></pre>
 <p>UI action: hide retry banner.</p>
+<h2 id="extension-ui-notifications">Extension UI notifications</h2>
+<h3><code>extension_ui_notification</code></h3>
+<p>Sent when an extension command calls <code>ctx.ui.notify()</code>. Pi Forge also emits a
+warning notification when an extension requests an interactive dialog, which is
+not supported in the browser UI.</p>
+<pre><code class="language-json">{
+  &quot;type&quot;: &quot;extension_ui_notification&quot;,
+  &quot;sessionId&quot;: &quot;01J7...&quot;,
+  &quot;message&quot;: &quot;Command feedback: normal&quot;,
+  &quot;level&quot;: &quot;info&quot;
+}
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>message</code></td>
+<td>string</td>
+<td>The extension-provided Markdown text.</td>
+</tr>
+<tr>
+<td><code>level</code></td>
+<td><code>&quot;info&quot; | &quot;warning&quot; | &quot;error&quot;</code></td>
+<td>Visual severity; defaults to <code>&quot;info&quot;</code>.</td>
+</tr>
+</tbody></table>
+<p>UI action: render each notification as Markdown in the chat timeline in arrival
+order. Notifications remain until the user dismisses them during the current
+browser session; they are not persisted through reload. They are separate from
+session-state banners, so multiple notifications stay independently visible
+when emitted consecutively.</p>
 <h2>Ordering guarantees</h2>
 <p>Within a single SSE connection:</p>
 <ol>

--- a/docs/sse-events.md
+++ b/docs/sse-events.md
@@ -341,11 +341,13 @@ not supported in the browser UI.
 
 | Field | Type | Notes |
 |---|---|---|
-| `message` | string | The extension-provided notification text. |
+| `message` | string | The extension-provided Markdown text. |
 | `level` | `"info" \| "warning" \| "error"` | Visual severity; defaults to `"info"`. |
 
-UI action: display each notification transiently in arrival order. These are
-separate from session-state banners, so multiple notifications are not lost
+UI action: render each notification as Markdown in the chat timeline in arrival
+order. Notifications remain until the user dismisses them during the current
+browser session; they are not persisted through reload. They are separate from
+session-state banners, so multiple notifications stay independently visible
 when emitted consecutively.
 
 ## Ordering guarantees

--- a/docs/sse-events.md
+++ b/docs/sse-events.md
@@ -322,6 +322,32 @@ UI action: show "Retrying in 4s..." banner with a countdown.
 
 UI action: hide retry banner.
 
+## Extension UI notifications
+
+### `extension_ui_notification`
+
+Sent when an extension command calls `ctx.ui.notify()`. Pi Forge also emits a
+warning notification when an extension requests an interactive dialog, which is
+not supported in the browser UI.
+
+```json
+{
+  "type": "extension_ui_notification",
+  "sessionId": "01J7...",
+  "message": "Command feedback: normal",
+  "level": "info"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `message` | string | The extension-provided notification text. |
+| `level` | `"info" \| "warning" \| "error"` | Visual severity; defaults to `"info"`. |
+
+UI action: display each notification transiently in arrival order. These are
+separate from session-state banners, so multiple notifications are not lost
+when emitted consecutively.
+
 ## Ordering guarantees
 
 Within a single SSE connection:

--- a/kubernetes/DEPLOY.md
+++ b/kubernetes/DEPLOY.md
@@ -99,7 +99,8 @@ oc apply -f kubernetes/openshift/deployment.yaml
 #    support pi-forge's UID/GID-switching identity sandbox. For quick
 #    testing, bind anyuid. For tighter deployments, apply the custom SCC,
 #    ClusterRole, and ClusterRoleBinding shown below instead. The custom
-#    SCC must include CHOWN if AGENT_TOOL_SANDBOX_CHOWN_PATHS is configured.
+#    SCC must include CHOWN for sandbox startup mount/workspace ownership
+#    preparation; AGENT_TOOL_SANDBOX_CHOWN_PATHS adds further paths to prepare.
 oc adm policy add-scc-to-user anyuid -z pi-forge -n pi-forge
 
 # 5. Verify
@@ -148,9 +149,10 @@ in [`docs/configuration.md`](../docs/configuration.md) and
   by default. To enable it on vanilla Kubernetes, the container security
   context must run the server as root and permit the sandbox capabilities.
   `SETUID`/`SETGID` are required for the identity switch. `CHOWN` is required
-  for browser-created workspace ownership handoff and when using
-  `AGENT_TOOL_SANDBOX_CHOWN_PATHS`; without it, startup fails on the first
-  ownership change.
+  for sandbox startup mount/workspace ownership preparation and browser-created
+  workspace ownership handoff, even when `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is
+  unset. That optional setting adds further permitted paths to prepare; without
+  `CHOWN`, sandbox startup fails on the first ownership change.
 
   ```yaml
   securityContext:
@@ -171,10 +173,11 @@ in [`docs/configuration.md`](../docs/configuration.md) and
   pi-forge's policy hooks.
 - **OpenShift SCC.** restricted-v2 random UID will not support identity
   sandbox. Use `anyuid` for a simple deployment, or a custom SCC that
-  allows UID 0 plus `SETUID`/`SETGID` for the app container and
-  `CHOWN`/`FOWNER` for the initContainer. `CHOWN` is also required by the app
-  container when `AGENT_TOOL_SANDBOX_CHOWN_PATHS` is configured; privileged
-  mode is not required. Keep SCC grants with namespace/security bootstrap, not
+  allows UID 0 plus `SETUID`/`SETGID` and `CHOWN` for the app container's
+  sandbox startup mount/workspace ownership preparation, plus `CHOWN`/`FOWNER`
+  for the initContainer. `AGENT_TOOL_SANDBOX_CHOWN_PATHS` adds further
+  permitted paths for the app container to prepare; privileged mode is not
+  required. Keep SCC grants with namespace/security bootstrap, not
   inside the `DeploymentConfig`. Replace `pi-forge` with your namespace and
   ServiceAccount names if they differ.
 
@@ -275,10 +278,11 @@ in [`docs/configuration.md`](../docs/configuration.md) and
 
   Security trade-offs: the custom SCC intentionally allows UID 0,
   `SETUID`/`SETGID`, and `CHOWN`/`FOWNER`, so bind it only to pi-forge's
-  ServiceAccount. `CHOWN` is needed by the initContainer, by browser-created
-  workspace ownership handoff, and by `AGENT_TOOL_SANDBOX_CHOWN_PATHS` when
-  configured. Do not add broader capabilities unless your storage or platform
-  policy requires them. Keep
+  ServiceAccount. `CHOWN` is needed by the initContainer, sandbox startup
+  mount/workspace ownership preparation, browser-created workspace ownership
+  handoff, and any further permitted paths from
+  `AGENT_TOOL_SANDBOX_CHOWN_PATHS`. Do not add broader capabilities unless your
+  storage or platform policy requires them. Keep
   `readOnlyRootFilesystem: true` in the pi-forge container and
   mount `/tmp` as `emptyDir`; the SCC above does not force it so operators
   can use overlays. Do not use `fsGroup` to make sensitive volumes broadly

--- a/kubernetes/kube/deployment.yaml
+++ b/kubernetes/kube/deployment.yaml
@@ -75,8 +75,9 @@ spec:
             capabilities:
               drop: ["ALL"]
               # SETUID/SETGID are required for sandbox user switching.
-              # CHOWN is required only when AGENT_TOOL_SANDBOX_CHOWN_PATHS
-              # is set; without CHOWN, startup fails on the chown step.
+              # CHOWN is required for sandbox startup mount/workspace ownership
+              # preparation even when AGENT_TOOL_SANDBOX_CHOWN_PATHS is unset;
+              # that option adds further permitted paths to prepare.
               add: ["SETUID", "SETGID", "CHOWN"]
             readOnlyRootFilesystem: true
             seccompProfile:
@@ -107,9 +108,9 @@ spec:
               value: "1001"
             - name: AGENT_TOOL_GID
               value: "1001"
-            # Optional: comma/space-separated existing non-secret paths
-            # to chown to AGENT_TOOL_UID:GID at startup. Requires CHOWN
-            # in the container capabilities above.
+            # Optional: comma/space-separated existing non-secret paths to prepare
+            # for AGENT_TOOL_UID with the server process group at startup. CHOWN is
+            # already required for standard sandbox mount/workspace preparation above.
             - name: AGENT_TOOL_SANDBOX_CHOWN_PATHS
               value: ""
             - name: LOG_LEVEL

--- a/kubernetes/openshift/deployment.yaml
+++ b/kubernetes/openshift/deployment.yaml
@@ -63,8 +63,9 @@ spec:
             capabilities:
               drop: ["ALL"]
               # SETUID/SETGID are required for sandbox user switching.
-              # CHOWN is required only when AGENT_TOOL_SANDBOX_CHOWN_PATHS
-              # is set; without CHOWN, startup fails on the chown step.
+              # CHOWN is required for sandbox startup mount/workspace ownership
+              # preparation even when AGENT_TOOL_SANDBOX_CHOWN_PATHS is unset;
+              # that option adds further permitted paths to prepare.
               add: ["SETUID", "SETGID", "CHOWN"]
             readOnlyRootFilesystem: true
           ports:
@@ -95,9 +96,9 @@ spec:
               value: "1001"
             - name: AGENT_TOOL_GID
               value: "1001"
-            # Optional: comma/space-separated existing non-secret paths
-            # to chown to AGENT_TOOL_UID:GID at startup. Requires CHOWN
-            # in the container capabilities above.
+            # Optional: comma/space-separated existing non-secret paths to prepare
+            # for AGENT_TOOL_UID with the server process group at startup. CHOWN is
+            # already required for standard sandbox mount/workspace preparation above.
             - name: AGENT_TOOL_SANDBOX_CHOWN_PATHS
               value: ""
             - name: LOG_LEVEL

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -28,6 +28,7 @@ import { deriveCounts, selectTodoState, useTodoStore } from "../store/todo-store
 import { countRunning, selectProcesses, useProcessesStore } from "../store/processes-store";
 import { extractClipboardImageFiles } from "../lib/clipboard-images";
 import { isChatSubmitShortcut } from "../lib/chat-input-keys";
+import { parseSkillInvocation } from "../lib/skill-command";
 import { ProcessesPopover, TodosPopover } from "./InputPopovers";
 
 /**
@@ -429,10 +430,10 @@ export function ChatInput({ sessionId }: Props) {
   const openSettings = useUiStore((s) => s.openSettings);
   const chatInsertRequest = useUiStore((s) => s.chatInsertRequest);
   const clearChatInsertRequest = useUiStore((s) => s.clearChatInsertRequest);
-  // Bumped by Settings → Prompts after every toggle so the slash
-  // palette refetches without requiring a project switch or full
-  // reload. Included in the prompts-fetch effect's deps.
+  // Bumped by Settings → Prompts / Skills after every toggle so the slash
+  // palette refetches without requiring a project switch or full reload.
   const promptsRefreshTrigger = useUiStore((s) => s.promptsRefreshTrigger);
+  const skillsRefreshTrigger = useUiStore((s) => s.skillsRefreshTrigger);
   const lastChatInsertSeqRef = useRef(0);
   const [slashSelectedIdx, setSlashSelectedIdx] = useState(0);
   const slashOpen = text.startsWith("/") && !text.includes("\n");
@@ -490,6 +491,39 @@ export function ChatInput({ sessionId }: Props) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [project?.id, promptsRefreshTrigger]);
+
+  /**
+   * Skills loaded by the active live-session project. The server validates
+   * against the live session again on invocation; this list only drives
+   * discovery and exact slash-command dispatch in the palette.
+   */
+  const [availableSkills, setAvailableSkills] = useState<{ name: string; description: string }[]>(
+    [],
+  );
+  useEffect(() => {
+    if (project === undefined) {
+      setAvailableSkills([]);
+      return;
+    }
+    let cancelled = false;
+    void api
+      .listSkills(project.id)
+      .then((res) => {
+        if (cancelled) return;
+        setAvailableSkills(
+          res.skills
+            .filter((skill) => skill.effective)
+            .map((skill) => ({ name: skill.name, description: skill.description })),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setAvailableSkills([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [project?.id, skillsRefreshTrigger]);
 
   // Quick-action prompt chips with `mode: "insert"` (and the "Use as
   // context" button on completed run cards) bridge through
@@ -652,6 +686,25 @@ export function ChatInput({ sessionId }: Props) {
         },
       });
     }
+    for (const skill of availableSkills) {
+      commands.push({
+        name: `/skill:${skill.name}`,
+        description: skill.description,
+        available: !isStreaming,
+        run: () => {
+          // Skills accept free-form additional instructions. Insert the exact
+          // command so Enter routes it to the validated skill endpoint.
+          const insert = `/skill:${skill.name} `;
+          setText(insert);
+          requestAnimationFrame(() => {
+            const ta = textareaRef.current;
+            if (ta === null) return;
+            ta.focus();
+            ta.setSelectionRange(insert.length, insert.length);
+          });
+        },
+      });
+    }
     return commands;
   }, [
     isStreaming,
@@ -661,6 +714,7 @@ export function ChatInput({ sessionId }: Props) {
     openSettings,
     minimalUi,
     availablePrompts,
+    availableSkills,
   ]);
 
   const slashFiltered = useMemo(() => {
@@ -688,6 +742,14 @@ export function ChatInput({ sessionId }: Props) {
     if (!availablePrompts.some((p) => p.name === firstWord)) return false;
     return text === `/${firstWord}` || text.startsWith(`/${firstWord} `);
   }, [slashOpen, text, availablePrompts]);
+
+  // Unlike the palette, exact known skill invocations may carry multiline
+  // free-form instructions. Keep their dispatch independent of `slashOpen`,
+  // which deliberately closes once the input contains a newline.
+  const skillInvocation = useMemo(
+    () => parseSkillInvocation(text, new Set(availableSkills.map((skill) => skill.name))),
+    [text, availableSkills],
+  );
 
   /**
    * Run the highlighted command. `overrideIdx` lets a tap handler
@@ -1233,10 +1295,10 @@ export function ChatInput({ sessionId }: Props) {
     // /-command dispatch — the keyboard path (Enter) handles this
     // first, but a click on Send also lands here and a `/foo` typed
     // input shouldn't slip through to the LLM as a regular prompt.
-    // Exception: pi prompt templates in `/<name> ...args` form bypass
-    // dispatch — the SDK's `session.prompt()` expands them at send
-    // time. See `isPromptInvocation` for the predicate.
-    if (slashOpen && !isPromptInvocation) {
+    // Exceptions: pi prompt templates still go through normal prompt
+    // submission, while exact known skill commands go to the validated
+    // skill endpoint below. See `isPromptInvocation` / `skillInvocation`.
+    if (slashOpen && !isPromptInvocation && skillInvocation === undefined) {
       if (slashFiltered.length > 0) {
         slashRunSelected();
       } else {
@@ -1281,7 +1343,19 @@ export function ChatInput({ sessionId }: Props) {
         historyDraftRef.current = "";
         return;
       }
-      if (isStreaming) {
+      if (skillInvocation !== undefined) {
+        if (isStreaming) {
+          setAttachmentError(
+            "Skills cannot run while the agent is streaming. Wait for the current run to finish.",
+          );
+          return;
+        }
+        if (attachments.length > 0) {
+          clearAttachments();
+          setAttachmentError("Attachments aren't sent with skills. Cleared.");
+        }
+        await api.invokeSkill(sessionId, skillInvocation.name, skillInvocation.instructions);
+      } else if (isStreaming) {
         // Steer doesn't accept attachments today — the SDK's steer()
         // takes (text, images?) which we COULD wire, but cleaner to
         // ship steer-with-text-only first. Clear immediately + warn
@@ -1345,15 +1419,12 @@ export function ChatInput({ sessionId }: Props) {
           return;
         }
         if (e.key === "Enter" || e.key === "Tab") {
-          // Pi-prompt invocation form (`/<knownname>` or
-          // `/<knownname> ...args`) — fall through to normal textarea
-          // handling. Shift+Enter inserts a newline for multiline
-          // prompt args; regular desktop Enter and Cmd/Ctrl+Enter
-          // submit and let pi expand the template at send time.
-          // Without this branch, Enter would re-fire the prompt
-          // entry's `run()` and clobber any args the user typed.
-          // (Tab still discovers / fills in.)
-          if (isPromptInvocation && e.key === "Enter") {
+          // Pi-prompt invocations and exact known skill invocations
+          // fall through to normal submit handling on Enter. This keeps
+          // prompt-template behavior unchanged and preserves all skill
+          // arguments instead of re-running a palette entry that would
+          // clobber them. Tab still discovers / fills in.
+          if ((isPromptInvocation || skillInvocation !== undefined) && e.key === "Enter") {
             // Intentionally fall through.
           } else {
             e.preventDefault();

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -457,6 +457,9 @@ export function ChatInput({ sessionId }: Props) {
   const [availablePrompts, setAvailablePrompts] = useState<
     { name: string; description: string; argumentHint?: string }[]
   >([]);
+  const [extensionCommands, setExtensionCommands] = useState<
+    { name: string; description?: string }[]
+  >([]);
   useEffect(() => {
     if (project === undefined) {
       setAvailablePrompts([]);
@@ -524,6 +527,24 @@ export function ChatInput({ sessionId }: Props) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [project?.id, skillsRefreshTrigger]);
+
+  // Extension commands are session-specific: packages and project settings
+  // are resolved when the live SDK session is created. A failed lookup leaves
+  // the built-in palette usable (for example while an old session is loading).
+  useEffect(() => {
+    let cancelled = false;
+    void api
+      .listExtensionCommands(sessionId)
+      .then((res) => {
+        if (!cancelled) setExtensionCommands(res.commands);
+      })
+      .catch(() => {
+        if (!cancelled) setExtensionCommands([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
 
   // Quick-action prompt chips with `mode: "insert"` (and the "Use as
   // context" button on completed run cards) bridge through
@@ -659,6 +680,27 @@ export function ChatInput({ sessionId }: Props) {
         },
       },
     ];
+    // SDK extension commands take precedence over pi-forge UI commands,
+    // matching the SDK's own prompt dispatch. Selection fills the exact
+    // invocation into the editor; submit then uses the ordinary prompt route
+    // so the SDK can run the handler immediately, including while streaming.
+    for (const command of [...extensionCommands].reverse()) {
+      commands.unshift({
+        name: `/${command.name}`,
+        description: command.description ?? "Extension command",
+        available: true,
+        run: () => {
+          const insert = `/${command.name} `;
+          setText(insert);
+          requestAnimationFrame(() => {
+            const ta = textareaRef.current;
+            if (ta === null) return;
+            ta.focus();
+            ta.setSelectionRange(insert.length, insert.length);
+          });
+        },
+      });
+    }
     // Append pi prompt templates after the built-in commands. The
     // SDK's `session.prompt()` expands `/<promptname> args` to the
     // template body at send time (`expandPromptTemplates: true` by
@@ -715,6 +757,7 @@ export function ChatInput({ sessionId }: Props) {
     minimalUi,
     availablePrompts,
     availableSkills,
+    extensionCommands,
   ]);
 
   const slashFiltered = useMemo(() => {
@@ -730,6 +773,8 @@ export function ChatInput({ sessionId }: Props) {
    * — pi's `session.prompt()` will expand the template at send time.
    * Without this bypass, Enter on `/<name> foo` re-fires the prompt
    * entry's `run()` which re-inserts `/<name> ` and clobbers the args.
+   * SDK extension commands use the same normal-submit path via
+   * `isExtensionCommandInvocation` below.
    *
    * Distinguishes from the still-typing-the-name case (e.g. text is
    * `/sum` while a prompt is named `summarize`) — that DOES go through
@@ -750,6 +795,16 @@ export function ChatInput({ sessionId }: Props) {
     () => parseSkillInvocation(text, new Set(availableSkills.map((skill) => skill.name))),
     [text, availableSkills],
   );
+
+  // The SDK parses extension commands using only a literal space as the
+  // separator. Preserve that exact invocation contract: bypass the local
+  // slash dispatcher and let the normal prompt endpoint call session.prompt.
+  const isExtensionCommandInvocation = useMemo(() => {
+    if (!slashOpen) return false;
+    const spaceIndex = text.indexOf(" ");
+    const name = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+    return extensionCommands.some((command) => command.name === name);
+  }, [slashOpen, text, extensionCommands]);
 
   /**
    * Run the highlighted command. `overrideIdx` lets a tap handler
@@ -1295,10 +1350,15 @@ export function ChatInput({ sessionId }: Props) {
     // /-command dispatch — the keyboard path (Enter) handles this
     // first, but a click on Send also lands here and a `/foo` typed
     // input shouldn't slip through to the LLM as a regular prompt.
-    // Exceptions: pi prompt templates still go through normal prompt
-    // submission, while exact known skill commands go to the validated
-    // skill endpoint below. See `isPromptInvocation` / `skillInvocation`.
-    if (slashOpen && !isPromptInvocation && skillInvocation === undefined) {
+    // Exceptions: pi prompt templates and SDK extension commands still go
+    // through normal prompt submission, while exact known skill commands go to
+    // the validated skill endpoint below. See their predicates above.
+    if (
+      slashOpen &&
+      !isPromptInvocation &&
+      skillInvocation === undefined &&
+      !isExtensionCommandInvocation
+    ) {
       if (slashFiltered.length > 0) {
         slashRunSelected();
       } else {
@@ -1355,7 +1415,7 @@ export function ChatInput({ sessionId }: Props) {
           setAttachmentError("Attachments aren't sent with skills. Cleared.");
         }
         await api.invokeSkill(sessionId, skillInvocation.name, skillInvocation.instructions);
-      } else if (isStreaming) {
+      } else if (isStreaming && !isExtensionCommandInvocation) {
         // Steer doesn't accept attachments today — the SDK's steer()
         // takes (text, images?) which we COULD wire, but cleaner to
         // ship steer-with-text-only first. Clear immediately + warn
@@ -1367,7 +1427,15 @@ export function ChatInput({ sessionId }: Props) {
         }
         await sendSteer(sessionId, rawValue);
       } else {
-        await sendPrompt(sessionId, rawValue, attachments.length > 0 ? attachments : undefined);
+        // Extension commands always use session.prompt(), not steer: the SDK
+        // executes them immediately during streaming and preserves their
+        // command-handler semantics.
+        await sendPrompt(
+          sessionId,
+          rawValue,
+          attachments.length > 0 ? attachments : undefined,
+          !isExtensionCommandInvocation,
+        );
       }
       setText("");
       clearAttachments();
@@ -1419,12 +1487,15 @@ export function ChatInput({ sessionId }: Props) {
           return;
         }
         if (e.key === "Enter" || e.key === "Tab") {
-          // Pi-prompt invocations and exact known skill invocations
-          // fall through to normal submit handling on Enter. This keeps
-          // prompt-template behavior unchanged and preserves all skill
-          // arguments instead of re-running a palette entry that would
-          // clobber them. Tab still discovers / fills in.
-          if ((isPromptInvocation || skillInvocation !== undefined) && e.key === "Enter") {
+          // Pi prompt-template, exact known skill, or SDK extension-command
+          // invocation — fall through to normal textarea handling on Enter.
+          // This preserves prompt/skill/extension arguments instead of
+          // re-running a palette entry that would clobber them. Tab still
+          // discovers / fills in.
+          if (
+            (isPromptInvocation || skillInvocation !== undefined || isExtensionCommandInvocation) &&
+            e.key === "Enter"
+          ) {
             // Intentionally fall through.
           } else {
             e.preventDefault();

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -25,12 +25,14 @@ import {
 } from "lucide-react";
 import {
   EMPTY_COMPACTIONS,
+  EMPTY_EXTENSION_NOTIFICATIONS,
   EMPTY_MESSAGES,
   EMPTY_STRING,
   useSessionStore,
   type ActiveTool,
   type AgentMessageLike,
   type CompactionEvent,
+  type ExtensionUiNotification,
 } from "../store/session-store";
 import type { ToolCallGeneration } from "../lib/tool-call-streaming";
 import { useActiveProject, useProjectStore } from "../store/project-store";
@@ -42,7 +44,8 @@ import { DiffBlock } from "./DiffBlock";
 import { SessionTreePanel } from "./SessionTreePanel";
 import { QuickActionsMenu } from "./QuickActionsMenu";
 import { QuickActionRunCard } from "./QuickActionRunCard";
-import { useQuickActionRunsStore } from "../store/quick-actions-store";
+import { useQuickActionRunsStore, type QuickActionRun } from "../store/quick-actions-store";
+import { placeChatTimelineItems, type ChatTimelinePosition } from "../lib/chat-timeline";
 import { parseSubagentDetails, type SubagentResult } from "../lib/subagent-parser";
 import { OrchestrationPanel } from "./OrchestrationPanel";
 import { useUiConfigStore } from "../store/ui-config-store";
@@ -88,6 +91,21 @@ interface Props {
   sessionId: string;
 }
 
+type TransientChatTimelineItem =
+  | { kind: "extension"; notification: ExtensionUiNotification; position: ChatTimelinePosition }
+  | { kind: "streaming"; position: ChatTimelinePosition }
+  | {
+      kind: "queued";
+      queued: { steering: string[]; followUp: string[] };
+      position: ChatTimelinePosition;
+    }
+  | { kind: "quick-action"; run: QuickActionRun; position: ChatTimelinePosition };
+
+const FALLBACK_TIMELINE_POSITION: ChatTimelinePosition = {
+  timestamp: Number.MAX_SAFE_INTEGER,
+  order: Number.MAX_SAFE_INTEGER,
+};
+
 /**
  * Phase 8 chat surface. Renders the SDK's AgentMessage union heuristically —
  * matches on `role` and `type` to pick a renderer per message kind. The shape
@@ -115,14 +133,17 @@ export function ChatView({ sessionId }: Props) {
   const generatingToolCall = useSessionStore((s) => s.toolCallGenerationBySession[sessionId]);
   const banner = useSessionStore((s) => s.bannerBySession[sessionId]);
   const clearBanner = useSessionStore((s) => s.clearBanner);
-  const extensionNotification = useSessionStore(
-    (s) => s.extensionNotificationsBySession[sessionId]?.[0],
-  );
-  const extensionNotificationCount = useSessionStore(
-    (s) => s.extensionNotificationsBySession[sessionId]?.length ?? 0,
+  const extensionNotifications = useSessionStore(
+    (s) => s.extensionNotificationsBySession[sessionId] ?? EMPTY_EXTENSION_NOTIFICATIONS,
   );
   const dismissExtensionUiNotification = useSessionStore((s) => s.dismissExtensionUiNotification);
   const queued = useSessionStore((s) => s.queuedBySession[sessionId]);
+  const streamingTimelinePosition = useSessionStore(
+    (s) => s.streamingTimelinePositionBySession[sessionId],
+  );
+  const queuedTimelinePosition = useSessionStore(
+    (s) => s.queuedTimelinePositionBySession[sessionId],
+  );
   const openStream = useSessionStore((s) => s.openStream);
   const closeStream = useSessionStore((s) => s.closeStream);
   // Pending scroll target set by the global search bar when the user
@@ -138,9 +159,60 @@ export function ChatView({ sessionId }: Props) {
   // bottom scrolls into view the same way a new message would.
   const allRuns = useQuickActionRunsStore((s) => s.runs);
   const sessionRuns = useMemo(
-    () => allRuns.filter((r) => r.sessionId === sessionId),
+    () =>
+      allRuns
+        .filter((r) => r.sessionId === sessionId)
+        .sort((a, b) => a.startedAt - b.startedAt || a.timelineOrder - b.timelineOrder),
     [allRuns, sessionId],
   );
+  const timelineSlots = useMemo(() => {
+    const transientItems: { item: TransientChatTimelineItem; position: ChatTimelinePosition }[] = [
+      ...extensionNotifications.map((notification) => ({
+        item: {
+          kind: "extension" as const,
+          notification,
+          position: { timestamp: notification.receivedAt, order: notification.arrivalOrder },
+        },
+        position: { timestamp: notification.receivedAt, order: notification.arrivalOrder },
+      })),
+      ...sessionRuns.map((run) => ({
+        item: {
+          kind: "quick-action" as const,
+          run,
+          position: { timestamp: run.startedAt, order: run.timelineOrder },
+        },
+        position: { timestamp: run.startedAt, order: run.timelineOrder },
+      })),
+    ];
+    if (isStreaming) {
+      transientItems.push({
+        item: {
+          kind: "streaming",
+          position: streamingTimelinePosition ?? FALLBACK_TIMELINE_POSITION,
+        },
+        position: streamingTimelinePosition ?? FALLBACK_TIMELINE_POSITION,
+      });
+    }
+    if (queued !== undefined) {
+      transientItems.push({
+        item: {
+          kind: "queued",
+          queued,
+          position: queuedTimelinePosition ?? FALLBACK_TIMELINE_POSITION,
+        },
+        position: queuedTimelinePosition ?? FALLBACK_TIMELINE_POSITION,
+      });
+    }
+    return placeChatTimelineItems(messages, transientItems);
+  }, [
+    extensionNotifications,
+    isStreaming,
+    messages,
+    queued,
+    queuedTimelinePosition,
+    sessionRuns,
+    streamingTimelinePosition,
+  ]);
 
   const [chatViewType, setChatViewType] = useState<ChatViewType>(readChatViewType);
   const setAndPersistChatViewType = (next: ChatViewType): void => {
@@ -153,13 +225,14 @@ export function ChatView({ sessionId }: Props) {
   };
 
   useEffect(() => {
-    if (extensionNotification === undefined) return;
-    const timer = window.setTimeout(
-      () => dismissExtensionUiNotification(sessionId),
-      EXTENSION_NOTIFICATION_TIMEOUT_MS,
+    const timers = extensionNotifications.map((notification) =>
+      window.setTimeout(
+        () => dismissExtensionUiNotification(sessionId, notification.id),
+        Math.max(0, notification.receivedAt + EXTENSION_NOTIFICATION_TIMEOUT_MS - Date.now()),
+      ),
     );
-    return () => window.clearTimeout(timer);
-  }, [dismissExtensionUiNotification, extensionNotification, sessionId]);
+    return () => timers.forEach((timer) => window.clearTimeout(timer));
+  }, [dismissExtensionUiNotification, extensionNotifications, sessionId]);
 
   // Phase 15 — session tree overlay. The button lives in a tiny
   // toolbar above the scroll container so it's always visible
@@ -289,6 +362,7 @@ export function ChatView({ sessionId }: Props) {
     generatingToolCall,
     queued,
     sessionRuns.length,
+    extensionNotifications,
     snapChatToBottom,
   ]);
 
@@ -462,43 +536,15 @@ export function ChatView({ sessionId }: Props) {
             </button>
           </div>
         )}
-        {extensionNotification !== undefined && (
-          <div
-            className={`flex items-start gap-2 border-b px-6 py-2 text-xs ${
-              extensionNotification.level === "error"
-                ? "border-red-700/40 bg-red-900/20 text-red-200 light:border-red-300 light:bg-red-50 light:text-red-800"
-                : extensionNotification.level === "warning"
-                  ? "border-amber-700/40 bg-amber-900/20 text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800"
-                  : "border-sky-700/40 bg-sky-900/20 text-sky-200 light:border-sky-300 light:bg-sky-50 light:text-sky-800"
-            }`}
-            role="status"
-            aria-live="polite"
-          >
-            <div className="flex-1">
-              <span className="font-medium">Extension:</span> {extensionNotification.message}
-              {extensionNotificationCount > 1 && (
-                <span className="ml-2 text-neutral-400 light:text-neutral-600">
-                  ({extensionNotificationCount} pending)
-                </span>
-              )}
-            </div>
-            <button
-              type="button"
-              onClick={() => dismissExtensionUiNotification(sessionId)}
-              className="-mr-1 shrink-0 rounded p-0.5 hover:bg-neutral-900/30 hover:text-white light:hover:bg-neutral-200"
-              title="Dismiss"
-              aria-label="Dismiss extension notification"
-            >
-              <X size={14} />
-            </button>
-          </div>
-        )}
         <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto px-6 py-4">
-          {messages.length === 0 && streamingText.length === 0 && !isStreaming && (
-            <p className="mt-12 text-center text-sm text-neutral-500">
-              No messages yet. Send a prompt to get started.
-            </p>
-          )}
+          {messages.length === 0 &&
+            streamingText.length === 0 &&
+            !isStreaming &&
+            extensionNotifications.length === 0 && (
+              <p className="mt-12 text-center text-sm text-neutral-500">
+                No messages yet. Send a prompt to get started.
+              </p>
+            )}
           <div ref={messageListRef} className="chat-message-list mx-auto max-w-3xl space-y-4">
             {(() => {
               // Pair toolCall blocks (in assistant messages) with their
@@ -581,6 +627,43 @@ export function ChatView({ sessionId }: Props) {
                   );
                 }
               };
+              const renderTimelineEntriesAt = (idx: number): void => {
+                const entries = timelineSlots[idx];
+                if (entries === undefined || entries.length === 0) return;
+                flushPendingBatch();
+                for (const entry of entries) {
+                  if (entry.kind === "extension") {
+                    out.push(
+                      <ExtensionNotificationEntry
+                        key={entry.notification.id}
+                        notification={entry.notification}
+                        onDismiss={() =>
+                          dismissExtensionUiNotification(sessionId, entry.notification.id)
+                        }
+                      />,
+                    );
+                  } else if (entry.kind === "streaming") {
+                    out.push(
+                      <StreamingTimelineEntry
+                        key={`streaming-${entry.position.timestamp}-${entry.position.order}`}
+                        streamingText={streamingText}
+                        activeTool={activeTool}
+                        generatingToolCall={generatingToolCall}
+                        onVisibleOrUpdate={followChatToBottom}
+                      />,
+                    );
+                  } else if (entry.kind === "queued") {
+                    out.push(
+                      <QueuedMessages
+                        key={`queued-${entry.position.timestamp}-${entry.position.order}`}
+                        queued={entry.queued}
+                      />,
+                    );
+                  } else {
+                    out.push(<QuickActionRunCard key={entry.run.runId} run={entry.run} />);
+                  }
+                }
+              };
               // Hide the LATEST compaction's kept window from inline
               // bubbles — those messages render inside that card's
               // expand drawer instead. Without this, after a compaction
@@ -619,6 +702,7 @@ export function ChatView({ sessionId }: Props) {
               for (let i = 0; i < messages.length; i++) {
                 const m = messages[i]!;
                 renderCardsAt(i);
+                renderTimelineEntriesAt(i);
                 if (isPairedToolResult(toolPairing, m)) {
                   continue; // rendered inline next to its toolCall
                 }
@@ -682,35 +766,9 @@ export function ChatView({ sessionId }: Props) {
               // messages have been pushed since. Rare; render at the
               // bottom for completeness.
               renderCardsAt(messages.length);
+              renderTimelineEntriesAt(messages.length);
               return out;
             })()}
-            {streamingText.length > 0 && (
-              <div
-                className="message-bubble rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3"
-                data-message-role="assistant"
-              >
-                <div className="mb-1 text-[10px] uppercase tracking-wider text-neutral-500">
-                  assistant (streaming)
-                </div>
-                <div className="text-neutral-100">
-                  <ChatMarkdown text={streamingText} />
-                  <span className="ml-1 inline-block h-3 w-1.5 animate-pulse bg-neutral-300 align-text-bottom" />
-                </div>
-              </div>
-            )}
-            {isStreaming && activeTool === undefined && generatingToolCall !== undefined && (
-              <ToolCallGenerationPlaceholder
-                toolCall={generatingToolCall}
-                onVisibleOrUpdate={followChatToBottom}
-              />
-            )}
-            {isStreaming && streamingText.length === 0 && generatingToolCall === undefined && (
-              <ActiveToolPlaceholder tool={activeTool} />
-            )}
-            {queued !== undefined && <QueuedMessages queued={queued} />}
-            {sessionRuns.map((run) => (
-              <QuickActionRunCard key={run.runId} run={run} />
-            ))}
           </div>
         </div>
       </div>
@@ -723,6 +781,88 @@ export function ChatView({ sessionId }: Props) {
       )}
     </ChatDiffViewContext.Provider>
   );
+}
+
+/**
+ * Extension feedback is intentionally rendered in the scrolling timeline,
+ * not as a session-state banner. It remains store-only and is dismissed after
+ * a short delay, so extension output never becomes part of Pi's transcript.
+ */
+function ExtensionNotificationEntry({
+  notification,
+  onDismiss,
+}: {
+  notification: ExtensionUiNotification;
+  onDismiss: () => void;
+}) {
+  const severityClass =
+    notification.level === "error"
+      ? "border-red-700/40 bg-red-900/20 text-red-100 light:border-red-300 light:bg-red-50 light:text-red-950"
+      : notification.level === "warning"
+        ? "border-amber-700/40 bg-amber-900/20 text-amber-100 light:border-amber-300 light:bg-amber-50 light:text-amber-950"
+        : "border-sky-700/40 bg-sky-900/20 text-sky-100 light:border-sky-300 light:bg-sky-50 light:text-sky-950";
+  return (
+    <div
+      className={`message-bubble flex items-start gap-3 rounded-lg border px-4 py-3 ${severityClass}`}
+      data-message-role="extension-notification"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 text-[10px] font-medium uppercase tracking-wider opacity-75">
+          extension {notification.level}
+        </div>
+        <ChatMarkdown text={notification.message} size="xs" />
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="-mr-1 shrink-0 rounded p-0.5 opacity-75 hover:bg-neutral-900/30 hover:text-white hover:opacity-100 light:hover:bg-neutral-200"
+        title="Dismiss"
+        aria-label="Dismiss extension notification"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}
+
+function StreamingTimelineEntry({
+  streamingText,
+  activeTool,
+  generatingToolCall,
+  onVisibleOrUpdate,
+}: {
+  streamingText: string;
+  activeTool: ActiveTool | undefined;
+  generatingToolCall: ToolCallGeneration | undefined;
+  onVisibleOrUpdate: () => void;
+}) {
+  if (streamingText.length > 0) {
+    return (
+      <div
+        className="message-bubble rounded-lg border border-neutral-800 bg-neutral-900 px-4 py-3"
+        data-message-role="assistant"
+      >
+        <div className="mb-1 text-[10px] uppercase tracking-wider text-neutral-500">
+          assistant (streaming)
+        </div>
+        <div className="text-neutral-100">
+          <ChatMarkdown text={streamingText} />
+          <span className="ml-1 inline-block h-3 w-1.5 animate-pulse bg-neutral-300 align-text-bottom" />
+        </div>
+      </div>
+    );
+  }
+  if (activeTool === undefined && generatingToolCall !== undefined) {
+    return (
+      <ToolCallGenerationPlaceholder
+        toolCall={generatingToolCall}
+        onVisibleOrUpdate={onVisibleOrUpdate}
+      />
+    );
+  }
+  return <ActiveToolPlaceholder tool={activeTool} />;
 }
 
 /**

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -77,7 +77,6 @@ const ChatDiffViewContext = createContext<{
 });
 
 const CHAT_VIEW_TYPE_KEY = "forge.chat.viewType";
-const EXTENSION_NOTIFICATION_TIMEOUT_MS = 6_000;
 function readChatViewType(): ChatViewType {
   try {
     return localStorage.getItem(CHAT_VIEW_TYPE_KEY) === "split" ? "split" : "unified";
@@ -223,16 +222,6 @@ export function ChatView({ sessionId }: Props) {
       // ignore — choice still applies for this session
     }
   };
-
-  useEffect(() => {
-    const timers = extensionNotifications.map((notification) =>
-      window.setTimeout(
-        () => dismissExtensionUiNotification(sessionId, notification.id),
-        Math.max(0, notification.receivedAt + EXTENSION_NOTIFICATION_TIMEOUT_MS - Date.now()),
-      ),
-    );
-    return () => timers.forEach((timer) => window.clearTimeout(timer));
-  }, [dismissExtensionUiNotification, extensionNotifications, sessionId]);
 
   // Phase 15 — session tree overlay. The button lives in a tiny
   // toolbar above the scroll container so it's always visible
@@ -785,8 +774,8 @@ export function ChatView({ sessionId }: Props) {
 
 /**
  * Extension feedback is intentionally rendered in the scrolling timeline,
- * not as a session-state banner. It remains store-only and is dismissed after
- * a short delay, so extension output never becomes part of Pi's transcript.
+ * not as a session-state banner. It remains store-only until the user dismisses
+ * it, so extension output never becomes part of Pi's transcript.
  */
 function ExtensionNotificationEntry({
   notification,

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -92,7 +92,6 @@ interface Props {
 
 type TransientChatTimelineItem =
   | { kind: "extension"; notification: ExtensionUiNotification; position: ChatTimelinePosition }
-  | { kind: "streaming"; position: ChatTimelinePosition }
   | {
       kind: "queued";
       queued: { steering: string[]; followUp: string[] };
@@ -137,9 +136,6 @@ export function ChatView({ sessionId }: Props) {
   );
   const dismissExtensionUiNotification = useSessionStore((s) => s.dismissExtensionUiNotification);
   const queued = useSessionStore((s) => s.queuedBySession[sessionId]);
-  const streamingTimelinePosition = useSessionStore(
-    (s) => s.streamingTimelinePositionBySession[sessionId],
-  );
   const queuedTimelinePosition = useSessionStore(
     (s) => s.queuedTimelinePositionBySession[sessionId],
   );
@@ -183,15 +179,6 @@ export function ChatView({ sessionId }: Props) {
         position: { timestamp: run.startedAt, order: run.timelineOrder },
       })),
     ];
-    if (isStreaming) {
-      transientItems.push({
-        item: {
-          kind: "streaming",
-          position: streamingTimelinePosition ?? FALLBACK_TIMELINE_POSITION,
-        },
-        position: streamingTimelinePosition ?? FALLBACK_TIMELINE_POSITION,
-      });
-    }
     if (queued !== undefined) {
       transientItems.push({
         item: {
@@ -203,15 +190,7 @@ export function ChatView({ sessionId }: Props) {
       });
     }
     return placeChatTimelineItems(messages, transientItems);
-  }, [
-    extensionNotifications,
-    isStreaming,
-    messages,
-    queued,
-    queuedTimelinePosition,
-    sessionRuns,
-    streamingTimelinePosition,
-  ]);
+  }, [extensionNotifications, messages, queued, queuedTimelinePosition, sessionRuns]);
 
   const [chatViewType, setChatViewType] = useState<ChatViewType>(readChatViewType);
   const setAndPersistChatViewType = (next: ChatViewType): void => {
@@ -631,16 +610,6 @@ export function ChatView({ sessionId }: Props) {
                         }
                       />,
                     );
-                  } else if (entry.kind === "streaming") {
-                    out.push(
-                      <StreamingTimelineEntry
-                        key={`streaming-${entry.position.timestamp}-${entry.position.order}`}
-                        streamingText={streamingText}
-                        activeTool={activeTool}
-                        generatingToolCall={generatingToolCall}
-                        onVisibleOrUpdate={followChatToBottom}
-                      />,
-                    );
                   } else if (entry.kind === "queued") {
                     out.push(
                       <QueuedMessages
@@ -756,6 +725,17 @@ export function ChatView({ sessionId }: Props) {
               // bottom for completeness.
               renderCardsAt(messages.length);
               renderTimelineEntriesAt(messages.length);
+              if (isStreaming) {
+                out.push(
+                  <StreamingTimelineEntry
+                    key="streaming-active"
+                    streamingText={streamingText}
+                    activeTool={activeTool}
+                    generatingToolCall={generatingToolCall}
+                    onVisibleOrUpdate={followChatToBottom}
+                  />,
+                );
+              }
               return out;
             })()}
           </div>

--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -74,6 +74,7 @@ const ChatDiffViewContext = createContext<{
 });
 
 const CHAT_VIEW_TYPE_KEY = "forge.chat.viewType";
+const EXTENSION_NOTIFICATION_TIMEOUT_MS = 6_000;
 function readChatViewType(): ChatViewType {
   try {
     return localStorage.getItem(CHAT_VIEW_TYPE_KEY) === "split" ? "split" : "unified";
@@ -114,6 +115,13 @@ export function ChatView({ sessionId }: Props) {
   const generatingToolCall = useSessionStore((s) => s.toolCallGenerationBySession[sessionId]);
   const banner = useSessionStore((s) => s.bannerBySession[sessionId]);
   const clearBanner = useSessionStore((s) => s.clearBanner);
+  const extensionNotification = useSessionStore(
+    (s) => s.extensionNotificationsBySession[sessionId]?.[0],
+  );
+  const extensionNotificationCount = useSessionStore(
+    (s) => s.extensionNotificationsBySession[sessionId]?.length ?? 0,
+  );
+  const dismissExtensionUiNotification = useSessionStore((s) => s.dismissExtensionUiNotification);
   const queued = useSessionStore((s) => s.queuedBySession[sessionId]);
   const openStream = useSessionStore((s) => s.openStream);
   const closeStream = useSessionStore((s) => s.closeStream);
@@ -143,6 +151,15 @@ export function ChatView({ sessionId }: Props) {
       // ignore — choice still applies for this session
     }
   };
+
+  useEffect(() => {
+    if (extensionNotification === undefined) return;
+    const timer = window.setTimeout(
+      () => dismissExtensionUiNotification(sessionId),
+      EXTENSION_NOTIFICATION_TIMEOUT_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [dismissExtensionUiNotification, extensionNotification, sessionId]);
 
   // Phase 15 — session tree overlay. The button lives in a tiny
   // toolbar above the scroll container so it's always visible
@@ -440,6 +457,37 @@ export function ChatView({ sessionId }: Props) {
               className="-mr-1 shrink-0 rounded p-0.5 text-amber-300 hover:bg-amber-900/40 hover:text-amber-100 light:text-amber-700 light:hover:bg-amber-100 light:hover:text-amber-900"
               title="Dismiss"
               aria-label="Dismiss banner"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        )}
+        {extensionNotification !== undefined && (
+          <div
+            className={`flex items-start gap-2 border-b px-6 py-2 text-xs ${
+              extensionNotification.level === "error"
+                ? "border-red-700/40 bg-red-900/20 text-red-200 light:border-red-300 light:bg-red-50 light:text-red-800"
+                : extensionNotification.level === "warning"
+                  ? "border-amber-700/40 bg-amber-900/20 text-amber-200 light:border-amber-300 light:bg-amber-50 light:text-amber-800"
+                  : "border-sky-700/40 bg-sky-900/20 text-sky-200 light:border-sky-300 light:bg-sky-50 light:text-sky-800"
+            }`}
+            role="status"
+            aria-live="polite"
+          >
+            <div className="flex-1">
+              <span className="font-medium">Extension:</span> {extensionNotification.message}
+              {extensionNotificationCount > 1 && (
+                <span className="ml-2 text-neutral-400 light:text-neutral-600">
+                  ({extensionNotificationCount} pending)
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => dismissExtensionUiNotification(sessionId)}
+              className="-mr-1 shrink-0 rounded p-0.5 hover:bg-neutral-900/30 hover:text-white light:hover:bg-neutral-200"
+              title="Dismiss"
+              aria-label="Dismiss extension notification"
             >
               <X size={14} />
             </button>

--- a/packages/client/src/components/QuickActionsMenu.tsx
+++ b/packages/client/src/components/QuickActionsMenu.tsx
@@ -8,6 +8,7 @@ import {
   type QuickActionRun,
 } from "../store/quick-actions-store";
 import { useUiConfigStore } from "../store/ui-config-store";
+import { createChatTimelinePosition } from "../lib/chat-timeline";
 import { useSessionStore } from "../store/session-store";
 import { useComposerStore } from "../store/composer-store";
 import { createClientId } from "../lib/client-id";
@@ -96,12 +97,14 @@ export function QuickActionsMenu({ sessionId, projectId }: Props) {
   const handleCommand = (action: QuickAction): void => {
     const runId = randomId();
     const controller = new AbortController();
+    const timelinePosition = createChatTimelinePosition();
     const run: QuickActionRun = {
       runId,
       sessionId,
       actionId: action.id,
       actionName: action.name,
-      startedAt: Date.now(),
+      startedAt: timelinePosition.timestamp,
+      timelineOrder: timelinePosition.order,
       status: "running",
       abort: () => {
         try {

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -843,6 +843,7 @@ function SelectSetting({
 function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) {
   const project = useActiveProject();
   const projects = useProjectStore((s) => s.projects);
+  const bumpSkillsRefresh = useUiStore((s) => s.bumpSkillsRefresh);
   const [skills, setSkills] = useState<SkillSummary[] | undefined>(undefined);
   /**
    * SDK-emitted warnings about skill files the loader rejected. The
@@ -899,6 +900,7 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
     try {
       const { skills: updated } = await api.setSkillEnabled(project.id, name, next, "global");
       setSkills(updated);
+      bumpSkillsRefresh();
     } catch (err) {
       onError(`Toggle failed: ${errorCode(err)}`);
     } finally {
@@ -923,6 +925,7 @@ function SkillsTab({ onError }: { onError: (msg: string | undefined) => void }) 
       // Pull the canonical state for both the active project's
       // skills view AND the cascade map.
       await refresh();
+      bumpSkillsRefresh();
     } catch (err) {
       onError(`Override write failed: ${errorCode(err)}`);
     } finally {

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1884,6 +1884,14 @@ export const api = {
     if (opts?.streamingBehavior !== undefined) body.streamingBehavior = opts.streamingBehavior;
     return request(path, vAccepted, { method: "POST", body });
   },
+  invokeSkill: (id: string, name: string, instructions?: string) => {
+    const body: Record<string, unknown> = { name };
+    if (instructions !== undefined) body.instructions = instructions;
+    return request(`/api/v1/sessions/${encodeURIComponent(id)}/skill`, vAccepted, {
+      method: "POST",
+      body,
+    });
+  },
   steer: (id: string, text: string, mode?: "steer" | "followUp") => {
     const body: Record<string, unknown> = { text };
     if (mode !== undefined) body.mode = mode;

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -32,6 +32,7 @@ import {
   type ServerThemeColors,
   type UiConfigResponse,
   type UnifiedSession,
+  type ExtensionCommandSummary,
   type SessionSummary,
   type PromptSummary,
   type SkillDiagnostic,
@@ -530,6 +531,24 @@ function vSkillOverrides(
     out[pid] = { enable, disable };
   }
   return { projects: out };
+}
+
+function vExtensionCommandList(
+  value: unknown,
+  status: number,
+): { commands: ExtensionCommandSummary[] } {
+  if (!isObject(value) || !Array.isArray(value.commands)) {
+    fail(status, "expected { commands: ExtensionCommandSummary[] }");
+  }
+  const commands = value.commands.map((command) => {
+    if (!isObject(command) || typeof command.name !== "string") {
+      fail(status, "expected ExtensionCommandSummary");
+    }
+    const summary: ExtensionCommandSummary = { name: command.name };
+    if (typeof command.description === "string") summary.description = command.description;
+    return summary;
+  });
+  return { commands };
 }
 
 function vPromptSummary(p: unknown, status: number): PromptSummary {
@@ -1788,6 +1807,8 @@ export const api = {
     }),
   getSession: (id: string) =>
     request(`/api/v1/sessions/${encodeURIComponent(id)}`, vSessionSummary),
+  listExtensionCommands: (id: string) =>
+    request(`/api/v1/sessions/${encodeURIComponent(id)}/extension-commands`, vExtensionCommandList),
   getMessages: (id: string) =>
     request(`/api/v1/sessions/${encodeURIComponent(id)}/messages`, (v, s) => {
       if (!isObject(v) || !Array.isArray(v.messages)) {

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -382,6 +382,12 @@ export interface UnifiedSession {
 
 export type ModelThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
+export interface ExtensionCommandSummary {
+  /** SDK invocation name without the leading slash. */
+  name: string;
+  description?: string;
+}
+
 export interface SessionSummary {
   sessionId: string;
   projectId: string;

--- a/packages/client/src/lib/chat-timeline.ts
+++ b/packages/client/src/lib/chat-timeline.ts
@@ -1,0 +1,47 @@
+export interface ChatTimelinePosition {
+  /** Unix epoch ms captured when this transient item entered the chat. */
+  timestamp: number;
+  /** Monotonic in-browser tie-breaker for items received in the same millisecond. */
+  order: number;
+}
+
+let nextTimelineOrder = 0;
+
+/**
+ * Give transient chat items a stable position without changing Pi's canonical
+ * transcript. `order` makes same-millisecond SSE events deterministic.
+ */
+export function createChatTimelinePosition(timestamp = Date.now()): ChatTimelinePosition {
+  return { timestamp, order: nextTimelineOrder++ };
+}
+
+type TimestampedMessage = Record<string, unknown>;
+
+/**
+ * Place transient items between canonical messages using their receipt time.
+ * Canonical messages remain in transcript order; items with equal timestamps
+ * follow the canonical message, matching the order in which SSE delivers it.
+ */
+export function placeChatTimelineItems<T>(
+  messages: readonly TimestampedMessage[],
+  items: readonly { item: T; position: ChatTimelinePosition }[],
+): T[][] {
+  const slots = Array.from({ length: messages.length + 1 }, () => [] as T[]);
+  const sorted = items
+    .map((entry, inputOrder) => ({ ...entry, inputOrder }))
+    .sort(
+      (a, b) =>
+        a.position.timestamp - b.position.timestamp ||
+        a.position.order - b.position.order ||
+        a.inputOrder - b.inputOrder,
+    );
+
+  for (const entry of sorted) {
+    const nextMessageIndex = messages.findIndex((message) => {
+      const timestamp = message.timestamp;
+      return typeof timestamp === "number" && timestamp > entry.position.timestamp;
+    });
+    slots[nextMessageIndex === -1 ? messages.length : nextMessageIndex]!.push(entry.item);
+  }
+  return slots;
+}

--- a/packages/client/src/lib/skill-command.ts
+++ b/packages/client/src/lib/skill-command.ts
@@ -1,0 +1,25 @@
+export interface SkillInvocation {
+  name: string;
+  instructions?: string;
+}
+
+/**
+ * Parse a skill slash command only when its name exactly matches an enabled
+ * palette entry. This keeps `/skill:unknown` in normal slash-command error
+ * handling rather than allowing an arbitrary SDK command through.
+ */
+export function parseSkillInvocation(
+  text: string,
+  availableSkillNames: ReadonlySet<string>,
+): SkillInvocation | undefined {
+  if (!text.startsWith("/skill:")) return undefined;
+  const firstSpace = text.search(/\s/);
+  const command = firstSpace === -1 ? text : text.slice(0, firstSpace);
+  const name = command.slice("/skill:".length);
+  if (name.length === 0 || !availableSkillNames.has(name)) return undefined;
+
+  const instructions = firstSpace === -1 ? undefined : text.slice(firstSpace).trim();
+  return instructions === undefined || instructions.length === 0
+    ? { name }
+    : { name, instructions };
+}

--- a/packages/client/src/store/quick-actions-store.ts
+++ b/packages/client/src/store/quick-actions-store.ts
@@ -70,6 +70,8 @@ export interface QuickActionRun {
   actionId: string;
   actionName: string;
   startedAt: number;
+  /** Monotonic tie-breaker for runs started in the same millisecond. */
+  timelineOrder: number;
   status: "running" | "done" | "aborted";
   result?: QuickActionRunResult;
   error?: string;

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -2,6 +2,8 @@ import { create } from "zustand";
 import { api, ApiError, type SessionSummary, type UnifiedSession } from "../lib/api-client";
 import { streamSSE } from "../lib/sse-client";
 import { extractToolCallGeneration, type ToolCallGeneration } from "../lib/tool-call-streaming";
+import { createChatTimelinePosition, type ChatTimelinePosition } from "../lib/chat-timeline";
+import { postCrossTab, subscribeCrossTab } from "../lib/cross-tab";
 
 type SessionActivityEvent =
   | { type: "session_activity_snapshot"; running: { sessionId: string }[] }
@@ -12,7 +14,6 @@ type SessionActivityEvent =
       running: boolean;
       reason?: "completed" | "disposed";
     };
-import { postCrossTab, subscribeCrossTab } from "../lib/cross-tab";
 import { useAskUserQuestionStore, type PendingAskQuestion } from "./ask-user-question-store";
 import { useTodoStore, type Task as TodoTaskShape } from "./todo-store";
 import { useProcessesStore, type ProcessInfo as ProcessShape } from "./processes-store";
@@ -31,6 +32,7 @@ export const EMPTY_SESSIONS: UnifiedSession[] = [];
 export const EMPTY_MESSAGES: AgentMessageLike[] = [];
 export const EMPTY_STRING = "";
 export const EMPTY_COMPACTIONS: CompactionEvent[] = [];
+export const EMPTY_EXTENSION_NOTIFICATIONS: ExtensionUiNotification[] = [];
 
 /**
  * Per-session pending streaming-text delta buffer + RAF id. We accumulate
@@ -122,9 +124,16 @@ export interface ActiveTool {
 }
 
 export interface ExtensionUiNotification {
+  id: string;
   message: string;
   level: "info" | "warning" | "error";
+  /** Receive-side timestamp; extension feedback is never written to Pi's transcript. */
+  receivedAt: number;
+  /** Monotonic tie-breaker for feedback received in the same millisecond. */
+  arrivalOrder: number;
 }
+
+export type ExtensionUiNotificationInput = Pick<ExtensionUiNotification, "message" | "level">;
 
 /**
  * Wire-shape of an SSE event from the bridge. `snapshot` carries the full
@@ -212,6 +221,8 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
   delete nextExtensionNotifications[sessionId];
   const nextStreamingText = { ...current.streamingTextBySession };
   delete nextStreamingText[sessionId];
+  const nextStreamingTimelinePosition = { ...current.streamingTimelinePositionBySession };
+  delete nextStreamingTimelinePosition[sessionId];
   const nextActiveTool = { ...current.activeToolBySession };
   delete nextActiveTool[sessionId];
   const nextToolCallGeneration = { ...current.toolCallGenerationBySession };
@@ -224,6 +235,8 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
   delete nextTurnWriteCount[sessionId];
   const nextQueued = { ...current.queuedBySession };
   delete nextQueued[sessionId];
+  const nextQueuedTimelinePosition = { ...current.queuedTimelinePositionBySession };
+  delete nextQueuedTimelinePosition[sessionId];
   const nextBottomPinRequest = { ...current.bottomPinRequestBySession };
   delete nextBottomPinRequest[sessionId];
   const byProject: Record<string, UnifiedSession[]> = {};
@@ -237,12 +250,14 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
     bannerBySession: nextBanner,
     extensionNotificationsBySession: nextExtensionNotifications,
     streamingTextBySession: nextStreamingText,
+    streamingTimelinePositionBySession: nextStreamingTimelinePosition,
     activeToolBySession: nextActiveTool,
     toolCallGenerationBySession: nextToolCallGeneration,
     agentEndCountBySession: nextAgentEndCount,
     fileRefreshCountBySession: nextFileRefreshCount,
     turnWriteCountBySession: nextTurnWriteCount,
     queuedBySession: nextQueued,
+    queuedTimelinePositionBySession: nextQueuedTimelinePosition,
     bottomPinRequestBySession: nextBottomPinRequest,
     byProject,
     activeSessionId: current.activeSessionId === sessionId ? undefined : current.activeSessionId,
@@ -292,6 +307,8 @@ interface SessionState {
    * messages array refetched by `getMessages` then carries the final text).
    */
   streamingTextBySession: Record<string, string>;
+  /** Receipt position for the live assistant entry currently in the chat. */
+  streamingTimelinePositionBySession: Record<string, ChatTimelinePosition | undefined>;
   /**
    * Per-session "agent is currently running tool X" indicator. Set on
    * tool_execution_start, cleared on tool_execution_end. The chat view
@@ -345,6 +362,8 @@ interface SessionState {
    * pop entries optimistically.
    */
   queuedBySession: Record<string, { steering: string[]; followUp: string[] } | undefined>;
+  /** Receipt position for the current queued-input snapshot. */
+  queuedTimelinePositionBySession: Record<string, ChatTimelinePosition | undefined>;
   /**
    * Per-session pending scroll target (zero-based message index) set
    * by the global search bar when a result is clicked. ChatView reads
@@ -421,13 +440,13 @@ interface SessionState {
    * the banner reappears on the next event.
    */
   clearBanner: (sessionId: string) => void;
-  /** Add extension feedback without overwriting a state banner or earlier notification. */
+  /** Add store-only extension feedback at its arrival position in the chat timeline. */
   enqueueExtensionUiNotification: (
     sessionId: string,
-    notification: ExtensionUiNotification,
+    notification: ExtensionUiNotificationInput,
   ) => void;
-  /** Dismiss the visible extension notification and advance its session queue. */
-  dismissExtensionUiNotification: (sessionId: string) => void;
+  /** Dismiss one extension notification without changing Pi's canonical transcript. */
+  dismissExtensionUiNotification: (sessionId: string, notificationId?: string) => void;
 }
 
 export const useSessionStore = create<SessionState>((set, get) => ({
@@ -441,6 +460,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   bannerBySession: {},
   extensionNotificationsBySession: {},
   streamingTextBySession: {},
+  streamingTimelinePositionBySession: {},
   activeToolBySession: {},
   toolCallGenerationBySession: {},
   agentEndCountBySession: {},
@@ -448,6 +468,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   turnWriteCountBySession: {},
   compactionEndCountBySession: {},
   queuedBySession: {},
+  queuedTimelinePositionBySession: {},
   pendingScrollByMessageIndex: {},
   bottomPinRequestBySession: {},
   error: undefined,
@@ -909,20 +930,31 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     }));
   },
   enqueueExtensionUiNotification: (sessionId, notification) => {
+    const position = createChatTimelinePosition();
+    const entry: ExtensionUiNotification = {
+      ...notification,
+      id: `extension-notification-${position.order}`,
+      receivedAt: position.timestamp,
+      arrivalOrder: position.order,
+    };
     set((s) => ({
       extensionNotificationsBySession: {
         ...s.extensionNotificationsBySession,
-        [sessionId]: [...(s.extensionNotificationsBySession[sessionId] ?? []), notification],
+        [sessionId]: [...(s.extensionNotificationsBySession[sessionId] ?? []), entry],
       },
     }));
   },
-  dismissExtensionUiNotification: (sessionId) => {
+  dismissExtensionUiNotification: (sessionId, notificationId) => {
     set((s) => {
       const notifications = s.extensionNotificationsBySession[sessionId] ?? [];
       if (notifications.length === 0) return {};
       const next = { ...s.extensionNotificationsBySession };
-      if (notifications.length === 1) delete next[sessionId];
-      else next[sessionId] = notifications.slice(1);
+      const remaining =
+        notificationId === undefined
+          ? notifications.slice(1)
+          : notifications.filter((notification) => notification.id !== notificationId);
+      if (remaining.length === 0) delete next[sessionId];
+      else next[sessionId] = remaining;
       return { extensionNotificationsBySession: next };
     });
   },
@@ -958,6 +990,13 @@ function applyEvent(
         ...s.streamingBySession,
         [sessionId]: event.isStreaming ?? false,
       },
+      streamingTimelinePositionBySession: {
+        ...s.streamingTimelinePositionBySession,
+        [sessionId]:
+          event.isStreaming === true
+            ? (s.streamingTimelinePositionBySession[sessionId] ?? createChatTimelinePosition())
+            : undefined,
+      },
       bannerBySession: {
         ...s.bannerBySession,
         [sessionId]:
@@ -983,6 +1022,10 @@ function applyEvent(
     set((s) => ({
       streamingBySession: { ...s.streamingBySession, [sessionId]: true },
       streamingTextBySession: { ...s.streamingTextBySession, [sessionId]: "" },
+      streamingTimelinePositionBySession: {
+        ...s.streamingTimelinePositionBySession,
+        [sessionId]: createChatTimelinePosition(),
+      },
       bannerBySession: { ...s.bannerBySession, [sessionId]: undefined },
       turnWriteCountBySession: { ...s.turnWriteCountBySession, [sessionId]: 0 },
       toolCallGenerationBySession: { ...s.toolCallGenerationBySession, [sessionId]: undefined },
@@ -1029,6 +1072,10 @@ function applyEvent(
             messagesBySession: { ...s.messagesBySession, [sessionId]: messages },
             streamingBySession: { ...s.streamingBySession, [sessionId]: false },
             streamingTextBySession: { ...s.streamingTextBySession, [sessionId]: "" },
+            streamingTimelinePositionBySession: {
+              ...s.streamingTimelinePositionBySession,
+              [sessionId]: undefined,
+            },
             activeToolBySession: { ...s.activeToolBySession, [sessionId]: undefined },
             toolCallGenerationBySession: {
               ...s.toolCallGenerationBySession,
@@ -1061,6 +1108,10 @@ function applyEvent(
         // disappears and the chat looks healthy when it isn't.
         set((s) => ({
           streamingBySession: { ...s.streamingBySession, [sessionId]: false },
+          streamingTimelinePositionBySession: {
+            ...s.streamingTimelinePositionBySession,
+            [sessionId]: undefined,
+          },
           activeToolBySession: { ...s.activeToolBySession, [sessionId]: undefined },
           toolCallGenerationBySession: { ...s.toolCallGenerationBySession, [sessionId]: undefined },
           bannerBySession: {
@@ -1101,6 +1152,11 @@ function applyEvent(
         // badge unmounts cleanly rather than rendering "queued: 0".
         [sessionId]:
           steering.length === 0 && followUp.length === 0 ? undefined : { steering, followUp },
+      },
+      queuedTimelinePositionBySession: {
+        ...s.queuedTimelinePositionBySession,
+        [sessionId]:
+          steering.length === 0 && followUp.length === 0 ? undefined : createChatTimelinePosition(),
       },
     }));
     return;

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -385,7 +385,16 @@ interface SessionState {
   consumePendingScroll: (sessionId: string) => number | undefined;
   /** Force the chat viewport to pin to the bottom for a user-originated entry. */
   requestScrollToBottom: (sessionId: string) => void;
-  sendPrompt: (sessionId: string, text: string, attachments?: File[]) => Promise<void>;
+  /**
+   * Send a prompt, optionally skipping the local user-message insert for an
+   * extension command that may finish without creating an agent turn.
+   */
+  sendPrompt: (
+    sessionId: string,
+    text: string,
+    attachments?: File[],
+    optimisticUserMessage?: boolean,
+  ) => Promise<void>;
   sendSteer: (sessionId: string, text: string, mode?: "steer" | "followUp") => Promise<void>;
   abortSession: (sessionId: string) => Promise<void>;
   disposeSession: (sessionId: string) => Promise<void>;
@@ -735,56 +744,54 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     }
   },
 
-  sendPrompt: async (sessionId, text, attachments) => {
+  sendPrompt: async (sessionId, text, attachments, optimisticUserMessage = true) => {
     set((s) => ({
       error: undefined,
       bannerBySession: { ...s.bannerBySession, [sessionId]: undefined },
     }));
-    // Optimistically append the user message so the chat reflects the input
-    // immediately. If the server rejects (no API key, no model, etc.) the
-    // catch below rolls it back. If it accepts, the eventual messages
-    // refetch on agent_end will replace this with the canonical entry.
-    //
-    // For attachments, we render image thumbnails inline and chips for
-    // text files. The optimistic shape mirrors what the SDK produces
-    // for user messages with attachments — text content + image
-    // blocks — so the renderer doesn't have to special-case the
-    // pre-refetch state.
-    const optimisticContent: Record<string, unknown>[] = [{ type: "text", text }];
-    if (attachments !== undefined) {
-      for (const f of attachments) {
-        if (f.type.startsWith("image/")) {
-          // Use a blob URL for the optimistic preview — cheap to
-          // render and gets garbage-collected when the canonical
-          // refetch replaces this entry.
-          optimisticContent.push({
-            type: "image",
-            mimeType: f.type,
-            data: URL.createObjectURL(f),
-            // Mark this is a blob URL the renderer should treat as a
-            // direct src rather than re-prefixing with `data:...`.
-            __blobUrl: true,
-          });
-        } else {
-          optimisticContent.push({
-            type: "file",
-            filename: f.name,
-            size: f.size,
-          });
+    // Extension commands can finish without an agent turn or a canonical user
+    // message. Their caller disables this insert so the transcript never
+    // retains a phantom entry. Normal prompts keep the immediate feedback.
+    let optimistic: AgentMessageLike | undefined;
+    if (optimisticUserMessage) {
+      // If the server rejects (no API key, no model, etc.) the catch below
+      // rolls this back. On agent_end, the canonical refetch replaces it.
+      const optimisticContent: Record<string, unknown>[] = [{ type: "text", text }];
+      if (attachments !== undefined) {
+        for (const f of attachments) {
+          if (f.type.startsWith("image/")) {
+            // Use a blob URL for the optimistic preview — cheap to render and
+            // garbage-collected when the canonical refetch replaces it.
+            optimisticContent.push({
+              type: "image",
+              mimeType: f.type,
+              data: URL.createObjectURL(f),
+              // Mark this is a blob URL the renderer should treat as a direct
+              // src rather than re-prefixing with `data:...`.
+              __blobUrl: true,
+            });
+          } else {
+            optimisticContent.push({
+              type: "file",
+              filename: f.name,
+              size: f.size,
+            });
+          }
         }
       }
+      const optimisticMessage: AgentMessageLike = {
+        role: "user",
+        content: optimisticContent,
+        timestamp: Date.now(),
+      };
+      optimistic = optimisticMessage;
+      set((s) => ({
+        messagesBySession: {
+          ...s.messagesBySession,
+          [sessionId]: [...(s.messagesBySession[sessionId] ?? []), optimisticMessage],
+        },
+      }));
     }
-    const optimistic: AgentMessageLike = {
-      role: "user",
-      content: optimisticContent,
-      timestamp: Date.now(),
-    };
-    set((s) => ({
-      messagesBySession: {
-        ...s.messagesBySession,
-        [sessionId]: [...(s.messagesBySession[sessionId] ?? []), optimistic],
-      },
-    }));
     try {
       const opts: Parameters<typeof api.prompt>[2] = {};
       if (attachments !== undefined && attachments.length > 0) opts.attachments = attachments;
@@ -797,14 +804,17 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       // Roll back the optimistic append on failure. Revoke any blob
       // URLs the optimistic message owns BEFORE we drop the
       // reference, otherwise they stay alive forever.
-      revokeOptimisticBlobUrls([optimistic]);
+      if (optimistic !== undefined) revokeOptimisticBlobUrls([optimistic]);
       set((s) => {
         const cur = s.messagesBySession[sessionId] ?? [];
         return {
-          messagesBySession: {
-            ...s.messagesBySession,
-            [sessionId]: cur.filter((m) => m !== optimistic),
-          },
+          messagesBySession:
+            optimistic === undefined
+              ? s.messagesBySession
+              : {
+                  ...s.messagesBySession,
+                  [sessionId]: cur.filter((m) => m !== optimistic),
+                },
           error: err instanceof ApiError ? err.code : (err as Error).message,
           bannerBySession: {
             ...s.bannerBySession,

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -221,8 +221,6 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
   delete nextExtensionNotifications[sessionId];
   const nextStreamingText = { ...current.streamingTextBySession };
   delete nextStreamingText[sessionId];
-  const nextStreamingTimelinePosition = { ...current.streamingTimelinePositionBySession };
-  delete nextStreamingTimelinePosition[sessionId];
   const nextActiveTool = { ...current.activeToolBySession };
   delete nextActiveTool[sessionId];
   const nextToolCallGeneration = { ...current.toolCallGenerationBySession };
@@ -250,7 +248,6 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
     bannerBySession: nextBanner,
     extensionNotificationsBySession: nextExtensionNotifications,
     streamingTextBySession: nextStreamingText,
-    streamingTimelinePositionBySession: nextStreamingTimelinePosition,
     activeToolBySession: nextActiveTool,
     toolCallGenerationBySession: nextToolCallGeneration,
     agentEndCountBySession: nextAgentEndCount,
@@ -307,8 +304,6 @@ interface SessionState {
    * messages array refetched by `getMessages` then carries the final text).
    */
   streamingTextBySession: Record<string, string>;
-  /** Receipt position for the live assistant entry currently in the chat. */
-  streamingTimelinePositionBySession: Record<string, ChatTimelinePosition | undefined>;
   /**
    * Per-session "agent is currently running tool X" indicator. Set on
    * tool_execution_start, cleared on tool_execution_end. The chat view
@@ -460,7 +455,6 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   bannerBySession: {},
   extensionNotificationsBySession: {},
   streamingTextBySession: {},
-  streamingTimelinePositionBySession: {},
   activeToolBySession: {},
   toolCallGenerationBySession: {},
   agentEndCountBySession: {},
@@ -990,13 +984,6 @@ function applyEvent(
         ...s.streamingBySession,
         [sessionId]: event.isStreaming ?? false,
       },
-      streamingTimelinePositionBySession: {
-        ...s.streamingTimelinePositionBySession,
-        [sessionId]:
-          event.isStreaming === true
-            ? (s.streamingTimelinePositionBySession[sessionId] ?? createChatTimelinePosition())
-            : undefined,
-      },
       bannerBySession: {
         ...s.bannerBySession,
         [sessionId]:
@@ -1022,10 +1009,6 @@ function applyEvent(
     set((s) => ({
       streamingBySession: { ...s.streamingBySession, [sessionId]: true },
       streamingTextBySession: { ...s.streamingTextBySession, [sessionId]: "" },
-      streamingTimelinePositionBySession: {
-        ...s.streamingTimelinePositionBySession,
-        [sessionId]: createChatTimelinePosition(),
-      },
       bannerBySession: { ...s.bannerBySession, [sessionId]: undefined },
       turnWriteCountBySession: { ...s.turnWriteCountBySession, [sessionId]: 0 },
       toolCallGenerationBySession: { ...s.toolCallGenerationBySession, [sessionId]: undefined },
@@ -1072,10 +1055,6 @@ function applyEvent(
             messagesBySession: { ...s.messagesBySession, [sessionId]: messages },
             streamingBySession: { ...s.streamingBySession, [sessionId]: false },
             streamingTextBySession: { ...s.streamingTextBySession, [sessionId]: "" },
-            streamingTimelinePositionBySession: {
-              ...s.streamingTimelinePositionBySession,
-              [sessionId]: undefined,
-            },
             activeToolBySession: { ...s.activeToolBySession, [sessionId]: undefined },
             toolCallGenerationBySession: {
               ...s.toolCallGenerationBySession,
@@ -1108,10 +1087,6 @@ function applyEvent(
         // disappears and the chat looks healthy when it isn't.
         set((s) => ({
           streamingBySession: { ...s.streamingBySession, [sessionId]: false },
-          streamingTimelinePositionBySession: {
-            ...s.streamingTimelinePositionBySession,
-            [sessionId]: undefined,
-          },
           activeToolBySession: { ...s.activeToolBySession, [sessionId]: undefined },
           toolCallGenerationBySession: { ...s.toolCallGenerationBySession, [sessionId]: undefined },
           bannerBySession: {

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -121,6 +121,11 @@ export interface ActiveTool {
   summary?: string;
 }
 
+export interface ExtensionUiNotification {
+  message: string;
+  level: "info" | "warning" | "error";
+}
+
 /**
  * Wire-shape of an SSE event from the bridge. `snapshot` carries the full
  * messages array on connect; everything else is an AgentSessionEvent
@@ -203,6 +208,8 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
   delete nextUnreadResponse[sessionId];
   const nextBanner = { ...current.bannerBySession };
   delete nextBanner[sessionId];
+  const nextExtensionNotifications = { ...current.extensionNotificationsBySession };
+  delete nextExtensionNotifications[sessionId];
   const nextStreamingText = { ...current.streamingTextBySession };
   delete nextStreamingText[sessionId];
   const nextActiveTool = { ...current.activeToolBySession };
@@ -228,6 +235,7 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
     streamingBySession: nextStreaming,
     unreadResponseBySession: nextUnreadResponse,
     bannerBySession: nextBanner,
+    extensionNotificationsBySession: nextExtensionNotifications,
     streamingTextBySession: nextStreamingText,
     activeToolBySession: nextActiveTool,
     toolCallGenerationBySession: nextToolCallGeneration,
@@ -272,6 +280,12 @@ interface SessionState {
   unreadResponseBySession: Record<string, boolean>;
   /** Per-session last-known toolEvent + retry banners (lightly modelled). */
   bannerBySession: Record<string, string | undefined>;
+  /**
+   * Extension-command notifications awaiting display. This is deliberately
+   * separate from banners: banners represent current session state, whereas
+   * notifications are transient feedback that must be shown in order.
+   */
+  extensionNotificationsBySession: Record<string, ExtensionUiNotification[] | undefined>;
   /**
    * Live assistant text being streamed in by message_update events. Reset on
    * agent_start, accumulates deltas, cleared on agent_end (the authoritative
@@ -407,6 +421,13 @@ interface SessionState {
    * the banner reappears on the next event.
    */
   clearBanner: (sessionId: string) => void;
+  /** Add extension feedback without overwriting a state banner or earlier notification. */
+  enqueueExtensionUiNotification: (
+    sessionId: string,
+    notification: ExtensionUiNotification,
+  ) => void;
+  /** Dismiss the visible extension notification and advance its session queue. */
+  dismissExtensionUiNotification: (sessionId: string) => void;
 }
 
 export const useSessionStore = create<SessionState>((set, get) => ({
@@ -418,6 +439,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   streamingBySession: {},
   unreadResponseBySession: {},
   bannerBySession: {},
+  extensionNotificationsBySession: {},
   streamingTextBySession: {},
   activeToolBySession: {},
   toolCallGenerationBySession: {},
@@ -886,6 +908,24 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       bannerBySession: { ...s.bannerBySession, [sessionId]: undefined },
     }));
   },
+  enqueueExtensionUiNotification: (sessionId, notification) => {
+    set((s) => ({
+      extensionNotificationsBySession: {
+        ...s.extensionNotificationsBySession,
+        [sessionId]: [...(s.extensionNotificationsBySession[sessionId] ?? []), notification],
+      },
+    }));
+  },
+  dismissExtensionUiNotification: (sessionId) => {
+    set((s) => {
+      const notifications = s.extensionNotificationsBySession[sessionId] ?? [];
+      if (notifications.length === 0) return {};
+      const next = { ...s.extensionNotificationsBySession };
+      if (notifications.length === 1) delete next[sessionId];
+      else next[sessionId] = notifications.slice(1);
+      return { extensionNotificationsBySession: next };
+    });
+  },
 }));
 
 /**
@@ -1136,6 +1176,19 @@ function applyEvent(
     const name = typeof event.name === "string" ? event.name : undefined;
     set((s) => renameSessionInLists(s, renamedSessionId, name));
     postCrossTab({ type: "session_renamed", sessionId: renamedSessionId, name });
+    return;
+  }
+
+  if (event.type === "extension_ui_notification") {
+    const message = typeof event.message === "string" ? event.message.trim() : "";
+    if (message.length === 0) return;
+    const level =
+      event.level === "warning" || event.level === "error" || event.level === "info"
+        ? event.level
+        : "info";
+    // Notifications are independent from state banners. Consecutive extension
+    // calls must remain visible in arrival order, including dialog fallbacks.
+    get().enqueueExtensionUiNotification(sessionId, { message, level });
     return;
   }
 

--- a/packages/client/src/store/ui-store.ts
+++ b/packages/client/src/store/ui-store.ts
@@ -68,6 +68,10 @@ interface UiState {
   /** Bump `promptsRefreshTrigger`. Called from PromptsTab after every
    *  global / project-scope toggle. */
   bumpPromptsRefresh: () => void;
+  /** Monotonic refresh trigger for the chat input's effective skill list. */
+  skillsRefreshTrigger: number;
+  /** Bump `skillsRefreshTrigger` after a Skills settings change. */
+  bumpSkillsRefresh: () => void;
   /**
    * Monotonic counters feeding the `seq` field on cross-component
    * requests. These NEVER reset on `clear*` — that's the whole point.
@@ -140,6 +144,10 @@ export const useUiStore = create<UiState>((set, get) => ({
   promptsRefreshTrigger: 0,
   bumpPromptsRefresh: () => {
     set((s) => ({ promptsRefreshTrigger: s.promptsRefreshTrigger + 1 }));
+  },
+  skillsRefreshTrigger: 0,
+  bumpSkillsRefresh: () => {
+    set((s) => ({ skillsRefreshTrigger: s.skillsRefreshTrigger + 1 }));
   },
   todoPanelOpen: (() => {
     try {

--- a/packages/server/src/routes/prompt.ts
+++ b/packages/server/src/routes/prompt.ts
@@ -1,7 +1,7 @@
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import { ConversionError, convertAttachment, pickConverter } from "../attachment-converters.js";
 import { config } from "../config.js";
-import { syncStoredApiKeyToRuntime } from "../config-manager.js";
+import { listSkills, syncStoredApiKeyToRuntime } from "../config-manager.js";
 import { formatErrorChain } from "../diagnostics.js";
 import { expandFileReferences, languageHintForPath } from "../file-references.js";
 import {
@@ -299,7 +299,7 @@ function composePromptText(parsed: ParsedMultipart): string {
  * sends are awaited for clean ordering of any onSend hooks (security
  * headers etc.) before the route handler proceeds.
  */
-async function preflight(
+async function requireLiveSession(
   req: FastifyRequest,
   reply: FastifyReply,
 ): Promise<LiveSession | undefined> {
@@ -344,6 +344,15 @@ async function preflight(
       .send({ error: "session_not_found", message: "no live session with that id" });
     return undefined;
   }
+  return live;
+}
+
+async function preflight(
+  req: FastifyRequest,
+  reply: FastifyReply,
+): Promise<LiveSession | undefined> {
+  const live = await requireLiveSession(req, reply);
+  if (live === undefined) return undefined;
   const model = live.session.model;
   if (model === undefined) {
     await reply.code(400).send({
@@ -609,6 +618,139 @@ export const promptRoutes: FastifyPluginAsync = async (fastify) => {
             ? { accepted: true, sessionName: generatedSessionName }
             : { accepted: true },
         );
+    },
+  );
+
+  fastify.post<{
+    Params: { id: string };
+    Body: { name: string; instructions?: string };
+  }>(
+    "/sessions/:id/skill",
+    {
+      config: {
+        rateLimit: {
+          max: config.rateLimits.promptMax,
+          timeWindow: config.rateLimits.promptWindowMs,
+        },
+      },
+      schema: {
+        description:
+          "Invoke an enabled skill already available to this live session. Returns 202 immediately; " +
+          "the expanded skill runs through the normal session prompt and streams over GET /sessions/:id/stream.",
+        tags: ["sessions"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          required: ["name"],
+          additionalProperties: false,
+          properties: {
+            name: { type: "string", minLength: 1 },
+            instructions: { type: "string" },
+          },
+        },
+        response: {
+          202: {
+            type: "object",
+            required: ["accepted"],
+            properties: { accepted: { type: "boolean", const: true } },
+          },
+          400: errorSchema,
+          404: errorSchema,
+          409: errorSchema,
+          500: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const live = await preflight(req, reply);
+      if (live === undefined) return reply;
+
+      // Validate against both views deliberately. `listSkills` tells us whether
+      // the skill is known and currently effective for this project, while the
+      // live resource loader is the authority for what THIS session loaded at
+      // creation/resume time. A skill can be enabled after a session starts,
+      // but the SDK will not make it available until a fresh session loads it.
+      let configuredSkills: Awaited<ReturnType<typeof listSkills>>["skills"];
+      try {
+        configuredSkills = (await listSkills(live.workspacePath, live.projectId)).skills;
+      } catch (err) {
+        reply.log.error({ err }, "skill invocation validation failed");
+        return reply.code(500).send({ error: "internal_error" });
+      }
+      const skill = configuredSkills.find((candidate) => candidate.name === req.body.name);
+      if (skill === undefined) {
+        return reply.code(404).send({
+          error: "skill_not_found",
+          message: `No skill named "${req.body.name}" is configured for this project.`,
+        });
+      }
+      if (!skill.effective) {
+        return reply.code(409).send({
+          error: "skill_not_effective",
+          message: `Skill "${req.body.name}" is disabled for this project.`,
+        });
+      }
+      if (
+        !live.session.resourceLoader
+          .getSkills()
+          .skills.some((candidate) => candidate.name === skill.name)
+      ) {
+        return reply.code(409).send({
+          error: "skill_unavailable_in_session",
+          message: `Skill "${req.body.name}" is not available to this live session. Start a new session after enabling or adding it.`,
+        });
+      }
+
+      // A skill starts a fresh SDK prompt rather than steering the current
+      // turn. Check immediately before calling the SDK because listSkills()
+      // above awaits and another request may have started a turn meanwhile.
+      // Letting the SDK reject later would hit the generic failure handler and
+      // falsely end that live turn.
+      if (live.session.isStreaming) {
+        return reply.code(409).send({
+          error: "session_streaming",
+          message: "Cannot invoke a skill while the session is streaming.",
+        });
+      }
+
+      // SDK 0.80.10 has no AgentSession.skill API. Its native slash-command
+      // expansion lives inside prompt(), so feed it the exact command form.
+      const skillPrompt = `/skill:${skill.name}${req.body.instructions ? ` ${req.body.instructions}` : ""}`;
+      try {
+        live.session.prompt(skillPrompt).catch((err: unknown) => {
+          const f = formatErrorChain(err);
+          process.stderr.write(
+            `${JSON.stringify({
+              level: "warn",
+              time: new Date().toISOString(),
+              msg: "session skill prompt rejected",
+              sessionId: req.params.id,
+              skill: skill.name,
+              error: f.message,
+              chain: f.chain,
+              stack: f.stack,
+            })}\n`,
+          );
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          for (const client of live.clients) {
+            try {
+              client.send({ type: "agent_end", sessionId: req.params.id, errorMessage });
+            } catch {
+              // A single client send-failure should not stop fan-out.
+            }
+          }
+        });
+      } catch (err) {
+        reply.log.warn(
+          { err: err instanceof Error ? err.message : String(err), sessionId: req.params.id },
+          "session skill prompt threw synchronously",
+        );
+      }
+      return reply.code(202).send({ accepted: true });
     },
   );
 };

--- a/packages/server/src/routes/prompt.ts
+++ b/packages/server/src/routes/prompt.ts
@@ -347,19 +347,27 @@ async function requireLiveSession(
   return live;
 }
 
-async function preflight(
-  req: FastifyRequest,
-  reply: FastifyReply,
-): Promise<LiveSession | undefined> {
-  const live = await requireLiveSession(req, reply);
-  if (live === undefined) return undefined;
+/**
+ * SDK extension commands are handled by `session.prompt()` before model/auth
+ * preflight and execute immediately even during an active agent run. Match
+ * the SDK's space-only parser exactly so this route neither misclassifies a
+ * command nor alters the text passed to its handler.
+ */
+function isRegisteredExtensionCommand(live: LiveSession, text: string): boolean {
+  if (!text.startsWith("/")) return false;
+  const spaceIndex = text.indexOf(" ");
+  const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+  return live.session.extensionRunner.getCommand(commandName) !== undefined;
+}
+
+async function validateModelForPrompt(live: LiveSession, reply: FastifyReply): Promise<boolean> {
   const model = live.session.model;
   if (model === undefined) {
     await reply.code(400).send({
       error: "no_model_configured",
       message: "no model is configured for this session",
     });
-    return undefined;
+    return false;
   }
   await live.session.modelRuntime.reloadConfig();
   await syncStoredApiKeyToRuntime(live.session.modelRuntime, model.provider);
@@ -368,8 +376,18 @@ async function preflight(
       error: "no_api_key",
       message: `No API key configured for provider "${model.provider}". Add one via PUT /api/v1/config/auth/${model.provider}.`,
     });
-    return undefined;
+    return false;
   }
+  return true;
+}
+
+async function preflight(
+  req: FastifyRequest,
+  reply: FastifyReply,
+): Promise<LiveSession | undefined> {
+  const live = await requireLiveSession(req, reply);
+  if (live === undefined) return undefined;
+  if (!(await validateModelForPrompt(live, reply))) return undefined;
   return live;
 }
 
@@ -447,7 +465,7 @@ export const promptRoutes: FastifyPluginAsync = async (fastify) => {
         });
       }
 
-      const live = await preflight(req, reply);
+      const live = await requireLiveSession(req, reply);
       if (live === undefined) return reply;
 
       let promptText: string;
@@ -491,7 +509,11 @@ export const promptRoutes: FastifyPluginAsync = async (fastify) => {
           return reply.code(400).send(parsed);
         }
         titleSourceText = parsed.text;
-        promptText = composePromptText(parsed);
+        // Commands receive only their typed invocation. Attachments are LLM
+        // context, so they have no command-handler representation.
+        promptText = isRegisteredExtensionCommand(live, parsed.text)
+          ? parsed.text
+          : composePromptText(parsed);
         streamingBehavior = parsed.streamingBehavior;
         images = parsed.images;
       } else {
@@ -500,20 +522,27 @@ export const promptRoutes: FastifyPluginAsync = async (fastify) => {
         streamingBehavior = req.body.streamingBehavior;
       }
 
-      // Expand `@<path>` file references inline (the chat input's
-      // `@`-autocomplete inserts these markers; server-side
-      // expansion keeps the LLM context as the source of truth and
-      // matches how attachments work). A path that doesn't resolve
-      // to a real file inside the workspace passes through untouched
-      // — see file-references.ts for the rules.
-      promptText = await expandFileReferences(promptText, live.workspacePath);
+      const isExtensionCommand = isRegisteredExtensionCommand(live, promptText);
+      if (!isExtensionCommand && !(await validateModelForPrompt(live, reply))) return reply;
 
-      // Name a brand-new, still-generic session from the user's first
-      // prompt before the agent run starts. This is deterministic (no
-      // extra LLM call), best-effort, and uses the user's typed text
-      // rather than expanded @file blocks / attachment bodies so large
-      // context blobs do not dominate the tab title.
-      const generatedSessionName = maybeNameSessionFromFirstPrompt(live, titleSourceText);
+      // Extension command handlers receive the exact text typed by the user.
+      // In particular, do not expand file references or create a session title
+      // before forwarding the command to the SDK's normal prompt path.
+      if (!isExtensionCommand) {
+        // Expand `@<path>` file references inline (the chat input's
+        // `@`-autocomplete inserts these markers; server-side expansion keeps
+        // the LLM context as the source of truth and matches attachments).
+        // A path that doesn't resolve to a real file inside the workspace
+        // passes through untouched — see file-references.ts for the rules.
+        promptText = await expandFileReferences(promptText, live.workspacePath);
+      }
+
+      // Name a brand-new, still-generic session from the user's first normal
+      // prompt before the agent run starts. Extension commands need not start
+      // an LLM run and must not change the session name as a side effect.
+      const generatedSessionName = isExtensionCommand
+        ? undefined
+        : maybeNameSessionFromFirstPrompt(live, titleSourceText);
 
       // No app-level composed-prompt cap: per-file size limits
       // already prevent runaway memory pressure during multipart

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -8,6 +8,7 @@ import {
   findProjectIdForSession,
   findSessionLocation,
   getSession,
+  listExtensionCommands,
   listSessionsForProject,
   rejectOrDisposeExternallyActiveSession,
   resumeSessionById,
@@ -341,6 +342,59 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
         bodyArgs.externalState = external.state;
       }
       return liveSummaryBody(bodyArgs);
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/sessions/:id/extension-commands",
+    {
+      schema: {
+        description:
+          "List SDK extension commands registered on a session, lazily resuming cold sessions when needed.",
+        tags: ["sessions"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["commands"],
+            properties: {
+              commands: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["name"],
+                  properties: {
+                    name: { type: "string" },
+                    description: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      let live = getSession(req.params.id);
+      if (live === undefined) {
+        try {
+          // ChatInput requests this alongside the SSE stream on session open.
+          // Resume here too so an initial request cannot lose a race with the
+          // stream's lazy resume and permanently hide extension commands.
+          live = await resumeSessionById(req.params.id);
+        } catch {
+          return notFound(reply);
+        }
+      }
+      if (await rejectExternalIfNeeded(req.params.id, live.projectId, live.workspacePath, reply)) {
+        return reply;
+      }
+      return { commands: listExtensionCommands(req.params.id) ?? [] };
     },
   );
 

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -6,6 +6,8 @@ import {
   createAgentSession,
   SessionManager,
   SettingsManager,
+  type ExtensionCommandContextActions,
+  type ExtensionUIContext,
   type PackageSource,
   type SessionInfo,
 } from "@earendil-works/pi-coding-agent";
@@ -378,6 +380,106 @@ export function findLastAssistantErrorMessage(
     return undefined;
   }
   return undefined;
+}
+
+const EXTENSION_UI_NOTIFICATION_MAX_LENGTH = 4_000;
+
+function emitExtensionUiNotification(
+  live: LiveSession,
+  message: string,
+  level: "info" | "warning" | "error" = "info",
+): void {
+  const text = message.trim().slice(0, EXTENSION_UI_NOTIFICATION_MAX_LENGTH);
+  if (text.length === 0) return;
+  const event = {
+    type: "extension_ui_notification" as const,
+    sessionId: live.sessionId,
+    message: text,
+    level,
+  };
+  for (const client of live.clients) {
+    try {
+      client.send(event);
+    } catch {
+      live.clients.delete(client);
+    }
+  }
+}
+
+/**
+ * Bind the SDK extension command context to Pi Forge's authenticated SSE
+ * session. Browser clients can show notifications, while terminal-only dialogs
+ * fail safely and explain their unsupported state to the user.
+ */
+async function bindWebExtensionContext(live: LiveSession): Promise<void> {
+  const unsupportedDialog = (): void => {
+    emitExtensionUiNotification(
+      live,
+      "This extension requested an interactive dialog, which Pi Forge does not support.",
+      "warning",
+    );
+  };
+  const uiContext = {
+    select: async () => {
+      unsupportedDialog();
+      return undefined;
+    },
+    confirm: async () => {
+      unsupportedDialog();
+      return false;
+    },
+    input: async () => {
+      unsupportedDialog();
+      return undefined;
+    },
+    notify: (message: string, level?: "info" | "warning" | "error") => {
+      emitExtensionUiNotification(live, message, level);
+    },
+    onTerminalInput: () => () => undefined,
+    setStatus: () => undefined,
+    setWorkingMessage: () => undefined,
+    setWorkingVisible: () => undefined,
+    setWorkingIndicator: () => undefined,
+    setHiddenThinkingLabel: () => undefined,
+    setWidget: () => undefined,
+    setFooter: () => undefined,
+    setHeader: () => undefined,
+    setTitle: () => undefined,
+    custom: async <T>() => {
+      unsupportedDialog();
+      return undefined as T;
+    },
+    pasteToEditor: () => undefined,
+    setEditorText: () => undefined,
+    getEditorText: () => "",
+    editor: async () => {
+      unsupportedDialog();
+      return undefined;
+    },
+    addAutocompleteProvider: () => undefined,
+    setEditorComponent: () => undefined,
+    getEditorComponent: () => undefined,
+    theme: {} as ExtensionUIContext["theme"],
+    getAllThemes: () => [],
+    getTheme: () => undefined,
+    setTheme: () => ({ success: false, error: "UI not available in Pi Forge" }),
+    getToolsExpanded: () => false,
+    setToolsExpanded: () => undefined,
+  } satisfies ExtensionUIContext;
+  const commandContextActions = {
+    waitForIdle: () => live.session.waitForIdle(),
+    newSession: async () => ({ cancelled: true }),
+    fork: async () => ({ cancelled: true }),
+    navigateTree: async () => ({ cancelled: true }),
+    switchSession: async () => ({ cancelled: true }),
+    reload: async () => undefined,
+  } satisfies ExtensionCommandContextActions;
+
+  await live.session.bindExtensions({
+    uiContext,
+    mode: "rpc",
+    commandContextActions,
+  });
 }
 
 function makeSubscribeHandler(live: LiveSession): () => void {
@@ -762,6 +864,7 @@ export async function createSession(
   };
   live.unsubscribe = makeSubscribeHandler(live);
   registry.set(live.sessionId, live);
+  await bindWebExtensionContext(live);
 
   // Set a meaningful default name on the new session so the sidebar
   // doesn't show every fresh-create as the indistinguishable
@@ -1106,6 +1209,7 @@ export async function resumeSession(
     };
     live.unsubscribe = makeSubscribeHandler(live);
     registry.set(live.sessionId, live);
+    await bindWebExtensionContext(live);
     return live;
   });
 }
@@ -1787,6 +1891,7 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
   };
   live.unsubscribe = makeSubscribeHandler(live);
   registry.set(live.sessionId, live);
+  await bindWebExtensionContext(live);
 
   // Disambiguate the fork's display name from its source. The SDK
   // copies session_info entries forward when forking, so the new
@@ -1889,6 +1994,7 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
       source.lastActivityAt = new Date();
       source.lastAgentStartIndex = undefined;
       source.unsubscribe = makeSubscribeHandler(source);
+      await bindWebExtensionContext(source);
     } catch (err) {
       // Log but don't fail the fork — the new session is fine.
       // The source is corrupted in memory; surface as a server log
@@ -2021,6 +2127,7 @@ export async function rebuildAgentSessionForTools(
   live.lastActivityAt = new Date();
   live.lastAgentStartIndex = undefined;
   live.unsubscribe = makeSubscribeHandler(live);
+  await bindWebExtensionContext(live);
   return live;
 }
 

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -431,6 +431,7 @@ function makeSubscribeHandler(live: LiveSession): () => void {
       success?: boolean;
       finalError?: string;
       errorMessage?: string;
+      name?: string;
     };
 
     if (verbose) {
@@ -492,6 +493,17 @@ function makeSubscribeHandler(live: LiveSession): () => void {
     // enrichment, a context-overflow / 401 / 5xx ends up emitting an
     // `agent_end` with no detail, the chat UI hides its spinner with
     // no error banner, and the user sees an empty assistant message.
+    if (e.type === "session_info_changed") {
+      // Extensions rename sessions through pi.setSessionName(), which emits
+      // this SDK-only event. Translate it to the established forge-native
+      // UI frame so the sidebar updates without a REST refresh.
+      outboundEvent = {
+        type: "session_renamed",
+        sessionId: live.sessionId,
+        projectId: live.projectId,
+        name: typeof e.name === "string" ? e.name : undefined,
+      } as unknown as AgentSessionEvent;
+    }
     if (e.type === "agent_end") {
       publishActivity(live, false, "completed");
       // Primary: session-level `errorMessage` — the SDK's
@@ -781,6 +793,25 @@ export function getSession(sessionId: string): LiveSession | undefined {
 }
 
 /**
+ * Registered SDK extension commands for a live session. Command names omit
+ * the slash because that is the SDK's canonical invocation-name format.
+ */
+export interface ExtensionCommandSummary {
+  name: string;
+  description?: string;
+}
+
+export function listExtensionCommands(sessionId: string): ExtensionCommandSummary[] | undefined {
+  const live = registry.get(sessionId);
+  if (live === undefined) return undefined;
+  return live.session.extensionRunner.getRegisteredCommands().map((command) => {
+    const summary: ExtensionCommandSummary = { name: command.invocationName };
+    if (command.description !== undefined) summary.description = command.description;
+    return summary;
+  });
+}
+
+/**
  * Return the live sessions, optionally filtered by project. Order is the
  * registry's Map insertion order — caller is responsible for sorting if a
  * particular order is wanted. Use `listSessionsForProject` if you want a
@@ -825,19 +856,9 @@ export function maybeNameSessionFromFirstPrompt(
   }
 
   live.lastActivityAt = new Date();
-  const event = {
-    type: "session_renamed" as const,
-    sessionId: live.sessionId,
-    projectId: live.projectId,
-    name: title,
-  };
-  for (const client of live.clients) {
-    try {
-      client.send(event);
-    } catch {
-      live.clients.delete(client);
-    }
-  }
+  // setSessionName emits the SDK's session_info_changed event. The registry
+  // subscription translates that event into the UI's session_renamed SSE
+  // frame, which also covers extension-initiated renames.
   return title;
 }
 

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -493,17 +493,17 @@ function makeSubscribeHandler(live: LiveSession): () => void {
     // enrichment, a context-overflow / 401 / 5xx ends up emitting an
     // `agent_end` with no detail, the chat UI hides its spinner with
     // no error banner, and the user sees an empty assistant message.
-    if (e.type === "session_info_changed") {
-      // Extensions rename sessions through pi.setSessionName(), which emits
-      // this SDK-only event. Translate it to the established forge-native
-      // UI frame so the sidebar updates without a REST refresh.
-      outboundEvent = {
-        type: "session_renamed",
-        sessionId: live.sessionId,
-        projectId: live.projectId,
-        name: typeof e.name === "string" ? e.name : undefined,
-      } as unknown as AgentSessionEvent;
-    }
+    // Preserve the SDK event for registry subscribers, while also emitting
+    // the forge-native frame that the SSE bridge exposes to the UI.
+    const renamedEvent =
+      e.type === "session_info_changed"
+        ? {
+            type: "session_renamed" as const,
+            sessionId: live.sessionId,
+            projectId: live.projectId,
+            name: typeof e.name === "string" ? e.name : undefined,
+          }
+        : undefined;
     if (e.type === "agent_end") {
       publishActivity(live, false, "completed");
       // Primary: session-level `errorMessage` — the SDK's
@@ -575,6 +575,15 @@ function makeSubscribeHandler(live: LiveSession): () => void {
         // Drop the client on send failure — Phase 5's SSE adapter will
         // also call disposeClient on its socket close hook.
         live.clients.delete(client);
+      }
+    }
+    if (renamedEvent !== undefined) {
+      for (const client of live.clients) {
+        try {
+          client.send(renamedEvent);
+        } catch {
+          live.clients.delete(client);
+        }
       }
     }
 

--- a/packages/server/src/sse-bridge.ts
+++ b/packages/server/src/sse-bridge.ts
@@ -183,6 +183,9 @@ const ALLOWED_EVENT_TYPES = new Set<string>([
   // Forge-native per-session rename event. Used for deterministic first-
   // prompt names and manual/cross-tab-compatible sidebar updates.
   "session_renamed",
+  // SDK extension-command UI notifications are bridged by session-registry
+  // into the authenticated session stream.
+  "extension_ui_notification",
 ]);
 
 export function isAllowedEvent(event: { type: string }): boolean {

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -143,9 +143,21 @@ const marked = new Marked({ gfm: true, breaks: false });
 
 // Add target=_blank to external links via a renderer override —
 // internal anchors (#section) and relative links shouldn't get it.
+// Keep repository Markdown links intact while emitting the Pages URL for
+// the extension-notification reference in the generated configuration page.
+const SITE_HREFS = new Map([
+  ["./sse-events.md#extension-ui-notifications", "./sse-events.html#extension-ui-notifications"],
+]);
+const SITE_HEADING_IDS = new Map([["Extension UI notifications", "extension-ui-notifications"]]);
+
 const renderer = {
+  heading(token) {
+    const id = SITE_HEADING_IDS.get(token.text);
+    const idAttr = id ? ` id="${id}"` : "";
+    return `<h${token.depth}${idAttr}>${this.parser.parseInline(token.tokens)}</h${token.depth}>\n`;
+  },
   link(token) {
-    const href = token.href;
+    const href = SITE_HREFS.get(token.href) ?? token.href;
     const text = this.parser.parseInline(token.tokens);
     const isExternal = /^https?:/i.test(href);
     const attrs = isExternal ? ` target="_blank" rel="noopener noreferrer"` : "";

--- a/tests/test-extension-commands.ts
+++ b/tests/test-extension-commands.ts
@@ -35,18 +35,21 @@ async function request(base: string, path: string, init?: RequestInit): Promise<
   return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
 }
 
-async function waitForSseEvent(
+async function waitForSseEvents(
   response: Response,
-  matches: (event: Record<string, unknown>) => boolean,
-): Promise<Record<string, unknown>> {
+  matches: ((event: Record<string, unknown>) => boolean)[],
+): Promise<Record<string, unknown>[]> {
   const reader = response.body?.getReader();
   if (reader === undefined) throw new Error("SSE response has no body");
   const decoder = new TextDecoder();
+  const found: (Record<string, unknown> | undefined)[] = [];
+  for (let i = 0; i < matches.length; i += 1) found.push(undefined);
+  let foundCount = 0;
   let pending = "";
   try {
     for (;;) {
       const { done, value } = await reader.read();
-      if (done) throw new Error("SSE stream ended before matching event");
+      if (done) throw new Error("SSE stream ended before matching events");
       pending += decoder.decode(value, { stream: true });
       for (;;) {
         const boundary = pending.indexOf("\n\n");
@@ -56,7 +59,16 @@ async function waitForSseEvent(
         const line = frame.split("\n").find((entry) => entry.startsWith("data: "));
         if (line === undefined) continue;
         const event = JSON.parse(line.slice("data: ".length)) as Record<string, unknown>;
-        if (matches(event)) return event;
+        for (let i = 0; i < matches.length; i += 1) {
+          const matcher = matches[i];
+          if (matcher !== undefined && found[i] === undefined && matcher(event)) {
+            found[i] = event;
+            foundCount += 1;
+          }
+        }
+        if (foundCount === matches.length) {
+          return found.filter((match): match is Record<string, unknown> => match !== undefined);
+        }
       }
     }
   } finally {
@@ -85,7 +97,9 @@ async function main(): Promise<void> {
       "export default function testCommand(pi) {",
       '  pi.registerCommand("test-command", {',
       '    description: "Set the session name from command arguments",',
-      "    handler: async (args) => {",
+      "    handler: async (args, ctx) => {",
+      '      await ctx.ui.confirm("Test dialog", "This dialog is intentionally unsupported in Pi Forge");',
+      '      ctx.ui.notify(`Command feedback: ${args}`, "info");',
       "      pi.setSessionName(`extension:${args}`);",
       "    },",
       "  });",
@@ -162,12 +176,19 @@ async function main(): Promise<void> {
       signal: sseController.signal,
     });
     assert("open SSE stream for extension rename → 200", stream.status === 200);
-    const renamedEvent =
+    const extensionEvents =
       stream.status === 200
-        ? waitForSseEvent(
-            stream,
+        ? waitForSseEvents(stream, [
+            (event) =>
+              event.type === "extension_ui_notification" &&
+              event.message ===
+                "This extension requested an interactive dialog, which Pi Forge does not support.",
+            (event) =>
+              event.type === "extension_ui_notification" &&
+              event.message === "Command feedback: normal" &&
+              event.level === "info",
             (event) => event.type === "session_renamed" && event.name === "extension:normal",
-          )
+          ])
         : undefined;
 
     const invoke = await request(base, `/api/v1/sessions/${sessionId}/prompt`, {
@@ -180,15 +201,15 @@ async function main(): Promise<void> {
       invoke.status === 202,
       JSON.stringify(invoke.body),
     );
-    let rename: Record<string, unknown> | undefined;
+    let receivedEvents: Record<string, unknown>[] | undefined;
     try {
-      if (invoke.status === 202 && renamedEvent !== undefined) {
+      if (invoke.status === 202 && extensionEvents !== undefined) {
         await new Promise((resolveFn) => setTimeout(resolveFn, 25));
-        rename = await Promise.race([
-          renamedEvent,
+        receivedEvents = await Promise.race([
+          extensionEvents,
           new Promise<never>((_, reject) =>
             setTimeout(
-              () => reject(new Error("timed out waiting for extension rename SSE")),
+              () => reject(new Error("timed out waiting for extension UI SSE events")),
               1_000,
             ),
           ),
@@ -196,28 +217,31 @@ async function main(): Promise<void> {
       }
     } catch (err) {
       assert(
-        "extension session_info_changed reaches UI as session_renamed SSE",
+        "extension UI feedback reaches the authenticated session SSE stream",
         false,
         err instanceof Error ? err.message : String(err),
       );
     } finally {
       // Always close the stream: Fastify.close() waits for open SSE clients.
       sseController.abort();
-      await renamedEvent?.catch(() => undefined);
+      await extensionEvents?.catch(() => undefined);
     }
-    if (rename !== undefined) {
-      assert(
-        "extension session_info_changed reaches UI as session_renamed SSE",
-        rename.sessionId === sessionId && rename.name === "extension:normal",
-        JSON.stringify(rename),
-      );
-    } else {
-      assert(
-        "extension session_info_changed reaches UI as session_renamed SSE",
-        false,
-        "extension command request was not accepted or the SSE stream was unavailable",
-      );
-    }
+    const [dialogFallback, notification, rename] = receivedEvents ?? [];
+    assert(
+      "unsupported extension dialog has a visible SSE fallback",
+      dialogFallback?.level === "warning",
+      JSON.stringify(dialogFallback),
+    );
+    assert(
+      "extension ctx.ui.notify reaches the authenticated session SSE stream",
+      notification?.sessionId === sessionId && notification?.message === "Command feedback: normal",
+      JSON.stringify(notification),
+    );
+    assert(
+      "extension session_info_changed reaches UI as session_renamed SSE",
+      rename?.sessionId === sessionId && rename?.name === "extension:normal",
+      JSON.stringify(rename),
+    );
     const afterNormal = await request(base, `/api/v1/sessions/${sessionId}`);
     assert(
       "normal prompt path invokes extension handler with args",

--- a/tests/test-extension-commands.ts
+++ b/tests/test-extension-commands.ts
@@ -79,7 +79,8 @@ async function main(): Promise<void> {
 
   await mkdir(join(configDir, "extensions"), { recursive: true });
   await writeFile(
-    join(configDir, "extensions", "test-command.mjs"),
+    // The SDK discovers direct extension files with .js or .ts suffixes.
+    join(configDir, "extensions", "test-command.js"),
     [
       "export default function testCommand(pi) {",
       '  pi.registerCommand("test-command", {',
@@ -105,7 +106,14 @@ async function main(): Promise<void> {
   const registry = (await import(
     resolve(repoRoot, "packages/server/dist/session-registry.js")
   )) as unknown as {
-    getSession: (id: string) => { session: { _isAgentRunActive: boolean } } | undefined;
+    getSession: (id: string) =>
+      | {
+          session: {
+            _isAgentRunActive: boolean;
+            sessionManager: { appendMessage: (message: unknown) => string };
+          };
+        }
+      | undefined;
     disposeSession: (id: string) => Promise<boolean>;
   };
 
@@ -138,10 +146,15 @@ async function main(): Promise<void> {
       commands.status === 200,
       JSON.stringify(commands.body),
     );
-    assert("registered command name is listed without slash", testCommand !== undefined);
+    assert(
+      "registered command name is listed without slash",
+      testCommand !== undefined,
+      JSON.stringify(commands.body),
+    );
     assert(
       "registered command description is listed",
       testCommand?.description === "Set the session name from command arguments",
+      JSON.stringify(commands.body),
     );
 
     const sseController = new AbortController();
@@ -149,10 +162,13 @@ async function main(): Promise<void> {
       signal: sseController.signal,
     });
     assert("open SSE stream for extension rename → 200", stream.status === 200);
-    const renamedEvent = waitForSseEvent(
-      stream,
-      (event) => event.type === "session_renamed" && event.name === "extension:normal",
-    );
+    const renamedEvent =
+      stream.status === 200
+        ? waitForSseEvent(
+            stream,
+            (event) => event.type === "session_renamed" && event.name === "extension:normal",
+          )
+        : undefined;
 
     const invoke = await request(base, `/api/v1/sessions/${sessionId}/prompt`, {
       method: "POST",
@@ -164,19 +180,44 @@ async function main(): Promise<void> {
       invoke.status === 202,
       JSON.stringify(invoke.body),
     );
-    await new Promise((resolveFn) => setTimeout(resolveFn, 25));
-    const rename = await Promise.race([
-      renamedEvent,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("timed out waiting for extension rename SSE")), 1_000),
-      ),
-    ]);
-    sseController.abort();
-    assert(
-      "extension session_info_changed reaches UI as session_renamed SSE",
-      rename.sessionId === sessionId && rename.name === "extension:normal",
-      JSON.stringify(rename),
-    );
+    let rename: Record<string, unknown> | undefined;
+    try {
+      if (invoke.status === 202 && renamedEvent !== undefined) {
+        await new Promise((resolveFn) => setTimeout(resolveFn, 25));
+        rename = await Promise.race([
+          renamedEvent,
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("timed out waiting for extension rename SSE")),
+              1_000,
+            ),
+          ),
+        ]);
+      }
+    } catch (err) {
+      assert(
+        "extension session_info_changed reaches UI as session_renamed SSE",
+        false,
+        err instanceof Error ? err.message : String(err),
+      );
+    } finally {
+      // Always close the stream: Fastify.close() waits for open SSE clients.
+      sseController.abort();
+      await renamedEvent?.catch(() => undefined);
+    }
+    if (rename !== undefined) {
+      assert(
+        "extension session_info_changed reaches UI as session_renamed SSE",
+        rename.sessionId === sessionId && rename.name === "extension:normal",
+        JSON.stringify(rename),
+      );
+    } else {
+      assert(
+        "extension session_info_changed reaches UI as session_renamed SSE",
+        false,
+        "extension command request was not accepted or the SSE stream was unavailable",
+      );
+    }
     const afterNormal = await request(base, `/api/v1/sessions/${sessionId}`);
     assert(
       "normal prompt path invokes extension handler with args",
@@ -210,6 +251,30 @@ async function main(): Promise<void> {
       (afterStreaming.body as { name?: string }).name === "extension:streaming",
       JSON.stringify(afterStreaming.body),
     );
+
+    // The SDK deliberately defers JSONL creation until an assistant message
+    // exists. Add a minimal assistant fixture so this test can cover the
+    // route's cold-session resume path without an LLM or API key.
+    if (live !== undefined) {
+      live.session.sessionManager.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "test fixture", id: "stub-1" }],
+        api: "messages",
+        provider: "anthropic",
+        model: "test-fixture",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      });
+    }
+    assert("persist session for cold command lookup", live !== undefined);
 
     const disposed = await registry.disposeSession(sessionId);
     assert("dispose session before cold command lookup", disposed);

--- a/tests/test-extension-commands.ts
+++ b/tests/test-extension-commands.ts
@@ -1,0 +1,252 @@
+/**
+ * SDK extension command integration test.
+ *
+ * Verifies that registered commands are listed from a live session and are
+ * forwarded through the existing prompt endpoint without model/auth preflight.
+ * The streaming assertion toggles the SDK's internal active-run marker only to
+ * exercise its documented command-before-queue dispatch without an LLM.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+interface JsonResponse {
+  status: number;
+  body: unknown;
+}
+
+async function request(base: string, path: string, init?: RequestInit): Promise<JsonResponse> {
+  const res = await fetch(`${base}${path}`, init);
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function waitForSseEvent(
+  response: Response,
+  matches: (event: Record<string, unknown>) => boolean,
+): Promise<Record<string, unknown>> {
+  const reader = response.body?.getReader();
+  if (reader === undefined) throw new Error("SSE response has no body");
+  const decoder = new TextDecoder();
+  let pending = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) throw new Error("SSE stream ended before matching event");
+      pending += decoder.decode(value, { stream: true });
+      for (;;) {
+        const boundary = pending.indexOf("\n\n");
+        if (boundary === -1) break;
+        const frame = pending.slice(0, boundary);
+        pending = pending.slice(boundary + 2);
+        const line = frame.split("\n").find((entry) => entry.startsWith("data: "));
+        if (line === undefined) continue;
+        const event = JSON.parse(line.slice("data: ".length)) as Record<string, unknown>;
+        if (matches(event)) return event;
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+}
+
+async function main(): Promise<void> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-extension-commands-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-extension-commands-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-extension-commands-data-"));
+  process.env.WORKSPACE_PATH = workspacePath;
+  process.env.PI_CONFIG_DIR = configDir;
+  process.env.FORGE_DATA_DIR = dataDir;
+  process.env.SESSION_DIR = join(workspacePath, ".pi", "sessions");
+  process.env.NODE_ENV = "test";
+  delete process.env.UI_PASSWORD;
+  delete process.env.JWT_SECRET;
+  delete process.env.API_KEY;
+
+  await mkdir(join(configDir, "extensions"), { recursive: true });
+  await writeFile(
+    join(configDir, "extensions", "test-command.mjs"),
+    [
+      "export default function testCommand(pi) {",
+      '  pi.registerCommand("test-command", {',
+      '    description: "Set the session name from command arguments",',
+      "    handler: async (args) => {",
+      "      pi.setSessionName(`extension:${args}`);",
+      "    },",
+      "  });",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const buildModule = (await import(
+    resolve(repoRoot, "packages/server/dist/index.js")
+  )) as unknown as {
+    buildServer: () => Promise<{
+      listen: (opts: { port: number; host: string }) => Promise<string>;
+      close: () => Promise<void>;
+    }>;
+  };
+  const registry = (await import(
+    resolve(repoRoot, "packages/server/dist/session-registry.js")
+  )) as unknown as {
+    getSession: (id: string) => { session: { _isAgentRunActive: boolean } } | undefined;
+    disposeSession: (id: string) => Promise<boolean>;
+  };
+
+  const fastify = await buildModule.buildServer();
+  const base = await fastify.listen({ port: 0, host: "127.0.0.1" });
+
+  try {
+    const project = await request(base, "/api/v1/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "extension-commands", path: workspacePath }),
+    });
+    assert("create project → 201", project.status === 201, JSON.stringify(project.body));
+    const projectId = (project.body as { id: string }).id;
+
+    const created = await request(base, "/api/v1/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ projectId }),
+    });
+    assert("create session → 201", created.status === 201, JSON.stringify(created.body));
+    const sessionId = (created.body as { sessionId: string }).sessionId;
+
+    const commands = await request(base, `/api/v1/sessions/${sessionId}/extension-commands`);
+    const commandList = (commands.body as { commands?: { name: string; description?: string }[] })
+      .commands;
+    const testCommand = commandList?.find((command) => command.name === "test-command");
+    assert(
+      "GET live extension commands → 200",
+      commands.status === 200,
+      JSON.stringify(commands.body),
+    );
+    assert("registered command name is listed without slash", testCommand !== undefined);
+    assert(
+      "registered command description is listed",
+      testCommand?.description === "Set the session name from command arguments",
+    );
+
+    const sseController = new AbortController();
+    const stream = await fetch(`${base}/api/v1/sessions/${sessionId}/stream`, {
+      signal: sseController.signal,
+    });
+    assert("open SSE stream for extension rename → 200", stream.status === 200);
+    const renamedEvent = waitForSseEvent(
+      stream,
+      (event) => event.type === "session_renamed" && event.name === "extension:normal",
+    );
+
+    const invoke = await request(base, `/api/v1/sessions/${sessionId}/prompt`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "/test-command normal" }),
+    });
+    assert(
+      "extension command prompt → 202 without a model",
+      invoke.status === 202,
+      JSON.stringify(invoke.body),
+    );
+    await new Promise((resolveFn) => setTimeout(resolveFn, 25));
+    const rename = await Promise.race([
+      renamedEvent,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("timed out waiting for extension rename SSE")), 1_000),
+      ),
+    ]);
+    sseController.abort();
+    assert(
+      "extension session_info_changed reaches UI as session_renamed SSE",
+      rename.sessionId === sessionId && rename.name === "extension:normal",
+      JSON.stringify(rename),
+    );
+    const afterNormal = await request(base, `/api/v1/sessions/${sessionId}`);
+    assert(
+      "normal prompt path invokes extension handler with args",
+      (afterNormal.body as { name?: string }).name === "extension:normal",
+      JSON.stringify(afterNormal.body),
+    );
+    const afterCommandMessages = await request(base, `/api/v1/sessions/${sessionId}/messages`);
+    assert(
+      "extension command creates no canonical user message",
+      (afterCommandMessages.body as { messages?: unknown[] }).messages?.length === 0,
+      JSON.stringify(afterCommandMessages.body),
+    );
+
+    const live = registry.getSession(sessionId);
+    if (live !== undefined) live.session._isAgentRunActive = true;
+    const streamingInvoke = await request(base, `/api/v1/sessions/${sessionId}/prompt`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "/test-command streaming" }),
+    });
+    if (live !== undefined) live.session._isAgentRunActive = false;
+    assert(
+      "extension command prompt → 202 while streaming without queue mode",
+      streamingInvoke.status === 202,
+      JSON.stringify(streamingInvoke.body),
+    );
+    await new Promise((resolveFn) => setTimeout(resolveFn, 25));
+    const afterStreaming = await request(base, `/api/v1/sessions/${sessionId}`);
+    assert(
+      "streaming prompt path invokes extension handler immediately",
+      (afterStreaming.body as { name?: string }).name === "extension:streaming",
+      JSON.stringify(afterStreaming.body),
+    );
+
+    const disposed = await registry.disposeSession(sessionId);
+    assert("dispose session before cold command lookup", disposed);
+    // disposeSession tombstones briefly to block stale SSE reconnects; wait
+    // through that guard before exercising the cold-session resume path.
+    await new Promise((resolveFn) => setTimeout(resolveFn, 1_600));
+    const coldCommands = await request(base, `/api/v1/sessions/${sessionId}/extension-commands`);
+    assert(
+      "cold extension command lookup lazy-resumes → 200",
+      coldCommands.status === 200,
+      JSON.stringify(coldCommands.body),
+    );
+    assert(
+      "cold extension command lookup retains registered commands",
+      (coldCommands.body as { commands?: { name: string }[] }).commands?.some(
+        (command) => command.name === "test-command",
+      ) === true,
+      JSON.stringify(coldCommands.body),
+    );
+
+    const missing = await request(base, "/api/v1/sessions/not-a-live-session/extension-commands");
+    assert("extension commands for unknown session → 404", missing.status === 404);
+  } finally {
+    await fastify.close();
+    await rm(workspacePath, { recursive: true, force: true }).catch(() => undefined);
+    await rm(configDir, { recursive: true, force: true }).catch(() => undefined);
+    await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+
+  if (failures > 0) {
+    console.log(`\n[test-extension-commands] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-extension-commands] PASS");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/test-extension-ui-notifications.ts
+++ b/tests/test-extension-ui-notifications.ts
@@ -53,20 +53,30 @@ try {
     message: "Command feedback: normal",
     level: "info",
   });
+  receivedAt = 2_750;
+  store.enqueueExtensionUiNotification(sessionId, {
+    message: "Command feedback: failed",
+    level: "error",
+  });
 } finally {
   Date.now = realDateNow;
 }
 
 let notifications = useSessionStore.getState().extensionNotificationsBySession[sessionId] ?? [];
 assert(
-  "queues consecutive extension notifications in arrival order",
-  notifications.length === 2 &&
+  "keeps info, warning, and error extension feedback in arrival order",
+  notifications.length === 3 &&
     notifications[0]?.level === "warning" &&
     notifications[0]?.receivedAt === 2_000 &&
     notifications[0]?.message.includes("**Interactive dialog unavailable.**") &&
+    notifications[1]?.level === "info" &&
     notifications[1]?.receivedAt === 2_500 &&
     notifications[1]?.arrivalOrder > (notifications[0]?.arrivalOrder ?? Number.MAX_SAFE_INTEGER) &&
-    notifications[1]?.message === "Command feedback: normal",
+    notifications[1]?.message === "Command feedback: normal" &&
+    notifications[2]?.level === "error" &&
+    notifications[2]?.receivedAt === 2_750 &&
+    notifications[2]?.arrivalOrder > (notifications[1]?.arrivalOrder ?? Number.MAX_SAFE_INTEGER) &&
+    notifications[2]?.message === "Command feedback: failed",
   JSON.stringify(notifications),
 );
 assert(
@@ -82,7 +92,7 @@ assert(
       position: { timestamp: notification.receivedAt, order: notification.arrivalOrder },
     })),
   )[1]?.join(" | ") ===
-    "**Interactive dialog unavailable.** Use the [attachment button](#upload). | Command feedback: normal",
+    "**Interactive dialog unavailable.** Use the [attachment button](#upload). | Command feedback: normal | Command feedback: failed",
 );
 assert(
   "orders extension feedback with streaming, queued, and quick-action entries",
@@ -96,7 +106,7 @@ assert(
       },
     },
     { item: "queued", position: { timestamp: 2_250, order: 3 } },
-    { item: "quick-action", position: { timestamp: 2_750, order: 4 } },
+    { item: "quick-action", position: { timestamp: 2_900, order: 4 } },
   ])[1]?.join(" | ") === "streaming | extension | queued | quick-action",
 );
 assert(
@@ -109,14 +119,24 @@ assert(
 useSessionStore.getState().dismissExtensionUiNotification(sessionId, notifications[0]?.id);
 notifications = useSessionStore.getState().extensionNotificationsBySession[sessionId] ?? [];
 assert(
-  "dismissing the visible notification advances to the next notification",
-  notifications.length === 1 && notifications[0]?.message === "Command feedback: normal",
+  "dismissing one notification preserves the remaining feedback",
+  notifications.length === 2 &&
+    notifications[0]?.message === "Command feedback: normal" &&
+    notifications[1]?.message === "Command feedback: failed",
   JSON.stringify(notifications),
 );
 
-useSessionStore.getState().dismissExtensionUiNotification(sessionId);
+useSessionStore.getState().dismissExtensionUiNotification(sessionId, notifications[0]?.id);
+notifications = useSessionStore.getState().extensionNotificationsBySession[sessionId] ?? [];
 assert(
-  "dismissing the final notification clears its queue",
+  "dismissing the next notification preserves later feedback",
+  notifications.length === 1 && notifications[0]?.message === "Command feedback: failed",
+  JSON.stringify(notifications),
+);
+
+useSessionStore.getState().dismissExtensionUiNotification(sessionId, notifications[0]?.id);
+assert(
+  "explicitly dismissing the final notification clears its queue",
   useSessionStore.getState().extensionNotificationsBySession[sessionId] === undefined,
 );
 

--- a/tests/test-extension-ui-notifications.ts
+++ b/tests/test-extension-ui-notifications.ts
@@ -18,6 +18,7 @@ Object.defineProperty(globalThis, "localStorage", {
 });
 
 const { useSessionStore } = await import("../packages/client/src/store/session-store");
+const { placeChatTimelineItems } = await import("../packages/client/src/lib/chat-timeline");
 
 let failures = 0;
 function assert(label: string, ok: boolean, detail?: string): void {
@@ -29,23 +30,42 @@ function assert(label: string, ok: boolean, detail?: string): void {
 }
 
 const sessionId = "extension-notification-session";
-useSessionStore.setState({ bannerBySession: { [sessionId]: "Retrying (attempt 1)" } });
+const canonicalMessages = [
+  { role: "user", content: "Canonical Pi transcript entry one", timestamp: 1_000 },
+  { role: "assistant", content: "Canonical Pi transcript entry two", timestamp: 3_000 },
+];
+useSessionStore.setState({
+  bannerBySession: { [sessionId]: "Retrying (attempt 1)" },
+  messagesBySession: { [sessionId]: canonicalMessages },
+});
 
 const store = useSessionStore.getState();
-store.enqueueExtensionUiNotification(sessionId, {
-  message: "This extension requested an interactive dialog, which Pi Forge does not support.",
-  level: "warning",
-});
-store.enqueueExtensionUiNotification(sessionId, {
-  message: "Command feedback: normal",
-  level: "info",
-});
+const realDateNow = Date.now;
+let receivedAt = 2_000;
+Date.now = () => receivedAt;
+try {
+  store.enqueueExtensionUiNotification(sessionId, {
+    message: "**Interactive dialog unavailable.** Use the [attachment button](#upload).",
+    level: "warning",
+  });
+  receivedAt = 2_500;
+  store.enqueueExtensionUiNotification(sessionId, {
+    message: "Command feedback: normal",
+    level: "info",
+  });
+} finally {
+  Date.now = realDateNow;
+}
 
 let notifications = useSessionStore.getState().extensionNotificationsBySession[sessionId] ?? [];
 assert(
   "queues consecutive extension notifications in arrival order",
   notifications.length === 2 &&
     notifications[0]?.level === "warning" &&
+    notifications[0]?.receivedAt === 2_000 &&
+    notifications[0]?.message.includes("**Interactive dialog unavailable.**") &&
+    notifications[1]?.receivedAt === 2_500 &&
+    notifications[1]?.arrivalOrder > (notifications[0]?.arrivalOrder ?? Number.MAX_SAFE_INTEGER) &&
     notifications[1]?.message === "Command feedback: normal",
   JSON.stringify(notifications),
 );
@@ -53,8 +73,40 @@ assert(
   "does not overwrite the existing session banner",
   useSessionStore.getState().bannerBySession[sessionId] === "Retrying (attempt 1)",
 );
+assert(
+  "places extension feedback received between canonical entries between those entries",
+  placeChatTimelineItems(
+    canonicalMessages,
+    notifications.map((notification) => ({
+      item: notification.message,
+      position: { timestamp: notification.receivedAt, order: notification.arrivalOrder },
+    })),
+  )[1]?.join(" | ") ===
+    "**Interactive dialog unavailable.** Use the [attachment button](#upload). | Command feedback: normal",
+);
+assert(
+  "orders extension feedback with streaming, queued, and quick-action entries",
+  placeChatTimelineItems(canonicalMessages, [
+    { item: "streaming", position: { timestamp: 1_500, order: 1 } },
+    {
+      item: "extension",
+      position: {
+        timestamp: notifications[0]?.receivedAt ?? 0,
+        order: notifications[0]?.arrivalOrder ?? 0,
+      },
+    },
+    { item: "queued", position: { timestamp: 2_250, order: 3 } },
+    { item: "quick-action", position: { timestamp: 2_750, order: 4 } },
+  ])[1]?.join(" | ") === "streaming | extension | queued | quick-action",
+);
+assert(
+  "does not add transient extension feedback to the canonical Pi transcript",
+  useSessionStore.getState().messagesBySession[sessionId] === canonicalMessages &&
+    useSessionStore.getState().messagesBySession[sessionId]?.length === 2,
+  JSON.stringify(useSessionStore.getState().messagesBySession[sessionId]),
+);
 
-useSessionStore.getState().dismissExtensionUiNotification(sessionId);
+useSessionStore.getState().dismissExtensionUiNotification(sessionId, notifications[0]?.id);
 notifications = useSessionStore.getState().extensionNotificationsBySession[sessionId] ?? [];
 assert(
   "dismissing the visible notification advances to the next notification",

--- a/tests/test-extension-ui-notifications.ts
+++ b/tests/test-extension-ui-notifications.ts
@@ -1,0 +1,72 @@
+export {};
+
+const values = new Map<string, string>();
+// session-store subscribes to cross-tab updates at module load. Disable Node's
+// BroadcastChannel so its open MessagePort cannot keep this focused test alive.
+Object.defineProperty(globalThis, "BroadcastChannel", { configurable: true, value: undefined });
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    getItem: (key: string): string | null => values.get(key) ?? null,
+    setItem: (key: string, value: string): void => {
+      values.set(key, value);
+    },
+    removeItem: (key: string): void => {
+      values.delete(key);
+    },
+  },
+});
+
+const { useSessionStore } = await import("../packages/client/src/store/session-store");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`PASS ${label}`);
+  else {
+    failures += 1;
+    console.error(`FAIL ${label}${detail === undefined ? "" : `: ${detail}`}`);
+  }
+}
+
+const sessionId = "extension-notification-session";
+useSessionStore.setState({ bannerBySession: { [sessionId]: "Retrying (attempt 1)" } });
+
+const store = useSessionStore.getState();
+store.enqueueExtensionUiNotification(sessionId, {
+  message: "This extension requested an interactive dialog, which Pi Forge does not support.",
+  level: "warning",
+});
+store.enqueueExtensionUiNotification(sessionId, {
+  message: "Command feedback: normal",
+  level: "info",
+});
+
+let notifications = useSessionStore.getState().extensionNotificationsBySession[sessionId] ?? [];
+assert(
+  "queues consecutive extension notifications in arrival order",
+  notifications.length === 2 &&
+    notifications[0]?.level === "warning" &&
+    notifications[1]?.message === "Command feedback: normal",
+  JSON.stringify(notifications),
+);
+assert(
+  "does not overwrite the existing session banner",
+  useSessionStore.getState().bannerBySession[sessionId] === "Retrying (attempt 1)",
+);
+
+useSessionStore.getState().dismissExtensionUiNotification(sessionId);
+notifications = useSessionStore.getState().extensionNotificationsBySession[sessionId] ?? [];
+assert(
+  "dismissing the visible notification advances to the next notification",
+  notifications.length === 1 && notifications[0]?.message === "Command feedback: normal",
+  JSON.stringify(notifications),
+);
+
+useSessionStore.getState().dismissExtensionUiNotification(sessionId);
+assert(
+  "dismissing the final notification clears its queue",
+  useSessionStore.getState().extensionNotificationsBySession[sessionId] === undefined,
+);
+
+if (failures > 0) process.exit(1);
+console.log("[test-extension-ui-notifications] PASS");

--- a/tests/test-skill-commands.ts
+++ b/tests/test-skill-commands.ts
@@ -1,0 +1,259 @@
+/**
+ * Skill slash-command integration coverage.
+ *
+ * Verifies the server's live-session validation and SDK-native prompt form
+ * without requiring an LLM provider. The session prompt is replaced with a
+ * fixture after session creation so the test can assert fire-and-forget
+ * argument forwarding directly.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseSkillInvocation } from "../packages/client/src/lib/skill-command.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+interface JsonResponse {
+  status: number;
+  body: unknown;
+}
+
+async function send(
+  base: string,
+  method: "POST" | "PUT",
+  path: string,
+  body: unknown,
+): Promise<JsonResponse> {
+  const res = await fetch(`${base}${path}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  return { status: res.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+async function writeSkill(workspacePath: string, name: string): Promise<void> {
+  const directory = join(workspacePath, ".pi", "skills", name);
+  await mkdir(directory, { recursive: true });
+  await writeFile(
+    join(directory, "SKILL.md"),
+    [
+      "---",
+      `name: ${name}`,
+      `description: ${name} skill description.`,
+      "---",
+      "",
+      `Run the ${name} skill.`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+async function main(): Promise<void> {
+  const workspacePath = await mkdtemp(join(tmpdir(), "pi-forge-skill-command-ws-"));
+  const configDir = await mkdtemp(join(tmpdir(), "pi-forge-skill-command-cfg-"));
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-skill-command-data-"));
+  process.env.WORKSPACE_PATH = workspacePath;
+  process.env.PI_CONFIG_DIR = configDir;
+  process.env.FORGE_DATA_DIR = dataDir;
+  process.env.SESSION_DIR = join(workspacePath, ".pi", "sessions");
+  process.env.NODE_ENV = "test";
+  delete process.env.UI_PASSWORD;
+  delete process.env.JWT_SECRET;
+  delete process.env.API_KEY;
+
+  await writeSkill(workspacePath, "hello");
+
+  const { buildServer } = (await import(resolve(repoRoot, "packages/server/dist/index.js"))) as {
+    buildServer: () => Promise<{
+      listen: (opts: { port: number; host: string }) => Promise<string>;
+      close: () => Promise<void>;
+    }>;
+  };
+  const { getSession, disposeAllSessions } = (await import(
+    resolve(repoRoot, "packages/server/dist/session-registry.js")
+  )) as {
+    getSession: (id: string) => { session: unknown } | undefined;
+    disposeAllSessions: () => void;
+  };
+
+  const fastify = await buildServer();
+  const base = await fastify.listen({ port: 0, host: "127.0.0.1" });
+  try {
+    const project = await send(base, "POST", "/api/v1/projects", {
+      name: "skill-command-test",
+      path: workspacePath,
+    });
+    assert("create project → 201", project.status === 201, JSON.stringify(project.body));
+    const projectId = (project.body as { id: string }).id;
+
+    const created = await send(base, "POST", "/api/v1/sessions", { projectId });
+    assert("create session → 201", created.status === 201, JSON.stringify(created.body));
+    const sessionId = (created.body as { sessionId: string }).sessionId;
+    const live = getSession(sessionId);
+    if (live === undefined) throw new Error("created session was not registered as live");
+
+    let promptText: string | undefined;
+    let promptCalls = 0;
+    let reloadCalls = 0;
+    const runtimeKeys: string[] = [];
+    const fakeSession = {
+      model: { provider: "test", id: "test-model" },
+      modelRuntime: {
+        reloadConfig: async () => {
+          reloadCalls += 1;
+        },
+        setRuntimeApiKey: async (provider: string, apiKey: string) => {
+          runtimeKeys.push(`${provider}:${apiKey}`);
+        },
+        removeRuntimeApiKey: async () => undefined,
+        hasConfiguredAuth: () => true,
+      },
+      resourceLoader: {
+        getSkills: () => ({ skills: [{ name: "hello" }] }),
+      },
+      isStreaming: false,
+      prompt: async (text: string): Promise<void> => {
+        promptCalls += 1;
+        promptText = text;
+      },
+    };
+    (live as unknown as { session: typeof fakeSession }).session = fakeSession;
+
+    const configured = await send(base, "PUT", "/api/v1/config/auth/test", {
+      apiKey: "skill-test-key",
+    });
+    assert("configure test provider credential → 200", configured.status === 200);
+
+    const invoked = await send(base, "POST", `/api/v1/sessions/${sessionId}/skill`, {
+      name: "hello",
+      instructions: "first second",
+    });
+    assert(
+      "enabled live skill invocation → 202",
+      invoked.status === 202,
+      JSON.stringify(invoked.body),
+    );
+    assert(
+      "skill prompt runs normal runtime-auth preflight",
+      reloadCalls === 1 && runtimeKeys.includes("test:skill-test-key"),
+      JSON.stringify({ reloadCalls, runtimeKeys }),
+    );
+    assert(
+      "skill arguments forward through SDK-native slash command",
+      promptText === "/skill:hello first second",
+      String(promptText),
+    );
+
+    promptText = undefined;
+    promptCalls = 0;
+    fakeSession.isStreaming = true;
+    const rejectedStreaming = await send(base, "POST", `/api/v1/sessions/${sessionId}/skill`, {
+      name: "hello",
+    });
+    assert(
+      "streaming session skill invocation → 409",
+      rejectedStreaming.status === 409,
+      JSON.stringify(rejectedStreaming.body),
+    );
+    assert(
+      "streaming session has stable error code",
+      (rejectedStreaming.body as { error?: string }).error === "session_streaming",
+      JSON.stringify(rejectedStreaming.body),
+    );
+    assert("streaming session does not call SDK prompt", promptCalls === 0, String(promptCalls));
+    fakeSession.isStreaming = false;
+
+    const disabled = await send(
+      base,
+      "PUT",
+      `/api/v1/config/skills/hello/enabled?projectId=${projectId}`,
+      { enabled: false },
+    );
+    assert("disable skill → 200", disabled.status === 200, JSON.stringify(disabled.body));
+    const rejectedDisabled = await send(base, "POST", `/api/v1/sessions/${sessionId}/skill`, {
+      name: "hello",
+    });
+    assert(
+      "disabled skill → 409",
+      rejectedDisabled.status === 409,
+      JSON.stringify(rejectedDisabled.body),
+    );
+    assert(
+      "disabled skill has stable error code",
+      (rejectedDisabled.body as { error?: string }).error === "skill_not_effective",
+      JSON.stringify(rejectedDisabled.body),
+    );
+
+    const rejectedUnknown = await send(base, "POST", `/api/v1/sessions/${sessionId}/skill`, {
+      name: "missing",
+    });
+    assert(
+      "unknown skill → 404",
+      rejectedUnknown.status === 404,
+      JSON.stringify(rejectedUnknown.body),
+    );
+    assert(
+      "unknown skill has stable error code",
+      (rejectedUnknown.body as { error?: string }).error === "skill_not_found",
+      JSON.stringify(rejectedUnknown.body),
+    );
+
+    await writeSkill(workspacePath, "added-later");
+    const rejectedUnavailable = await send(base, "POST", `/api/v1/sessions/${sessionId}/skill`, {
+      name: "added-later",
+    });
+    assert(
+      "skill absent from the live resource loader → 409",
+      rejectedUnavailable.status === 409,
+      JSON.stringify(rejectedUnavailable.body),
+    );
+    assert(
+      "unavailable live skill has stable error code",
+      (rejectedUnavailable.body as { error?: string }).error === "skill_unavailable_in_session",
+      JSON.stringify(rejectedUnavailable.body),
+    );
+
+    const names = new Set(["hello"]);
+    const parsed = parseSkillInvocation("/skill:hello first second", names);
+    assert(
+      "client parser preserves argument-bearing exact skill invocation",
+      parsed?.name === "hello" && parsed.instructions === "first second",
+      JSON.stringify(parsed),
+    );
+    const multiline = parseSkillInvocation("/skill:hello first\nsecond", names);
+    assert(
+      "client parser preserves multiline skill instructions",
+      multiline?.name === "hello" && multiline.instructions === "first\nsecond",
+      JSON.stringify(multiline),
+    );
+    assert(
+      "client parser rejects unknown names",
+      parseSkillInvocation("/skill:missing arg", names) === undefined,
+    );
+  } finally {
+    disposeAllSessions();
+    await fastify.close();
+    await rm(workspacePath, { recursive: true, force: true });
+    await rm(configDir, { recursive: true, force: true });
+    await rm(dataDir, { recursive: true, force: true });
+  }
+
+  if (failures > 0) process.exitCode = 1;
+}
+
+void main();

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
     "noImplicitOverride": true,
     "noUncheckedIndexedAccess": true,
@@ -14,7 +14,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": ["node", "vite/client"]
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Please fill this in so reviewers can land
it quickly. See CONTRIBUTING.md for the full workflow. -->

## What this changes

Adds skill and SDK extension slash commands to the chat composer. Enabled skills use a validated, SDK-native `/skill:<name> [instructions]` flow; session-registered extension commands use the normal prompt path (including during streaming) and can emit dismissible Markdown feedback into the chat timeline.

## Type of change

- [ ] `fix:` bug fix (no API change)
- [x] `feat:` new feature
- [ ] `refactor:` internal change, no behavior difference
- [x] `docs:` documentation only
- [ ] `chore:` tooling, deps, build
- [x] `test:` adding or fixing tests
- [ ] `perf:` performance improvement

## Scope

- [x] Server (`packages/server/`)
- [x] Client (`packages/client/`)
- [x] Docker / deploy (`docker/`, `kubernetes/`)
- [x] Docs (`docs/`, `README.md`, root markdown)
- [x] Tests (`tests/`)

Server: adds documented skill invocation and extension-command listing routes, validates enabled/live skills, preserves exact extension input, and bridges extension UI feedback over authenticated SSE. Client: adds palette discovery/precedence, skill dispatch, and ordered transient timeline notifications. Docs include slash-command behavior, the `extension_ui_notification` SSE contract, generated site output, and the branch's related sandbox/deployment documentation updates.

## How to verify

```bash
npm run build
npm run check
npx tsx tests/test-skill-commands.ts
npx tsx tests/test-extension-commands.ts
npx tsx tests/test-extension-ui-notifications.ts
```

Verified results: `npm run build` and the three focused test scripts passed. The focused tests cover skill preflight/validation and streaming rejection; live and cold-session extension command discovery/dispatch, streaming dispatch, dialog fallback, rename fan-out, and SSE notification delivery; plus notification ordering, Markdown timeline placement, dismissal, and canonical-transcript isolation.

## Screenshots / recordings (UI changes only)

No visual assets attached.

## Risk and rollback

Extension commands intentionally bypass model/auth preflight and may run while a session streams, but only when registered on that live session. Browser UI support is limited to notifications; interactive extension dialogs receive a warning fallback. Notifications are browser-session-only and are not persisted. Roll back by reverting this PR; no migration, environment, or session-format change is required.

## Checklist

- [x] Atomic commit(s) — one logical change per commit, conventional-commit prefix
- [x] No `Co-Authored-By` lines or AI-attribution trailers (per [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] `npm run check` passes (`tsc` + `eslint` + `prettier --check`) — run in CI / before merge
- [x] `npm run build` passes
- [x] Relevant `tests/test-*.ts` script run and passing
- [x] New/changed routes have JSON Schema (`schema.body`, `schema.response`, `schema.tags`) so they show up in `/api/docs`
- [x] No `process.env.*` reads outside `packages/server/src/config.ts`
- [x] No direct `fs.*` calls in route handlers (goes through `file-manager.ts` / `git-runner.ts`)
- [x] No raw `fetch()` in components (goes through `lib/api-client.ts`)
- [ ] Default exports — none added (project convention is named exports) — verify during review
- [ ] If changing config files / env vars, updated [`docs/configuration.md`](../docs/configuration.md) and the env vars table in [`README.md`](../README.md)
- [x] If changing the SSE event surface, updated [`docs/sse-events.md`](../docs/sse-events.md)
- [ ] If adding a new HTTP route, updated [`docs/api-examples.md`](../docs/api-examples.md) where useful

## Notes for reviewers

Please focus on dispatch precedence: an exact enabled `/skill:<name>` stays on the validated skill path, while a registered extension command wins over a colliding forge UI command. Also review that extension feedback remains ordered and dismissible without entering Pi's canonical transcript, and that `docs/sse-events.md` and generated site anchors match the emitted SSE payload.
