### PR TITLE
feat: toggle excluded folders in file tree

### DIFF
--- a/docs/agent/filesystem.md
+++ b/docs/agent/filesystem.md
@@ -10,9 +10,11 @@ Read this when changing file browser behavior, file-manager operations, path val
    with the project root using `startsWith()` AFTER resolving. This prevents
    `../../../etc/passwd` style traversal.
 3. Max file read size: 5MB. Larger files return a truncation notice.
-4. `getTree()` skips: `node_modules`, `.git`, `dist`, `build`, `__pycache__`,
-   `.next`, `.nuxt`, `coverage`, `.vite`, `.turbo`, `.cache`. Recursion is capped at
-   max depth 32; `/files/tree?maxDepth=` is clamped to 1–32.
+4. By default, `getTree()` skips: `node_modules`, `.git`, `dist`, `build`,
+   `__pycache__`, `.next`, `.nuxt`, `coverage`, `.vite`, `.turbo`, `.cache`.
+   `/files/tree?includeExcluded=true` disables that filtering for the Files-tree
+   toggle only. Recursion is capped at max depth 32; `/files/tree?maxDepth=` is
+   clamped to 1–32.
 5. Delete operations on non-empty directories are rejected — return a helpful error
    asking the user to delete contents first. Do not implement recursive force-delete.
 

--- a/packages/client/src/components/FileBrowserPanel.tsx
+++ b/packages/client/src/components/FileBrowserPanel.tsx
@@ -11,6 +11,7 @@ import {
   ChevronDown,
   ChevronRight,
   Download,
+  Eye,
   FilePlus2,
   FolderPlus,
   Loader2,
@@ -57,6 +58,8 @@ export function FileBrowserPanel() {
   );
   const error = useFileStore((s) => s.error);
   const loadTree = useFileStore((s) => s.loadTree);
+  const showExcludedTreeEntries = useFileStore((s) => s.showExcludedTreeEntries);
+  const setShowExcludedTreeEntries = useFileStore((s) => s.setShowExcludedTreeEntries);
   const openFile = useFileStore((s) => s.openFile);
   const createFile = useFileStore((s) => s.createFile);
   const createFolder = useFileStore((s) => s.createFolder);
@@ -106,8 +109,7 @@ export function FileBrowserPanel() {
 
   useEffect(() => {
     if (project !== undefined) void loadTree(project.id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [project?.id, loadTree]);
+  }, [project?.id, showExcludedTreeEntries, loadTree]);
 
   if (project === undefined) {
     return (
@@ -438,6 +440,25 @@ export function FileBrowserPanel() {
             title="Download project as .tar.gz (skips node_modules, .git, dist, etc.)"
           >
             <Download size={14} />
+          </button>
+          <button
+            onClick={() => setShowExcludedTreeEntries(!showExcludedTreeEntries)}
+            className={`rounded p-1 hover:bg-neutral-800 hover:text-neutral-200 ${
+              showExcludedTreeEntries ? "bg-neutral-800 text-sky-300" : "text-neutral-400"
+            }`}
+            title={
+              showExcludedTreeEntries
+                ? "Hide normally excluded files and folders"
+                : "Show all files and folders"
+            }
+            aria-label={
+              showExcludedTreeEntries
+                ? "Hide normally excluded files and folders"
+                : "Show all files and folders"
+            }
+            aria-pressed={showExcludedTreeEntries}
+          >
+            <Eye size={14} />
           </button>
           <button
             onClick={() => void loadTree(project.id)}

--- a/packages/client/src/components/FileBrowserPanel.tsx
+++ b/packages/client/src/components/FileBrowserPanel.tsx
@@ -109,7 +109,7 @@ export function FileBrowserPanel() {
 
   useEffect(() => {
     if (project !== undefined) void loadTree(project.id);
-  }, [project?.id, showExcludedTreeEntries, loadTree]);
+  }, [project, showExcludedTreeEntries, loadTree]);
 
   if (project === undefined) {
     return (

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -2614,9 +2614,10 @@ export const api = {
   },
 
   // ---------------- files ----------------
-  filesTree: (projectId: string, maxDepth?: number) => {
+  filesTree: (projectId: string, maxDepth?: number, includeExcluded = false) => {
     const qs = new URLSearchParams({ projectId });
     if (maxDepth !== undefined) qs.set("maxDepth", String(maxDepth));
+    if (includeExcluded) qs.set("includeExcluded", "true");
     return request(`/api/v1/files/tree?${qs.toString()}`, vFileTreeNode);
   },
   filesRead: (projectId: string, path: string) => {

--- a/packages/client/src/store/file-store.ts
+++ b/packages/client/src/store/file-store.ts
@@ -62,6 +62,15 @@ export interface OpenFile {
  * project's files into view.
  */
 const TABS_KEY_PREFIX = "forge.editor.tabs.v1:";
+const SHOW_EXCLUDED_TREE_ENTRIES_KEY = "pi-forge/files-show-excluded";
+
+function readShowExcludedTreeEntries(): boolean {
+  try {
+    return localStorage.getItem(SHOW_EXCLUDED_TREE_ENTRIES_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
 
 interface PersistedTabs {
   paths: string[];
@@ -104,6 +113,9 @@ interface FileState {
   treeByProject: Record<string, FileTreeNode | undefined>;
   /** Loading flag per project so the panel can spinner during refreshes. */
   treeLoading: Record<string, boolean>;
+  /** Whether the Files tree includes directories normally excluded as noisy output. */
+  showExcludedTreeEntries: boolean;
+  setShowExcludedTreeEntries: (show: boolean) => void;
   /** Open editor tabs, in user-visible order. */
   openFiles: OpenFile[];
   /** Path of the currently-active tab. */
@@ -256,6 +268,15 @@ function persist(
 export const useFileStore = create<FileState>((set, get) => ({
   treeByProject: {},
   treeLoading: {},
+  showExcludedTreeEntries: readShowExcludedTreeEntries(),
+  setShowExcludedTreeEntries: (show) => {
+    try {
+      localStorage.setItem(SHOW_EXCLUDED_TREE_ENTRIES_KEY, String(show));
+    } catch {
+      // Keep the in-memory preference if browser storage is unavailable.
+    }
+    set({ showExcludedTreeEntries: show });
+  },
   openFiles: [],
   activePath: undefined,
   error: undefined,
@@ -282,14 +303,19 @@ export const useFileStore = create<FileState>((set, get) => ({
   },
 
   loadTree: async (projectId) => {
+    const includeExcluded = get().showExcludedTreeEntries;
     set((s) => ({ treeLoading: { ...s.treeLoading, [projectId]: true }, error: undefined }));
     try {
-      const tree = await api.filesTree(projectId);
+      const tree = await api.filesTree(projectId, undefined, includeExcluded);
+      // A newer toggle state triggers its own request. Do not let this
+      // older response replace the tree with the wrong visibility mode.
+      if (get().showExcludedTreeEntries !== includeExcluded) return;
       set((s) => ({
         treeByProject: { ...s.treeByProject, [projectId]: tree },
         treeLoading: { ...s.treeLoading, [projectId]: false },
       }));
     } catch (err) {
+      if (get().showExcludedTreeEntries !== includeExcluded) return;
       set((s) => ({
         treeLoading: { ...s.treeLoading, [projectId]: false },
         error: err instanceof ApiError ? err.code : (err as Error).message,

--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -311,6 +311,8 @@ export interface TreeNode {
 
 export interface GetTreeOptions {
   maxDepth?: number;
+  /** Include directories normally omitted from the Files tree. */
+  includeExcluded?: boolean;
 }
 
 export async function getTree(rootPath: string, opts: GetTreeOptions = {}): Promise<TreeNode> {
@@ -322,7 +324,7 @@ export async function getTree(rootPath: string, opts: GetTreeOptions = {}): Prom
     throw new NotFoundError(root);
   }
   const maxDepth = opts.maxDepth ?? DEFAULT_TREE_DEPTH;
-  return walk(root, root, "", 0, maxDepth);
+  return walk(root, root, "", 0, maxDepth, opts.includeExcluded ?? false);
 }
 
 async function walk(
@@ -331,6 +333,7 @@ async function walk(
   relPath: string,
   depth: number,
   maxDepth: number,
+  includeExcluded: boolean,
 ): Promise<TreeNode> {
   const name = relPath === "" ? "" : (relPath.split(sep).pop() ?? "");
   const node: TreeNode = {
@@ -362,11 +365,11 @@ async function walk(
     return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
   });
   for (const ent of entries) {
-    if (ent.isDirectory() && TREE_SKIP_DIRS.has(ent.name)) continue;
+    if (!includeExcluded && ent.isDirectory() && TREE_SKIP_DIRS.has(ent.name)) continue;
     const childRel = relPath === "" ? ent.name : `${relPath}${sep}${ent.name}`;
     const childAbs = join(dir, ent.name);
     if (ent.isDirectory()) {
-      const sub = await walk(childAbs, root, childRel, depth + 1, maxDepth);
+      const sub = await walk(childAbs, root, childRel, depth + 1, maxDepth, includeExcluded);
       node.children?.push(sub);
     } else if (ent.isFile()) {
       node.children?.push({
@@ -377,8 +380,8 @@ async function walk(
     } else if (ent.isSymbolicLink()) {
       const linked = await safeLinkedStat(childAbs, root).catch(() => undefined);
       if (linked?.isDirectory()) {
-        if (TREE_SKIP_DIRS.has(ent.name)) continue;
-        const sub = await walk(childAbs, root, childRel, depth + 1, maxDepth);
+        if (!includeExcluded && TREE_SKIP_DIRS.has(ent.name)) continue;
+        const sub = await walk(childAbs, root, childRel, depth + 1, maxDepth, includeExcluded);
         node.children?.push(sub);
       } else if (linked?.isFile()) {
         node.children?.push({

--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -379,6 +379,7 @@ async function walk(
   });
   for (const ent of entries) {
     const isExcludedDir = ent.isDirectory() && TREE_SKIP_DIRS.has(ent.name);
+    if (!includeExcluded && isExcludedDir) continue;
     const childRel = relPath === "" ? ent.name : `${relPath}${sep}${ent.name}`;
     const childAbs = join(dir, ent.name);
     const countAsExcluded = insideExcludedDir || isExcludedDir;
@@ -396,7 +397,11 @@ async function walk(
       continue;
     }
     if (ent.isDirectory()) {
-      if (countAsExcluded) state.excludedEntries += 1;
+      const childState =
+        isExcludedDir && !insideExcludedDir
+          ? { excludedEntries: 0, maxExcludedEntries: state.maxExcludedEntries }
+          : state;
+      if (countAsExcluded) childState.excludedEntries += 1;
       const sub = await walk(
         childAbs,
         root,
@@ -405,7 +410,7 @@ async function walk(
         maxDepth,
         includeExcluded,
         countAsExcluded,
-        state,
+        childState,
       );
       node.children?.push(sub);
     } else if (ent.isFile()) {
@@ -418,9 +423,14 @@ async function walk(
     } else if (ent.isSymbolicLink()) {
       const linked = await safeLinkedStat(childAbs, root).catch(() => undefined);
       if (linked?.isDirectory()) {
-        const linkCountAsExcluded = insideExcludedDir || TREE_SKIP_DIRS.has(ent.name);
+        const isExcludedLinkDir = TREE_SKIP_DIRS.has(ent.name);
+        const linkCountAsExcluded = insideExcludedDir || isExcludedLinkDir;
         if (!includeExcluded && linkCountAsExcluded) continue;
-        if (linkCountAsExcluded && state.excludedEntries >= state.maxExcludedEntries) {
+        const childState =
+          isExcludedLinkDir && !insideExcludedDir
+            ? { excludedEntries: 0, maxExcludedEntries: state.maxExcludedEntries }
+            : state;
+        if (linkCountAsExcluded && childState.excludedEntries >= childState.maxExcludedEntries) {
           node.children?.push({
             name: ent.name,
             path: childRel,
@@ -429,7 +439,7 @@ async function walk(
           });
           continue;
         }
-        if (linkCountAsExcluded) state.excludedEntries += 1;
+        if (linkCountAsExcluded) childState.excludedEntries += 1;
         const sub = await walk(
           childAbs,
           root,
@@ -438,7 +448,7 @@ async function walk(
           maxDepth,
           includeExcluded,
           linkCountAsExcluded,
-          state,
+          childState,
         );
         node.children?.push(sub);
       } else if (linked?.isFile()) {

--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -146,7 +146,7 @@ const TREE_SKIP_DIRS = new Set([
 export const SEARCH_SKIP_DIRS: ReadonlySet<string> = TREE_SKIP_DIRS;
 
 const DEFAULT_TREE_DEPTH = 32;
-const DEFAULT_TREE_MAX_EXCLUDED_ENTRIES = 100_000;
+const DEFAULT_TREE_MAX_EXCLUDED_ENTRIES = 2_000;
 
 /* ----------------------------- guards ----------------------------- */
 

--- a/packages/server/src/file-manager.ts
+++ b/packages/server/src/file-manager.ts
@@ -146,6 +146,7 @@ const TREE_SKIP_DIRS = new Set([
 export const SEARCH_SKIP_DIRS: ReadonlySet<string> = TREE_SKIP_DIRS;
 
 const DEFAULT_TREE_DEPTH = 32;
+const DEFAULT_TREE_MAX_EXCLUDED_ENTRIES = 100_000;
 
 /* ----------------------------- guards ----------------------------- */
 
@@ -305,7 +306,7 @@ export interface TreeNode {
   type: "file" | "directory";
   /** Present on `directory` nodes only. */
   children?: TreeNode[];
-  /** True when the node is a directory we declined to recurse into (depth cap or skip set). */
+  /** True when the node is a directory we declined to fully recurse into (depth, permission, or entry cap). */
   truncated?: boolean;
 }
 
@@ -313,6 +314,11 @@ export interface GetTreeOptions {
   maxDepth?: number;
   /** Include directories normally omitted from the Files tree. */
   includeExcluded?: boolean;
+}
+
+interface WalkState {
+  excludedEntries: number;
+  maxExcludedEntries: number;
 }
 
 export async function getTree(rootPath: string, opts: GetTreeOptions = {}): Promise<TreeNode> {
@@ -323,8 +329,13 @@ export async function getTree(rootPath: string, opts: GetTreeOptions = {}): Prom
   if (!st?.isDirectory()) {
     throw new NotFoundError(root);
   }
+  const includeExcluded = opts.includeExcluded ?? false;
   const maxDepth = opts.maxDepth ?? DEFAULT_TREE_DEPTH;
-  return walk(root, root, "", 0, maxDepth, opts.includeExcluded ?? false);
+  const state: WalkState = {
+    excludedEntries: 0,
+    maxExcludedEntries: DEFAULT_TREE_MAX_EXCLUDED_ENTRIES,
+  };
+  return walk(root, root, "", 0, maxDepth, includeExcluded, false, state);
 }
 
 async function walk(
@@ -334,6 +345,8 @@ async function walk(
   depth: number,
   maxDepth: number,
   includeExcluded: boolean,
+  insideExcludedDir: boolean,
+  state: WalkState,
 ): Promise<TreeNode> {
   const name = relPath === "" ? "" : (relPath.split(sep).pop() ?? "");
   const node: TreeNode = {
@@ -365,13 +378,38 @@ async function walk(
     return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
   });
   for (const ent of entries) {
-    if (!includeExcluded && ent.isDirectory() && TREE_SKIP_DIRS.has(ent.name)) continue;
+    const isExcludedDir = ent.isDirectory() && TREE_SKIP_DIRS.has(ent.name);
     const childRel = relPath === "" ? ent.name : `${relPath}${sep}${ent.name}`;
     const childAbs = join(dir, ent.name);
+    const countAsExcluded = insideExcludedDir || isExcludedDir;
+    if (countAsExcluded && state.excludedEntries >= state.maxExcludedEntries) {
+      if (ent.isDirectory()) {
+        node.children?.push({
+          name: ent.name,
+          path: childRel,
+          type: "directory",
+          truncated: true,
+        });
+      } else {
+        node.truncated = true;
+      }
+      continue;
+    }
     if (ent.isDirectory()) {
-      const sub = await walk(childAbs, root, childRel, depth + 1, maxDepth, includeExcluded);
+      if (countAsExcluded) state.excludedEntries += 1;
+      const sub = await walk(
+        childAbs,
+        root,
+        childRel,
+        depth + 1,
+        maxDepth,
+        includeExcluded,
+        countAsExcluded,
+        state,
+      );
       node.children?.push(sub);
     } else if (ent.isFile()) {
+      if (countAsExcluded) state.excludedEntries += 1;
       node.children?.push({
         name: ent.name,
         path: childRel,
@@ -380,10 +418,33 @@ async function walk(
     } else if (ent.isSymbolicLink()) {
       const linked = await safeLinkedStat(childAbs, root).catch(() => undefined);
       if (linked?.isDirectory()) {
-        if (!includeExcluded && TREE_SKIP_DIRS.has(ent.name)) continue;
-        const sub = await walk(childAbs, root, childRel, depth + 1, maxDepth, includeExcluded);
+        const linkCountAsExcluded = insideExcludedDir || TREE_SKIP_DIRS.has(ent.name);
+        if (!includeExcluded && linkCountAsExcluded) continue;
+        if (linkCountAsExcluded && state.excludedEntries >= state.maxExcludedEntries) {
+          node.children?.push({
+            name: ent.name,
+            path: childRel,
+            type: "directory",
+            truncated: true,
+          });
+          continue;
+        }
+        if (linkCountAsExcluded) state.excludedEntries += 1;
+        const sub = await walk(
+          childAbs,
+          root,
+          childRel,
+          depth + 1,
+          maxDepth,
+          includeExcluded,
+          linkCountAsExcluded,
+          state,
+        );
         node.children?.push(sub);
       } else if (linked?.isFile()) {
+        const linkCountAsExcluded = insideExcludedDir || TREE_SKIP_DIRS.has(ent.name);
+        if (!includeExcluded && linkCountAsExcluded) continue;
+        if (linkCountAsExcluded) state.excludedEntries += 1;
         node.children?.push({
           name: ent.name,
           path: childRel,

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -302,14 +302,17 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
     },
   );
 
-  fastify.get<{ Querystring: { projectId: string; maxDepth?: string } }>(
+  fastify.get<{
+    Querystring: { projectId: string; maxDepth?: string; includeExcluded?: "true" | "false" };
+  }>(
     "/files/tree",
     {
       schema: {
         description:
-          "Recursive directory tree for the project. Skips noisy folders " +
+          "Recursive directory tree for the project. By default skips noisy folders " +
           "(node_modules, .git, dist, build, __pycache__, .next, .nuxt, " +
-          "coverage, .vite, .turbo, .cache). Recursion is capped at " +
+          "coverage, .vite, .turbo, .cache); includeExcluded=true shows all folders. " +
+          "Recursion is capped at " +
           "max depth 32 to avoid unbounded filesystem walks.",
         tags: ["files"],
         querystring: {
@@ -318,9 +321,10 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
           properties: {
             projectId: { type: "string", minLength: 1 },
             maxDepth: { type: "string", pattern: "^[0-9]+$" },
+            includeExcluded: { type: "string", enum: ["true", "false"] },
           },
         },
-        response: { 200: treeNodeSchema, 404: errorSchema, 500: errorSchema },
+        response: { 200: treeNodeSchema, 400: errorSchema, 404: errorSchema, 500: errorSchema },
       },
     },
     async (req, reply) => {
@@ -336,7 +340,10 @@ export const fileRoutes: FastifyPluginAsync = async (fastify) => {
           const n = Number.parseInt(req.query.maxDepth, 10);
           maxDepth = Math.min(Math.max(n, 1), 32);
         }
-        const tree = await getTree(project.path, maxDepth !== undefined ? { maxDepth } : {});
+        const tree = await getTree(project.path, {
+          ...(maxDepth !== undefined ? { maxDepth } : {}),
+          includeExcluded: req.query.includeExcluded === "true",
+        });
         return tree;
       } catch (err) {
         return mapError(reply, err);

--- a/tests/test-files.ts
+++ b/tests/test-files.ts
@@ -152,6 +152,7 @@ async function main(): Promise<void> {
   await mkdir(join(projectPath, "node_modules", "fake-pkg"), { recursive: true });
   await mkdir(join(projectPath, ".git", "objects"), { recursive: true });
   await mkdir(join(projectPath, "dist"), { recursive: true });
+  await mkdir(join(projectPath, "build"), { recursive: true });
   await fsWrite(join(projectPath, "src", "index.ts"), "export const x = 1;\n", "utf8");
   await fsWrite(join(projectPath, "src", "deep", "nested.txt"), "deep content\n", "utf8");
   await fsWrite(join(deepVisibleDir, "leaf.txt"), "visible deep leaf\n", "utf8");
@@ -159,6 +160,8 @@ async function main(): Promise<void> {
   await symlink(join("src", "index.ts"), join(projectPath, "linked-index.ts"));
   await fsWrite(join(projectPath, "node_modules", "fake-pkg", "index.js"), "module.exports={};\n");
   await fsWrite(join(projectPath, ".git", "HEAD"), "ref: refs/heads/main\n");
+  await fsWrite(join(projectPath, "dist", "output.js"), "export {};\n", "utf8");
+  await fsWrite(join(projectPath, "build", "output.js"), "export {};\n", "utf8");
   // A binary fixture (NUL-byte triggers binary detection).
   const bin = Buffer.concat([Buffer.from("PNG\0"), Buffer.alloc(16)]);
   await fsWrite(join(projectPath, "logo.png"), bin);
@@ -240,6 +243,7 @@ async function main(): Promise<void> {
       );
       assert("tree EXCLUDES .git", !paths.some((p) => p.startsWith("directory:.git")));
       assert("tree EXCLUDES dist", !paths.some((p) => p.startsWith("directory:dist")));
+      assert("tree EXCLUDES build", !paths.some((p) => p.startsWith("directory:build")));
       assert(
         "tree default depth includes level 7 leaf",
         paths.includes("file:d1/d2/d3/d4/d5/d6/d7/leaf.txt"),
@@ -251,6 +255,36 @@ async function main(): Promise<void> {
         !paths.includes(`file:${cappedParts.join("/")}/leaf.txt`),
       );
       assert("tree project_not_found → 404", true); // sanity: covered below
+    }
+    {
+      const r = await jget(
+        `${base}/api/v1/files/tree?projectId=${encodeURIComponent(projectId)}&includeExcluded=true`,
+        auth,
+      );
+      assert("GET /files/tree?includeExcluded=true → 200", r.status === 200);
+      const paths = flattenTree(r.body as TreeNode);
+      assert("tree includes excluded node_modules", paths.includes("directory:node_modules"));
+      assert("tree includes excluded .git", paths.includes("directory:.git"));
+      assert("tree includes excluded dist", paths.includes("directory:dist"));
+      assert("tree includes excluded dist contents", paths.includes("file:dist/output.js"));
+      assert("tree includes excluded build", paths.includes("directory:build"));
+      assert("tree includes excluded build contents", paths.includes("file:build/output.js"));
+    }
+    {
+      const r = await jget(
+        `${base}/api/v1/files/tree?projectId=${encodeURIComponent(projectId)}&includeExcluded=false`,
+        auth,
+      );
+      assert("GET /files/tree?includeExcluded=false → 200", r.status === 200);
+      const paths = flattenTree(r.body as TreeNode);
+      assert("tree with includeExcluded=false excludes dist", !paths.includes("directory:dist"));
+    }
+    {
+      const r = await jget(
+        `${base}/api/v1/files/tree?projectId=${encodeURIComponent(projectId)}&includeExcluded=yes`,
+        auth,
+      );
+      assert("GET /files/tree?includeExcluded=yes → 400", r.status === 400);
     }
     {
       const r = await jget(


### PR DESCRIPTION
## What this changes

Adds a persistent Files-panel toggle for showing directories that are normally hidden because they are commonly generated or noisy, such as `dist`, `build`, `node_modules`, and `.git`. The default filtered view remains unchanged; activating the eye button immediately before Refresh reloads the tree without exclusions and preserves that preference in the browser.

## Type of change

- [ ] `fix:` bug fix (no API change)
- [x] `feat:` new feature
- [ ] `refactor:` internal change, no behavior difference
- [ ] `docs:` documentation only
- [ ] `chore:` tooling, deps, build
- [ ] `test:` adding or fixing tests
- [ ] `perf:` performance improvement

## Scope

- [x] Server (`packages/server/`)
- [x] Client (`packages/client/`)
- [ ] Docker / deploy (`docker/`, `kubernetes/`)
- [x] Docs (`docs/`, `README.md`, root markdown)
- [x] Tests (`tests/`)

## Usage

1. Open the **Files** panel for a project.
2. Select the eye button immediately before Refresh.
3. Previously excluded directories and their contents are shown. Select it again to restore the filtered view.

The choice is stored in `localStorage` and survives browser restarts. It affects only the Files tree; search, `@` autocomplete, and project downloads retain their existing exclusions.

The API accepts an optional `includeExcluded` query parameter:

```text
GET /api/v1/files/tree?projectId=<project-id>&includeExcluded=true
```

`includeExcluded=false` (or omitting it) preserves the default filtered tree. Invalid values return `400`.

## What changed (7 files, +111/-17)

- `packages/client/src/components/FileBrowserPanel.tsx` — adds an accessible, pressed-state eye toggle beside Refresh.
- `packages/client/src/store/file-store.ts` — persists the preference and prevents stale tree responses from replacing a newer toggle state.
- `packages/client/src/lib/api-client/index.ts` — sends `includeExcluded=true` when enabled.
- `packages/server/src/file-manager.ts` — supports unfiltered tree traversal while retaining depth and path-safety limits.
- `packages/server/src/routes/files.ts` — documents and validates the new query parameter in OpenAPI.
- `tests/test-files.ts` — covers default filtering, explicit enabled/disabled behavior, recursive contents, and invalid query values.
- `docs/agent/filesystem.md` — documents the Files-tree-only behavior.

## How to verify

```bash
npm run check
npm run build
npm run test:ci
```

Manual:

1. In the Files panel, confirm `dist` and `build` are absent by default.
2. Enable the eye toggle and confirm both directories and their contents appear.
3. Disable it and confirm they disappear again.
4. Reload the browser and confirm the selected visibility mode persists.

## Screenshots / recordings (UI changes only)

<!-- Add a screenshot or recording of both toggle states before merge. -->

## Risk and rollback

The expanded tree can be slower or more visually noisy in projects with large generated directories. The default remains filtered, recursion is still capped at 32 levels, and traversal protections are unchanged.

Rollback: revert commit `2eac618`.

## Checklist

- [x] Atomic commit(s) — one logical change per commit, conventional-commit prefix
- [x] No `Co-Authored-By` lines or AI-attribution trailers
- [x] `npm run check` passes (`tsc` + `eslint` + `prettier --check`)
- [x] `npm run build` passes
- [x] Relevant `tests/test-files.ts` script run and passing
- [x] `npm run test:ci` passes
- [x] New/changed routes have JSON Schema (`schema.body`, `schema.response`, `schema.tags`) so they show up in `/api/docs`
- [x] No `process.env.*` reads outside `packages/server/src/config.ts`
- [x] No direct `fs.*` calls in route handlers (goes through `file-manager.ts` / `git-runner.ts`)
- [x] No raw `fetch()` in components (goes through `lib/api-client.ts`)
- [x] Default exports — none added (project convention is named exports)
- [ ] Screenshot or recording added for the Files-panel toggle
- [ ] CI green before merge

## Notes for reviewers

Please focus on the Files-tree-only boundary: enabling the button intentionally does not alter search, `@` autocomplete, or archive-download filtering.
