### PR TITLE
Feat/session activity indicator

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -75,6 +75,14 @@ export function App() {
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
 
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
+  const openActivityStream = useSessionStore((s) => s.openActivityStream);
+  const closeActivityStream = useSessionStore((s) => s.closeActivityStream);
+
+  useEffect(() => {
+    if (!isAuthenticated || mustChangePassword) return;
+    openActivityStream();
+    return closeActivityStream;
+  }, [isAuthenticated, mustChangePassword, openActivityStream, closeActivityStream]);
 
   /* Mobile drawer state. The sidebar slides off-screen at < 768 px and
      reappears via the hamburger button OR a left-edge swipe gesture.

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -5,7 +5,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
-import { ChevronDown, ChevronRight, X } from "lucide-react";
+import { ChevronDown, ChevronRight, LoaderCircle, X } from "lucide-react";
 import { EMPTY_SESSIONS, useSessionStore } from "../store/session-store";
 import { useProjectStore } from "../store/project-store";
 import { ConfirmDialog } from "./Modal";
@@ -27,6 +27,7 @@ export function SessionList({ projectId }: Props) {
   // for why we don't write `?? []` directly in Zustand selectors.
   const sessions = useSessionStore((s) => s.byProject[projectId] ?? EMPTY_SESSIONS);
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
+  const streamingBySession = useSessionStore((s) => s.streamingBySession);
   const loadSessionsForProject = useSessionStore((s) => s.loadSessionsForProject);
   const setActiveSession = useSessionStore((s) => s.setActiveSession);
   const disposeSession = useSessionStore((s) => s.disposeSession);
@@ -272,6 +273,7 @@ export function SessionList({ projectId }: Props) {
         key={s.sessionId}
         session={s}
         isActive={s.sessionId === activeSessionId}
+        isRunning={streamingBySession[s.sessionId] ?? false}
         isSelected={selectedIds.has(s.sessionId)}
         isRenaming={renamingId === s.sessionId}
         renameDraft={renameDraft}
@@ -355,6 +357,7 @@ const CLICK_TO_CONFIRM_MS = 3000;
 interface SessionRowProps {
   session: UnifiedSession;
   isActive: boolean;
+  isRunning: boolean;
   isSelected: boolean;
   isRenaming: boolean;
   renameDraft: string;
@@ -379,6 +382,7 @@ function SessionRow(props: SessionRowProps) {
   const {
     session: s,
     isActive,
+    isRunning,
     isSelected,
     isRenaming,
     renameDraft,
@@ -431,6 +435,15 @@ function SessionRow(props: SessionRowProps) {
         </button>
       ) : (
         <span className="inline-block h-4 w-4 shrink-0" aria-hidden="true" />
+      )}
+      {isRunning ? (
+        <LoaderCircle
+          size={12}
+          className="shrink-0 animate-spin text-cyan-400"
+          aria-label="Agent is working"
+        />
+      ) : (
+        <span className="inline-block h-3 w-3 shrink-0" aria-hidden="true" />
       )}
       {isRenaming ? (
         <input

--- a/packages/client/src/components/SessionList.tsx
+++ b/packages/client/src/components/SessionList.tsx
@@ -28,6 +28,7 @@ export function SessionList({ projectId }: Props) {
   const sessions = useSessionStore((s) => s.byProject[projectId] ?? EMPTY_SESSIONS);
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
   const streamingBySession = useSessionStore((s) => s.streamingBySession);
+  const unreadResponseBySession = useSessionStore((s) => s.unreadResponseBySession);
   const loadSessionsForProject = useSessionStore((s) => s.loadSessionsForProject);
   const setActiveSession = useSessionStore((s) => s.setActiveSession);
   const disposeSession = useSessionStore((s) => s.disposeSession);
@@ -274,6 +275,7 @@ export function SessionList({ projectId }: Props) {
         session={s}
         isActive={s.sessionId === activeSessionId}
         isRunning={streamingBySession[s.sessionId] ?? false}
+        hasUnreadResponse={unreadResponseBySession[s.sessionId] ?? false}
         isSelected={selectedIds.has(s.sessionId)}
         isRenaming={renamingId === s.sessionId}
         renameDraft={renameDraft}
@@ -358,6 +360,7 @@ interface SessionRowProps {
   session: UnifiedSession;
   isActive: boolean;
   isRunning: boolean;
+  hasUnreadResponse: boolean;
   isSelected: boolean;
   isRenaming: boolean;
   renameDraft: string;
@@ -383,6 +386,7 @@ function SessionRow(props: SessionRowProps) {
     session: s,
     isActive,
     isRunning,
+    hasUnreadResponse,
     isSelected,
     isRenaming,
     renameDraft,
@@ -441,6 +445,13 @@ function SessionRow(props: SessionRowProps) {
           size={12}
           className="shrink-0 animate-spin text-cyan-400"
           aria-label="Agent is working"
+        />
+      ) : hasUnreadResponse ? (
+        <span
+          className="forge-session-unread h-2 w-2 shrink-0 rounded-full bg-amber-400"
+          role="status"
+          aria-label="New response"
+          title="New response"
         />
       ) : (
         <span className="inline-block h-3 w-3 shrink-0" aria-hidden="true" />

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -644,3 +644,19 @@
 [data-theme="light"] img[src="/icons/icon.svg"] {
   filter: invert(1);
 }
+
+@keyframes forge-session-unread-flash {
+  0%,
+  45% {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.forge-session-unread {
+  animation: forge-session-unread-flash 700ms ease-out 1;
+}

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -2,6 +2,10 @@ import { create } from "zustand";
 import { api, ApiError, type SessionSummary, type UnifiedSession } from "../lib/api-client";
 import { streamSSE } from "../lib/sse-client";
 import { extractToolCallGeneration, type ToolCallGeneration } from "../lib/tool-call-streaming";
+
+type SessionActivityEvent =
+  | { type: "session_activity_snapshot"; running: { sessionId: string }[] }
+  | { type: "session_activity_changed"; sessionId: string; projectId: string; running: boolean };
 import { postCrossTab, subscribeCrossTab } from "../lib/cross-tab";
 import { useAskUserQuestionStore, type PendingAskQuestion } from "./ask-user-question-store";
 import { useTodoStore, type Task as TodoTaskShape } from "./todo-store";
@@ -66,6 +70,7 @@ const refetchState = new Map<string, RefetchState>();
  * through `set()`.
  */
 const controllers = new Map<string, AbortController>();
+let activityController: AbortController | undefined;
 
 /**
  * Phase 8 keeps the message type loose — pi's AgentMessage union is rich
@@ -334,6 +339,9 @@ interface SessionState {
   setActiveSession: (sessionId: string | undefined) => void;
   openStream: (sessionId: string) => void;
   closeStream: (sessionId: string) => void;
+  /** Opens the single global sidebar activity stream. */
+  openActivityStream: () => void;
+  closeActivityStream: () => void;
   /**
    * Force a one-shot messages refetch for a session, independent of
    * the SSE event loop. Used after operations that change the
@@ -416,6 +424,42 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         error: err instanceof ApiError ? err.code : (err as Error).message,
       });
     }
+  },
+
+  openActivityStream: () => {
+    if (activityController !== undefined) return;
+    const ctrl = new AbortController();
+    activityController = ctrl;
+    void streamSSE<SessionActivityEvent>("/api/v1/session-activity/stream", {
+      signal: ctrl.signal,
+      onEvent: (event) => {
+        if (event.type === "session_activity_snapshot") {
+          set((s) => {
+            const next: Record<string, boolean> = Object.fromEntries(
+              Object.keys(s.streamingBySession).map((id) => [id, false]),
+            );
+            for (const entry of event.running) next[entry.sessionId] = true;
+            return { streamingBySession: next };
+          });
+          return;
+        }
+        if (event.type === "session_activity_changed") {
+          set((s) => ({
+            streamingBySession: { ...s.streamingBySession, [event.sessionId]: event.running },
+          }));
+        }
+      },
+      onClose: () => {
+        if (activityController === ctrl) activityController = undefined;
+      },
+    }).catch(() => {
+      if (activityController === ctrl) activityController = undefined;
+    });
+  },
+
+  closeActivityStream: () => {
+    activityController?.abort();
+    activityController = undefined;
   },
 
   createSession: async (projectId) => {

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -5,7 +5,13 @@ import { extractToolCallGeneration, type ToolCallGeneration } from "../lib/tool-
 
 type SessionActivityEvent =
   | { type: "session_activity_snapshot"; running: { sessionId: string }[] }
-  | { type: "session_activity_changed"; sessionId: string; projectId: string; running: boolean };
+  | {
+      type: "session_activity_changed";
+      sessionId: string;
+      projectId: string;
+      running: boolean;
+      reason?: "completed" | "disposed";
+    };
 import { postCrossTab, subscribeCrossTab } from "../lib/cross-tab";
 import { useAskUserQuestionStore, type PendingAskQuestion } from "./ask-user-question-store";
 import { useTodoStore, type Task as TodoTaskShape } from "./todo-store";
@@ -193,6 +199,8 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
   delete nextMessages[sessionId];
   const nextStreaming = { ...current.streamingBySession };
   delete nextStreaming[sessionId];
+  const nextUnreadResponse = { ...current.unreadResponseBySession };
+  delete nextUnreadResponse[sessionId];
   const nextBanner = { ...current.bannerBySession };
   delete nextBanner[sessionId];
   const nextStreamingText = { ...current.streamingTextBySession };
@@ -218,6 +226,7 @@ function removeSessionFromState(current: SessionState, sessionId: string): Parti
   return {
     messagesBySession: nextMessages,
     streamingBySession: nextStreaming,
+    unreadResponseBySession: nextUnreadResponse,
     bannerBySession: nextBanner,
     streamingTextBySession: nextStreamingText,
     activeToolBySession: nextActiveTool,
@@ -259,6 +268,8 @@ interface SessionState {
   pendingDraftBySession: Record<string, string>;
   /** Per-session streaming state from snapshot/agent_start/agent_end. */
   streamingBySession: Record<string, boolean>;
+  /** Completed responses in chats that have not been selected since completion. */
+  unreadResponseBySession: Record<string, boolean>;
   /** Per-session last-known toolEvent + retry banners (lightly modelled). */
   bannerBySession: Record<string, string | undefined>;
   /**
@@ -396,6 +407,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   compactionsBySession: {},
   pendingDraftBySession: {},
   streamingBySession: {},
+  unreadResponseBySession: {},
   bannerBySession: {},
   streamingTextBySession: {},
   activeToolBySession: {},
@@ -446,6 +458,10 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         if (event.type === "session_activity_changed") {
           set((s) => ({
             streamingBySession: { ...s.streamingBySession, [event.sessionId]: event.running },
+            unreadResponseBySession:
+              event.reason === "completed" && event.sessionId !== s.activeSessionId
+                ? { ...s.unreadResponseBySession, [event.sessionId]: true }
+                : s.unreadResponseBySession,
           }));
         }
       },
@@ -587,7 +603,13 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   setActiveSession: (sessionId) => {
     if (sessionId !== undefined) localStorage.setItem(ACTIVE_SESSION_KEY, sessionId);
     else localStorage.removeItem(ACTIVE_SESSION_KEY);
-    set({ activeSessionId: sessionId });
+    set((s) => ({
+      activeSessionId: sessionId,
+      unreadResponseBySession:
+        sessionId === undefined
+          ? s.unreadResponseBySession
+          : { ...s.unreadResponseBySession, [sessionId]: false },
+    }));
   },
 
   openStream: (sessionId) => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,6 +17,7 @@ import { authRoutes } from "./routes/auth.js";
 import { projectRoutes } from "./routes/projects.js";
 import { sessionRoutes } from "./routes/sessions.js";
 import { streamRoutes } from "./routes/stream.js";
+import { sessionActivityRoutes } from "./routes/session-activity.js";
 import { promptRoutes } from "./routes/prompt.js";
 import { controlRoutes } from "./routes/control.js";
 import { configRoutes } from "./routes/config.js";
@@ -439,6 +440,7 @@ export async function buildServer(): Promise<FastifyInstance> {
       await api.register(projectRoutes);
       await api.register(sessionRoutes);
       await api.register(streamRoutes);
+      await api.register(sessionActivityRoutes);
       await api.register(promptRoutes);
       await api.register(controlRoutes);
       await api.register(configRoutes);

--- a/packages/server/src/routes/session-activity.ts
+++ b/packages/server/src/routes/session-activity.ts
@@ -1,0 +1,51 @@
+import type { FastifyPluginAsync } from "fastify";
+import { serializeSSE } from "../sse-bridge.js";
+import { listRunningSessionActivity } from "../session-registry.js";
+import { subscribeSessionActivity } from "../session-activity.js";
+
+/** Lightweight global lifecycle stream used exclusively by the sidebar. */
+export const sessionActivityRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get(
+    "/session-activity/stream",
+    {
+      schema: {
+        description: "Open a global SSE stream of sessions with an active agent turn.",
+        tags: ["sessions"],
+      },
+    },
+    async (_req, reply) => {
+      reply.hijack();
+      const raw = reply.raw;
+      raw.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no",
+      });
+      let closed = false;
+      let unsubscribe = (): void => undefined;
+      const close = (): void => {
+        if (closed) return;
+        closed = true;
+        unsubscribe();
+        raw.off("close", close);
+        raw.off("error", close);
+      };
+      const send = (event: { type: string; [key: string]: unknown }): void => {
+        if (closed || raw.destroyed) return;
+        try {
+          raw.write(serializeSSE(event));
+        } catch {
+          close();
+        }
+      };
+      raw.on("close", close);
+      raw.on("error", close);
+      send({ type: "session_activity_snapshot", running: listRunningSessionActivity() });
+      unsubscribe = subscribeSessionActivity((activity) => {
+        send({ type: "session_activity_changed", ...activity });
+      });
+      return reply;
+    },
+  );
+};

--- a/packages/server/src/session-activity.ts
+++ b/packages/server/src/session-activity.ts
@@ -2,6 +2,7 @@ export interface SessionActivity {
   sessionId: string;
   projectId: string;
   running: boolean;
+  reason?: "completed" | "disposed" | undefined;
 }
 
 type Listener = (activity: SessionActivity) => void;

--- a/packages/server/src/session-activity.ts
+++ b/packages/server/src/session-activity.ts
@@ -1,0 +1,18 @@
+export interface SessionActivity {
+  sessionId: string;
+  projectId: string;
+  running: boolean;
+}
+
+type Listener = (activity: SessionActivity) => void;
+
+const listeners = new Set<Listener>();
+
+export function subscribeSessionActivity(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function publishSessionActivity(activity: SessionActivity): void {
+  for (const listener of listeners) listener(activity);
+}

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -191,8 +191,12 @@ export function listRunningSessionActivity(): SessionActivity[] {
     .map((live) => ({ sessionId: live.sessionId, projectId: live.projectId, running: true }));
 }
 
-function publishActivity(live: LiveSession, running: boolean): void {
-  publishSessionActivity({ sessionId: live.sessionId, projectId: live.projectId, running });
+function publishActivity(
+  live: LiveSession,
+  running: boolean,
+  reason?: "completed" | "disposed",
+): void {
+  publishSessionActivity({ sessionId: live.sessionId, projectId: live.projectId, running, reason });
 }
 
 /**
@@ -489,7 +493,7 @@ function makeSubscribeHandler(live: LiveSession): () => void {
     // `agent_end` with no detail, the chat UI hides its spinner with
     // no error banner, and the user sees an empty assistant message.
     if (e.type === "agent_end") {
-      publishActivity(live, false);
+      publishActivity(live, false, "completed");
       // Primary: session-level `errorMessage` — the SDK's
       // documented authoritative field. Most failure modes set
       // this (auth failures, validation, etc.).
@@ -1239,7 +1243,7 @@ export async function disposeSession(sessionId: string): Promise<boolean> {
     // because we await it last.
     await processManager.disposeSession(sessionId).catch(() => undefined);
   } finally {
-    publishActivity(live, false);
+    publishActivity(live, false, "disposed");
     registry.delete(sessionId);
     // Tombstone the id so a polling SSE client can't re-resume the
     // session before deleteColdSession's file unlink runs. The

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -46,6 +46,7 @@ import { archiveSessionFiles } from "./session-archive.js";
 import { generateSessionTitleFromPrompt, isGenericSessionName } from "./session-title.js";
 import { getExternalSubagentStatusForSession } from "./subagents-external.js";
 import { readSandboxSettings } from "./sandbox-settings.js";
+import { publishSessionActivity, type SessionActivity } from "./session-activity.js";
 
 /**
  * Minimal SSE client contract used by the registry to fan out events.
@@ -183,6 +184,16 @@ export class ExternalSubagentActiveError extends Error {
 }
 
 const registry = new Map<string, LiveSession>();
+
+export function listRunningSessionActivity(): SessionActivity[] {
+  return Array.from(registry.values())
+    .filter((live) => live.session.isStreaming)
+    .map((live) => ({ sessionId: live.sessionId, projectId: live.projectId, running: true }));
+}
+
+function publishActivity(live: LiveSession, running: boolean): void {
+  publishSessionActivity({ sessionId: live.sessionId, projectId: live.projectId, running });
+}
 
 /**
  * Built-in pi tools we activate on every session. Pi's SDK ships
@@ -370,6 +381,7 @@ function makeSubscribeHandler(live: LiveSession): () => void {
   return live.session.subscribe((event: AgentSessionEvent) => {
     live.lastActivityAt = new Date();
     if (event.type === "agent_start") {
+      publishActivity(live, true);
       // Capture BEFORE the SDK appends turn messages, so the index points
       // at the first message of the new turn (the user prompt or the
       // steered/follow-up entry).
@@ -477,6 +489,7 @@ function makeSubscribeHandler(live: LiveSession): () => void {
     // `agent_end` with no detail, the chat UI hides its spinner with
     // no error banner, and the user sees an empty assistant message.
     if (e.type === "agent_end") {
+      publishActivity(live, false);
       // Primary: session-level `errorMessage` — the SDK's
       // documented authoritative field. Most failure modes set
       // this (auth failures, validation, etc.).
@@ -1226,6 +1239,7 @@ export async function disposeSession(sessionId: string): Promise<boolean> {
     // because we await it last.
     await processManager.disposeSession(sessionId).catch(() => undefined);
   } finally {
+    publishActivity(live, false);
     registry.delete(sessionId);
     // Tombstone the id so a polling SSE client can't re-resume the
     // session before deleteColdSession's file unlink runs. The

--- a/tests/test-session-activity.ts
+++ b/tests/test-session-activity.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import {
+  publishSessionActivity,
+  subscribeSessionActivity,
+  type SessionActivity,
+} from "../packages/server/src/session-activity.js";
+
+const received: SessionActivity[] = [];
+const unsubscribe = subscribeSessionActivity((activity) => received.push(activity));
+publishSessionActivity({ sessionId: "session-1", projectId: "project-1", running: true });
+unsubscribe();
+publishSessionActivity({ sessionId: "session-1", projectId: "project-1", running: false });
+
+assert.deepEqual(received, [{ sessionId: "session-1", projectId: "project-1", running: true }]);
+console.log("Session activity tests passed.");


### PR DESCRIPTION
## What this changes

Adds a unified session-activity status to the Projects sidebar. A cyan spinner appears beside every chat with an active agent turn, including after navigating to another chat. When an agent completes in a non-selected chat, that row flashes once and then shows a persistent amber dot. Selecting the chat clears the dot.

## Type of change

- [ ] `fix:` bug fix (no API change)
- [x] `feat:` new feature
- [ ] `refactor:` internal change, no behavior difference
- [ ] `docs:` documentation only
- [ ] `chore:` tooling, deps, build
- [ ] `test:` adding or fixing tests
- [ ] `perf:` performance improvement

## Scope

- [x] Server (`packages/server/`)
- [x] Client (`packages/client/`)
- [ ] Docker / deploy (`docker/`, `kubernetes/`)
- [ ] Docs (`docs/`, `README.md`, root markdown)
- [x] Tests (`tests/`)

## Usage

1. Start an agent turn in chat A. Its sidebar row shows a cyan spinner.
2. Switch to chat B while A is still running. The spinner for A remains visible.
3. When A completes, its row flashes once and retains an amber dot.
4. Select chat A; the amber dot clears immediately.

Idle live sessions do not animate. Aborted, disposed, or deleted sessions do not receive an unread-response indicator.

## What changed (8 files, +166/-1; follow-up: 5 files, +60/-6)

### Activity indicator — `ca8fec1 feat(sidebar): show active session indicators`

- `packages/server/src/session-activity.ts` — lightweight publish/subscribe channel for session activity transitions.
- `packages/server/src/routes/session-activity.ts` — authenticated global SSE stream, including an initial running-session snapshot and safe cleanup on disconnect/error.
- `packages/server/src/session-registry.ts` — reports agent start/end and disposal transitions.
- `packages/server/src/index.ts` — registers the activity stream route.
- `packages/client/src/App.tsx` — owns the authenticated global stream lifecycle.
- `packages/client/src/store/session-store.ts` — applies global activity snapshots and changes to all sidebar rows.
- `packages/client/src/components/SessionList.tsx` — renders the animated cyan spinner beside running chats.
- `tests/test-session-activity.ts` — covers activity event subscription and cleanup.

### Unread response indicator — `d9c832f feat(sidebar): mark unread session responses`

- `packages/server/src/session-activity.ts` and `packages/server/src/session-registry.ts` — distinguish normal completion from disposal.
- `packages/client/src/store/session-store.ts` — tracks unread completed responses; clears state on selection and deletion.
- `packages/client/src/components/SessionList.tsx` — replaces an inactive spinner with an amber unread-response indicator.
- `packages/client/src/index.css` — gives newly completed background chats a one-time flash animation.

## How to verify

```bash
npm run build
npx tsc -p packages/server/tsconfig.json --noEmit
npx tsc -p packages/client/tsconfig.json --noEmit
npx tsx tests/test-session-activity.ts
```

Manual:

1. Start work in chat A and move to chat B while it is running.
2. Confirm chat A keeps its cyan spinner while active.
3. Confirm completion changes it to a briefly flashing amber dot.
4. Open chat A and confirm the dot clears.
5. Abort a running chat or delete it and confirm no amber dot remains.
6. Refresh while a chat is running and confirm the global stream restores its spinner from the initial snapshot.

## Screenshots / recordings (UI changes only)

<!-- Add a short recording showing the spinner, navigation to another chat, completion flash, amber dot, and clear-on-open behavior. -->

## Risk and rollback

The global SSE connection adds one lightweight authenticated browser connection and internal lifecycle metadata. It does not alter session files, user configuration, or prompt APIs.

Rollback: revert commits `d9c832f` and `ca8fec1` (in reverse order), or revert their Testing merge commits.

## Checklist

- [x] Atomic commit(s) — one logical change per commit, conventional-commit prefix
- [x] No `Co-Authored-By` lines or AI-attribution trailers
- [x] Server and client TypeScript checks pass
- [x] `npm run build` passes
- [x] `tests/test-session-activity.ts` passes
- [ ] Changed SSE event surface documented in `docs/sse-events.md`
- [x] No `process.env.*` reads outside `packages/server/src/config.ts`
- [x] No direct `fs.*` calls in route handlers
- [x] No raw `fetch()` in components
- [x] Default exports — none added
- [ ] Screenshot or recording added
- [ ] CI green before merge

## Notes for reviewers

Please verify that the global stream reports only active agent turns, remains connected across chat navigation, and cleans up on disconnect. For the amber dot, only `completed` transitions in non-selected chats may set unread state; `disposed` must only clear activity.
