### PR TITLE
feat: support env-backed MCP headers

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -4,11 +4,12 @@ Read this when changing environment variables, CLI flags, pi SDK config files, p
 
 ## Environment Variables & CLI Flags
 
-**All `process.env` reads are centralized in `packages/server/src/config.ts`.**
-Never read `process.env` directly in any other server file — always import the
+**All operational `process.env` reads are centralized in `packages/server/src/config.ts`.**
+Never read fixed pi-forge setting env vars directly in any other server file — always import the
 frozen `config` object from there. The handful of `process.env` reads that DO
 live outside config.ts are debug-only (`DEBUG_FETCH`, `DEBUG_AGENT_EVENTS`,
-`SHELL`) — keep them out of operational config.
+`SHELL`) or user-named dynamic config references such as MCP env-backed HTTP
+headers — keep them out of operational config.
 
 **Every operationally-relevant env var has an equivalent `--flag`** on the
 `pi-forge` command. The table in `packages/server/src/cli.ts` is the single

--- a/docs/agent/mcp.md
+++ b/docs/agent/mcp.md
@@ -9,6 +9,9 @@ Pi does NOT have native MCP (Model Context Protocol) support. MCP is provided by
 ## Owned Data Files
 
 - `FORGE_DATA_DIR/mcp.json` — MCP server registry, owned by `mcp/manager.ts`.
+  Remote `headers` values may be literal strings or `{ env: "VAR_NAME" }`; the
+  latter resolves dynamically from the pi-forge process env without returning the
+  resolved value to clients.
 - Tool overrides can include built-ins and MCP tools; read `docs/agent/config.md` and relevant tests before changing cascade behavior.
 
 ## Tests

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -26,7 +26,8 @@ falls back to SSE — covers
 which transport they expose.
 
 Static-header auth (Bearer tokens, custom headers) for remote
-servers; explicit env-passthrough for stdio. OAuth per-server
+servers; header values can also be sourced from pi-forge environment
+variables. Stdio servers use explicit env-passthrough. OAuth per-server
 consent flows are not implemented.
 
 ## Where servers live
@@ -59,7 +60,8 @@ to swap a global server for a project-specific one).
       "transport": "auto",
       "enabled": true,
       "headers": {
-        "Authorization": "Bearer sk-..."
+        "Authorization": "Bearer sk-...",
+        "X-API-Key": { "env": "MY_MCP_TOKEN" }
       }
     },
     "everything": {
@@ -97,7 +99,7 @@ shape, so existing files don't need rewriting:
 | `enabled` | boolean | both | `true` | Disabled servers don't connect or contribute tools. |
 | `url` | string | remote | — | The MCP endpoint URL. Required for remote servers. |
 | `transport` | `"auto"` \| `"streamable-http"` \| `"sse"` | remote | `"auto"` | Connection probe order. `auto` tries StreamableHTTP first. |
-| `headers` | `Record<string, string>` | remote | (none) | Forwarded on every MCP RPC. Treated as secret on read — `GET /mcp/servers` returns `***REDACTED***` for every value. |
+| `headers` | `Record<string, string \| { env: string }>` | remote | (none) | Forwarded on every MCP RPC. Literal values are treated as secret on read — `GET /mcp/servers` returns `***REDACTED***`. Env-backed values return only `{ "env": "VAR_NAME" }` and are resolved from pi-forge's environment when requests are sent. |
 | `command` | string | stdio | — | Executable to spawn. Resolved via PATH if not absolute. Required for stdio servers. |
 | `args` | `string[]` | stdio | `[]` | CLI args appended to `command`. |
 | `env` | `Record<string, string>` | stdio | (none) | Subprocess env. Pi-forge env is **not** inherited by default (see "Stdio env" below). Treated as secret on read. |
@@ -239,8 +241,9 @@ was omitted. Image blocks pass through unchanged.
 
 **Status stuck in `error`** — Settings → MCP, expand the row, read
 `lastError`. Common causes:
-- **Remote:** wrong URL, missing `Authorization` header, server
-  returning 4xx on `tools/list`.
+- **Remote:** wrong URL, missing `Authorization` header, env-backed
+  header variable not set in the pi-forge process, server returning
+  4xx on `tools/list`.
 - **Stdio:** command not found (resolve via absolute path or check
   PATH passthrough), missing required env var, subprocess crashed at
   startup (the child's stderr is inherited — check the pi-forge log).
@@ -258,7 +261,9 @@ transport actually works.
 **Headers / env show `***REDACTED***`** — read-path sentinel, not
 real data. The on-disk file still has the real value. On save, a
 sentinel value preserves the prior secret; a new value overwrites it
-(same pattern as `models.json`).
+(same pattern as `models.json`). Env-backed headers instead show the
+env var name (for example `{ "env": "MY_MCP_TOKEN" }`), never the
+resolved value.
 
 **Tools don't appear after editing project `.mcp.json`** — the file
 is read once per project per server lifetime. Probe the row or

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import {
   api,
   ApiError,
   type AuthSummary,
+  type McpHeaderValue,
   type McpServerConfig,
   type McpServerStatus,
   type McpTransport,
@@ -3319,6 +3320,15 @@ function BackupTab({ onError }: { onError: (msg: string | undefined) => void }) 
 
 // ---------------- MCP tab ----------------
 
+interface SecretRow {
+  key: string;
+  value: string;
+}
+
+interface HeaderRow extends SecretRow {
+  source: "literal" | "env";
+}
+
 interface McpDraft {
   name: string;
   /** Discriminator. The form picks the field set based on this. */
@@ -3328,7 +3338,7 @@ interface McpDraft {
   url: string;
   transport: McpTransport;
   /** Headers as a flat ordered list so the user can manage rows. */
-  headers: { key: string; value: string }[];
+  headers: HeaderRow[];
   /** Remote-only: allow self-signed / invalid HTTPS certs for this server. */
   ignoreCertificateErrors: boolean;
   // Stdio fields
@@ -3340,13 +3350,22 @@ interface McpDraft {
   argsText: string;
   /** Env as a flat ordered list; same shape + redaction handling as
    *  headers, so the form reuses the same row UI. */
-  env: { key: string; value: string }[];
+  env: SecretRow[];
   /** Optional cwd; blank ↦ default (project path for project
    *  servers, pi-forge process cwd for global). */
   cwd: string;
 }
 
 const SECRET_PLACEHOLDER = "***REDACTED***";
+
+function isHeaderEnvValue(value: McpHeaderValue): value is { env: string } {
+  return typeof value === "object" && value !== null && typeof value.env === "string";
+}
+
+function headerValueToRow(key: string, value: McpHeaderValue): HeaderRow {
+  if (isHeaderEnvValue(value)) return { key, value: value.env, source: "env" };
+  return { key, value, source: "literal" };
+}
 
 function emptyDraft(): McpDraft {
   return {
@@ -3505,7 +3524,7 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
       enabled: cfg.enabled !== false,
       url: cfg.url ?? "",
       transport: cfg.transport ?? "auto",
-      headers: Object.entries(cfg.headers ?? {}).map(([k, v]) => ({ key: k, value: v })),
+      headers: Object.entries(cfg.headers ?? {}).map(([k, v]) => headerValueToRow(k, v)),
       ignoreCertificateErrors: cfg.ignoreCertificateErrors === true,
       command: cfg.command ?? "",
       argsText: (cfg.args ?? []).join("\n"),
@@ -3538,10 +3557,14 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
       body.url = draft.url;
       body.transport = draft.transport;
       if (draft.ignoreCertificateErrors) body.ignoreCertificateErrors = true;
-      const headers: Record<string, string> = {};
+      const headers: Record<string, McpHeaderValue> = {};
       for (const h of draft.headers) {
         if (h.key.trim().length === 0) continue;
-        headers[h.key] = h.value;
+        if (h.source === "env" && h.value.trim().length === 0) {
+          onError(`Env var name is required for header '${h.key}'.`);
+          return;
+        }
+        headers[h.key] = h.source === "env" ? { env: h.value.trim() } : h.value;
       }
       if (Object.keys(headers).length > 0) body.headers = headers;
     } else {
@@ -4275,14 +4298,7 @@ function McpDraftForm(props: {
       </div>
 
       {draft.kind === "remote" ? (
-        <SecretRowsEditor
-          label="Headers"
-          emptyHint="No headers. Add `Authorization: Bearer …` here for auth."
-          keyPlaceholder="Authorization"
-          valuePlaceholder="Bearer …"
-          rows={draft.headers}
-          onChange={(next) => setField("headers", next)}
-        />
+        <HeaderRowsEditor rows={draft.headers} onChange={(next) => setField("headers", next)} />
       ) : (
         <SecretRowsEditor
           label="Env"
@@ -4313,20 +4329,101 @@ function McpDraftForm(props: {
   );
 }
 
+function HeaderRowsEditor(props: { rows: HeaderRow[]; onChange: (next: HeaderRow[]) => void }) {
+  const { rows } = props;
+  return (
+    <div className="mt-3">
+      <div className="mb-1 flex items-center justify-between">
+        <h5 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+          Headers
+        </h5>
+        <button
+          onClick={() => props.onChange([...rows, { key: "", value: "", source: "literal" }])}
+          className="rounded border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-300 hover:border-neutral-500"
+        >
+          + Header
+        </button>
+      </div>
+      {rows.length === 0 && (
+        <p className="text-[11px] italic text-neutral-600">
+          No headers. Add literal auth headers or reference an env var such as MY_MCP_TOKEN.
+        </p>
+      )}
+      {rows.map((r, i) => (
+        <div key={i} className="mb-1 grid grid-cols-[1fr_auto_2fr_auto] gap-1">
+          <input
+            value={r.key}
+            onChange={(e) => {
+              const next = [...rows];
+              next[i] = { ...r, key: e.target.value };
+              props.onChange(next);
+            }}
+            placeholder="Authorization"
+            className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-[11px] font-mono text-neutral-100 outline-none focus:border-neutral-500"
+          />
+          <select
+            value={r.source}
+            onChange={(e) => {
+              const next = [...rows];
+              next[i] = { ...r, source: e.target.value as HeaderRow["source"] };
+              props.onChange(next);
+            }}
+            className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-[11px] text-neutral-100 outline-none focus:border-neutral-500"
+          >
+            <option value="literal">literal</option>
+            <option value="env">env</option>
+          </select>
+          <input
+            value={r.value === SECRET_PLACEHOLDER ? "" : r.value}
+            onChange={(e) => {
+              const next = [...rows];
+              next[i] = { ...r, value: e.target.value };
+              props.onChange(next);
+            }}
+            placeholder={
+              r.source === "env"
+                ? "MY_MCP_TOKEN"
+                : r.value === SECRET_PLACEHOLDER
+                  ? "leave blank to keep stored value"
+                  : "Bearer …"
+            }
+            type={r.source === "env" ? "text" : "password"}
+            className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-[11px] font-mono text-neutral-100 outline-none focus:border-neutral-500"
+          />
+          <button
+            onClick={() => props.onChange(rows.filter((_, j) => j !== i))}
+            className="rounded border border-neutral-700 px-2 text-[11px] text-neutral-400 hover:text-red-300 light:hover:text-red-700"
+            title="Remove header"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <p className="mt-1 text-[10px] text-neutral-500">
+        Env-backed headers store only the variable name; pi-forge resolves the value when sending
+        MCP requests.
+      </p>
+      {rows.some((r) => r.value === SECRET_PLACEHOLDER) && (
+        <p className="mt-1 text-[10px] italic text-neutral-500">
+          Literal values with the redaction sentinel keep their stored value when you save.
+        </p>
+      )}
+    </div>
+  );
+}
+
 /**
- * Shared key/value editor used by both the Headers (remote) and Env
- * (stdio) sections. Same visual + the same redaction-sentinel
- * round-trip pattern — the value field renders blank when the
- * stored value is the sentinel so the user types a replacement
- * instead of "editing" the placeholder.
+ * Shared key/value editor used by the Env (stdio) section. The value
+ * field renders blank when the stored value is the sentinel so the
+ * user types a replacement instead of "editing" the placeholder.
  */
 function SecretRowsEditor(props: {
   label: string;
   emptyHint: string;
   keyPlaceholder: string;
   valuePlaceholder: string;
-  rows: { key: string; value: string }[];
-  onChange: (next: { key: string; value: string }[]) => void;
+  rows: SecretRow[];
+  onChange: (next: SecretRow[]) => void;
 }) {
   const { rows } = props;
   return (

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -43,6 +43,10 @@ export interface ChangePasswordResponse {
 // ---------------- MCP ----------------
 
 export type McpTransport = "auto" | "streamable-http" | "sse";
+export interface McpHeaderEnvValue {
+  env: string;
+}
+export type McpHeaderValue = string | McpHeaderEnvValue;
 export type McpConnectionState =
   | "idle"
   | "connecting"
@@ -56,7 +60,7 @@ export interface McpServerConfig {
   // remote-only (mutually exclusive with `command`)
   url?: string;
   transport?: McpTransport;
-  headers?: Record<string, string>;
+  headers?: Record<string, McpHeaderValue>;
   ignoreCertificateErrors?: boolean;
   // stdio-only (mutually exclusive with `url`)
   command?: string;

--- a/packages/server/src/mcp/config.ts
+++ b/packages/server/src/mcp/config.ts
@@ -35,6 +35,14 @@ import { config } from "../config.js";
  */
 
 export type McpTransport = "auto" | "streamable-http" | "sse";
+export interface McpHeaderEnvValue {
+  env: string;
+}
+export type McpHeaderValue = string | McpHeaderEnvValue;
+
+export function isMcpHeaderEnvValue(value: McpHeaderValue): value is McpHeaderEnvValue {
+  return typeof value === "object" && value !== null && typeof value.env === "string";
+}
 
 export interface McpServerConfig {
   /** Default true. Disabled servers don't connect or contribute tools. */
@@ -53,11 +61,15 @@ export interface McpServerConfig {
   transport?: McpTransport;
   /**
    * Per-request headers (e.g. `{ "Authorization": "Bearer ..." }`).
-   * Forwarded on every MCP RPC. Treated as secret on the read path —
+   * Values may be literal strings (backward-compatible) or
+   * `{ "env": "VAR_NAME" }` references that resolve from the
+   * pi-forge process environment when an MCP HTTP request is made.
+   * Literal values are treated as secret on the read path —
    * `readMcpJsonRedacted` replaces every value with the sentinel.
+   * Env-backed values preserve only the env var name on the read path.
    * Ignored for stdio servers.
    */
-  headers?: Record<string, string>;
+  headers?: Record<string, McpHeaderValue>;
   /**
    * Remote-only escape hatch for local/self-signed HTTPS MCP endpoints.
    * When true, TLS certificate validation is disabled for this server's
@@ -226,8 +238,8 @@ export async function readMcpJsonRedacted(): Promise<McpJson> {
     const cleaned = copyServerCleaned(server);
     if (server.headers !== undefined) {
       cleaned.headers = {};
-      for (const k of Object.keys(server.headers)) {
-        cleaned.headers[k] = SECRET_PLACEHOLDER;
+      for (const [k, v] of Object.entries(server.headers)) {
+        cleaned.headers[k] = isMcpHeaderEnvValue(v) ? { env: v.env } : SECRET_PLACEHOLDER;
       }
     }
     if (server.env !== undefined) {
@@ -266,6 +278,58 @@ function mergeSecretMap(
   return out;
 }
 
+function mergeHeaderMap(
+  next: Record<string, McpHeaderValue>,
+  prior: Record<string, McpHeaderValue> | undefined,
+): Record<string, McpHeaderValue> {
+  const out: Record<string, McpHeaderValue> = {};
+  for (const [k, v] of Object.entries(next)) {
+    if (v === SECRET_PLACEHOLDER) {
+      if (prior?.[k] !== undefined) out[k] = prior[k];
+    } else if (isMcpHeaderEnvValue(v)) {
+      out[k] = { env: v.env };
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function validateEnvName(name: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+}
+
+/**
+ * Resolve remote MCP headers for an outbound HTTP request. This is the
+ * deliberate exception to the usual operational-env centralization rule:
+ * header env names are user-authored dynamic MCP config, not pi-forge
+ * operational settings with a fixed CLI/env surface.
+ */
+export function resolveMcpHeaders(
+  headers: Record<string, McpHeaderValue> | undefined,
+): Record<string, string> | undefined {
+  if (headers === undefined) return undefined;
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (isMcpHeaderEnvValue(value)) {
+      const envName = value.env.trim();
+      if (!validateEnvName(envName)) {
+        throw new Error(`MCP header '${name}' references an invalid environment variable name`);
+      }
+      const resolved = process.env[envName];
+      if (resolved === undefined) {
+        throw new Error(
+          `MCP header '${name}' requires environment variable ${envName}, but it is not set`,
+        );
+      }
+      out[name] = resolved;
+    } else {
+      out[name] = value;
+    }
+  }
+  return out;
+}
+
 /**
  * Write `mcp.json`, merging the secret-placeholder for `headers`
  * AND `env` values back to the prior persisted value. Without this,
@@ -285,7 +349,7 @@ export async function writeMcpJson(next: McpJson): Promise<void> {
   for (const [name, server] of Object.entries(next.servers ?? {})) {
     const merged = copyServerCleaned(server);
     if (server.headers !== undefined) {
-      merged.headers = mergeSecretMap(server.headers, existing.servers[name]?.headers);
+      merged.headers = mergeHeaderMap(server.headers, existing.servers[name]?.headers);
     }
     if (server.env !== undefined) {
       merged.env = mergeSecretMap(server.env, existing.servers[name]?.env);

--- a/packages/server/src/mcp/manager.ts
+++ b/packages/server/src/mcp/manager.ts
@@ -13,6 +13,8 @@ import {
   isStdioConfig,
   normalizeMcpTruncationConfig,
   readMcpJson,
+  resolveMcpHeaders,
+  type McpHeaderValue,
   type McpServerConfig,
   type McpTransport,
 } from "./config.js";
@@ -656,13 +658,15 @@ const insecureHttpsAgent = new UndiciAgent({ connect: { rejectUnauthorized: fals
 
 async function openStreamableHttp(
   url: URL,
-  headers: Record<string, string> | undefined,
+  headers: Record<string, McpHeaderValue> | undefined,
   ignoreCertificateErrors: boolean,
 ): Promise<OpenedConnection> {
   const fetchWithTlsPolicy = makeFetchWithTlsPolicy(ignoreCertificateErrors);
+  const fetchWithHeaders = makeFetchWithMcpHeaders(fetchWithTlsPolicy, headers);
+  const requestHeaders = resolveMcpHeaders(headers);
   const transport = new StreamableHTTPClientTransport(url, {
-    ...(headers !== undefined ? { requestInit: { headers } } : {}),
-    fetch: fetchWithTlsPolicy,
+    ...(requestHeaders !== undefined ? { requestInit: { headers: requestHeaders } } : {}),
+    fetch: fetchWithHeaders,
   });
   const client = new Client({ name: "pi-forge", version: "1.0.0" }, { capabilities: {} });
   await client.connect(transport as unknown as SdkTransport);
@@ -671,21 +675,19 @@ async function openStreamableHttp(
 
 async function openSse(
   url: URL,
-  headers: Record<string, string> | undefined,
+  headers: Record<string, McpHeaderValue> | undefined,
   ignoreCertificateErrors: boolean,
 ): Promise<OpenedConnection> {
   const fetchWithTlsPolicy = makeFetchWithTlsPolicy(ignoreCertificateErrors);
+  const fetchWithHeaders = makeFetchWithMcpHeaders(fetchWithTlsPolicy, headers);
+  const requestHeaders = resolveMcpHeaders(headers);
   const transport = new SSEClientTransport(url, {
-    ...(headers !== undefined ? { requestInit: { headers } } : {}),
+    ...(requestHeaders !== undefined ? { requestInit: { headers: requestHeaders } } : {}),
     // Custom EventSource fetch factory so the SSE GET also carries headers and
     // the per-server TLS policy. Browsers' native EventSource doesn't accept
     // headers, but the MCP SDK's bundled eventsource shim does via this hook.
     eventSourceInit: {
-      fetch: (input: string | URL, init?: RequestInit) =>
-        fetchWithTlsPolicy(input, {
-          ...init,
-          headers: { ...((init?.headers as Record<string, string>) ?? {}), ...(headers ?? {}) },
-        }),
+      fetch: (input: string | URL, init?: RequestInit) => fetchWithHeaders(input, init),
     } as unknown as EventSourceInit,
   });
   const client = new Client({ name: "pi-forge", version: "1.0.0" }, { capabilities: {} });
@@ -700,6 +702,20 @@ function makeFetchWithTlsPolicy(ignoreCertificateErrors: boolean): typeof fetch 
       ...init,
       dispatcher: insecureHttpsAgent,
     } as FetchWithDispatcherInit);
+}
+
+function makeFetchWithMcpHeaders(
+  baseFetch: typeof fetch,
+  headers: Record<string, McpHeaderValue> | undefined,
+): typeof fetch {
+  if (headers === undefined) return baseFetch;
+  return async (input, init) => {
+    const resolved = resolveMcpHeaders(headers);
+    return await baseFetch(input, {
+      ...init,
+      headers: { ...((init?.headers as Record<string, string>) ?? {}), ...(resolved ?? {}) },
+    });
+  };
 }
 
 /* -------------------------- project-scope read -------------------------- */

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -5,6 +5,7 @@ import {
   setMcpDisabled,
   setMcpTruncationConfig,
   upsertMcpServer,
+  type McpHeaderValue,
   type McpServerConfig,
   type McpTransport,
 } from "../mcp/config.js";
@@ -28,7 +29,7 @@ interface McpServerBody {
   // remote
   url?: string;
   transport?: McpTransport;
-  headers?: Record<string, string>;
+  headers?: Record<string, McpHeaderValue>;
   ignoreCertificateErrors?: boolean;
   // stdio
   command?: string;
@@ -50,7 +51,17 @@ const serverConfigSchema = {
     transport: { type: "string", enum: ["auto", "streamable-http", "sse"] },
     headers: {
       type: "object",
-      additionalProperties: { type: "string" },
+      additionalProperties: {
+        anyOf: [
+          { type: "string" },
+          {
+            type: "object",
+            required: ["env"],
+            additionalProperties: false,
+            properties: { env: { type: "string", minLength: 1 } },
+          },
+        ],
+      },
     },
     ignoreCertificateErrors: { type: "boolean" },
     command: { type: "string", minLength: 1 },

--- a/tests/test-mcp.ts
+++ b/tests/test-mcp.ts
@@ -64,7 +64,10 @@ interface FixtureServer {
  * SSE on failure, so this also exercises the fallback path
  * end-to-end against a live network listener.
  */
-async function spawnFixtureServer(opts?: { toolPrefix?: string }): Promise<FixtureServer> {
+async function spawnFixtureServer(opts?: {
+  toolPrefix?: string;
+  requiredHeader?: { name: string; value: string };
+}): Promise<FixtureServer> {
   const prefix = opts?.toolPrefix ?? "";
 
   let calls = 0;
@@ -107,6 +110,16 @@ async function spawnFixtureServer(opts?: { toolPrefix?: string }): Promise<Fixtu
     void (async () => {
       const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
       try {
+        const requiredHeader = opts?.requiredHeader;
+        if (
+          requiredHeader !== undefined &&
+          req.headers[requiredHeader.name.toLowerCase()] !== requiredHeader.value
+        ) {
+          res.statusCode = 401;
+          res.setHeader("content-type", "application/json");
+          res.end(JSON.stringify({ error: "missing required header" }));
+          return;
+        }
         if (req.method === "GET" && url.pathname === "/sse") {
           const transport = new SSEServerTransport("/messages", res);
           sessions.set(transport.sessionId, transport);
@@ -334,7 +347,63 @@ async function main(): Promise<void> {
     await config.setMcpTruncationConfig({ enabled: true, maxChars: 30000 });
     await manager.reloadGlobal();
 
-    // ---- Case D: per-server enabled:false → server moves to disabled ----
+    // ---- Case D: env-backed and literal remote headers ----
+    const headerFixture = await spawnFixtureServer({
+      requiredHeader: { name: "Authorization", value: "Bearer env-secret" },
+    });
+    try {
+      process.env.TEST_MCP_HEADER_TOKEN = "Bearer env-secret";
+      await config.writeMcpJson({
+        servers: {
+          headered: {
+            url: headerFixture.url,
+            headers: {
+              Authorization: { env: "TEST_MCP_HEADER_TOKEN" },
+              "X-Literal": "literal-value",
+            },
+          },
+        },
+      });
+      const redacted = await config.readMcpJsonRedacted();
+      assert(
+        "headers: env-backed value is not redacted away",
+        JSON.stringify(redacted.servers.headered?.headers?.Authorization) ===
+          JSON.stringify({ env: "TEST_MCP_HEADER_TOKEN" }),
+        JSON.stringify(redacted.servers.headered?.headers),
+      );
+      assert(
+        "headers: literal value is redacted",
+        redacted.servers.headered?.headers?.["X-Literal"] === "***REDACTED***",
+        JSON.stringify(redacted.servers.headered?.headers),
+      );
+      await manager.reloadGlobal();
+      await waitForState("headered", {}, "connected");
+      assert(
+        "headers: env-backed value resolves and connects",
+        manager.getStatus().find((s) => s.name === "headered")?.state === "connected",
+      );
+      delete process.env.TEST_MCP_HEADER_TOKEN;
+      await manager.probe("global", "headered");
+      const missingStatus = manager.getStatus().find((s) => s.name === "headered");
+      assert(
+        "headers: missing env var produces user-visible error",
+        missingStatus?.state === "error" &&
+          (missingStatus.lastError ?? "").includes("TEST_MCP_HEADER_TOKEN"),
+        JSON.stringify(missingStatus),
+      );
+    } finally {
+      delete process.env.TEST_MCP_HEADER_TOKEN;
+      await headerFixture.close();
+    }
+
+    // Re-enable original fixture for the next cases.
+    await config.writeMcpJson({
+      servers: { test: { url: fixture.url } },
+    });
+    await manager.reloadGlobal();
+    await waitForState("test", {}, "connected");
+
+    // ---- Case E: per-server enabled:false → server moves to disabled ----
     await config.writeMcpJson({
       servers: { test: { url: fixture.url, enabled: false } },
     });


### PR DESCRIPTION
## Summary

MCP remote server headers previously only accepted literal string values, which made operators store bearer tokens or API keys directly in `${FORGE_DATA_DIR}/mcp.json`. This PR adds env-backed MCP header values so a header can preserve only an environment variable name in the registry/UI while pi-forge resolves the secret value when it connects to or calls the MCP server.

Missing or invalid env vars fail the MCP connection with a clear status error instead of crashing the server or leaking the resolved secret.

## Usage

Configure a remote MCP server header with either the existing literal form or the new env-backed form:

```json
{
  "servers": {
    "authenticated": {
      "url": "https://mcp.example.com/sse",
      "headers": {
        "Authorization": { "env": "MY_MCP_TOKEN" },
        "X-Static": "literal-value"
      }
    }
  }
}
```

In Settings → MCP, header rows now let you choose `literal` or `env`. Env-backed headers store/display only the env var name; literal values keep the existing `***REDACTED***` read-path behavior.

## What changed (9 files)

- `packages/server/src/mcp/config.ts` — adds `McpHeaderValue`, redaction/merge support for `{ env }` headers, and a resolver for dynamic user-named env vars.
- `packages/server/src/mcp/manager.ts` — resolves env-backed headers when MCP HTTP/SSE fetches are sent and surfaces missing env vars as connection errors.
- `packages/server/src/routes/mcp.ts` — accepts string or `{ env: string }` header values in API schemas.
- `packages/client/src/lib/api-client/types.ts` — updates MCP header types for the client.
- `packages/client/src/components/SettingsPanel.tsx` — adds literal/env header source selection in Settings → MCP without exposing resolved env values.
- `tests/test-mcp.ts` — covers env-backed header success, missing env var errors, and literal header redaction compatibility.
- `docs/mcp.md`, `docs/agent/mcp.md`, `docs/agent/config.md` — documents user-facing behavior and the dynamic-env exception to fixed operational env handling.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `npx tsx tests/test-mcp.ts`
- [x] `npx tsx tests/test-mcp-truncation.ts`
- [x] Manual: user tested the env-backed MCP header flow with a local authenticated fixture and confirmed it worked
- [ ] CI green before merge
