### PR TITLE
fix: allow sandboxed reads of pi docs

### DIFF
--- a/packages/server/src/agent-tool-overrides.ts
+++ b/packages/server/src/agent-tool-overrides.ts
@@ -18,7 +18,11 @@ import {
   type WriteOperations,
 } from "@earendil-works/pi-coding-agent";
 import { createForgeBashOperations } from "./agent-bash-operations.js";
-import { assertAgentToolPathAllowed, resolveAgentToolPath } from "./agent-tool-policy.js";
+import {
+  assertAgentToolReadPathAllowed,
+  resolveAgentToolPath,
+  resolveAgentToolReadPath,
+} from "./agent-tool-policy.js";
 import {
   applySandboxParentChainHandoff,
   applySandboxPathHandoff,
@@ -29,26 +33,30 @@ function guard(workspacePath: string, absolutePath: string): string {
   return resolveAgentToolPath(workspacePath, absolutePath);
 }
 
+function readGuard(workspacePath: string, absolutePath: string): string {
+  return resolveAgentToolReadPath(workspacePath, absolutePath);
+}
+
 export function createSandboxedToolDefinitions(
   workspacePath: string,
   toolEnv: Record<string, string> = {},
 ): ToolDefinition[] {
   const readOps: ReadOperations = {
-    readFile: async (absolutePath) => readFile(guard(workspacePath, absolutePath)),
-    access: async (absolutePath) => access(guard(workspacePath, absolutePath)),
+    readFile: async (absolutePath) => readFile(readGuard(workspacePath, absolutePath)),
+    access: async (absolutePath) => access(readGuard(workspacePath, absolutePath)),
     detectImageMimeType: async () => undefined,
   };
 
   const grepOps: GrepOperations = {
     isDirectory: async (absolutePath) =>
-      (await stat(guard(workspacePath, absolutePath))).isDirectory(),
-    readFile: async (absolutePath) => readFile(guard(workspacePath, absolutePath), "utf8"),
+      (await stat(readGuard(workspacePath, absolutePath))).isDirectory(),
+    readFile: async (absolutePath) => readFile(readGuard(workspacePath, absolutePath), "utf8"),
   };
 
   const findOps: FindOperations = {
     exists: async (absolutePath) => {
       try {
-        await access(guard(workspacePath, absolutePath));
+        await access(readGuard(workspacePath, absolutePath));
         return true;
       } catch (err) {
         const e = err as NodeJS.ErrnoException;
@@ -57,7 +65,7 @@ export function createSandboxedToolDefinitions(
       }
     },
     glob: async (pattern, cwd, options) => {
-      const safeCwd = guard(workspacePath, cwd);
+      const safeCwd = readGuard(workspacePath, cwd);
       const results = await glob(pattern, {
         cwd: safeCwd,
         absolute: true,
@@ -67,7 +75,7 @@ export function createSandboxedToolDefinitions(
       });
       const allowed: string[] = [];
       for (const result of results) {
-        assertAgentToolPathAllowed(workspacePath, result);
+        assertAgentToolReadPathAllowed(workspacePath, result);
         allowed.push(result);
         if (allowed.length >= options.limit) break;
       }
@@ -78,7 +86,7 @@ export function createSandboxedToolDefinitions(
   const lsOps: LsOperations = {
     exists: async (absolutePath) => {
       try {
-        await access(guard(workspacePath, absolutePath));
+        await access(readGuard(workspacePath, absolutePath));
         return true;
       } catch (err) {
         const e = err as NodeJS.ErrnoException;
@@ -86,8 +94,8 @@ export function createSandboxedToolDefinitions(
         throw err;
       }
     },
-    stat: async (absolutePath) => stat(guard(workspacePath, absolutePath)),
-    readdir: async (absolutePath) => readdir(guard(workspacePath, absolutePath)),
+    stat: async (absolutePath) => stat(readGuard(workspacePath, absolutePath)),
+    readdir: async (absolutePath) => readdir(readGuard(workspacePath, absolutePath)),
   };
 
   const editOps: EditOperations = {

--- a/packages/server/src/agent-tool-policy.ts
+++ b/packages/server/src/agent-tool-policy.ts
@@ -5,6 +5,12 @@ import { config } from "./config.js";
 const PROTECTED_PI_CONFIG_FILES = new Set(["auth.json", "models.json", "settings.json"]);
 const HOME_SECRET_DIRS = new Set([".ssh", ".aws", ".kube", ".gnupg"]);
 const DENIED_PREFIXES = ["/proc", "/etc", "/run/secrets", "/var/run/secrets"];
+const PI_CODING_AGENT_PACKAGE_DIR = "/app/node_modules/@earendil-works/pi-coding-agent";
+const PI_DOCUMENTATION_PATHS = [
+  { path: resolve(PI_CODING_AGENT_PACKAGE_DIR, "README.md"), allowDescendants: false },
+  { path: resolve(PI_CODING_AGENT_PACKAGE_DIR, "docs"), allowDescendants: true },
+  { path: resolve(PI_CODING_AGENT_PACKAGE_DIR, "examples"), allowDescendants: true },
+];
 
 export class AgentToolPathDeniedError extends Error {
   constructor(message: string) {
@@ -41,6 +47,21 @@ function piConfigRelativePath(
   const rel = relative(piConfigReal, candidate).split(sep).join("/");
   if (rel === "" || rel.startsWith("../")) return undefined;
   return rel;
+}
+
+function assertPiDocumentationPathAllowed(baseResolved: string, resolvedReal: string): boolean {
+  for (const allowed of PI_DOCUMENTATION_PATHS) {
+    const rootResolved = resolve(allowed.path);
+    const rootReal = realpathExistingOrParent(rootResolved);
+    if (allowed.allowDescendants) {
+      if (pathWithin(baseResolved, rootResolved) && pathWithin(resolvedReal, rootReal)) {
+        return true;
+      }
+    } else if (baseResolved === rootResolved && resolvedReal === rootReal) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function assertPiConfigPathAllowed(
@@ -87,7 +108,11 @@ function denyIfSensitiveAbsolute(abs: string, workspaceReal: string, piConfigRea
   }
 }
 
-export function resolveAgentToolPath(workspacePath: string, requestedPath: string): string {
+function resolveAgentToolPathForMode(
+  workspacePath: string,
+  requestedPath: string,
+  options: { allowPiDocumentation: boolean },
+): string {
   if (requestedPath.trim() === "") {
     throw new AgentToolPathDeniedError("empty path is not allowed");
   }
@@ -117,9 +142,28 @@ export function resolveAgentToolPath(workspacePath: string, requestedPath: strin
     return baseResolved;
   }
 
+  if (
+    options.allowPiDocumentation &&
+    assertPiDocumentationPathAllowed(baseResolved, resolvedReal)
+  ) {
+    return baseResolved;
+  }
+
   throw new AgentToolPathDeniedError(`${baseResolved} is outside allowed roots`);
+}
+
+export function resolveAgentToolPath(workspacePath: string, requestedPath: string): string {
+  return resolveAgentToolPathForMode(workspacePath, requestedPath, { allowPiDocumentation: false });
+}
+
+export function resolveAgentToolReadPath(workspacePath: string, requestedPath: string): string {
+  return resolveAgentToolPathForMode(workspacePath, requestedPath, { allowPiDocumentation: true });
 }
 
 export function assertAgentToolPathAllowed(workspacePath: string, requestedPath: string): void {
   resolveAgentToolPath(workspacePath, requestedPath);
+}
+
+export function assertAgentToolReadPathAllowed(workspacePath: string, requestedPath: string): void {
+  resolveAgentToolReadPath(workspacePath, requestedPath);
 }

--- a/packages/server/src/file-references.ts
+++ b/packages/server/src/file-references.ts
@@ -1,5 +1,5 @@
 import { extname, join } from "node:path";
-import { resolveAgentToolPath } from "./agent-tool-policy.js";
+import { resolveAgentToolReadPath } from "./agent-tool-policy.js";
 import { config } from "./config.js";
 import { checkFileReference, readFile } from "./file-manager.js";
 
@@ -150,7 +150,7 @@ export async function expandFileReferences(text: string, workspacePath: string):
     matches.map(async (mm): Promise<Classification> => {
       try {
         const abs = config.agentToolSandbox.enabled
-          ? resolveAgentToolPath(workspacePath, mm.path)
+          ? resolveAgentToolReadPath(workspacePath, mm.path)
           : join(workspacePath, mm.path);
         const check = config.agentToolSandbox.enabled
           ? await checkFileReference(abs, abs)

--- a/tests/test-agent-tool-sandbox.ts
+++ b/tests/test-agent-tool-sandbox.ts
@@ -4,7 +4,15 @@
  * Unit-style coverage for startup config validation, path policy,
  * sandboxed SDK tool overrides, and @file expansion scoping.
  */
-import { mkdirSync, mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -642,26 +650,36 @@ try {
   await assertRejects("protected pi config file rejected", () =>
     read.execute("t11", { path: resolve(piConfig, "auth.json") }, undefined, undefined, {}),
   );
-  const piDocsRead = await read.execute("t12", { path: piSdkDocsReadme }, undefined, undefined, {});
-  assert("pi SDK README read works", JSON.stringify(piDocsRead).includes("pi"));
-  const piDocsLs = await ls.execute("t13", { path: piSdkDocsDir }, undefined, undefined, {});
-  assert("pi SDK docs ls works", JSON.stringify(piDocsLs).includes(".md"));
-  const piDocsGrep = await grep.execute(
-    "t13b",
-    { pattern: "pi", path: piSdkDocsReadme },
-    undefined,
-    undefined,
-    {},
-  );
-  assert("pi SDK docs grep works", JSON.stringify(piDocsGrep).includes("pi"));
-  const piExamplesFind = await find.execute(
-    "t14",
-    { pattern: "**/*", path: piSdkExamplesDir },
-    undefined,
-    undefined,
-    {},
-  );
-  assert("pi SDK examples find works", JSON.stringify(piExamplesFind).includes("README.md"));
+  if (existsSync(piSdkDocsReadme) && existsSync(piSdkDocsDir) && existsSync(piSdkExamplesDir)) {
+    const piDocsRead = await read.execute(
+      "t12",
+      { path: piSdkDocsReadme },
+      undefined,
+      undefined,
+      {},
+    );
+    assert("pi SDK README read works", JSON.stringify(piDocsRead).includes("pi"));
+    const piDocsLs = await ls.execute("t13", { path: piSdkDocsDir }, undefined, undefined, {});
+    assert("pi SDK docs ls works", JSON.stringify(piDocsLs).includes(".md"));
+    const piDocsGrep = await grep.execute(
+      "t13b",
+      { pattern: "pi", path: piSdkDocsReadme },
+      undefined,
+      undefined,
+      {},
+    );
+    assert("pi SDK docs grep works", JSON.stringify(piDocsGrep).includes("pi"));
+    const piExamplesFind = await find.execute(
+      "t14",
+      { pattern: "**/*", path: piSdkExamplesDir },
+      undefined,
+      undefined,
+      {},
+    );
+    assert("pi SDK examples find works", JSON.stringify(piExamplesFind).includes("README.md"));
+  } else {
+    assert("pi SDK docs tool-read coverage skipped because /app docs are unavailable", true);
+  }
   await assertRejects("pi SDK package metadata read rejected", () =>
     read.execute("t15", { path: piSdkPackageJson }, undefined, undefined, {}),
   );
@@ -686,8 +704,12 @@ try {
     project,
   );
   assert("allowed pi config non-secret expands", expandedPi.includes("profile ok"));
-  const expandedPiDocs = await expandFileReferences(`see @${piSdkDocsReadme}`, project);
-  assert("pi SDK README expands", expandedPiDocs.includes("```markdown"));
+  if (existsSync(piSdkDocsReadme)) {
+    const expandedPiDocs = await expandFileReferences(`see @${piSdkDocsReadme}`, project);
+    assert("pi SDK README expands", expandedPiDocs.includes("```markdown"));
+  } else {
+    assert("pi SDK README expansion skipped because /app docs are unavailable", true);
+  }
   const deniedAuth = await expandFileReferences(`see @${resolve(piConfig, "auth.json")}`, project);
   assert("protected pi config rejected", deniedAuth.includes("not included"));
   const deniedOutside = await expandFileReferences(

--- a/tests/test-agent-tool-sandbox.ts
+++ b/tests/test-agent-tool-sandbox.ts
@@ -34,6 +34,10 @@ const outside = resolve(tmp, "outside");
 const chownWorkspaceTarget = resolve(workspace, "chown-me");
 const chownAttemptTarget = resolve(workspace, "chown-attempt");
 const chownSkillsTarget = resolve(piConfig, "skills", "startup-owned");
+const piSdkDocsReadme = "/app/node_modules/@earendil-works/pi-coding-agent/README.md";
+const piSdkDocsDir = "/app/node_modules/@earendil-works/pi-coding-agent/docs";
+const piSdkExamplesDir = "/app/node_modules/@earendil-works/pi-coding-agent/examples";
+const piSdkPackageJson = "/app/node_modules/@earendil-works/pi-coding-agent/package.json";
 mkdirSync(workspace, { recursive: true });
 mkdirSync(project, { recursive: true });
 mkdirSync(shared, { recursive: true });
@@ -201,9 +205,12 @@ try {
     }
   }
 
-  const { resolveAgentToolPath } = (await import(
+  const { resolveAgentToolPath, resolveAgentToolReadPath } = (await import(
     resolve(repoRoot, "packages/server/dist/agent-tool-policy.js")
-  )) as { resolveAgentToolPath: (workspacePath: string, requestedPath: string) => string };
+  )) as {
+    resolveAgentToolPath: (workspacePath: string, requestedPath: string) => string;
+    resolveAgentToolReadPath: (workspacePath: string, requestedPath: string) => string;
+  };
   const { createSandboxedToolDefinitions } = (await import(
     resolve(repoRoot, "packages/server/dist/agent-tool-overrides.js")
   )) as { createSandboxedToolDefinitions: (workspacePath: string) => any[] };
@@ -540,6 +547,26 @@ try {
       );
     }
   }
+  function readAllowed(label: string, requested: string): void {
+    try {
+      resolveAgentToolReadPath(project, requested);
+      assert(label, true);
+    } catch (err) {
+      assert(label, false, (err as Error).message);
+    }
+  }
+  function readDenied(label: string, requested: string): void {
+    try {
+      resolveAgentToolReadPath(project, requested);
+      assert(label, false, "allowed unexpectedly");
+    } catch (err) {
+      assert(
+        label,
+        (err as Error).message.startsWith("agent_tool_path_denied"),
+        (err as Error).message,
+      );
+    }
+  }
 
   console.log("\npath policy");
   allowed("relative project path allowed", "hello.txt");
@@ -554,6 +581,12 @@ try {
   denied("symlink escape rejected", "escape-link");
   denied("/proc/self/environ rejected", "/proc/self/environ");
   denied("FORGE_DATA_DIR rejected", resolve(forgeData, "jwt-secret"));
+  readAllowed("pi SDK README read path allowed", piSdkDocsReadme);
+  readAllowed("pi SDK docs dir read path allowed", piSdkDocsDir);
+  readAllowed("pi SDK examples dir read path allowed", piSdkExamplesDir);
+  readDenied("pi SDK package metadata read path rejected", piSdkPackageJson);
+  denied("pi SDK README write path rejected", piSdkDocsReadme);
+  denied("pi SDK docs write path rejected", resolve(piSdkDocsDir, "extensions.md"));
 
   console.log("\ntool overrides");
   const tools = new Map(createSandboxedToolDefinitions(project).map((tool) => [tool.name, tool]));
@@ -609,6 +642,41 @@ try {
   await assertRejects("protected pi config file rejected", () =>
     read.execute("t11", { path: resolve(piConfig, "auth.json") }, undefined, undefined, {}),
   );
+  const piDocsRead = await read.execute("t12", { path: piSdkDocsReadme }, undefined, undefined, {});
+  assert("pi SDK README read works", JSON.stringify(piDocsRead).includes("pi"));
+  const piDocsLs = await ls.execute("t13", { path: piSdkDocsDir }, undefined, undefined, {});
+  assert("pi SDK docs ls works", JSON.stringify(piDocsLs).includes(".md"));
+  const piDocsGrep = await grep.execute(
+    "t13b",
+    { pattern: "pi", path: piSdkDocsReadme },
+    undefined,
+    undefined,
+    {},
+  );
+  assert("pi SDK docs grep works", JSON.stringify(piDocsGrep).includes("pi"));
+  const piExamplesFind = await find.execute(
+    "t14",
+    { pattern: "**/*", path: piSdkExamplesDir },
+    undefined,
+    undefined,
+    {},
+  );
+  assert("pi SDK examples find works", JSON.stringify(piExamplesFind).includes("README.md"));
+  await assertRejects("pi SDK package metadata read rejected", () =>
+    read.execute("t15", { path: piSdkPackageJson }, undefined, undefined, {}),
+  );
+  await assertRejects("pi SDK README write rejected", () =>
+    write.execute("t16", { path: piSdkDocsReadme, content: "x" }, undefined, undefined, {}),
+  );
+  await assertRejects("pi SDK docs edit rejected", () =>
+    edit.execute(
+      "t17",
+      { path: resolve(piSdkDocsDir, "extensions.md"), edits: [{ oldText: "pi", newText: "pi" }] },
+      undefined,
+      undefined,
+      {},
+    ),
+  );
 
   console.log("\n@file expansion");
   const expandedWorkspace = await expandFileReferences("see @hello.txt", project);
@@ -618,6 +686,8 @@ try {
     project,
   );
   assert("allowed pi config non-secret expands", expandedPi.includes("profile ok"));
+  const expandedPiDocs = await expandFileReferences(`see @${piSdkDocsReadme}`, project);
+  assert("pi SDK README expands", expandedPiDocs.includes("```markdown"));
   const deniedAuth = await expandFileReferences(`see @${resolve(piConfig, "auth.json")}`, project);
   assert("protected pi config rejected", deniedAuth.includes("not included"));
   const deniedOutside = await expandFileReferences(


### PR DESCRIPTION
## Summary

Sandbox mode overrides the SDK built-in file tools, and those overrides used the same strict workspace/PI_CONFIG path policy for both reads and writes. That meant agents could not read the documented pi SDK documentation paths even though the system instructions tell them to use those docs for pi-specific work.

This PR adds a read-only exception for the known pi SDK documentation locations while keeping writes and unrelated external paths blocked.

## Usage

No operator changes are required. With `AGENT_TOOL_SANDBOX_ENABLED=true`, sandboxed agent tools can now read/list/search:

```text
/app/node_modules/@earendil-works/pi-coding-agent/README.md
/app/node_modules/@earendil-works/pi-coding-agent/docs
/app/node_modules/@earendil-works/pi-coding-agent/examples
```

Write/edit tools still reject those paths, and arbitrary package files such as `package.json` remain outside the allowlist.

## What changed (4 files)

- `packages/server/src/agent-tool-policy.ts` — adds a read-mode resolver that allowlists only the pi SDK README, docs, and examples paths.
- `packages/server/src/agent-tool-overrides.ts` — uses the read-mode resolver for sandboxed `read`, `grep`, `find`, and `ls` operations while keeping `write`/`edit` on the stricter policy.
- `packages/server/src/file-references.ts` — lets sandboxed `@file` expansion use the read-mode path resolver.
- `tests/test-agent-tool-sandbox.ts` — covers allowed pi docs reads/list/search and denied package metadata/writes/edits.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `npx tsx tests/test-agent-tool-sandbox.ts`
- [ ] CI green before merge
