### PR TITLE
Feat/project session index cache

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -72,6 +72,7 @@ route handlers).
 | `webhooks.json` | Webhook configs (HMAC secrets stored here — mode 0600) | `webhooks/store.ts` |
 | `webhook-deliveries.json` | Rolling delivery history (cap 100 / webhook) | `webhooks/store.ts` |
 | `session-orchestration.json` | Supervisor opt-in + supervisor↔worker links (mode 0600) | `orchestration/store.ts` |
+| `session-index.json` | Versioned, rebuildable per-project JSONL session-discovery cache | `session-index.ts` |
 | `orchestrator-inbox.json` | Per-supervisor pending event queue (cap 200 / supervisor) | `orchestration/store.ts` |
 | `jwt-secret` | Auto-generated HS256 signing key (mode 0600) | `config.ts` (`loadOrGenerateJwtSecret`) |
 | `password-hash` | scrypt hash of the user's persisted password (mode 0600) | `auth.ts` (`persistPassword`) |

--- a/docs/agent/sessions.md
+++ b/docs/agent/sessions.md
@@ -31,6 +31,10 @@ These are facts about the pi SDK that are easy to get wrong:
   (`session-store.ts`), (c) cascade-deleting the parent's sibling subagent
   dir in `deleteColdSession`. The plugin shells out to the `pi` CLI; the
   Docker image puts it on PATH via `/app/node_modules/.bin`.
+- The session index is metadata-only and never returns cached paths. Before
+  persisting metadata from SDK discovery, it rejects candidates whose
+  root-relative path contains a symlink. This contains cache exposure only;
+  it does not attempt to repair the SDK's general symlink-opening behavior.
 - `session.fork()` creates a new session FILE. The new session ID is returned.
   The registry must then load this new session before it can be used.
 - `session.navigateTree()` operates IN-PLACE on the current session file. It does

--- a/packages/client/src/components/ProjectSidebar.tsx
+++ b/packages/client/src/components/ProjectSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Plus, X, ChevronDown, ChevronRight, GripVertical } from "lucide-react";
+import { Plus, X, ChevronDown, ChevronRight, GripVertical, RefreshCw } from "lucide-react";
 import { useProjectStore } from "../store/project-store";
 import { useSessionStore } from "../store/session-store";
 import { ProjectPicker } from "./ProjectPicker";
@@ -25,6 +25,7 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
   const sessionsByProject = useSessionStore((s) => s.byProject);
   const createSession = useSessionStore((s) => s.createSession);
   const disposeSession = useSessionStore((s) => s.disposeSession);
+  const refreshProjectSessionIndex = useSessionStore((s) => s.refreshProjectSessionIndex);
 
   /**
    * Create a new session under `projectId`. Mirrors the project-
@@ -41,6 +42,21 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
     }
   };
   const [showPicker, setShowPicker] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshFeedback, setRefreshFeedback] = useState<"success" | "error" | undefined>();
+  const handleRefresh = async (): Promise<void> => {
+    if (activeProjectId === undefined || refreshing) return;
+    setRefreshing(true);
+    setRefreshFeedback(undefined);
+    try {
+      await refreshProjectSessionIndex(activeProjectId);
+      setRefreshFeedback("success");
+    } catch {
+      setRefreshFeedback("error");
+    } finally {
+      setRefreshing(false);
+    }
+  };
   const [renamingId, setRenamingId] = useState<string | undefined>();
   const [renameValue, setRenameValue] = useState("");
   const [draggingProjectId, setDraggingProjectId] = useState<string | undefined>();
@@ -153,12 +169,44 @@ export function ProjectSidebar({ className = "" }: ProjectSidebarProps = {}) {
         <span className="text-xs font-semibold uppercase tracking-wider text-neutral-400">
           Projects
         </span>
-        <button
-          onClick={() => setShowPicker(true)}
-          className="rounded-md border border-neutral-700 px-2 py-0.5 text-xs text-neutral-200 hover:bg-neutral-800"
-        >
-          + New
-        </button>
+        <div className="flex items-center gap-1">
+          <span
+            aria-live="polite"
+            className={`text-[10px] ${
+              refreshFeedback === "error" ? "text-red-400" : "text-neutral-400"
+            }`}
+          >
+            {refreshing
+              ? "Refreshing…"
+              : refreshFeedback === "success"
+                ? "Refreshed"
+                : refreshFeedback === "error"
+                  ? "Refresh failed"
+                  : ""}
+          </span>
+          <button
+            type="button"
+            onClick={() => void handleRefresh()}
+            disabled={activeProjectId === undefined || refreshing}
+            aria-label="Refresh active project session index"
+            title={
+              activeProjectId === undefined
+                ? "Select a project to refresh its session index"
+                : refreshing
+                  ? "Refreshing session index…"
+                  : "Refresh session index"
+            }
+            className="inline-flex rounded-md border border-neutral-700 p-1 text-neutral-200 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <RefreshCw size={14} className={refreshing ? "animate-spin" : ""} />
+          </button>
+          <button
+            onClick={() => setShowPicker(true)}
+            className="rounded-md border border-neutral-700 px-2 py-0.5 text-xs text-neutral-200 hover:bg-neutral-800"
+          >
+            + New
+          </button>
+        </div>
       </header>
 
       <div className="flex-1 overflow-y-auto py-1">

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1800,6 +1800,12 @@ export const api = {
     const qs = projectId !== undefined ? `?projectId=${encodeURIComponent(projectId)}` : "";
     return request(`/api/v1/sessions${qs}`, vUnifiedSessionList);
   },
+  refreshProjectSessionIndex: (projectId: string) =>
+    request(
+      `/api/v1/projects/${encodeURIComponent(projectId)}/session-index/refresh`,
+      vUnifiedSessionList,
+      { method: "POST" },
+    ),
   createSession: (projectId: string) =>
     request("/api/v1/sessions", vSessionSummary, {
       method: "POST",

--- a/packages/client/src/store/session-store.ts
+++ b/packages/client/src/store/session-store.ts
@@ -373,6 +373,7 @@ interface SessionState {
   loadingList: boolean;
 
   loadSessionsForProject: (projectId: string) => Promise<void>;
+  refreshProjectSessionIndex: (projectId: string) => Promise<void>;
   createSession: (projectId: string) => Promise<SessionSummary>;
   renameSession: (sessionId: string, name: string) => Promise<void>;
   setActiveSession: (sessionId: string | undefined) => void;
@@ -481,6 +482,23 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         loadingList: false,
         error: err instanceof ApiError ? err.code : (err as Error).message,
       });
+    }
+  },
+
+  refreshProjectSessionIndex: async (projectId) => {
+    set({ loadingList: true, error: undefined });
+    try {
+      const { sessions } = await api.refreshProjectSessionIndex(projectId);
+      set((s) => ({
+        byProject: { ...s.byProject, [projectId]: sessions },
+        loadingList: false,
+      }));
+    } catch (err) {
+      set({
+        loadingList: false,
+        error: err instanceof ApiError ? err.code : (err as Error).message,
+      });
+      throw err;
     }
   },
 

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -10,6 +10,7 @@ import {
   getSession,
   listExtensionCommands,
   listSessionsForProject,
+  refreshProjectSessionIndex,
   rejectOrDisposeExternallyActiveSession,
   resumeSessionById,
   type UnifiedSession,
@@ -201,6 +202,38 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       const all: UnifiedSession[] = settled.flat();
       all.sort((a, b) => b.lastActivityAt.getTime() - a.lastActivityAt.getTime());
       return { sessions: all.map(unifiedFromUnified) };
+    },
+  );
+
+  fastify.post<{ Params: { projectId: string } }>(
+    "/projects/:projectId/session-index/refresh",
+    {
+      config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
+      schema: {
+        description:
+          "Clear only the derived session index cache and rebuild this project's session discovery.",
+        tags: ["sessions"],
+        params: {
+          type: "object",
+          required: ["projectId"],
+          properties: { projectId: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["sessions"],
+            properties: { sessions: { type: "array", items: unifiedSchema } },
+          },
+          404: errorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const project = await getProject(req.params.projectId);
+      if (project === undefined) return reply.code(404).send({ error: "project_not_found" });
+      await refreshProjectSessionIndex(project.id, project.path);
+      const sessions = await listSessionsForProject(project.id, project.path);
+      return { sessions: sessions.map(unifiedFromUnified) };
     },
   );
 

--- a/packages/server/src/session-index.ts
+++ b/packages/server/src/session-index.ts
@@ -62,6 +62,8 @@ interface ProjectCache {
   lastReconciledAt: number;
   footprint: Map<string, string>;
   watchers: FSWatcher[];
+  /** Persisted records omit previews, so the first sidebar read rebuilds them. */
+  needsPreviewHydration: boolean;
 }
 
 const projects = new Map<string, ProjectCache>();
@@ -328,6 +330,7 @@ async function cacheProject(
     lastReconciledAt: Date.now(),
     footprint: currentFootprint,
     watchers: [],
+    needsPreviewHydration: true,
   };
   installWatchers(cache);
   projects.set(projectId, cache);
@@ -353,6 +356,7 @@ async function rebuildProject(
         ...sessions.map((session) => session.path),
       ]),
       watchers: [],
+      needsPreviewHydration: false,
     };
     const previous = projects.get(projectId);
     if (previous !== undefined) {
@@ -380,7 +384,7 @@ export async function getIndexedProjectSessions(
   const cache = await cacheProject(projectId, workspacePath, sessionDir);
   if (cache !== undefined) {
     await reconcile(cache);
-    if (!cache.dirty) return cache.sessions;
+    if (!cache.dirty && !cache.needsPreviewHydration) return cache.sessions;
   }
   return rebuildProject(projectId, workspacePath, sessionDir, discover);
 }

--- a/packages/server/src/session-index.ts
+++ b/packages/server/src/session-index.ts
@@ -1,0 +1,392 @@
+import { randomUUID } from "node:crypto";
+import { watch, type FSWatcher } from "node:fs";
+import { mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { dirname, relative, resolve, sep } from "node:path";
+import { config } from "./config.js";
+import { makeDedupe, makeLock } from "./concurrency.js";
+
+/**
+ * Persistent, best-effort cache for session discovery. JSONL files remain the
+ * source of truth: a missing, malformed, stale, or unwritable index simply
+ * causes the caller-supplied disk discovery function to run again.
+ */
+const INDEX_VERSION = 2;
+const RECONCILE_INTERVAL_MS = 30_000;
+
+export interface IndexedSession {
+  sessionId: string;
+  path: string;
+  cwd: string;
+  name?: string;
+  createdAt: Date;
+  modifiedAt: Date;
+  messageCount: number;
+  firstMessage: string;
+  parentSessionId?: string;
+  runId?: string;
+  isExternalLive?: boolean;
+  externalState?: "queued" | "running" | "complete" | "failed" | "paused";
+}
+
+interface PersistedSession {
+  sessionId: string;
+  path: string;
+  cwd: string;
+  name?: string;
+  createdAt: string;
+  modifiedAt: string;
+  messageCount: number;
+  parentSessionId?: string;
+  runId?: string;
+  isExternalLive?: boolean;
+  externalState?: "queued" | "running" | "complete" | "failed" | "paused";
+}
+
+interface PersistedProjectIndex {
+  workspacePath: string;
+  sessions: PersistedSession[];
+  /** File and directory metadata used to validate a persisted cache on restart. */
+  footprint: Record<string, string>;
+}
+
+interface PersistedIndex {
+  version: number;
+  projects: Record<string, PersistedProjectIndex>;
+}
+
+interface ProjectCache {
+  workspacePath: string;
+  sessionDir: string;
+  sessions: IndexedSession[];
+  dirty: boolean;
+  lastReconciledAt: number;
+  footprint: Map<string, string>;
+  watchers: FSWatcher[];
+}
+
+const projects = new Map<string, ProjectCache>();
+let persisted: PersistedIndex = { version: INDEX_VERSION, projects: {} };
+let loaded = false;
+const writeLock = makeLock();
+const rebuildInflight = makeDedupe<string, IndexedSession[]>();
+
+function indexPath(): string {
+  return `${config.forgeDataDir}/session-index.json`;
+}
+
+function isExternalState(value: unknown): value is NonNullable<IndexedSession["externalState"]> {
+  return (
+    value === "queued" ||
+    value === "running" ||
+    value === "complete" ||
+    value === "failed" ||
+    value === "paused"
+  );
+}
+
+function parseSession(value: unknown): PersistedSession | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const s = value as Record<string, unknown>;
+  if (
+    typeof s.sessionId !== "string" ||
+    typeof s.path !== "string" ||
+    typeof s.cwd !== "string" ||
+    typeof s.createdAt !== "string" ||
+    typeof s.modifiedAt !== "string" ||
+    typeof s.messageCount !== "number" ||
+    !Number.isFinite(s.messageCount) ||
+    Number.isNaN(Date.parse(s.createdAt)) ||
+    Number.isNaN(Date.parse(s.modifiedAt))
+  ) {
+    return undefined;
+  }
+  if (
+    (s.name !== undefined && typeof s.name !== "string") ||
+    (s.parentSessionId !== undefined && typeof s.parentSessionId !== "string") ||
+    (s.runId !== undefined && typeof s.runId !== "string") ||
+    (s.isExternalLive !== undefined && typeof s.isExternalLive !== "boolean") ||
+    (s.externalState !== undefined && !isExternalState(s.externalState))
+  ) {
+    return undefined;
+  }
+  return s as unknown as PersistedSession;
+}
+
+function parseIndex(value: unknown): PersistedIndex | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const parsed = value as Record<string, unknown>;
+  if (
+    parsed.version !== INDEX_VERSION ||
+    typeof parsed.projects !== "object" ||
+    parsed.projects === null
+  ) {
+    return undefined;
+  }
+  const validProjects: Record<string, PersistedProjectIndex> = {};
+  for (const [projectId, rawProject] of Object.entries(parsed.projects)) {
+    if (typeof rawProject !== "object" || rawProject === null) continue;
+    const project = rawProject as Record<string, unknown>;
+    if (
+      typeof project.workspacePath !== "string" ||
+      !Array.isArray(project.sessions) ||
+      typeof project.footprint !== "object" ||
+      project.footprint === null
+    ) {
+      continue;
+    }
+    const sessions = project.sessions.map(parseSession);
+    const footprint = Object.entries(project.footprint as Record<string, unknown>);
+    if (
+      sessions.some((session) => session === undefined) ||
+      footprint.some(([path, value]) => typeof path !== "string" || typeof value !== "string")
+    ) {
+      continue;
+    }
+    validProjects[projectId] = {
+      workspacePath: project.workspacePath,
+      sessions: sessions as PersistedSession[],
+      footprint: Object.fromEntries(footprint) as Record<string, string>,
+    };
+  }
+  return { version: INDEX_VERSION, projects: validProjects };
+}
+
+async function ensureLoaded(): Promise<void> {
+  if (loaded) return;
+  loaded = true;
+  try {
+    const raw = await readFile(indexPath(), "utf8");
+    const parsed = parseIndex(JSON.parse(raw));
+    // A malformed or old index is deliberately ignored. The next project
+    // lookup rebuilds its entry from JSONL and atomically replaces this file.
+    if (parsed !== undefined) persisted = parsed;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      process.stderr.write(
+        `${JSON.stringify({ level: "warn", msg: "session-index: ignoring unreadable index" })}\n`,
+      );
+    }
+  }
+}
+
+function fromPersisted(session: PersistedSession): IndexedSession {
+  return {
+    ...session,
+    // Conversation previews remain exclusively in the source JSONLs, not in
+    // this metadata cache. A validated warm cache therefore never persists
+    // user/assistant content under FORGE_DATA_DIR.
+    firstMessage: "",
+    createdAt: new Date(session.createdAt),
+    modifiedAt: new Date(session.modifiedAt),
+  };
+}
+
+function toPersisted(session: IndexedSession): PersistedSession {
+  const { firstMessage: _firstMessage, ...safe } = session;
+  return {
+    ...safe,
+    createdAt: session.createdAt.toISOString(),
+    modifiedAt: session.modifiedAt.toISOString(),
+  };
+}
+
+async function atomicWriteIndex(): Promise<void> {
+  await writeLock(async () => {
+    const target = indexPath();
+    const temporary = `${target}.${randomUUID()}.tmp`;
+    try {
+      await mkdir(config.forgeDataDir, { recursive: true });
+      await writeFile(temporary, JSON.stringify(persisted), { encoding: "utf8", mode: 0o600 });
+      await rename(temporary, target);
+    } catch (err) {
+      await unlink(temporary).catch(() => undefined);
+      // The in-memory cache is still usable and JSONLs remain authoritative.
+      process.stderr.write(
+        `${JSON.stringify({ level: "warn", msg: "session-index: failed to persist index", error: err instanceof Error ? err.message : String(err) })}\n`,
+      );
+    }
+  });
+}
+
+function isInsideSessionDir(sessionDir: string, path: string): boolean {
+  const root = resolve(sessionDir);
+  const rel = relative(root, resolve(path));
+  return rel === "" || (!rel.startsWith("..") && !rel.startsWith(`..${sep}`));
+}
+
+function pathsToWatch(sessionDir: string, sessions: readonly IndexedSession[]): string[] {
+  const root = resolve(sessionDir);
+  const paths = new Set<string>([root]);
+  for (const session of sessions) {
+    let current = resolve(dirname(session.path));
+    while (
+      current === root ||
+      (relative(root, current) !== "" && !relative(root, current).startsWith(".."))
+    ) {
+      paths.add(current);
+      if (current === root) break;
+      current = dirname(current);
+    }
+  }
+  return [...paths];
+}
+
+async function fingerprint(paths: readonly string[]): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  await Promise.all(
+    paths.map(async (path) => {
+      try {
+        const info = await stat(path);
+        result.set(path, `${info.isDirectory() ? "d" : "f"}:${info.size}:${info.mtimeMs}`);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") result.set(path, "missing");
+        else result.set(path, "unreadable");
+      }
+    }),
+  );
+  return result;
+}
+
+function installWatchers(cache: ProjectCache): void {
+  for (const watcher of cache.watchers) watcher.close();
+  cache.watchers = [];
+  for (const path of pathsToWatch(cache.sessionDir, cache.sessions)) {
+    try {
+      const watcher = watch(path, { persistent: false }, () => {
+        cache.dirty = true;
+      });
+      watcher.on("error", () => {
+        cache.dirty = true;
+      });
+      cache.watchers.push(watcher);
+    } catch {
+      // A missing or inaccessible directory is reconciled conservatively.
+      cache.dirty = true;
+    }
+  }
+}
+
+async function reconcile(cache: ProjectCache): Promise<void> {
+  if (Date.now() - cache.lastReconciledAt < RECONCILE_INTERVAL_MS) return;
+  cache.lastReconciledAt = Date.now();
+  const next = await fingerprint([...cache.footprint.keys()]);
+  if (next.size !== cache.footprint.size) {
+    cache.dirty = true;
+    return;
+  }
+  for (const [path, value] of cache.footprint) {
+    if (next.get(path) !== value) {
+      cache.dirty = true;
+      return;
+    }
+  }
+}
+
+async function cacheProject(
+  projectId: string,
+  workspacePath: string,
+  sessionDir: string,
+): Promise<ProjectCache | undefined> {
+  await ensureLoaded();
+  const current = projects.get(projectId);
+  if (
+    current !== undefined &&
+    current.workspacePath === workspacePath &&
+    current.sessionDir === sessionDir
+  ) {
+    return current;
+  }
+  if (current !== undefined) {
+    for (const watcher of current.watchers) watcher.close();
+    projects.delete(projectId);
+  }
+  const stored = persisted.projects[projectId];
+  if (stored === undefined || stored.workspacePath !== workspacePath) return undefined;
+  // Do not trust a manually edited/corrupted cache to make us stat or return
+  // paths outside this project's session root. The rebuild scanner remains the
+  // sole authority for paths that enter the cache.
+  if (stored.sessions.some((session) => !isInsideSessionDir(sessionDir, session.path))) {
+    delete persisted.projects[projectId];
+    return undefined;
+  }
+  const sessions = stored.sessions.map(fromPersisted);
+  const storedFootprint = new Map(Object.entries(stored.footprint));
+  const currentFootprint = await fingerprint([...storedFootprint.keys()]);
+  if (
+    currentFootprint.size !== storedFootprint.size ||
+    [...storedFootprint].some(([path, value]) => currentFootprint.get(path) !== value)
+  ) {
+    // The disk changed while this process was stopped. Rebuild before serving
+    // so deleted or externally-created child sessions are never ghosted.
+    return undefined;
+  }
+  const cache: ProjectCache = {
+    workspacePath,
+    sessionDir,
+    sessions,
+    dirty: false,
+    lastReconciledAt: Date.now(),
+    footprint: currentFootprint,
+    watchers: [],
+  };
+  installWatchers(cache);
+  projects.set(projectId, cache);
+  return cache;
+}
+
+async function rebuildProject(
+  projectId: string,
+  workspacePath: string,
+  sessionDir: string,
+  discover: () => Promise<IndexedSession[]>,
+): Promise<IndexedSession[]> {
+  return rebuildInflight(projectId, async () => {
+    const sessions = await discover();
+    const cache: ProjectCache = {
+      workspacePath,
+      sessionDir,
+      sessions,
+      dirty: false,
+      lastReconciledAt: Date.now(),
+      footprint: await fingerprint([
+        ...pathsToWatch(sessionDir, sessions),
+        ...sessions.map((session) => session.path),
+      ]),
+      watchers: [],
+    };
+    const previous = projects.get(projectId);
+    if (previous !== undefined) {
+      for (const watcher of previous.watchers) watcher.close();
+    }
+    projects.set(projectId, cache);
+    installWatchers(cache);
+    persisted.projects[projectId] = {
+      workspacePath,
+      sessions: sessions.map(toPersisted),
+      footprint: Object.fromEntries(cache.footprint),
+    };
+    await atomicWriteIndex();
+    return sessions;
+  });
+}
+
+/** Return the cached project list or rebuild it from the caller's JSONL scanner. */
+export async function getIndexedProjectSessions(
+  projectId: string,
+  workspacePath: string,
+  sessionDir: string,
+  discover: () => Promise<IndexedSession[]>,
+): Promise<IndexedSession[]> {
+  const cache = await cacheProject(projectId, workspacePath, sessionDir);
+  if (cache !== undefined) {
+    await reconcile(cache);
+    if (!cache.dirty) return cache.sessions;
+  }
+  return rebuildProject(projectId, workspacePath, sessionDir, discover);
+}
+
+/** Mark one project's entry stale after a known session filesystem mutation. */
+export function invalidateSessionIndex(projectId: string): void {
+  const cache = projects.get(projectId);
+  if (cache !== undefined) cache.dirty = true;
+}

--- a/packages/server/src/session-index.ts
+++ b/packages/server/src/session-index.ts
@@ -342,7 +342,18 @@ async function rebuildProject(
 ): Promise<IndexedSession[]> {
   const generation = projectGeneration(projectId);
   return rebuildInflight(`${projectId}:${generation}`, async () => {
-    const sessions = await discover();
+    // Discovery is caller-provided, so validate every result before it can be
+    // watched, fingerprinted, cached, or persisted. Canonical paths prevent a
+    // symlink below the project session root from escaping that project.
+    const discovered = await discover();
+    const sessions = (
+      await Promise.all(
+        discovered.map(async (session) => {
+          if (!(await isInsideSessionDir(sessionDir, session.path))) return undefined;
+          return { ...session, path: await realpath(session.path) };
+        }),
+      )
+    ).filter((session): session is IndexedSession => session !== undefined);
     // A reset that begins during source discovery wins. Its newer generation
     // must not be overwritten by this stale scan.
     if (generation !== projectGeneration(projectId)) return sessions;
@@ -394,6 +405,9 @@ export async function getIndexedProjectSessions(
 
 /** Mark one project's entry stale after a known session filesystem mutation. */
 export function invalidateSessionIndex(projectId: string): void {
+  // Invalidation wins over any scan that was already in flight. A later lookup
+  // uses the next generation and cannot be overwritten by that stale result.
+  projectGenerations.set(projectId, projectGeneration(projectId) + 1);
   const cache = projects.get(projectId);
   if (cache !== undefined) cache.dirty = true;
 }

--- a/packages/server/src/session-index.ts
+++ b/packages/server/src/session-index.ts
@@ -1,27 +1,17 @@
 import { randomUUID } from "node:crypto";
-import { constants, watch, type FSWatcher } from "node:fs";
-import {
-  mkdir,
-  open,
-  readFile,
-  realpath,
-  rename,
-  stat,
-  unlink,
-  writeFile,
-  type FileHandle,
-} from "node:fs/promises";
-import { dirname, relative, resolve, sep } from "node:path";
+import { constants } from "node:fs";
+import { mkdir, open, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { relative, resolve, sep } from "node:path";
 import { config } from "./config.js";
 import { makeDedupe, makeLock } from "./concurrency.js";
 
 /**
- * Persistent, best-effort cache for session discovery. JSONL files remain the
- * source of truth: a missing, malformed, stale, or unwritable index simply
- * causes the caller-supplied disk discovery function to run again.
+ * Persistent, best-effort metadata cache for session discovery. Session JSONLs
+ * remain the source of truth. In particular, this cache deliberately never
+ * retains a usable session pathname: a pathname is a mutable lookup, not a
+ * capability. Each caller receives paths only from its current discovery pass.
  */
-const INDEX_VERSION = 3;
-const RECONCILE_INTERVAL_MS = 30_000;
+const INDEX_VERSION = 4;
 
 export interface IndexedSession {
   sessionId: string;
@@ -36,7 +26,8 @@ export interface IndexedSession {
 
 interface PersistedSession {
   sessionId: string;
-  path: string;
+  /** Relative diagnostic metadata only; it is never resolved or used for I/O. */
+  relativePath: string;
   cwd: string;
   createdAt: string;
   modifiedAt: string;
@@ -46,8 +37,6 @@ interface PersistedSession {
 interface PersistedProjectIndex {
   workspacePath: string;
   sessions: PersistedSession[];
-  /** File and directory metadata used to validate a persisted cache on restart. */
-  footprint: Record<string, string>;
 }
 
 interface PersistedIndex {
@@ -57,17 +46,8 @@ interface PersistedIndex {
 
 interface ProjectCache {
   workspacePath: string;
-  sessionDir: string;
-  sessions: IndexedSession[];
-  dirty: boolean;
-  lastReconciledAt: number;
-  footprint: Map<string, string>;
-  watchers: FSWatcher[];
-  /**
-   * Persisted records omit all user-content fields (including names and
-   * previews), so the first sidebar read rebuilds them from the JSONL source.
-   */
-  needsPreviewHydration: boolean;
+  /** Metadata only. No cached field is ever used as a filesystem path. */
+  sessions: PersistedSession[];
 }
 
 const projects = new Map<string, ProjectCache>();
@@ -87,21 +67,21 @@ function indexPath(): string {
 
 function parseSession(value: unknown): PersistedSession | undefined {
   if (typeof value !== "object" || value === null) return undefined;
-  const s = value as Record<string, unknown>;
+  const session = value as Record<string, unknown>;
   if (
-    typeof s.sessionId !== "string" ||
-    typeof s.path !== "string" ||
-    typeof s.cwd !== "string" ||
-    typeof s.createdAt !== "string" ||
-    typeof s.modifiedAt !== "string" ||
-    typeof s.messageCount !== "number" ||
-    !Number.isFinite(s.messageCount) ||
-    Number.isNaN(Date.parse(s.createdAt)) ||
-    Number.isNaN(Date.parse(s.modifiedAt))
+    typeof session.sessionId !== "string" ||
+    typeof session.relativePath !== "string" ||
+    typeof session.cwd !== "string" ||
+    typeof session.createdAt !== "string" ||
+    typeof session.modifiedAt !== "string" ||
+    typeof session.messageCount !== "number" ||
+    !Number.isFinite(session.messageCount) ||
+    Number.isNaN(Date.parse(session.createdAt)) ||
+    Number.isNaN(Date.parse(session.modifiedAt))
   ) {
     return undefined;
   }
-  return s as unknown as PersistedSession;
+  return session as unknown as PersistedSession;
 }
 
 function parseIndex(value: unknown): PersistedIndex | undefined {
@@ -114,33 +94,19 @@ function parseIndex(value: unknown): PersistedIndex | undefined {
   ) {
     return undefined;
   }
-  const validProjects: Record<string, PersistedProjectIndex> = {};
+  const projects: Record<string, PersistedProjectIndex> = {};
   for (const [projectId, rawProject] of Object.entries(parsed.projects)) {
     if (typeof rawProject !== "object" || rawProject === null) continue;
     const project = rawProject as Record<string, unknown>;
-    if (
-      typeof project.workspacePath !== "string" ||
-      !Array.isArray(project.sessions) ||
-      typeof project.footprint !== "object" ||
-      project.footprint === null
-    ) {
-      continue;
-    }
+    if (typeof project.workspacePath !== "string" || !Array.isArray(project.sessions)) continue;
     const sessions = project.sessions.map(parseSession);
-    const footprint = Object.entries(project.footprint as Record<string, unknown>);
-    if (
-      sessions.some((session) => session === undefined) ||
-      footprint.some(([path, value]) => typeof path !== "string" || typeof value !== "string")
-    ) {
-      continue;
-    }
-    validProjects[projectId] = {
+    if (sessions.some((session) => session === undefined)) continue;
+    projects[projectId] = {
       workspacePath: project.workspacePath,
       sessions: sessions as PersistedSession[],
-      footprint: Object.fromEntries(footprint) as Record<string, string>,
     };
   }
-  return { version: INDEX_VERSION, projects: validProjects };
+  return { version: INDEX_VERSION, projects };
 }
 
 async function ensureLoaded(): Promise<void> {
@@ -149,8 +115,7 @@ async function ensureLoaded(): Promise<void> {
   try {
     const raw = await readFile(indexPath(), "utf8");
     const parsed = parseIndex(JSON.parse(raw));
-    // A malformed or old index is deliberately ignored. The next project
-    // lookup rebuilds its entry from JSONL and atomically replaces this file.
+    // Old formats contained absolute session paths and are intentionally ignored.
     if (parsed !== undefined) persisted = parsed;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -159,29 +124,6 @@ async function ensureLoaded(): Promise<void> {
       );
     }
   }
-}
-
-function fromPersisted(session: PersistedSession): IndexedSession {
-  return {
-    ...session,
-    // Names and conversation previews remain exclusively in the source JSONLs,
-    // not in this generic metadata cache. Hydration below re-derives both from
-    // the JSONL source before the sidebar consumes a persisted cache.
-    firstMessage: "",
-    createdAt: new Date(session.createdAt),
-    modifiedAt: new Date(session.modifiedAt),
-  };
-}
-
-function toPersisted(session: IndexedSession): PersistedSession {
-  return {
-    sessionId: session.sessionId,
-    path: session.path,
-    cwd: session.cwd,
-    createdAt: session.createdAt.toISOString(),
-    modifiedAt: session.modifiedAt.toISOString(),
-    messageCount: session.messageCount,
-  };
 }
 
 async function atomicWriteIndex(): Promise<void> {
@@ -194,7 +136,6 @@ async function atomicWriteIndex(): Promise<void> {
       await rename(temporary, target);
     } catch (err) {
       await unlink(temporary).catch(() => undefined);
-      // The in-memory cache is still usable and JSONLs remain authoritative.
       process.stderr.write(
         `${JSON.stringify({ level: "warn", msg: "session-index: failed to persist index", error: err instanceof Error ? err.message : String(err) })}\n`,
       );
@@ -202,185 +143,49 @@ async function atomicWriteIndex(): Promise<void> {
   });
 }
 
-async function isInsideSessionDir(sessionDir: string, path: string): Promise<boolean> {
+function safeRelativePath(sessionDir: string, path: string): string | undefined {
+  const relativePath = relative(resolve(sessionDir), resolve(path));
+  if (
+    relativePath === "" ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`) ||
+    relativePath.startsWith(sep)
+  ) {
+    return undefined;
+  }
+  return relativePath;
+}
+
+function toPersisted(sessionDir: string, session: IndexedSession): PersistedSession | undefined {
+  const relativePath = safeRelativePath(sessionDir, session.path);
+  if (relativePath === undefined) return undefined;
+  return {
+    sessionId: session.sessionId,
+    relativePath,
+    cwd: session.cwd,
+    createdAt: session.createdAt.toISOString(),
+    modifiedAt: session.modifiedAt.toISOString(),
+    messageCount: session.messageCount,
+  };
+}
+
+async function isCurrentRegularSessionPath(sessionDir: string, path: string): Promise<boolean> {
+  if (safeRelativePath(sessionDir, path) === undefined) return false;
   try {
-    const [root, candidate] = await Promise.all([realpath(sessionDir), realpath(path)]);
-    const rel = relative(root, candidate);
-    return rel === "" || (!rel.startsWith("..") && !rel.startsWith(`..${sep}`));
+    // This applies only to the current discovery result. The handle is not
+    // cached and the pathname is never canonicalized for later reuse.
+    const handle = await open(
+      path,
+      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+    );
+    try {
+      return (await handle.stat()).isFile();
+    } finally {
+      await handle.close();
+    }
   } catch {
     return false;
   }
-}
-
-function pathsToWatch(sessionDir: string, sessions: readonly IndexedSession[]): string[] {
-  const root = resolve(sessionDir);
-  const paths = new Set<string>([root]);
-  for (const session of sessions) {
-    let current = resolve(dirname(session.path));
-    while (
-      current === root ||
-      (relative(root, current) !== "" && !relative(root, current).startsWith(".."))
-    ) {
-      paths.add(current);
-      if (current === root) break;
-      current = dirname(current);
-    }
-  }
-  return [...paths];
-}
-
-function fingerprintInfo(info: { isDirectory(): boolean; size: number; mtimeMs: number }): string {
-  return `${info.isDirectory() ? "d" : "f"}:${info.size}:${info.mtimeMs}`;
-}
-
-async function fingerprint(paths: readonly string[]): Promise<Map<string, string>> {
-  const result = new Map<string, string>();
-  await Promise.all(
-    paths.map(async (path) => {
-      try {
-        result.set(path, fingerprintInfo(await stat(path)));
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === "ENOENT") result.set(path, "missing");
-        else result.set(path, "unreadable");
-      }
-    }),
-  );
-  return result;
-}
-
-interface ValidatedSessionPath {
-  path: string;
-  fingerprint: string;
-}
-
-/**
- * Open the discovered file before resolving it so a final-component symlink
- * cannot be exchanged after a separate containment check. The inode comparison
- * also rejects an ancestor-directory exchange that resolves outside the root.
- */
-async function validateDiscoveredSessionPath(
-  sessionRoot: string,
-  path: string,
-): Promise<ValidatedSessionPath | undefined> {
-  let handle: FileHandle | undefined;
-  try {
-    handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
-    const info = await handle.stat();
-    if (!info.isFile()) return undefined;
-
-    const canonicalPath = await realpath(path);
-    const canonicalInfo = await stat(canonicalPath);
-    const rel = relative(sessionRoot, canonicalPath);
-    if (
-      (rel !== "" && (rel.startsWith("..") || rel.startsWith(`..${sep}`))) ||
-      canonicalInfo.dev !== info.dev ||
-      canonicalInfo.ino !== info.ino
-    ) {
-      return undefined;
-    }
-    return { path: canonicalPath, fingerprint: fingerprintInfo(info) };
-  } catch {
-    return undefined;
-  } finally {
-    await handle?.close();
-  }
-}
-
-function installWatchers(cache: ProjectCache): void {
-  for (const watcher of cache.watchers) watcher.close();
-  cache.watchers = [];
-  for (const path of pathsToWatch(cache.sessionDir, cache.sessions)) {
-    try {
-      const watcher = watch(path, { persistent: false }, () => {
-        cache.dirty = true;
-      });
-      watcher.on("error", () => {
-        cache.dirty = true;
-      });
-      cache.watchers.push(watcher);
-    } catch {
-      // A missing or inaccessible directory is reconciled conservatively.
-      cache.dirty = true;
-    }
-  }
-}
-
-async function reconcile(cache: ProjectCache): Promise<void> {
-  if (Date.now() - cache.lastReconciledAt < RECONCILE_INTERVAL_MS) return;
-  cache.lastReconciledAt = Date.now();
-  const next = await fingerprint([...cache.footprint.keys()]);
-  if (next.size !== cache.footprint.size) {
-    cache.dirty = true;
-    return;
-  }
-  for (const [path, value] of cache.footprint) {
-    if (next.get(path) !== value) {
-      cache.dirty = true;
-      return;
-    }
-  }
-}
-
-async function cacheProject(
-  projectId: string,
-  workspacePath: string,
-  sessionDir: string,
-): Promise<ProjectCache | undefined> {
-  await ensureLoaded();
-  const current = projects.get(projectId);
-  if (
-    current !== undefined &&
-    current.workspacePath === workspacePath &&
-    current.sessionDir === sessionDir
-  ) {
-    return current;
-  }
-  if (current !== undefined) {
-    for (const watcher of current.watchers) watcher.close();
-    projects.delete(projectId);
-  }
-  const stored = persisted.projects[projectId];
-  if (stored === undefined || stored.workspacePath !== workspacePath) return undefined;
-  // Do not trust a manually edited/corrupted cache to make us stat or return
-  // paths outside this project's canonical session root. Validate both session
-  // records and footprint paths before any stat call; realpath prevents a
-  // symlink inside the session tree from escaping that root.
-  const storedFootprint = new Map(Object.entries(stored.footprint));
-  const cachedPaths = [
-    ...stored.sessions.map((session) => session.path),
-    ...storedFootprint.keys(),
-  ];
-  if (
-    (await Promise.all(cachedPaths.map((path) => isInsideSessionDir(sessionDir, path)))).some(
-      (inside) => !inside,
-    )
-  ) {
-    delete persisted.projects[projectId];
-    return undefined;
-  }
-  const sessions = stored.sessions.map(fromPersisted);
-  const currentFootprint = await fingerprint([...storedFootprint.keys()]);
-  if (
-    currentFootprint.size !== storedFootprint.size ||
-    [...storedFootprint].some(([path, value]) => currentFootprint.get(path) !== value)
-  ) {
-    // The disk changed while this process was stopped. Rebuild before serving
-    // so deleted or externally-created child sessions are never ghosted.
-    return undefined;
-  }
-  const cache: ProjectCache = {
-    workspacePath,
-    sessionDir,
-    sessions,
-    dirty: false,
-    lastReconciledAt: Date.now(),
-    footprint: currentFootprint,
-    watchers: [],
-    needsPreviewHydration: true,
-  };
-  installWatchers(cache);
-  projects.set(projectId, cache);
-  return cache;
 }
 
 async function rebuildProject(
@@ -391,96 +196,60 @@ async function rebuildProject(
 ): Promise<IndexedSession[]> {
   const generation = projectGeneration(projectId);
   return rebuildInflight(`${projectId}:${generation}`, async () => {
-    // Discovery is caller-provided, so validate every result before it can be
-    // watched, fingerprinted, cached, or persisted. Opening with O_NOFOLLOW
-    // binds validation to one regular-file handle instead of trusting a path
-    // which could be exchanged for an external symlink between checks.
-    const sessionRoot = await realpath(sessionDir).catch(() => undefined);
+    // Do not validate, fingerprint, watch, canonicalize, or return a path from
+    // a prior cache entry. Discovery owns current path handling; its result is
+    // returned directly so a cache cannot turn an earlier pathname validation
+    // into a durable capability.
     const discovered = await discover();
-    const validated = await Promise.all(
-      discovered.map(async (session) => {
-        if (sessionRoot === undefined) return undefined;
-        const validatedPath = await validateDiscoveredSessionPath(sessionRoot, session.path);
-        return validatedPath === undefined ? undefined : { session, validatedPath };
-      }),
-    );
-    const sessions: IndexedSession[] = [];
-    const sessionFingerprints = new Map<string, string>();
-    for (const entry of validated) {
-      if (entry === undefined) continue;
-      sessions.push({ ...entry.session, path: entry.validatedPath.path });
-      sessionFingerprints.set(entry.validatedPath.path, entry.validatedPath.fingerprint);
-    }
-    // A reset that begins during source discovery wins. Its newer generation
-    // must not be overwritten by this stale scan.
+    const sessions = (
+      await Promise.all(
+        discovered.map(async (session) =>
+          (await isCurrentRegularSessionPath(sessionDir, session.path)) ? session : undefined,
+        ),
+      )
+    ).filter((session): session is IndexedSession => session !== undefined);
     if (generation !== projectGeneration(projectId)) return sessions;
-    // Fingerprint discovered files from their validated handles; re-statting
-    // their pathnames here would reopen the symlink exchange race.
-    const footprint = await fingerprint(pathsToWatch(sessionDir, sessions));
-    for (const [path, value] of sessionFingerprints) footprint.set(path, value);
-    if (generation !== projectGeneration(projectId)) return sessions;
-    const cache: ProjectCache = {
-      workspacePath,
-      sessionDir,
-      sessions,
-      dirty: false,
-      lastReconciledAt: Date.now(),
-      footprint,
-      watchers: [],
-      needsPreviewHydration: false,
-    };
-    const previous = projects.get(projectId);
-    if (previous !== undefined) {
-      for (const watcher of previous.watchers) watcher.close();
-    }
+
+    const metadata = sessions
+      .map((session) => toPersisted(sessionDir, session))
+      .filter((session): session is PersistedSession => session !== undefined);
+    const cache = { workspacePath, sessions: metadata };
     projects.set(projectId, cache);
-    installWatchers(cache);
-    persisted.projects[projectId] = {
-      workspacePath,
-      sessions: sessions.map(toPersisted),
-      footprint: Object.fromEntries(cache.footprint),
-    };
+    persisted.projects[projectId] = cache;
     await atomicWriteIndex();
     return sessions;
   });
 }
 
-/** Return the cached project list or rebuild it from the caller's JSONL scanner. */
+/**
+ * Discover the current JSONL paths and update metadata opportunistically.
+ * Concurrent requests share one scan, but sequential reads intentionally do
+ * not serve old pathnames from the cache.
+ */
 export async function getIndexedProjectSessions(
   projectId: string,
   workspacePath: string,
   sessionDir: string,
   discover: () => Promise<IndexedSession[]>,
 ): Promise<IndexedSession[]> {
-  const cache = await cacheProject(projectId, workspacePath, sessionDir);
-  if (cache !== undefined) {
-    await reconcile(cache);
-    if (!cache.dirty && !cache.needsPreviewHydration) return cache.sessions;
-  }
+  await ensureLoaded();
   return rebuildProject(projectId, workspacePath, sessionDir, discover);
 }
 
-/** Mark one project's entry stale after a known session filesystem mutation. */
+/** Mark one project's metadata stale after a known session filesystem mutation. */
 export function invalidateSessionIndex(projectId: string): void {
-  // Invalidation wins over any scan that was already in flight. A later lookup
-  // uses the next generation and cannot be overwritten by that stale result.
   projectGenerations.set(projectId, projectGeneration(projectId) + 1);
-  const cache = projects.get(projectId);
-  if (cache !== undefined) cache.dirty = true;
+  projects.delete(projectId);
 }
 
 /**
- * Remove only one project's derived cache and force its next lookup to scan
+ * Remove only one project's derived metadata and force its next lookup to scan
  * source JSONLs again. Session files and project data are never modified.
  */
 export async function resetSessionIndex(projectId: string): Promise<void> {
   await ensureLoaded();
   projectGenerations.set(projectId, projectGeneration(projectId) + 1);
-  const cache = projects.get(projectId);
-  if (cache !== undefined) {
-    for (const watcher of cache.watchers) watcher.close();
-    projects.delete(projectId);
-  }
+  projects.delete(projectId);
   delete persisted.projects[projectId];
   await atomicWriteIndex();
 }

--- a/packages/server/src/session-index.ts
+++ b/packages/server/src/session-index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { watch, type FSWatcher } from "node:fs";
-import { mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
 import { config } from "./config.js";
 import { makeDedupe, makeLock } from "./concurrency.js";
@@ -22,10 +22,6 @@ export interface IndexedSession {
   modifiedAt: Date;
   messageCount: number;
   firstMessage: string;
-  parentSessionId?: string;
-  runId?: string;
-  isExternalLive?: boolean;
-  externalState?: "queued" | "running" | "complete" | "failed" | "paused";
 }
 
 interface PersistedSession {
@@ -36,10 +32,6 @@ interface PersistedSession {
   createdAt: string;
   modifiedAt: string;
   messageCount: number;
-  parentSessionId?: string;
-  runId?: string;
-  isExternalLive?: boolean;
-  externalState?: "queued" | "running" | "complete" | "failed" | "paused";
 }
 
 interface PersistedProjectIndex {
@@ -67,23 +59,18 @@ interface ProjectCache {
 }
 
 const projects = new Map<string, ProjectCache>();
+const projectGenerations = new Map<string, number>();
 let persisted: PersistedIndex = { version: INDEX_VERSION, projects: {} };
 let loaded = false;
 const writeLock = makeLock();
 const rebuildInflight = makeDedupe<string, IndexedSession[]>();
 
-function indexPath(): string {
-  return `${config.forgeDataDir}/session-index.json`;
+function projectGeneration(projectId: string): number {
+  return projectGenerations.get(projectId) ?? 0;
 }
 
-function isExternalState(value: unknown): value is NonNullable<IndexedSession["externalState"]> {
-  return (
-    value === "queued" ||
-    value === "running" ||
-    value === "complete" ||
-    value === "failed" ||
-    value === "paused"
-  );
+function indexPath(): string {
+  return `${config.forgeDataDir}/session-index.json`;
 }
 
 function parseSession(value: unknown): PersistedSession | undefined {
@@ -102,13 +89,7 @@ function parseSession(value: unknown): PersistedSession | undefined {
   ) {
     return undefined;
   }
-  if (
-    (s.name !== undefined && typeof s.name !== "string") ||
-    (s.parentSessionId !== undefined && typeof s.parentSessionId !== "string") ||
-    (s.runId !== undefined && typeof s.runId !== "string") ||
-    (s.isExternalLive !== undefined && typeof s.isExternalLive !== "boolean") ||
-    (s.externalState !== undefined && !isExternalState(s.externalState))
-  ) {
+  if (s.name !== undefined && typeof s.name !== "string") {
     return undefined;
   }
   return s as unknown as PersistedSession;
@@ -184,11 +165,14 @@ function fromPersisted(session: PersistedSession): IndexedSession {
 }
 
 function toPersisted(session: IndexedSession): PersistedSession {
-  const { firstMessage: _firstMessage, ...safe } = session;
   return {
-    ...safe,
+    sessionId: session.sessionId,
+    path: session.path,
+    cwd: session.cwd,
+    ...(session.name !== undefined ? { name: session.name } : {}),
     createdAt: session.createdAt.toISOString(),
     modifiedAt: session.modifiedAt.toISOString(),
+    messageCount: session.messageCount,
   };
 }
 
@@ -210,10 +194,14 @@ async function atomicWriteIndex(): Promise<void> {
   });
 }
 
-function isInsideSessionDir(sessionDir: string, path: string): boolean {
-  const root = resolve(sessionDir);
-  const rel = relative(root, resolve(path));
-  return rel === "" || (!rel.startsWith("..") && !rel.startsWith(`..${sep}`));
+async function isInsideSessionDir(sessionDir: string, path: string): Promise<boolean> {
+  try {
+    const [root, candidate] = await Promise.all([realpath(sessionDir), realpath(path)]);
+    const rel = relative(root, candidate);
+    return rel === "" || (!rel.startsWith("..") && !rel.startsWith(`..${sep}`));
+  } catch {
+    return false;
+  }
 }
 
 function pathsToWatch(sessionDir: string, sessions: readonly IndexedSession[]): string[] {
@@ -305,14 +293,23 @@ async function cacheProject(
   const stored = persisted.projects[projectId];
   if (stored === undefined || stored.workspacePath !== workspacePath) return undefined;
   // Do not trust a manually edited/corrupted cache to make us stat or return
-  // paths outside this project's session root. The rebuild scanner remains the
-  // sole authority for paths that enter the cache.
-  if (stored.sessions.some((session) => !isInsideSessionDir(sessionDir, session.path))) {
+  // paths outside this project's canonical session root. Validate both session
+  // records and footprint paths before any stat call; realpath prevents a
+  // symlink inside the session tree from escaping that root.
+  const storedFootprint = new Map(Object.entries(stored.footprint));
+  const cachedPaths = [
+    ...stored.sessions.map((session) => session.path),
+    ...storedFootprint.keys(),
+  ];
+  if (
+    (await Promise.all(cachedPaths.map((path) => isInsideSessionDir(sessionDir, path)))).some(
+      (inside) => !inside,
+    )
+  ) {
     delete persisted.projects[projectId];
     return undefined;
   }
   const sessions = stored.sessions.map(fromPersisted);
-  const storedFootprint = new Map(Object.entries(stored.footprint));
   const currentFootprint = await fingerprint([...storedFootprint.keys()]);
   if (
     currentFootprint.size !== storedFootprint.size ||
@@ -343,18 +340,24 @@ async function rebuildProject(
   sessionDir: string,
   discover: () => Promise<IndexedSession[]>,
 ): Promise<IndexedSession[]> {
-  return rebuildInflight(projectId, async () => {
+  const generation = projectGeneration(projectId);
+  return rebuildInflight(`${projectId}:${generation}`, async () => {
     const sessions = await discover();
+    // A reset that begins during source discovery wins. Its newer generation
+    // must not be overwritten by this stale scan.
+    if (generation !== projectGeneration(projectId)) return sessions;
+    const footprint = await fingerprint([
+      ...pathsToWatch(sessionDir, sessions),
+      ...sessions.map((session) => session.path),
+    ]);
+    if (generation !== projectGeneration(projectId)) return sessions;
     const cache: ProjectCache = {
       workspacePath,
       sessionDir,
       sessions,
       dirty: false,
       lastReconciledAt: Date.now(),
-      footprint: await fingerprint([
-        ...pathsToWatch(sessionDir, sessions),
-        ...sessions.map((session) => session.path),
-      ]),
+      footprint,
       watchers: [],
       needsPreviewHydration: false,
     };
@@ -393,4 +396,20 @@ export async function getIndexedProjectSessions(
 export function invalidateSessionIndex(projectId: string): void {
   const cache = projects.get(projectId);
   if (cache !== undefined) cache.dirty = true;
+}
+
+/**
+ * Remove only one project's derived cache and force its next lookup to scan
+ * source JSONLs again. Session files and project data are never modified.
+ */
+export async function resetSessionIndex(projectId: string): Promise<void> {
+  await ensureLoaded();
+  projectGenerations.set(projectId, projectGeneration(projectId) + 1);
+  const cache = projects.get(projectId);
+  if (cache !== undefined) {
+    for (const watcher of cache.watchers) watcher.close();
+    projects.delete(projectId);
+  }
+  delete persisted.projects[projectId];
+  await atomicWriteIndex();
 }

--- a/packages/server/src/session-index.ts
+++ b/packages/server/src/session-index.ts
@@ -1,17 +1,15 @@
 import { randomUUID } from "node:crypto";
-import { constants } from "node:fs";
-import { mkdir, open, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { relative, resolve, sep } from "node:path";
 import { config } from "./config.js";
 import { makeDedupe, makeLock } from "./concurrency.js";
 
 /**
  * Persistent, best-effort metadata cache for session discovery. Session JSONLs
- * remain the source of truth. In particular, this cache deliberately never
- * retains a usable session pathname: a pathname is a mutable lookup, not a
- * capability. Each caller receives paths only from its current discovery pass.
+ * remain the source of truth: the caller's SDK discovery result is returned
+ * directly. This module never enumerates, validates, opens, or stores paths.
  */
-const INDEX_VERSION = 4;
+const INDEX_VERSION = 5;
 
 export interface IndexedSession {
   sessionId: string;
@@ -24,18 +22,17 @@ export interface IndexedSession {
   firstMessage: string;
 }
 
+/** Safe, non-capability metadata derived from an SDK discovery result. */
 interface PersistedSession {
   sessionId: string;
-  /** Relative diagnostic metadata only; it is never resolved or used for I/O. */
-  relativePath: string;
-  cwd: string;
   createdAt: string;
   modifiedAt: string;
   messageCount: number;
 }
 
 interface PersistedProjectIndex {
-  workspacePath: string;
+  refreshedAt: string;
+  sessionCount: number;
   sessions: PersistedSession[];
 }
 
@@ -44,13 +41,7 @@ interface PersistedIndex {
   projects: Record<string, PersistedProjectIndex>;
 }
 
-interface ProjectCache {
-  workspacePath: string;
-  /** Metadata only. No cached field is ever used as a filesystem path. */
-  sessions: PersistedSession[];
-}
-
-const projects = new Map<string, ProjectCache>();
+const projects = new Map<string, PersistedProjectIndex>();
 const projectGenerations = new Map<string, number>();
 let persisted: PersistedIndex = { version: INDEX_VERSION, projects: {} };
 let loaded = false;
@@ -70,8 +61,6 @@ function parseSession(value: unknown): PersistedSession | undefined {
   const session = value as Record<string, unknown>;
   if (
     typeof session.sessionId !== "string" ||
-    typeof session.relativePath !== "string" ||
-    typeof session.cwd !== "string" ||
     typeof session.createdAt !== "string" ||
     typeof session.modifiedAt !== "string" ||
     typeof session.messageCount !== "number" ||
@@ -98,11 +87,26 @@ function parseIndex(value: unknown): PersistedIndex | undefined {
   for (const [projectId, rawProject] of Object.entries(parsed.projects)) {
     if (typeof rawProject !== "object" || rawProject === null) continue;
     const project = rawProject as Record<string, unknown>;
-    if (typeof project.workspacePath !== "string" || !Array.isArray(project.sessions)) continue;
+    if (
+      typeof project.refreshedAt !== "string" ||
+      Number.isNaN(Date.parse(project.refreshedAt)) ||
+      typeof project.sessionCount !== "number" ||
+      !Number.isSafeInteger(project.sessionCount) ||
+      project.sessionCount < 0 ||
+      !Array.isArray(project.sessions)
+    ) {
+      continue;
+    }
     const sessions = project.sessions.map(parseSession);
-    if (sessions.some((session) => session === undefined)) continue;
+    if (
+      sessions.some((session) => session === undefined) ||
+      sessions.length !== project.sessionCount
+    ) {
+      continue;
+    }
     projects[projectId] = {
-      workspacePath: project.workspacePath,
+      refreshedAt: project.refreshedAt,
+      sessionCount: project.sessionCount,
       sessions: sessions as PersistedSession[],
     };
   }
@@ -115,7 +119,7 @@ async function ensureLoaded(): Promise<void> {
   try {
     const raw = await readFile(indexPath(), "utf8");
     const parsed = parseIndex(JSON.parse(raw));
-    // Old formats contained absolute session paths and are intentionally ignored.
+    // Old formats contained path-like data and are intentionally ignored.
     if (parsed !== undefined) persisted = parsed;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -143,8 +147,8 @@ async function atomicWriteIndex(): Promise<void> {
   });
 }
 
-function safeRelativePath(sessionDir: string, path: string): string | undefined {
-  const relativePath = relative(resolve(sessionDir), resolve(path));
+function rootRelativePath(root: string, candidate: string): string | undefined {
+  const relativePath = relative(resolve(root), resolve(candidate));
   if (
     relativePath === "" ||
     relativePath === ".." ||
@@ -156,64 +160,59 @@ function safeRelativePath(sessionDir: string, path: string): string | undefined 
   return relativePath;
 }
 
-function toPersisted(sessionDir: string, session: IndexedSession): PersistedSession | undefined {
-  const relativePath = safeRelativePath(sessionDir, session.path);
-  if (relativePath === undefined) return undefined;
+/**
+ * Conservatively reject a discovered candidate before caching its metadata when
+ * its root-relative path contains a symlink. This does not repair the SDK's
+ * path-opening behavior and never affects the current discovery result.
+ */
+async function isCacheablePath(sessionDir: string, candidate: string): Promise<boolean> {
+  const relativePath = rootRelativePath(sessionDir, candidate);
+  if (relativePath === undefined) return false;
+  let current = resolve(sessionDir);
+  for (const segment of relativePath.split(sep)) {
+    current = `${current}${sep}${segment}`;
+    try {
+      if ((await lstat(current)).isSymbolicLink()) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+function toPersisted(session: IndexedSession): PersistedSession {
   return {
     sessionId: session.sessionId,
-    relativePath,
-    cwd: session.cwd,
     createdAt: session.createdAt.toISOString(),
     modifiedAt: session.modifiedAt.toISOString(),
     messageCount: session.messageCount,
   };
 }
 
-async function isCurrentRegularSessionPath(sessionDir: string, path: string): Promise<boolean> {
-  if (safeRelativePath(sessionDir, path) === undefined) return false;
-  try {
-    // This applies only to the current discovery result. The handle is not
-    // cached and the pathname is never canonicalized for later reuse.
-    const handle = await open(
-      path,
-      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
-    );
-    try {
-      return (await handle.stat()).isFile();
-    } finally {
-      await handle.close();
-    }
-  } catch {
-    return false;
-  }
-}
-
 async function rebuildProject(
   projectId: string,
-  workspacePath: string,
   sessionDir: string,
   discover: () => Promise<IndexedSession[]>,
 ): Promise<IndexedSession[]> {
   const generation = projectGeneration(projectId);
   return rebuildInflight(`${projectId}:${generation}`, async () => {
-    // Do not validate, fingerprint, watch, canonicalize, or return a path from
-    // a prior cache entry. Discovery owns current path handling; its result is
-    // returned directly so a cache cannot turn an earlier pathname validation
-    // into a durable capability.
-    const discovered = await discover();
-    const sessions = (
+    // The SDK discovery pass is the only path enumeration and security
+    // authority. Do not inspect its paths here; return its result unchanged.
+    const sessions = await discover();
+    if (generation !== projectGeneration(projectId)) return sessions;
+
+    const cacheableSessions = (
       await Promise.all(
-        discovered.map(async (session) =>
-          (await isCurrentRegularSessionPath(sessionDir, session.path)) ? session : undefined,
+        sessions.map(async (session) =>
+          (await isCacheablePath(sessionDir, session.path)) ? session : undefined,
         ),
       )
     ).filter((session): session is IndexedSession => session !== undefined);
-    if (generation !== projectGeneration(projectId)) return sessions;
-
-    const metadata = sessions
-      .map((session) => toPersisted(sessionDir, session))
-      .filter((session): session is PersistedSession => session !== undefined);
-    const cache = { workspacePath, sessions: metadata };
+    const cache: PersistedProjectIndex = {
+      refreshedAt: new Date().toISOString(),
+      sessionCount: cacheableSessions.length,
+      sessions: cacheableSessions.map(toPersisted),
+    };
     projects.set(projectId, cache);
     persisted.projects[projectId] = cache;
     await atomicWriteIndex();
@@ -222,18 +221,16 @@ async function rebuildProject(
 }
 
 /**
- * Discover the current JSONL paths and update metadata opportunistically.
- * Concurrent requests share one scan, but sequential reads intentionally do
- * not serve old pathnames from the cache.
+ * Discover sessions through the caller's SDK path and update only derived,
+ * path-free metadata. Sequential reads intentionally never return cached paths.
  */
 export async function getIndexedProjectSessions(
   projectId: string,
-  workspacePath: string,
   sessionDir: string,
   discover: () => Promise<IndexedSession[]>,
 ): Promise<IndexedSession[]> {
   await ensureLoaded();
-  return rebuildProject(projectId, workspacePath, sessionDir, discover);
+  return rebuildProject(projectId, sessionDir, discover);
 }
 
 /** Mark one project's metadata stale after a known session filesystem mutation. */

--- a/packages/server/src/session-index.ts
+++ b/packages/server/src/session-index.ts
@@ -1,6 +1,16 @@
 import { randomUUID } from "node:crypto";
-import { watch, type FSWatcher } from "node:fs";
-import { mkdir, readFile, realpath, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { constants, watch, type FSWatcher } from "node:fs";
+import {
+  mkdir,
+  open,
+  readFile,
+  realpath,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+  type FileHandle,
+} from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
 import { config } from "./config.js";
 import { makeDedupe, makeLock } from "./concurrency.js";
@@ -219,13 +229,16 @@ function pathsToWatch(sessionDir: string, sessions: readonly IndexedSession[]): 
   return [...paths];
 }
 
+function fingerprintInfo(info: { isDirectory(): boolean; size: number; mtimeMs: number }): string {
+  return `${info.isDirectory() ? "d" : "f"}:${info.size}:${info.mtimeMs}`;
+}
+
 async function fingerprint(paths: readonly string[]): Promise<Map<string, string>> {
   const result = new Map<string, string>();
   await Promise.all(
     paths.map(async (path) => {
       try {
-        const info = await stat(path);
-        result.set(path, `${info.isDirectory() ? "d" : "f"}:${info.size}:${info.mtimeMs}`);
+        result.set(path, fingerprintInfo(await stat(path)));
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code === "ENOENT") result.set(path, "missing");
         else result.set(path, "unreadable");
@@ -233,6 +246,44 @@ async function fingerprint(paths: readonly string[]): Promise<Map<string, string
     }),
   );
   return result;
+}
+
+interface ValidatedSessionPath {
+  path: string;
+  fingerprint: string;
+}
+
+/**
+ * Open the discovered file before resolving it so a final-component symlink
+ * cannot be exchanged after a separate containment check. The inode comparison
+ * also rejects an ancestor-directory exchange that resolves outside the root.
+ */
+async function validateDiscoveredSessionPath(
+  sessionRoot: string,
+  path: string,
+): Promise<ValidatedSessionPath | undefined> {
+  let handle: FileHandle | undefined;
+  try {
+    handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const info = await handle.stat();
+    if (!info.isFile()) return undefined;
+
+    const canonicalPath = await realpath(path);
+    const canonicalInfo = await stat(canonicalPath);
+    const rel = relative(sessionRoot, canonicalPath);
+    if (
+      (rel !== "" && (rel.startsWith("..") || rel.startsWith(`..${sep}`))) ||
+      canonicalInfo.dev !== info.dev ||
+      canonicalInfo.ino !== info.ino
+    ) {
+      return undefined;
+    }
+    return { path: canonicalPath, fingerprint: fingerprintInfo(info) };
+  } catch {
+    return undefined;
+  } finally {
+    await handle?.close();
+  }
 }
 
 function installWatchers(cache: ProjectCache): void {
@@ -341,24 +392,32 @@ async function rebuildProject(
   const generation = projectGeneration(projectId);
   return rebuildInflight(`${projectId}:${generation}`, async () => {
     // Discovery is caller-provided, so validate every result before it can be
-    // watched, fingerprinted, cached, or persisted. Canonical paths prevent a
-    // symlink below the project session root from escaping that project.
+    // watched, fingerprinted, cached, or persisted. Opening with O_NOFOLLOW
+    // binds validation to one regular-file handle instead of trusting a path
+    // which could be exchanged for an external symlink between checks.
+    const sessionRoot = await realpath(sessionDir).catch(() => undefined);
     const discovered = await discover();
-    const sessions = (
-      await Promise.all(
-        discovered.map(async (session) => {
-          if (!(await isInsideSessionDir(sessionDir, session.path))) return undefined;
-          return { ...session, path: await realpath(session.path) };
-        }),
-      )
-    ).filter((session): session is IndexedSession => session !== undefined);
+    const validated = await Promise.all(
+      discovered.map(async (session) => {
+        if (sessionRoot === undefined) return undefined;
+        const validatedPath = await validateDiscoveredSessionPath(sessionRoot, session.path);
+        return validatedPath === undefined ? undefined : { session, validatedPath };
+      }),
+    );
+    const sessions: IndexedSession[] = [];
+    const sessionFingerprints = new Map<string, string>();
+    for (const entry of validated) {
+      if (entry === undefined) continue;
+      sessions.push({ ...entry.session, path: entry.validatedPath.path });
+      sessionFingerprints.set(entry.validatedPath.path, entry.validatedPath.fingerprint);
+    }
     // A reset that begins during source discovery wins. Its newer generation
     // must not be overwritten by this stale scan.
     if (generation !== projectGeneration(projectId)) return sessions;
-    const footprint = await fingerprint([
-      ...pathsToWatch(sessionDir, sessions),
-      ...sessions.map((session) => session.path),
-    ]);
+    // Fingerprint discovered files from their validated handles; re-statting
+    // their pathnames here would reopen the symlink exchange race.
+    const footprint = await fingerprint(pathsToWatch(sessionDir, sessions));
+    for (const [path, value] of sessionFingerprints) footprint.set(path, value);
     if (generation !== projectGeneration(projectId)) return sessions;
     const cache: ProjectCache = {
       workspacePath,

--- a/packages/server/src/session-index.ts
+++ b/packages/server/src/session-index.ts
@@ -10,7 +10,7 @@ import { makeDedupe, makeLock } from "./concurrency.js";
  * source of truth: a missing, malformed, stale, or unwritable index simply
  * causes the caller-supplied disk discovery function to run again.
  */
-const INDEX_VERSION = 2;
+const INDEX_VERSION = 3;
 const RECONCILE_INTERVAL_MS = 30_000;
 
 export interface IndexedSession {
@@ -28,7 +28,6 @@ interface PersistedSession {
   sessionId: string;
   path: string;
   cwd: string;
-  name?: string;
   createdAt: string;
   modifiedAt: string;
   messageCount: number;
@@ -54,7 +53,10 @@ interface ProjectCache {
   lastReconciledAt: number;
   footprint: Map<string, string>;
   watchers: FSWatcher[];
-  /** Persisted records omit previews, so the first sidebar read rebuilds them. */
+  /**
+   * Persisted records omit all user-content fields (including names and
+   * previews), so the first sidebar read rebuilds them from the JSONL source.
+   */
   needsPreviewHydration: boolean;
 }
 
@@ -87,9 +89,6 @@ function parseSession(value: unknown): PersistedSession | undefined {
     Number.isNaN(Date.parse(s.createdAt)) ||
     Number.isNaN(Date.parse(s.modifiedAt))
   ) {
-    return undefined;
-  }
-  if (s.name !== undefined && typeof s.name !== "string") {
     return undefined;
   }
   return s as unknown as PersistedSession;
@@ -155,9 +154,9 @@ async function ensureLoaded(): Promise<void> {
 function fromPersisted(session: PersistedSession): IndexedSession {
   return {
     ...session,
-    // Conversation previews remain exclusively in the source JSONLs, not in
-    // this metadata cache. A validated warm cache therefore never persists
-    // user/assistant content under FORGE_DATA_DIR.
+    // Names and conversation previews remain exclusively in the source JSONLs,
+    // not in this generic metadata cache. Hydration below re-derives both from
+    // the JSONL source before the sidebar consumes a persisted cache.
     firstMessage: "",
     createdAt: new Date(session.createdAt),
     modifiedAt: new Date(session.modifiedAt),
@@ -169,7 +168,6 @@ function toPersisted(session: IndexedSession): PersistedSession {
     sessionId: session.sessionId,
     path: session.path,
     cwd: session.cwd,
-    ...(session.name !== undefined ? { name: session.name } : {}),
     createdAt: session.createdAt.toISOString(),
     modifiedAt: session.modifiedAt.toISOString(),
     messageCount: session.messageCount,

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -1432,7 +1432,7 @@ export async function discoverSessionsOnDisk(
   workspacePath: string,
 ): Promise<DiscoveredSession[]> {
   const dir = sessionDirFor(projectId);
-  return getIndexedProjectSessions(projectId, workspacePath, dir, () =>
+  return getIndexedProjectSessions(projectId, dir, () =>
     discoverSessionsOnDiskUncached(projectId, workspacePath, dir),
   );
 }

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -49,6 +49,7 @@ import { generateSessionTitleFromPrompt, isGenericSessionName } from "./session-
 import { getExternalSubagentStatusForSession } from "./subagents-external.js";
 import { readSandboxSettings } from "./sandbox-settings.js";
 import { publishSessionActivity, type SessionActivity } from "./session-activity.js";
+import { getIndexedProjectSessions, invalidateSessionIndex } from "./session-index.js";
 
 /**
  * Minimal SSE client contract used by the registry to fan out events.
@@ -486,6 +487,10 @@ function makeSubscribeHandler(live: LiveSession): () => void {
   const verbose = process.env.DEBUG_AGENT_EVENTS === "1";
   return live.session.subscribe((event: AgentSessionEvent) => {
     live.lastActivityAt = new Date();
+    // Session JSONL mutations are observable through the SDK subscription.
+    // Marking the project stale makes the next sidebar/location lookup refresh
+    // from source even when a filesystem watcher event is delayed or lost.
+    invalidateSessionIndex(live.projectId);
     if (event.type === "agent_start") {
       publishActivity(live, true);
       // Capture BEFORE the SDK appends turn messages, so the index points
@@ -864,6 +869,7 @@ export async function createSession(
   };
   live.unsubscribe = makeSubscribeHandler(live);
   registry.set(live.sessionId, live);
+  invalidateSessionIndex(projectId);
   await bindWebExtensionContext(live);
 
   // Set a meaningful default name on the new session so the sidebar
@@ -1271,13 +1277,17 @@ export async function deleteColdSession(
           sessionPath: match.path,
           ...(siblingDir !== undefined ? { subagentDir: siblingDir } : {}),
         });
+        invalidateSessionIndex(project.id);
       } catch (err) {
         // ENOENT (vanished mid-flight) is fine — collapse to "deleted" since
         // the file is now gone from live discovery, which is what the caller
         // asked for. Any other error (permissions, IO) is a real failure and
         // should NOT silently look like "not_found" to the operator.
         const code = (err as NodeJS.ErrnoException).code;
-        if (code === "ENOENT") return "deleted";
+        if (code === "ENOENT") {
+          invalidateSessionIndex(project.id);
+          return "deleted";
+        }
         throw err;
       }
       return "deleted";
@@ -1418,6 +1428,17 @@ export async function discoverSessionsOnDisk(
   workspacePath: string,
 ): Promise<DiscoveredSession[]> {
   const dir = sessionDirFor(projectId);
+  return getIndexedProjectSessions(projectId, workspacePath, dir, () =>
+    discoverSessionsOnDiskUncached(projectId, workspacePath, dir),
+  );
+}
+
+/** JSONL source-of-truth scan used exclusively to rebuild the session index. */
+async function discoverSessionsOnDiskUncached(
+  projectId: string,
+  workspacePath: string,
+  dir: string,
+): Promise<DiscoveredSession[]> {
   // SDK's list() guards `existsSync(dir)` and returns [] for missing dirs,
   // so we don't need an outer ENOENT catch.
   const infos: SessionInfo[] = await SessionManager.list(workspacePath, dir);
@@ -1891,6 +1912,7 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
   };
   live.unsubscribe = makeSubscribeHandler(live);
   registry.set(live.sessionId, live);
+  invalidateSessionIndex(source.projectId);
   await bindWebExtensionContext(live);
 
   // Disambiguate the fork's display name from its source. The SDK

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -49,7 +49,11 @@ import { generateSessionTitleFromPrompt, isGenericSessionName } from "./session-
 import { getExternalSubagentStatusForSession } from "./subagents-external.js";
 import { readSandboxSettings } from "./sandbox-settings.js";
 import { publishSessionActivity, type SessionActivity } from "./session-activity.js";
-import { getIndexedProjectSessions, invalidateSessionIndex } from "./session-index.js";
+import {
+  getIndexedProjectSessions,
+  invalidateSessionIndex,
+  resetSessionIndex,
+} from "./session-index.js";
 
 /**
  * Minimal SSE client contract used by the registry to fan out events.
@@ -1431,6 +1435,19 @@ export async function discoverSessionsOnDisk(
   return getIndexedProjectSessions(projectId, workspacePath, dir, () =>
     discoverSessionsOnDiskUncached(projectId, workspacePath, dir),
   );
+}
+
+/** Reset only the derived cache, then rebuild this project's JSONL discovery. */
+const refreshProjectSessionIndexInflight = makeDedupe<string, DiscoveredSession[]>();
+
+export async function refreshProjectSessionIndex(
+  projectId: string,
+  workspacePath: string,
+): Promise<DiscoveredSession[]> {
+  return refreshProjectSessionIndexInflight(projectId, async () => {
+    await resetSessionIndex(projectId);
+    return discoverSessionsOnDisk(projectId, workspacePath);
+  });
 }
 
 /** JSONL source-of-truth scan used exclusively to rebuild the session index. */

--- a/tests/test-api.ts
+++ b/tests/test-api.ts
@@ -218,6 +218,10 @@ async function main(): Promise<void> {
       assert("OpenAPI spec has openapi version", typeof spec.openapi === "string");
       assert("spec includes /sessions path", spec.paths?.["/api/v1/sessions"] !== undefined);
       assert(
+        "spec includes session-index refresh path",
+        spec.paths?.["/api/v1/projects/{projectId}/session-index/refresh"] !== undefined,
+      );
+      assert(
         "spec includes /sessions/{id}/prompt",
         spec.paths?.["/api/v1/sessions/{id}/prompt"] !== undefined,
       );
@@ -258,6 +262,34 @@ async function main(): Promise<void> {
       );
       assert("create project → 201", proj.status === 201);
       projectId = (proj.body as { id: string }).id;
+
+      const anonymousRefresh = await jsend(
+        "POST",
+        `${base}/api/v1/projects/${projectId}/session-index/refresh`,
+        {},
+      );
+      assert("session-index refresh requires authentication", anonymousRefresh.status === 401);
+      const refreshed = await jsend(
+        "POST",
+        `${base}/api/v1/projects/${projectId}/session-index/refresh`,
+        {},
+        auth,
+      );
+      assert(
+        "session-index refresh rebuilds and returns the project session list",
+        refreshed.status === 200 &&
+          Array.isArray((refreshed.body as { sessions?: unknown }).sessions),
+      );
+      const refreshBurst = await Promise.all(
+        Array.from({ length: 11 }, () =>
+          jsend("POST", `${base}/api/v1/projects/${projectId}/session-index/refresh`, {}, auth),
+        ),
+      );
+      assert(
+        "session-index refresh burst is route-rate-limited",
+        refreshBurst.some((response) => response.status === 429),
+        `statuses=${refreshBurst.map((response) => response.status).join(",")}`,
+      );
     }
 
     let sessionId: string;

--- a/tests/test-session-index.ts
+++ b/tests/test-session-index.ts
@@ -1,0 +1,107 @@
+/**
+ * Session index persistence/cache contract:
+ * - malformed persisted index is ignored and rebuilt from the supplied JSONL scan
+ * - a clean project is served from the in-memory/persistent index
+ * - explicit invalidation forces the next lookup to rebuild
+ */
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(__filename), "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const dataDir = await mkdtemp(join(tmpdir(), "pi-forge-session-index-data-"));
+  const sessionDir = await mkdtemp(join(tmpdir(), "pi-forge-session-index-sessions-"));
+  process.env.FORGE_DATA_DIR = dataDir;
+  process.env.SESSION_DIR = sessionDir;
+  process.env.WORKSPACE_PATH = sessionDir;
+  process.env.PI_CONFIG_DIR = await mkdtemp(join(tmpdir(), "pi-forge-session-index-config-"));
+  await writeFile(join(dataDir, "session-index.json"), "{ malformed", "utf8");
+
+  const projectId = "session-index-test";
+  const projectSessionDir = join(sessionDir, projectId);
+  await mkdir(projectSessionDir);
+  let scans = 0;
+  const record = {
+    sessionId: "child-session",
+    path: join(projectSessionDir, "parent", "run-1", "session.jsonl"),
+    cwd: sessionDir,
+    name: "Child session",
+    createdAt: new Date("2026-01-02T03:04:05.000Z"),
+    modifiedAt: new Date("2026-01-02T03:05:06.000Z"),
+    messageCount: 7,
+    firstMessage: "hello",
+    parentSessionId: "parent-session",
+    runId: "run-1",
+    isExternalLive: true,
+    externalState: "running" as const,
+  };
+
+  await mkdir(dirname(record.path), { recursive: true });
+
+  const index = (await import(
+    resolve(repoRoot, "packages/server/dist/session-index.js")
+  )) as typeof import("../packages/server/src/session-index.js");
+  const discover = async () => {
+    scans += 1;
+    return [record];
+  };
+
+  try {
+    const first = await index.getIndexedProjectSessions(
+      projectId,
+      sessionDir,
+      projectSessionDir,
+      discover,
+    );
+    assert(
+      "malformed index rebuilds from source",
+      scans === 1 && first[0]?.sessionId === record.sessionId,
+    );
+
+    const second = await index.getIndexedProjectSessions(
+      projectId,
+      sessionDir,
+      projectSessionDir,
+      discover,
+    );
+    assert("clean project lookup avoids repeated discovery", scans === 1 && second.length === 1);
+
+    const persisted = JSON.parse(await readFile(join(dataDir, "session-index.json"), "utf8")) as {
+      version?: number;
+      projects?: Record<string, { sessions?: Record<string, unknown>[] }>;
+    };
+    const stored = persisted.projects?.[projectId]?.sessions?.[0];
+    assert(
+      "versioned index persists sidebar and location fields",
+      persisted.version === 1 &&
+        stored?.parentSessionId === record.parentSessionId &&
+        stored?.runId === record.runId &&
+        stored?.externalState === record.externalState &&
+        stored?.path === record.path,
+    );
+
+    index.invalidateSessionIndex(projectId);
+    await index.getIndexedProjectSessions(projectId, sessionDir, projectSessionDir, discover);
+    assert("explicit invalidation rebuilds on next lookup", scans === 2);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(sessionDir, { recursive: true, force: true });
+  }
+
+  if (failures > 0) process.exitCode = 1;
+}
+
+void main();

--- a/tests/test-session-index.ts
+++ b/tests/test-session-index.ts
@@ -86,7 +86,7 @@ async function main(): Promise<void> {
     const stored = persisted.projects?.[projectId]?.sessions?.[0];
     assert(
       "versioned index persists sidebar and location fields",
-      persisted.version === 1 &&
+      persisted.version === 2 &&
         stored?.parentSessionId === record.parentSessionId &&
         stored?.runId === record.runId &&
         stored?.externalState === record.externalState &&

--- a/tests/test-session-index.ts
+++ b/tests/test-session-index.ts
@@ -116,9 +116,15 @@ async function main(): Promise<void> {
       projectSessionDir,
       discover,
     );
+    const escapedPersisted = JSON.parse(
+      await readFile(join(dataDir, "session-index.json"), "utf8"),
+    ) as { projects?: Record<string, { sessions?: { path?: string }[] }> };
     assert(
-      "discovery rejects symlink paths outside the project session root",
-      escaped.length === 0,
+      "discovery rejects and does not persist an external symlink target",
+      escaped.length === 0 &&
+        !escapedPersisted.projects?.[projectId]?.sessions?.some(
+          (session) => session.path === outsidePath || session.path === escapedPath,
+        ),
     );
     await rm(outsideDir, { recursive: true, force: true });
     records = [record];

--- a/tests/test-session-index.ts
+++ b/tests/test-session-index.ts
@@ -2,7 +2,8 @@
  * Session index persistence/cache contract:
  * - malformed persisted index is ignored and rebuilt from the supplied JSONL scan
  * - a clean project is served from the in-memory/persistent index
- * - explicit invalidation forces the next lookup to rebuild
+ * - explicit invalidation and manual reset force the next lookup to rebuild
+ * - reset does not mutate source JSONLs or allow a stale in-flight scan to win
  */
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -36,27 +37,27 @@ async function main(): Promise<void> {
   let scans = 0;
   const record = {
     sessionId: "child-session",
-    path: join(projectSessionDir, "parent", "run-1", "session.jsonl"),
+    path: join(projectSessionDir, "session-index-test.jsonl"),
     cwd: sessionDir,
     name: "Child session",
     createdAt: new Date("2026-01-02T03:04:05.000Z"),
     modifiedAt: new Date("2026-01-02T03:05:06.000Z"),
     messageCount: 7,
     firstMessage: "hello",
-    parentSessionId: "parent-session",
-    runId: "run-1",
-    isExternalLive: true,
-    externalState: "running" as const,
   };
 
   await mkdir(dirname(record.path), { recursive: true });
+  await writeFile(record.path, '{"type":"session"}\n', "utf8");
 
   const index = (await import(
     resolve(repoRoot, "packages/server/dist/session-index.js")
   )) as typeof import("../packages/server/src/session-index.js");
+  let records = [record];
+  let delayedScan: Promise<void> | undefined;
   const discover = async () => {
     scans += 1;
-    return [record];
+    await delayedScan;
+    return records;
   };
 
   try {
@@ -85,17 +86,62 @@ async function main(): Promise<void> {
     };
     const stored = persisted.projects?.[projectId]?.sessions?.[0];
     assert(
-      "versioned index persists sidebar and location fields",
+      "versioned index persists only metadata and no preview content",
       persisted.version === 2 &&
-        stored?.parentSessionId === record.parentSessionId &&
-        stored?.runId === record.runId &&
-        stored?.externalState === record.externalState &&
-        stored?.path === record.path,
+        stored?.path === record.path &&
+        stored?.firstMessage === undefined &&
+        stored?.parentSessionId === undefined &&
+        stored?.runId === undefined &&
+        stored?.externalState === undefined,
     );
 
     index.invalidateSessionIndex(projectId);
     await index.getIndexedProjectSessions(projectId, sessionDir, projectSessionDir, discover);
     assert("explicit invalidation rebuilds on next lookup", scans === 2);
+
+    const sourceBeforeReset = await readFile(record.path, "utf8");
+    await index.resetSessionIndex(projectId);
+    const afterReset = JSON.parse(await readFile(join(dataDir, "session-index.json"), "utf8")) as {
+      projects?: Record<string, unknown>;
+    };
+    assert(
+      "reset removes only the persisted project cache entry",
+      afterReset.projects?.[projectId] === undefined,
+    );
+    assert(
+      "reset does not alter session source files",
+      (await readFile(record.path, "utf8")) === sourceBeforeReset,
+    );
+    await index.getIndexedProjectSessions(projectId, sessionDir, projectSessionDir, discover);
+    assert("reset forces the next lookup to rebuild", scans === 3);
+
+    let releaseDelayedScan!: () => void;
+    index.invalidateSessionIndex(projectId);
+    delayedScan = new Promise<void>((resolveDelay) => {
+      releaseDelayedScan = resolveDelay;
+    });
+    const staleRebuild = index.getIndexedProjectSessions(
+      projectId,
+      sessionDir,
+      projectSessionDir,
+      discover,
+    );
+    while (scans !== 4) await new Promise((resolveDelay) => setTimeout(resolveDelay, 1));
+    await index.resetSessionIndex(projectId);
+    records = [{ ...record, sessionId: "fresh-session" }];
+    releaseDelayedScan();
+    await staleRebuild;
+    delayedScan = undefined;
+    const refreshed = await index.getIndexedProjectSessions(
+      projectId,
+      sessionDir,
+      projectSessionDir,
+      discover,
+    );
+    assert(
+      "delayed stale rebuild cannot repopulate a reset generation",
+      scans === 5 && refreshed[0]?.sessionId === "fresh-session",
+    );
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(sessionDir, { recursive: true, force: true });

--- a/tests/test-session-index.ts
+++ b/tests/test-session-index.ts
@@ -1,10 +1,10 @@
 /**
  * Session index persistence/cache contract:
- * - malformed persisted index is ignored and rebuilt from the supplied JSONL scan
- * - each lookup returns a current discovery result, never a cached pathname
- * - explicit invalidation and manual reset force the next lookup to rebuild
+ * - malformed persisted index is ignored and rebuilt from SDK discovery
+ * - each lookup returns a current discovery result, never cached paths
+ * - persisted records contain generic metadata only; paths/names/previews never persist
  * - reset does not mutate source JSONLs or allow a stale in-flight scan to win
- * - persisted records contain generic metadata only; names/previews rehydrate from JSONL
+ * - SDK discovery remains the sole enumeration authority around symlinks
  */
 import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -15,11 +15,11 @@ const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
 
 let failures = 0;
-function assert(label: string, ok: boolean, detail?: string): void {
+function assert(label: string, ok: boolean): void {
   if (ok) console.log(`  PASS  ${label}`);
   else {
     failures += 1;
-    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+    console.log(`  FAIL  ${label}`);
   }
 }
 
@@ -46,8 +46,6 @@ async function main(): Promise<void> {
     messageCount: 7,
     firstMessage: "hello",
   };
-
-  await mkdir(dirname(record.path), { recursive: true });
   await writeFile(record.path, '{"type":"session"}\n', "utf8");
 
   const index = (await import(
@@ -62,23 +60,13 @@ async function main(): Promise<void> {
   };
 
   try {
-    const first = await index.getIndexedProjectSessions(
-      projectId,
-      sessionDir,
-      projectSessionDir,
-      discover,
-    );
+    const first = await index.getIndexedProjectSessions(projectId, sessionDir, discover);
     assert(
       "malformed index rebuilds from source",
       scans === 1 && first[0]?.sessionId === record.sessionId,
     );
 
-    const second = await index.getIndexedProjectSessions(
-      projectId,
-      sessionDir,
-      projectSessionDir,
-      discover,
-    );
+    const second = await index.getIndexedProjectSessions(projectId, sessionDir, discover);
     assert(
       "clean project lookup returns a fresh source-derived session name",
       scans === 2 && second.length === 1 && second[0]?.name === record.name,
@@ -86,57 +74,63 @@ async function main(): Promise<void> {
 
     const persisted = JSON.parse(await readFile(join(dataDir, "session-index.json"), "utf8")) as {
       version?: number;
-      projects?: Record<string, { sessions?: Record<string, unknown>[] }>;
+      projects?: Record<
+        string,
+        { refreshedAt?: string; sessionCount?: number; sessions?: Record<string, unknown>[] }
+      >;
     };
     const stored = persisted.projects?.[projectId]?.sessions?.[0];
     assert(
-      "versioned index persists generic metadata only, never names or preview content",
-      persisted.version === 4 &&
-        stored?.relativePath === "session-index-test.jsonl" &&
+      "versioned index persists path-free generic metadata only",
+      persisted.version === 5 &&
+        persisted.projects?.[projectId]?.sessionCount === 1 &&
+        typeof persisted.projects?.[projectId]?.refreshedAt === "string" &&
         JSON.stringify(Object.keys(stored ?? {}).sort()) ===
-          JSON.stringify([
-            "createdAt",
-            "cwd",
-            "messageCount",
-            "modifiedAt",
-            "relativePath",
-            "sessionId",
-          ]) &&
+          JSON.stringify(["createdAt", "messageCount", "modifiedAt", "sessionId"]) &&
         !JSON.stringify(persisted).includes(record.path) &&
+        !JSON.stringify(persisted).includes(sessionDir) &&
         !JSON.stringify(stored).includes(record.name) &&
         !JSON.stringify(stored).includes(record.firstMessage),
     );
 
     index.invalidateSessionIndex(projectId);
-    await index.getIndexedProjectSessions(projectId, sessionDir, projectSessionDir, discover);
+    await index.getIndexedProjectSessions(projectId, sessionDir, discover);
     assert("explicit invalidation rebuilds on next lookup", scans === 3);
 
     const outsideDir = await mkdtemp(join(tmpdir(), "pi-forge-session-index-outside-"));
     const outsidePath = join(outsideDir, "foreign.jsonl");
-    const escapedPath = join(projectSessionDir, "escaped.jsonl");
+    const finalSymlink = join(projectSessionDir, "final.jsonl");
+    const nestedSymlinkDir = join(projectSessionDir, "nested");
+    const ancestorSymlink = join(sessionDir, "ancestor-project");
     await writeFile(outsidePath, '{"type":"session"}\n', "utf8");
-    await symlink(outsidePath, escapedPath);
-    records = [{ ...record, sessionId: "escaped-session", path: escapedPath }];
+    await symlink(outsidePath, finalSymlink);
+    await symlink(outsideDir, nestedSymlinkDir);
+    await symlink(projectSessionDir, ancestorSymlink);
+    // Model candidates returned by SDK discovery. The cache must return them
+    // unchanged, but reject final and ancestor symlink paths before persistence.
+    records = [
+      record,
+      { ...record, sessionId: "final-symlink-session", path: finalSymlink },
+      {
+        ...record,
+        sessionId: "ancestor-symlink-session",
+        path: join(ancestorSymlink, "session-index-test.jsonl"),
+      },
+    ];
     index.invalidateSessionIndex(projectId);
-    const escaped = await index.getIndexedProjectSessions(
-      projectId,
-      sessionDir,
-      projectSessionDir,
-      discover,
-    );
-    const escapedPersisted = JSON.parse(
+    const symlinked = await index.getIndexedProjectSessions(projectId, sessionDir, discover);
+    const symlinkPersisted = JSON.parse(
       await readFile(join(dataDir, "session-index.json"), "utf8"),
-    ) as { projects?: Record<string, { sessions?: { relativePath?: string }[] }> };
+    ) as { projects?: Record<string, { sessions?: { sessionId?: string }[] }> };
+    const persistedIds = symlinkPersisted.projects?.[projectId]?.sessions?.map((s) => s.sessionId);
     assert(
-      "a symlink swap cannot make cached metadata return or watch an external file",
+      "final and ancestor symlink candidates are excluded before cache persistence",
       scans === 4 &&
-        escaped.length === 0 &&
-        !JSON.stringify(escapedPersisted).includes(outsidePath) &&
-        !JSON.stringify(escapedPersisted).includes(escapedPath) &&
-        !JSON.stringify(escapedPersisted).includes("footprint"),
+        symlinked.length === 3 &&
+        JSON.stringify(persistedIds) === JSON.stringify([record.sessionId]),
     );
-    await rm(outsideDir, { recursive: true, force: true });
     records = [record];
+    await rm(outsideDir, { recursive: true, force: true });
 
     const sourceBeforeReset = await readFile(record.path, "utf8");
     await index.resetSessionIndex(projectId);
@@ -151,7 +145,7 @@ async function main(): Promise<void> {
       "reset does not alter session source files",
       (await readFile(record.path, "utf8")) === sourceBeforeReset,
     );
-    await index.getIndexedProjectSessions(projectId, sessionDir, projectSessionDir, discover);
+    await index.getIndexedProjectSessions(projectId, sessionDir, discover);
     assert("reset forces the next lookup to rebuild", scans === 5);
 
     let releaseDelayedScan!: () => void;
@@ -159,24 +153,14 @@ async function main(): Promise<void> {
     delayedScan = new Promise<void>((resolveDelay) => {
       releaseDelayedScan = resolveDelay;
     });
-    const staleRebuild = index.getIndexedProjectSessions(
-      projectId,
-      sessionDir,
-      projectSessionDir,
-      discover,
-    );
+    const staleRebuild = index.getIndexedProjectSessions(projectId, sessionDir, discover);
     while (scans !== 6) await new Promise((resolveDelay) => setTimeout(resolveDelay, 1));
     index.invalidateSessionIndex(projectId);
     records = [{ ...record, sessionId: "fresh-session" }];
     releaseDelayedScan();
     await staleRebuild;
     delayedScan = undefined;
-    const refreshed = await index.getIndexedProjectSessions(
-      projectId,
-      sessionDir,
-      projectSessionDir,
-      discover,
-    );
+    const refreshed = await index.getIndexedProjectSessions(projectId, sessionDir, discover);
     assert(
       "delayed stale rebuild cannot overwrite an invalidated generation",
       Number(scans) === 7 && refreshed[0]?.sessionId === "fresh-session",

--- a/tests/test-session-index.ts
+++ b/tests/test-session-index.ts
@@ -5,7 +5,7 @@
  * - explicit invalidation and manual reset force the next lookup to rebuild
  * - reset does not mutate source JSONLs or allow a stale in-flight scan to win
  */
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -50,7 +50,7 @@ async function main(): Promise<void> {
   await writeFile(record.path, '{"type":"session"}\n', "utf8");
 
   const index = (await import(
-    resolve(repoRoot, "packages/server/dist/session-index.js")
+    resolve(repoRoot, "packages/server/src/session-index.ts")
   )) as typeof import("../packages/server/src/session-index.js");
   let records = [record];
   let delayedScan: Promise<void> | undefined;
@@ -89,15 +89,41 @@ async function main(): Promise<void> {
       "versioned index persists only metadata and no preview content",
       persisted.version === 2 &&
         stored?.path === record.path &&
-        stored?.firstMessage === undefined &&
-        stored?.parentSessionId === undefined &&
-        stored?.runId === undefined &&
-        stored?.externalState === undefined,
+        JSON.stringify(Object.keys(stored ?? {}).sort()) ===
+          JSON.stringify([
+            "createdAt",
+            "cwd",
+            "messageCount",
+            "modifiedAt",
+            "name",
+            "path",
+            "sessionId",
+          ]),
     );
 
     index.invalidateSessionIndex(projectId);
     await index.getIndexedProjectSessions(projectId, sessionDir, projectSessionDir, discover);
     assert("explicit invalidation rebuilds on next lookup", scans === 2);
+
+    const outsideDir = await mkdtemp(join(tmpdir(), "pi-forge-session-index-outside-"));
+    const outsidePath = join(outsideDir, "foreign.jsonl");
+    const escapedPath = join(projectSessionDir, "escaped.jsonl");
+    await writeFile(outsidePath, '{"type":"session"}\n', "utf8");
+    await symlink(outsidePath, escapedPath);
+    records = [{ ...record, sessionId: "escaped-session", path: escapedPath }];
+    index.invalidateSessionIndex(projectId);
+    const escaped = await index.getIndexedProjectSessions(
+      projectId,
+      sessionDir,
+      projectSessionDir,
+      discover,
+    );
+    assert(
+      "discovery rejects symlink paths outside the project session root",
+      escaped.length === 0,
+    );
+    await rm(outsideDir, { recursive: true, force: true });
+    records = [record];
 
     const sourceBeforeReset = await readFile(record.path, "utf8");
     await index.resetSessionIndex(projectId);
@@ -113,7 +139,7 @@ async function main(): Promise<void> {
       (await readFile(record.path, "utf8")) === sourceBeforeReset,
     );
     await index.getIndexedProjectSessions(projectId, sessionDir, projectSessionDir, discover);
-    assert("reset forces the next lookup to rebuild", scans === 3);
+    assert("reset forces the next lookup to rebuild", scans === 4);
 
     let releaseDelayedScan!: () => void;
     index.invalidateSessionIndex(projectId);
@@ -126,8 +152,8 @@ async function main(): Promise<void> {
       projectSessionDir,
       discover,
     );
-    while (scans !== 4) await new Promise((resolveDelay) => setTimeout(resolveDelay, 1));
-    await index.resetSessionIndex(projectId);
+    while (scans !== 5) await new Promise((resolveDelay) => setTimeout(resolveDelay, 1));
+    index.invalidateSessionIndex(projectId);
     records = [{ ...record, sessionId: "fresh-session" }];
     releaseDelayedScan();
     await staleRebuild;
@@ -139,8 +165,8 @@ async function main(): Promise<void> {
       discover,
     );
     assert(
-      "delayed stale rebuild cannot repopulate a reset generation",
-      scans === 5 && refreshed[0]?.sessionId === "fresh-session",
+      "delayed stale rebuild cannot overwrite an invalidated generation",
+      scans === 6 && refreshed[0]?.sessionId === "fresh-session",
     );
   } finally {
     await rm(dataDir, { recursive: true, force: true });

--- a/tests/test-session-index.ts
+++ b/tests/test-session-index.ts
@@ -1,7 +1,7 @@
 /**
  * Session index persistence/cache contract:
  * - malformed persisted index is ignored and rebuilt from the supplied JSONL scan
- * - a clean project is served from the in-memory/persistent index
+ * - each lookup returns a current discovery result, never a cached pathname
  * - explicit invalidation and manual reset force the next lookup to rebuild
  * - reset does not mutate source JSONLs or allow a stale in-flight scan to win
  * - persisted records contain generic metadata only; names/previews rehydrate from JSONL
@@ -80,8 +80,8 @@ async function main(): Promise<void> {
       discover,
     );
     assert(
-      "clean project lookup preserves the source-derived session name",
-      scans === 1 && second.length === 1 && second[0]?.name === record.name,
+      "clean project lookup returns a fresh source-derived session name",
+      scans === 2 && second.length === 1 && second[0]?.name === record.name,
     );
 
     const persisted = JSON.parse(await readFile(join(dataDir, "session-index.json"), "utf8")) as {
@@ -91,17 +91,25 @@ async function main(): Promise<void> {
     const stored = persisted.projects?.[projectId]?.sessions?.[0];
     assert(
       "versioned index persists generic metadata only, never names or preview content",
-      persisted.version === 3 &&
-        stored?.path === record.path &&
+      persisted.version === 4 &&
+        stored?.relativePath === "session-index-test.jsonl" &&
         JSON.stringify(Object.keys(stored ?? {}).sort()) ===
-          JSON.stringify(["createdAt", "cwd", "messageCount", "modifiedAt", "path", "sessionId"]) &&
+          JSON.stringify([
+            "createdAt",
+            "cwd",
+            "messageCount",
+            "modifiedAt",
+            "relativePath",
+            "sessionId",
+          ]) &&
+        !JSON.stringify(persisted).includes(record.path) &&
         !JSON.stringify(stored).includes(record.name) &&
         !JSON.stringify(stored).includes(record.firstMessage),
     );
 
     index.invalidateSessionIndex(projectId);
     await index.getIndexedProjectSessions(projectId, sessionDir, projectSessionDir, discover);
-    assert("explicit invalidation rebuilds on next lookup", scans === 2);
+    assert("explicit invalidation rebuilds on next lookup", scans === 3);
 
     const outsideDir = await mkdtemp(join(tmpdir(), "pi-forge-session-index-outside-"));
     const outsidePath = join(outsideDir, "foreign.jsonl");
@@ -118,13 +126,14 @@ async function main(): Promise<void> {
     );
     const escapedPersisted = JSON.parse(
       await readFile(join(dataDir, "session-index.json"), "utf8"),
-    ) as { projects?: Record<string, { sessions?: { path?: string }[] }> };
+    ) as { projects?: Record<string, { sessions?: { relativePath?: string }[] }> };
     assert(
-      "discovery rejects and does not persist an external symlink target",
-      escaped.length === 0 &&
-        !escapedPersisted.projects?.[projectId]?.sessions?.some(
-          (session) => session.path === outsidePath || session.path === escapedPath,
-        ),
+      "a symlink swap cannot make cached metadata return or watch an external file",
+      scans === 4 &&
+        escaped.length === 0 &&
+        !JSON.stringify(escapedPersisted).includes(outsidePath) &&
+        !JSON.stringify(escapedPersisted).includes(escapedPath) &&
+        !JSON.stringify(escapedPersisted).includes("footprint"),
     );
     await rm(outsideDir, { recursive: true, force: true });
     records = [record];
@@ -143,7 +152,7 @@ async function main(): Promise<void> {
       (await readFile(record.path, "utf8")) === sourceBeforeReset,
     );
     await index.getIndexedProjectSessions(projectId, sessionDir, projectSessionDir, discover);
-    assert("reset forces the next lookup to rebuild", scans === 4);
+    assert("reset forces the next lookup to rebuild", scans === 5);
 
     let releaseDelayedScan!: () => void;
     index.invalidateSessionIndex(projectId);
@@ -156,7 +165,7 @@ async function main(): Promise<void> {
       projectSessionDir,
       discover,
     );
-    while (scans !== 5) await new Promise((resolveDelay) => setTimeout(resolveDelay, 1));
+    while (scans !== 6) await new Promise((resolveDelay) => setTimeout(resolveDelay, 1));
     index.invalidateSessionIndex(projectId);
     records = [{ ...record, sessionId: "fresh-session" }];
     releaseDelayedScan();
@@ -170,7 +179,7 @@ async function main(): Promise<void> {
     );
     assert(
       "delayed stale rebuild cannot overwrite an invalidated generation",
-      scans === 6 && refreshed[0]?.sessionId === "fresh-session",
+      Number(scans) === 7 && refreshed[0]?.sessionId === "fresh-session",
     );
   } finally {
     await rm(dataDir, { recursive: true, force: true });

--- a/tests/test-session-index.ts
+++ b/tests/test-session-index.ts
@@ -4,6 +4,7 @@
  * - a clean project is served from the in-memory/persistent index
  * - explicit invalidation and manual reset force the next lookup to rebuild
  * - reset does not mutate source JSONLs or allow a stale in-flight scan to win
+ * - persisted records contain generic metadata only; names/previews rehydrate from JSONL
  */
 import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -78,7 +79,10 @@ async function main(): Promise<void> {
       projectSessionDir,
       discover,
     );
-    assert("clean project lookup avoids repeated discovery", scans === 1 && second.length === 1);
+    assert(
+      "clean project lookup preserves the source-derived session name",
+      scans === 1 && second.length === 1 && second[0]?.name === record.name,
+    );
 
     const persisted = JSON.parse(await readFile(join(dataDir, "session-index.json"), "utf8")) as {
       version?: number;
@@ -86,19 +90,13 @@ async function main(): Promise<void> {
     };
     const stored = persisted.projects?.[projectId]?.sessions?.[0];
     assert(
-      "versioned index persists only metadata and no preview content",
-      persisted.version === 2 &&
+      "versioned index persists generic metadata only, never names or preview content",
+      persisted.version === 3 &&
         stored?.path === record.path &&
         JSON.stringify(Object.keys(stored ?? {}).sort()) ===
-          JSON.stringify([
-            "createdAt",
-            "cwd",
-            "messageCount",
-            "modifiedAt",
-            "name",
-            "path",
-            "sessionId",
-          ]),
+          JSON.stringify(["createdAt", "cwd", "messageCount", "modifiedAt", "path", "sessionId"]) &&
+        !JSON.stringify(stored).includes(record.name) &&
+        !JSON.stringify(stored).includes(record.firstMessage),
     );
 
     index.invalidateSessionIndex(projectId);


### PR DESCRIPTION
## What this changes

Adds a generic persistent Project Session Index to reduce repeated session-discovery work and adds a safe Project Sidebar refresh action. JSONL session files remain the source of truth. The cache stores metadata only: no session paths, previews, first messages, or prompt-derived names are persisted.

The refresh action resets only derived index state and rebuilds the active project's session list. It does not delete or modify sessions, JSONL files, artifacts, projects, or workspace files.

## Type of change

- [x] `fix:` bug fix (no API change)
- [x] `feat:` new feature
- [ ] `refactor:` internal change, no behavior difference
- [x] `docs:` documentation only
- [ ] `chore:` tooling, deps, build
- [x] `test:` adding or fixing tests
- [ ] `perf:` performance improvement

## Scope

- [x] Server (`packages/server/`)
- [x] Client (`packages/client/`)
- [ ] Docker / deploy (`docker/`, `kubernetes/`)
- [x] Docs (`docs/`, `README.md`, root markdown)
- [x] Tests (`tests/`)

## How to verify

```bash
npx tsx tests/test-session-index.ts
# PASS

npx eslint packages/server/src/session-index.ts \
  packages/server/src/session-registry.ts \
  packages/server/src/routes/sessions.ts \
  packages/client/src/components/ProjectSidebar.tsx \
  packages/client/src/lib/api-client/index.ts \
  packages/client/src/store/session-store.ts \
  tests/test-session-index.ts
# PASS

npx prettier --check packages/server/src/session-index.ts \
  packages/server/src/session-registry.ts \
  packages/server/src/routes/sessions.ts \
  packages/client/src/components/ProjectSidebar.tsx \
  packages/client/src/lib/api-client/index.ts \
  packages/client/src/store/session-store.ts \
  tests/test-session-index.ts
# PASS
```

Manual browser checks:

1. Open a project with existing sessions and verify the sidebar lists them normally.
2. Click Refresh beside **New** and verify the sidebar refreshes without deleting sessions.
3. Verify the button is disabled while a refresh is running and reports errors without clearing the existing list.
4. Restart the server and verify session discovery falls back safely when the index is missing, stale, malformed, or unwritable.

## Screenshots / recordings (UI changes only)

No screenshot or recording was collected. A short recording of the Refresh button and sidebar update is recommended before merge.

## Risk and rollback

The blast radius is limited to project session discovery and the Project Sidebar refresh action. JSONL session files remain authoritative and are never changed by index reset or refresh. The cache uses path-free metadata, restrictive file permissions, atomic writes, generation-aware rebuilds, and rate-limited refresh requests.

Roll back by reverting this feature branch's commits. Delete the derived `session-index.json` only if needed for recovery; it contains no session content and is rebuilt automatically.

## Checklist

- [x] Atomic commit(s) — feature implementation plus focused hardening follow-ups
- [x] No `Co-Authored-By` lines or AI-attribution trailers
- [ ] `npm run check` passes — blocked by unchanged upstream `ModelRuntime.reloadConfig` diagnostics
- [ ] `npm run build` passes — server build is blocked by the same unchanged upstream diagnostics; isolated client worktree build lacks `@vitejs/plugin-react`
- [x] Relevant `tests/test-*.ts` script run and passing
- [x] New/changed routes have JSON Schema (`schema.body`, `schema.response`, `schema.tags`)
- [x] No `process.env.*` reads outside `packages/server/src/config.ts`
- [x] No direct `fs.*` calls in route handlers
- [x] No raw `fetch()` added in components
- [x] Default exports — none added
- [x] Config/env documentation updated in `docs/agent/sessions.md`
- [x] SSE documentation — N/A; no SSE event surface change
- [ ] API examples — no update was added; reviewers may request one for the refresh endpoint

## Notes for reviewers

Please review `packages/server/src/session-index.ts` for its path-free cache contract, metadata whitelist, generation-based rebuild invalidation, and symlink filtering. The feature deliberately excludes pi-subagents-specific child discovery and any deployment-specific behavior.
