### PR TITLE
Feat/project sidebar resize

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -73,6 +73,30 @@ function readPersistedProjectsWidth(): number {
   return Math.min(Math.max(parsed, MIN_PROJECTS_WIDTH), MAX_PROJECTS_WIDTH);
 }
 
+export function getProjectsMaxWidth(
+  viewportWidth: number,
+  filesWidth: number,
+  editorWidth: number,
+  filesOpen: boolean,
+  editorVisible: boolean,
+): number {
+  return Math.max(
+    MIN_PROJECTS_WIDTH,
+    Math.min(
+      MAX_PROJECTS_WIDTH,
+      viewportWidth -
+        MIN_CHAT_WIDTH -
+        (filesOpen ? filesWidth + 4 : 0) -
+        (editorVisible ? editorWidth + 4 : 0) -
+        4,
+    ),
+  );
+}
+
+export function clampProjectsWidth(width: number, maxWidth: number): number {
+  return Math.min(Math.max(width, MIN_PROJECTS_WIDTH), maxWidth);
+}
+
 export function App() {
   const ready = useAuthStore((s) => s.ready);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
@@ -231,6 +255,7 @@ export function App() {
   // it through the ref so the divider can read the start width without
   // a stale-closure bug across drags.
   const [projectsWidth, setProjectsWidth] = useState<number>(readPersistedProjectsWidth);
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
   const [filesWidth, setFilesWidth] = useState<number>(() =>
     readPersistedWidth(FILES_WIDTH_KEY, DEFAULT_FILES_WIDTH),
   );
@@ -255,6 +280,23 @@ export function App() {
 
   const openFilesCount = useFileStore((s) => s.openFiles.length);
   const editorVisible = editorOpen && openFilesCount > 0;
+  const projectsMaxWidth = getProjectsMaxWidth(
+    viewportWidth,
+    filesWidth,
+    editorWidth,
+    filesOpen,
+    editorVisible,
+  );
+
+  useEffect(() => {
+    const onResize = (): void => setViewportWidth(window.innerWidth);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  useEffect(() => {
+    setProjectsWidth((current) => clampProjectsWidth(current, projectsMaxWidth));
+  }, [projectsMaxWidth]);
 
   // Drives the modified-file count badge on the Git tab. Polls via
   // the hook regardless of which tab is currently visible — we want
@@ -650,14 +692,8 @@ export function App() {
               onResize={setProjectsWidth}
               direction={1}
               minSize={MIN_PROJECTS_WIDTH}
-              maxSize={Math.max(
-                MIN_PROJECTS_WIDTH,
-                window.innerWidth -
-                  MIN_CHAT_WIDTH -
-                  (filesOpen ? filesWidth + 4 : 0) -
-                  (editorVisible ? editorWidth + 4 : 0) -
-                  4,
-              )}
+              maxSize={projectsMaxWidth}
+              ariaLabel="Resize project sidebar"
             />
           )}
           <main className="flex flex-1 overflow-hidden">

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -40,14 +40,18 @@ type RightPaneTab = "files" | "search" | "changes" | "git" | "context" | "proces
 /* Persisted pane widths. Stored in localStorage so the user-tuned
    layout survives reloads. Defaults err on the side of "the chat is the
    primary surface" — files is narrow, editor is medium. */
+const PROJECTS_WIDTH_KEY = "pi-forge/projects-width";
 const FILES_WIDTH_KEY = "pi-forge/files-width";
 const EDITOR_WIDTH_KEY = "pi-forge/editor-width";
 const TERMINAL_HEIGHT_KEY = "pi-forge/terminal-height";
 const TODO_PANEL_HEIGHT_KEY = "pi-forge/todo-panel-height";
+const DEFAULT_PROJECTS_WIDTH = 256;
 const DEFAULT_FILES_WIDTH = 280;
 const DEFAULT_EDITOR_WIDTH = 480;
 const DEFAULT_TERMINAL_HEIGHT = 280;
 const DEFAULT_TODO_PANEL_HEIGHT = 200;
+const MIN_PROJECTS_WIDTH = 200;
+const MAX_PROJECTS_WIDTH = 640;
 const MIN_FILES_WIDTH = 200;
 const MIN_EDITOR_WIDTH = 320;
 const MIN_CHAT_WIDTH = 320;
@@ -59,6 +63,14 @@ function readPersistedWidth(key: string, fallback: number): number {
   if (raw === null) return fallback;
   const n = Number.parseInt(raw, 10);
   return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function readPersistedProjectsWidth(): number {
+  const raw = localStorage.getItem(PROJECTS_WIDTH_KEY);
+  if (raw === null) return DEFAULT_PROJECTS_WIDTH;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_PROJECTS_WIDTH;
+  return Math.min(Math.max(parsed, MIN_PROJECTS_WIDTH), MAX_PROJECTS_WIDTH);
 }
 
 export function App() {
@@ -218,14 +230,20 @@ export function App() {
   // the live value in state so drags re-render the layout, and mirror
   // it through the ref so the divider can read the start width without
   // a stale-closure bug across drags.
+  const [projectsWidth, setProjectsWidth] = useState<number>(readPersistedProjectsWidth);
   const [filesWidth, setFilesWidth] = useState<number>(() =>
     readPersistedWidth(FILES_WIDTH_KEY, DEFAULT_FILES_WIDTH),
   );
   const [editorWidth, setEditorWidth] = useState<number>(() =>
     readPersistedWidth(EDITOR_WIDTH_KEY, DEFAULT_EDITOR_WIDTH),
   );
+  const projectsWidthRef = useRef(projectsWidth);
   const filesWidthRef = useRef(filesWidth);
   const editorWidthRef = useRef(editorWidth);
+  useEffect(() => {
+    projectsWidthRef.current = projectsWidth;
+    localStorage.setItem(PROJECTS_WIDTH_KEY, String(Math.round(projectsWidth)));
+  }, [projectsWidth]);
   useEffect(() => {
     filesWidthRef.current = filesWidth;
     localStorage.setItem(FILES_WIDTH_KEY, String(filesWidth));
@@ -624,7 +642,24 @@ export function App() {
               "md:static md:inset-auto md:z-auto md:shadow-none md:transition-none " +
               (drawerOpen ? "max-md:translate-x-0" : "max-md:-translate-x-full")
             }
+            {...(isMobile ? {} : { style: { width: `${projectsWidth}px` } })}
           />
+          {!isMobile && (
+            <ResizableDivider
+              getStartSize={() => projectsWidthRef.current}
+              onResize={setProjectsWidth}
+              direction={1}
+              minSize={MIN_PROJECTS_WIDTH}
+              maxSize={Math.max(
+                MIN_PROJECTS_WIDTH,
+                window.innerWidth -
+                  MIN_CHAT_WIDTH -
+                  (filesOpen ? filesWidth + 4 : 0) -
+                  (editorVisible ? editorWidth + 4 : 0) -
+                  4,
+              )}
+            />
+          )}
           <main className="flex flex-1 overflow-hidden">
             {/* Layout when files pane is open:
                   chat (flex) | divider | editor (when ≥1 tab) | divider | files
@@ -746,7 +781,11 @@ export function App() {
                       minSize={MIN_EDITOR_WIDTH}
                       maxSize={Math.max(
                         MIN_EDITOR_WIDTH,
-                        window.innerWidth - (filesOpen ? filesWidth : 0) - MIN_CHAT_WIDTH - 240, // 240 ≈ ProjectSidebar
+                        window.innerWidth -
+                          (filesOpen ? filesWidth + 4 : 0) -
+                          MIN_CHAT_WIDTH -
+                          (projectsWidth + 4) -
+                          4,
                       )}
                     />
                     <div
@@ -891,8 +930,9 @@ export function App() {
                         MIN_FILES_WIDTH,
                         window.innerWidth -
                           MIN_CHAT_WIDTH -
-                          240 -
-                          (editorVisible ? MIN_EDITOR_WIDTH : 0),
+                          (projectsWidth + 4) -
+                          (editorVisible ? MIN_EDITOR_WIDTH + 4 : 0) -
+                          4,
                       )}
                     />
                     <div

--- a/packages/client/src/components/ProjectSidebar.tsx
+++ b/packages/client/src/components/ProjectSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 import { Plus, X, ChevronDown, ChevronRight, GripVertical } from "lucide-react";
 import { useProjectStore } from "../store/project-store";
 import { useSessionStore } from "../store/session-store";
@@ -11,9 +11,11 @@ export interface ProjectSidebarProps {
    *  drawer wrapper to layer in fixed-position transform classes
    *  without ProjectSidebar needing to know it's in a drawer. */
   className?: string;
+  /** Desktop sizing supplied by the App-level pane manager. */
+  style?: CSSProperties;
 }
 
-export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
+export function ProjectSidebar({ className = "", style }: ProjectSidebarProps = {}) {
   const projects = useProjectStore((s) => s.projects);
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
   const collapsed = useProjectStore((s) => s.collapsed);
@@ -145,6 +147,7 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
       // mobile. env() returns 0 on devices without insets, so this
       // is a no-op on desktop and on non-notched phones.
       style={{
+        ...style,
         paddingTop: "env(safe-area-inset-top)",
         paddingBottom: "env(safe-area-inset-bottom)",
       }}

--- a/packages/client/src/components/ResizableDivider.tsx
+++ b/packages/client/src/components/ResizableDivider.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useRef, type PointerEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent,
+} from "react";
 
 /**
  * Drag-handle between two adjacent panes. Supports both orientations:
@@ -38,6 +43,10 @@ interface Props {
   minSize: number;
   maxSize: number;
   orientation?: "vertical" | "horizontal";
+  /** Accessible name announced for this specific divider. */
+  ariaLabel?: string;
+  /** Keyboard resize increment in pixels. */
+  keyboardStep?: number;
 }
 
 export function ResizableDivider({
@@ -47,6 +56,8 @@ export function ResizableDivider({
   minSize,
   maxSize,
   orientation = "vertical",
+  ariaLabel = "Resize pane",
+  keyboardStep = 16,
 }: Props) {
   const dragRef = useRef<{ start: number; startSize: number } | null>(null);
   const horizontal = orientation === "horizontal";
@@ -77,6 +88,27 @@ export function ResizableDivider({
     };
   }, []);
 
+  const clamp = (value: number): number => Math.min(Math.max(value, minSize), maxSize);
+
+  const onKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>): void => {
+    const increaseKey = horizontal ? "ArrowDown" : "ArrowRight";
+    const decreaseKey = horizontal ? "ArrowUp" : "ArrowLeft";
+    if (e.key === "Home") {
+      e.preventDefault();
+      onResize(minSize);
+      return;
+    }
+    if (e.key === "End") {
+      e.preventDefault();
+      onResize(maxSize);
+      return;
+    }
+    if (e.key !== increaseKey && e.key !== decreaseKey) return;
+    e.preventDefault();
+    const physicalDelta = e.key === increaseKey ? keyboardStep : -keyboardStep;
+    onResize(clamp(getStartSize() + physicalDelta * direction));
+  };
+
   const onPointerDown = (e: PointerEvent<HTMLDivElement>): void => {
     e.preventDefault();
     e.currentTarget.setPointerCapture(e.pointerId);
@@ -93,7 +125,7 @@ export function ResizableDivider({
     const cur = horizontal ? e.clientY : e.clientX;
     const delta = cur - dragRef.current.start;
     const next = dragRef.current.startSize + delta * direction;
-    onResize(Math.min(Math.max(next, minSize), maxSize));
+    onResize(clamp(next));
   };
 
   const onPointerUp = (e: PointerEvent<HTMLDivElement>): void => {
@@ -119,7 +151,13 @@ export function ResizableDivider({
       onPointerCancel={onPointerUp}
       className={`${baseCls} ${sizeCls}`}
       role="separator"
+      tabIndex={0}
+      aria-label={ariaLabel}
       aria-orientation={horizontal ? "horizontal" : "vertical"}
+      aria-valuemin={minSize}
+      aria-valuemax={maxSize}
+      aria-valuenow={Math.round(clamp(getStartSize()))}
+      onKeyDown={onKeyDown}
     >
       {/* Slightly wider invisible hitbox so the drag handle is easier
           to grab without making the visible bar fat. */}

--- a/tests/test-project-sidebar-resize.ts
+++ b/tests/test-project-sidebar-resize.ts
@@ -6,6 +6,7 @@ const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
 const appPath = resolve(repoRoot, "packages/client/src/App.tsx");
 const sidebarPath = resolve(repoRoot, "packages/client/src/components/ProjectSidebar.tsx");
+const dividerPath = resolve(repoRoot, "packages/client/src/components/ResizableDivider.tsx");
 
 let failures = 0;
 function assert(label: string, ok: boolean): void {
@@ -17,9 +18,10 @@ function assert(label: string, ok: boolean): void {
 }
 
 async function main(): Promise<void> {
-  const [app, sidebar] = await Promise.all([
+  const [app, sidebar, divider] = await Promise.all([
     readFile(appPath, "utf8"),
     readFile(sidebarPath, "utf8"),
+    readFile(dividerPath, "utf8"),
   ]);
 
   assert(
@@ -40,8 +42,37 @@ async function main(): Promise<void> {
     !app.includes("240 ≈ ProjectSidebar") && app.includes("projectsWidth + 4"),
   );
   assert(
+    "clamps the project width against a responsive max while preserving chat width",
+    app.includes("getProjectsMaxWidth") &&
+      app.includes("MIN_CHAT_WIDTH") &&
+      app.includes("setProjectsWidth((current) => clampProjectsWidth(current, projectsMaxWidth))"),
+  );
+  assert(
+    "updates responsive project limits when the viewport changes",
+    app.includes('window.addEventListener("resize", onResize)'),
+  );
+  assert(
+    "keeps the desktop-only divider hidden on mobile",
+    app.includes("{!isMobile && (") && app.includes('ariaLabel="Resize project sidebar"'),
+  );
+  assert(
     "accepts App-owned desktop sidebar sizing",
     sidebar.includes("style?: CSSProperties") && sidebar.includes("...style,"),
+  );
+  assert(
+    "exposes the divider as a keyboard-operable range separator",
+    divider.includes("tabIndex={0}") &&
+      divider.includes("aria-valuemin={minSize}") &&
+      divider.includes("aria-valuemax={maxSize}") &&
+      divider.includes("aria-valuenow={Math.round(clamp(getStartSize()))}") &&
+      divider.includes("onKeyDown={onKeyDown}"),
+  );
+  assert(
+    "supports keyboard resize and range endpoints",
+    divider.includes('e.key === "Home"') &&
+      divider.includes('e.key === "End"') &&
+      divider.includes("keyboardStep") &&
+      divider.includes("physicalDelta * direction"),
   );
 
   if (failures > 0) process.exitCode = 1;

--- a/tests/test-project-sidebar-resize.ts
+++ b/tests/test-project-sidebar-resize.ts
@@ -1,0 +1,50 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(__filename), "..");
+const appPath = resolve(repoRoot, "packages/client/src/App.tsx");
+const sidebarPath = resolve(repoRoot, "packages/client/src/components/ProjectSidebar.tsx");
+
+let failures = 0;
+function assert(label: string, ok: boolean): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const [app, sidebar] = await Promise.all([
+    readFile(appPath, "utf8"),
+    readFile(sidebarPath, "utf8"),
+  ]);
+
+  assert(
+    "defines a dedicated persisted project sidebar width key",
+    app.includes('PROJECTS_WIDTH_KEY = "pi-forge/projects-width"'),
+  );
+  assert("clamps persisted project sidebar widths", app.includes("readPersistedProjectsWidth"));
+  assert(
+    "renders a desktop-only divider after the project sidebar",
+    /<ResizableDivider[\s\S]*?getStartSize=\{\(\) => projectsWidthRef\.current\}/.test(app),
+  );
+  assert(
+    "keeps the mobile drawer free of an inline desktop width",
+    app.includes("...(isMobile ? {} : { style: { width: `${projectsWidth}px` } })"),
+  );
+  assert(
+    "uses the live project width in right-pane constraints",
+    !app.includes("240 ≈ ProjectSidebar") && app.includes("projectsWidth + 4"),
+  );
+  assert(
+    "accepts App-owned desktop sidebar sizing",
+    sidebar.includes("style?: CSSProperties") && sidebar.includes("...style,"),
+  );
+
+  if (failures > 0) process.exitCode = 1;
+}
+
+void main();


### PR DESCRIPTION
## What this changes

Makes the desktop Project Sidebar resizable. The selected width is persisted locally, clamped to the available layout width so the chat remains usable, and the existing mobile drawer behavior is unchanged. The shared resize divider now supports keyboard resizing and exposes appropriate ARIA range metadata.

## Type of change

- [ ] `fix:` bug fix (no API change)
- [x] `feat:` new feature
- [ ] `refactor:` internal change, no behavior difference
- [ ] `docs:` documentation only
- [ ] `chore:` tooling, deps, build
- [x] `test:` adding or fixing tests
- [ ] `perf:` performance improvement

## Scope

- [ ] Server (`packages/server/`)
- [x] Client (`packages/client/`)
- [ ] Docker / deploy (`docker/`, `kubernetes/`)
- [ ] Docs (`docs/`, `README.md`, root markdown)
- [x] Tests (`tests/`)

## How to verify

```bash
npx tsx tests/test-project-sidebar-resize.ts
# PASS

npx tsc --noEmit -p packages/client/tsconfig.json
# PASS

npx eslint packages/client/src/App.tsx \
  packages/client/src/components/ProjectSidebar.tsx \
  packages/client/src/components/ResizableDivider.tsx \
  tests/test-project-sidebar-resize.ts
# PASS

npx prettier --check packages/client/src/App.tsx \
  packages/client/src/components/ProjectSidebar.tsx \
  packages/client/src/components/ResizableDivider.tsx \
  tests/test-project-sidebar-resize.ts
# PASS
```

Manual browser checks:

1. Drag the Project Sidebar divider on desktop and reload; verify the width persists.
2. Narrow the viewport and open right-side panes; verify the sidebar clamps and the chat keeps its minimum width.
3. Focus the divider, use its keyboard controls, and verify the accessible value changes.
4. Verify the mobile project drawer has no resize divider and continues to work normally.

## Screenshots / recordings (UI changes only)

No screenshot or recording was collected. A short desktop resize and keyboard-accessibility recording is recommended before merge.

## Risk and rollback

Risk is limited to client layout and persisted local sidebar-width state. No API, configuration, migration, or persisted server data changes are involved.

Roll back by reverting commits `f697427` and `ec4bdbe`. A previously stored browser width remains harmless because values are validated and clamped.

## Checklist

- [x] Atomic commit(s) — feature implementation and hardening follow-up only
- [x] No `Co-Authored-By` lines or AI-attribution trailers
- [ ] `npm run check` passes — repository-wide gate was not green because of unrelated baseline diagnostics
- [ ] `npm run build` passes — the isolated worktree lacks the base-worktree `@vitejs/plugin-react` dependency
- [x] Relevant `tests/test-*.ts` script run and passing
- [x] New/changed routes have JSON Schema — N/A; no routes changed
- [x] No `process.env.*` reads outside `packages/server/src/config.ts` — N/A; no server code changed
- [x] No direct `fs.*` calls in route handlers — N/A; no routes changed
- [x] No raw `fetch()` added in components
- [x] Default exports — none added
- [x] Config/env documentation — N/A; no config/env changes
- [x] SSE documentation — N/A; no SSE changes
- [x] API examples — N/A; no HTTP routes added

## Notes for reviewers

Please review the responsive maximum-width calculation in `App.tsx` and the generalized keyboard/ARIA behavior in `ResizableDivider.tsx`, since the divider is shared by other desktop layout panes.
