### PR TITLE
fix: keep long-running SSE streams alive

### DIFF
--- a/packages/client/src/lib/sse-client.ts
+++ b/packages/client/src/lib/sse-client.ts
@@ -18,8 +18,8 @@ import { clearStoredToken, getStoredToken } from "./auth-client";
  *     suppresses reconnect.
  *
  * Reconnect policy:
- *   - 401 / 404 / 409 are treated as terminal (auth gone, session deleted,
- *     or externally active read-only subagent) — do not retry; reject immediately.
+ *   - 401 / 404 / 409 / 410 are treated as terminal (auth gone, session
+ *     deleted, externally active read-only subagent, or tombstoned) — do not retry; reject immediately.
  *   - Any other non-2xx, network-level error, or post-200 stream EOF
  *     triggers a backoff (1s → 2s → 4s → 8s → 16s, capped at 30s).
  *     `onReconnect` is invoked between attempts so the UI can show a
@@ -45,7 +45,7 @@ export interface StreamSSEOptions<T> {
   maxReconnects?: number;
 }
 
-const TERMINAL_STATUS = new Set([401, 404, 409]);
+const TERMINAL_STATUS = new Set([401, 404, 409, 410]);
 const MAX_BACKOFF_MS = 30_000;
 
 function backoffDelay(attempt: number): number {

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -31,14 +31,8 @@ import {
   MAX_ADDENDUM_BYTES,
   setProjectSystemPromptAddendum,
 } from "../system-prompt-overrides.js";
+import { SSE_HEARTBEAT_INTERVAL_MS, SSE_HEARTBEAT_LINE } from "../sse-bridge.js";
 import { errorSchema } from "./_schemas.js";
-
-/**
- * Heartbeat cadence for the clone SSE stream. Same value as
- * `sse-bridge.ts:HEARTBEAT_INTERVAL_MS` — keeps comfortable margin
- * under the OpenShift HAProxy `timeout server` default of 30s.
- */
-const CLONE_HEARTBEAT_INTERVAL_MS = 20_000;
 
 /**
  * One-shot padding flush after the `started` event so OpenShift's
@@ -586,7 +580,7 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
         }
         return;
       }
-      heartbeat = setInterval(() => writeRaw(": heartbeat\n\n"), CLONE_HEARTBEAT_INTERVAL_MS);
+      heartbeat = setInterval(() => writeRaw(SSE_HEARTBEAT_LINE), SSE_HEARTBEAT_INTERVAL_MS);
       heartbeat.unref();
 
       // Abort the clone if the client disconnects mid-stream.

--- a/packages/server/src/routes/stream.ts
+++ b/packages/server/src/routes/stream.ts
@@ -8,7 +8,12 @@ import {
   SessionTombstonedError,
   ExternalSubagentActiveError,
 } from "../session-registry.js";
-import { createSSEClient, serializeSSE } from "../sse-bridge.js";
+import {
+  createSSEClient,
+  serializeSSE,
+  SSE_HEARTBEAT_INTERVAL_MS,
+  SSE_HEARTBEAT_LINE,
+} from "../sse-bridge.js";
 import {
   getExternalSubagentStatusForSession,
   readSessionMessagesFromDisk,
@@ -41,6 +46,7 @@ async function createReadOnlyExternalSubagentSSE(
   reply.hijack();
   const raw = reply.raw;
   let watcher: FSWatcher | undefined;
+  let heartbeatTimer: NodeJS.Timeout | undefined;
   let closed = false;
 
   const close = (): void => {
@@ -48,6 +54,10 @@ async function createReadOnlyExternalSubagentSSE(
     closed = true;
     watcher?.close();
     watcher = undefined;
+    if (heartbeatTimer !== undefined) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = undefined;
+    }
     try {
       raw.end();
     } catch {
@@ -87,7 +97,18 @@ async function createReadOnlyExternalSubagentSSE(
   } catch {
     // A one-shot read-only snapshot is still better than resuming the child.
   }
+  // Keep read-only external subagent streams alive behind reverse proxies too.
+  // They may sit idle between filesystem writes while the child process runs.
+  heartbeatTimer = setInterval(() => {
+    try {
+      raw.write(SSE_HEARTBEAT_LINE);
+    } catch {
+      close();
+    }
+  }, SSE_HEARTBEAT_INTERVAL_MS);
+  heartbeatTimer.unref();
   raw.on("close", close);
+  raw.on("error", close);
   return true;
 }
 

--- a/packages/server/src/sse-bridge.ts
+++ b/packages/server/src/sse-bridge.ts
@@ -42,7 +42,7 @@ const BACKPRESSURE_LIMIT_BYTES = 8 * 1024 * 1024;
  * and the browser shows "reconnecting." 20s gives us comfortable
  * margin under the typical 30s default.
  */
-const HEARTBEAT_INTERVAL_MS = 20_000;
+export const SSE_HEARTBEAT_INTERVAL_MS = 20_000;
 
 /**
  * Heartbeat payload, padded to 2KB.
@@ -69,8 +69,8 @@ const HEARTBEAT_INTERVAL_MS = 20_000;
  * frames in `tcpdump` / `curl -N` can identify what they're looking
  * at; the underscore padding is just deliberate filler.
  */
-const HEARTBEAT_PADDING_BYTES = 2048;
-const HEARTBEAT_LINE = `: heartbeat ${"_".repeat(HEARTBEAT_PADDING_BYTES - 14)}\n\n`;
+const SSE_HEARTBEAT_PADDING_BYTES = 2048;
+export const SSE_HEARTBEAT_LINE = `: heartbeat ${"_".repeat(SSE_HEARTBEAT_PADDING_BYTES - 14)}\n\n`;
 
 /**
  * One-shot padding flush we send right after the `compaction_start`
@@ -613,16 +613,16 @@ export function createSSEClient(reply: FastifyReply, live: LiveSession): SSEClie
 
     // Idle-timer reset + buffer-flush for L7 proxies (OpenShift
     // HAProxy router, nginx, ALB, etc.). Comment line, no `data:`
-    // field — EventSource skips it. HEARTBEAT_LINE is padded to 2KB
-    // to defeat HAProxy's small-write buffering so heartbeats
+    // field — EventSource skips it. SSE_HEARTBEAT_LINE is padded
+    // to 2KB to defeat HAProxy's small-write buffering so heartbeats
     // actually reach the client during long idle gaps; see the
-    // HEARTBEAT_LINE doc-comment for the full rationale. Uses
+    // SSE_HEARTBEAT_LINE doc-comment for the full rationale. Uses
     // writeRaw so the same backpressure guard applies; if the
     // socket is wedged the heartbeat will trip the limit and call
     // close(), which tears the timer down.
     heartbeatTimer = setInterval(() => {
-      writeRaw(HEARTBEAT_LINE);
-    }, HEARTBEAT_INTERVAL_MS);
+      writeRaw(SSE_HEARTBEAT_LINE);
+    }, SSE_HEARTBEAT_INTERVAL_MS);
     // Don't keep the Node event loop alive just for heartbeats — when
     // the socket closes the close handler clears the timer anyway.
     heartbeatTimer.unref();

--- a/tests/test-sse.ts
+++ b/tests/test-sse.ts
@@ -62,6 +62,8 @@ interface TestRegistry {
   disposeAllSessions: () => void;
 }
 interface TestBridge {
+  SSE_HEARTBEAT_INTERVAL_MS: number;
+  SSE_HEARTBEAT_LINE: string;
   isAllowedEvent: (event: { type: string }) => boolean;
   serializeSSE: (event: object & { type: string }) => string;
   buildSnapshot: (live: TestLive) => {
@@ -131,6 +133,22 @@ async function main(): Promise<void> {
     "serializeSSE format is `data: <json>\\n\\n`",
     wire === 'data: {"type":"agent_start","sessionId":"abc"}\n\n',
     wire,
+  );
+  assert(
+    "heartbeat cadence stays below common 30s proxy idle timeout",
+    bridge.SSE_HEARTBEAT_INTERVAL_MS > 0 && bridge.SSE_HEARTBEAT_INTERVAL_MS < 30_000,
+    String(bridge.SSE_HEARTBEAT_INTERVAL_MS),
+  );
+  assert(
+    "heartbeat is an SSE comment ignored by clients",
+    bridge.SSE_HEARTBEAT_LINE.startsWith(": heartbeat ") &&
+      !bridge.SSE_HEARTBEAT_LINE.includes("data:") &&
+      bridge.SSE_HEARTBEAT_LINE.endsWith("\n\n"),
+  );
+  assert(
+    "heartbeat is padded enough to flush proxy buffers",
+    Buffer.byteLength(bridge.SSE_HEARTBEAT_LINE, "utf8") >= 2048,
+    String(Buffer.byteLength(bridge.SSE_HEARTBEAT_LINE, "utf8")),
   );
 
   const fastify = await buildModule.buildServer();


### PR DESCRIPTION
## Summary

Long-running agent turns can leave the session SSE stream idle while a tool call or external subagent is still generating. Behind reverse proxies such as HAProxy/OpenShift, that idle gap can close the stream and surface a misleading browser banner:

```text
Reconnecting — server closed stream
```

This PR reuses the padded SSE heartbeat for all long-lived session-related streams so idle proxy timers and small-write buffering are defeated without changing message state. Heartbeats are SSE comments, so clients ignore them and snapshot-on-connect semantics are preserved.

## Usage

No user-facing controls are required. Operators get resilient SSE streams automatically on existing endpoints:

```bash
GET /api/v1/sessions/:id/stream
POST /api/v1/projects/clone
```

Existing clients safely ignore heartbeat comment frames. Session reconnects still rehydrate from the initial `snapshot` event.

## What changed (5 files, +53/-20)

- `packages/server/src/sse-bridge.ts` — exports the padded 20s SSE heartbeat constants and keeps the existing heartbeat cleanup/backpressure behavior for normal session streams.
- `packages/server/src/routes/stream.ts` — adds padded heartbeat timers to read-only external subagent SSE streams and clears timers/watchers on close/error.
- `packages/server/src/routes/projects.ts` — switches clone progress SSE from a tiny heartbeat to the shared padded heartbeat.
- `packages/client/src/lib/sse-client.ts` — treats `410 session_tombstoned` as terminal so deleted-session reconnect loops stop cleanly.
- `tests/test-sse.ts` — asserts heartbeat cadence, comment-frame shape, and padding size.

## Test plan

- [x] `npm run build`
- [x] `NODE_OPTIONS=--max-old-space-size=4096 npm run check`
- [x] `npx tsx tests/test-sse.ts`
- [x] `npx tsx tests/test-session.ts`
- [ ] CI green before merge
