### PR TITLE
fix(theme): preserve palette selection contrast

### DIFF
--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -1994,7 +1994,10 @@ export function ChatInput({ sessionId }: Props) {
                       }}
                       onMouseEnter={() => setSlashSelectedIdx(i)}
                       disabled={!cmd.available}
-                      className={`block w-full px-3 py-2.5 text-left text-[14px] md:py-1 md:text-[12px] ${
+                      data-forge-palette-active={
+                        i === slashSelectedIdx && cmd.available ? "true" : "false"
+                      }
+                      className={`forge-palette-item block w-full px-3 py-2.5 text-left text-[14px] md:py-1 md:text-[12px] ${
                         i === slashSelectedIdx && cmd.available
                           ? "bg-neutral-800 text-neutral-100"
                           : "text-neutral-300 hover:bg-neutral-900/80"
@@ -2044,7 +2047,8 @@ export function ChatInput({ sessionId }: Props) {
                         acInsert(path);
                       }}
                       onMouseEnter={() => setAcSelectedIdx(i)}
-                      className={`block w-full truncate px-3 py-2.5 text-left font-mono text-[14px] md:py-1 md:text-[12px] ${
+                      data-forge-palette-active={i === acSelectedIdx ? "true" : "false"}
+                      className={`forge-palette-item block w-full truncate px-3 py-2.5 text-left font-mono text-[14px] md:py-1 md:text-[12px] ${
                         i === acSelectedIdx
                           ? "bg-neutral-800 text-neutral-100"
                           : "text-neutral-300 hover:bg-neutral-900/80"

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -186,6 +186,27 @@
   color: var(--forge-text-primary);
 }
 
+/* The generic composer button rule above makes every button use the panel
+   surface. Palette rows are an interactive exception: a mouse hover and the
+   keyboard-selected row must use the separately configurable highlight pair.
+   Apply the text color to descendants too because their Tailwind text classes
+   otherwise override the button's inherited foreground under a server theme. */
+[data-server-theme="on"]
+  .forge-chat-input-root
+  .forge-palette-item[data-forge-palette-active="true"],
+[data-server-theme="on"] .forge-chat-input-root .forge-palette-item:not(:disabled):hover {
+  background-color: var(--forge-highlight-bg) !important;
+  color: var(--forge-highlight-text) !important;
+}
+
+[data-server-theme="on"]
+  .forge-chat-input-root
+  .forge-palette-item[data-forge-palette-active="true"]
+  *,
+[data-server-theme="on"] .forge-chat-input-root .forge-palette-item:not(:disabled):hover * {
+  color: var(--forge-highlight-text) !important;
+}
+
 [data-server-theme="on"] .message-bubble[data-message-role="user"] {
   background: var(--forge-user-bubble-bg);
   color: var(--forge-text-primary);


### PR DESCRIPTION
## What this changes

Fixes invisible keyboard and hover selection in the slash-command palette and `@` file autocomplete when global custom colors are enabled. The composer-wide custom-theme rule applied `Panel background` to every button, overriding the palettes' active-row styles. Active and hoverable palette rows now use the configured `Highlight background` and `Highlight text` colors instead.

## Type of change

- [x] `fix:` bug fix (no API change)
- [ ] `feat:` new feature
- [ ] `refactor:` internal change, no behavior difference
- [ ] `docs:` documentation only
- [ ] `chore:` tooling, deps, build
- [ ] `test:` adding or fixing tests
- [ ] `perf:` performance improvement

## Scope

- [ ] Server (`packages/server/`)
- [x] Client (`packages/client/`)
- [ ] Docker / deploy (`docker/`, `kubernetes/`)
- [ ] Docs (`docs/`, `README.md`, root markdown)
- [ ] Tests (`tests/`)

## Usage

1. Open **Settings → Appearance** and enable global custom colors.
2. Set contrasting values for **Panel background**, **Highlight background**, and **Highlight text**.
3. Type `/` in the chat composer, then use arrow keys or hover a command.
4. Type `@` followed by a file query and repeat the selection check.

The selected or hovered, enabled row must use the configured highlight pair. Disabled slash commands remain dimmed and do not receive the hover highlight.

## What changed (2 files, +27/-2)

- `packages/client/src/components/ChatInput.tsx` — marks active rows in slash-command and `@` completion palettes with a stable palette-item hook.
- `packages/client/src/index.css` — applies the server theme's highlight foreground/background only to active or enabled-hovered palette items, including their nested labels; ordinary composer buttons retain panel styling.

## How to verify

```bash
npm run check
npm run build
```

Manual:

1. Enable global custom colors with `Panel background` visibly different from `Highlight background`.
2. In the slash-command palette, use arrow keys and mouse hover; the selected entry must remain clearly visible.
3. Repeat with `@` autocomplete.
4. Disable custom colors and confirm the normal theme behavior is unchanged.

## Screenshots / recordings (UI changes only)

<!-- Add before/after screenshots or a short recording showing keyboard navigation and hover with global custom colors enabled. -->

## Risk and rollback

Scope is limited to palette rows within the chat composer while global custom colors are enabled. No server API, persisted data, or deployment configuration changes.

Rollback: revert commit `67be16a`.

## Checklist

- [x] Atomic commit(s) — one logical change per commit, conventional-commit prefix
- [x] No `Co-Authored-By` lines or AI-attribution trailers
- [x] `npm run check` passes (`tsc` + `eslint` + `prettier --check`)
- [x] `npm run build` passes
- [x] No new/changed HTTP routes
- [x] No `process.env.*` reads outside `packages/server/src/config.ts`
- [x] No raw `fetch()` in components
- [x] Default exports — none added
- [ ] Screenshot or recording added
- [ ] CI green before merge

## Notes for reviewers

Please verify selector scope and specificity: the highlight override must beat the generic custom-theme composer button rule, but must not affect Send, Abort, attachment, or other non-palette buttons.
