### PR TITLE
fix: harden MCP tool failure handling

### DIFF
--- a/packages/server/src/mcp/manager.ts
+++ b/packages/server/src/mcp/manager.ts
@@ -493,8 +493,84 @@ async function connectEntry(entry: PoolEntry): Promise<void> {
     entry.tools = [];
     entry.bridged = [];
     entry.state = "error";
-    entry.lastError = err instanceof Error ? err.message : String(err);
+    entry.lastError = sanitizeMcpDiagnostic(err instanceof Error ? err.message : String(err));
+    logMcpConnectionFailure(entry, err);
   }
+}
+
+function logMcpConnectionFailure(entry: PoolEntry, err: unknown): void {
+  const error = err as { name?: unknown; code?: unknown; cause?: unknown };
+  const code =
+    typeof error?.code === "string" || typeof error?.code === "number" ? error.code : undefined;
+  const name = typeof error?.name === "string" ? error.name : undefined;
+  const cause =
+    error?.cause instanceof Error ? sanitizeMcpDiagnostic(error.cause.message) : undefined;
+  console.warn(
+    "[mcp] connection failure",
+    JSON.stringify({
+      server: entry.name,
+      scope: entry.scope === "global" ? "global" : `project:${entry.scope.project}`,
+      kind: isStdioConfig(entry.config) ? "stdio" : "remote",
+      ...(name !== undefined ? { errorName: name } : {}),
+      ...(code !== undefined ? { code } : {}),
+      message: sanitizeMcpDiagnostic(err instanceof Error ? err.message : String(err)),
+      ...(cause !== undefined ? { cause } : {}),
+    }),
+  );
+}
+
+function attachStdioStderrLogger(
+  transport: StdioClientTransport,
+  command: string,
+  scope: Scope,
+): void {
+  const stderr = transport.stderr;
+  if (stderr === null) return;
+  const safeCommand = sanitizeMcpDiagnostic(command);
+  let chunksLogged = 0;
+  stderr.on("data", (chunk: Buffer | string) => {
+    chunksLogged += 1;
+    if (chunksLogged > 20) {
+      if (chunksLogged === 21) {
+        console.warn(
+          "[mcp] stdio stderr suppressed",
+          JSON.stringify({ command: safeCommand, reason: "too_many_chunks" }),
+        );
+      }
+      return;
+    }
+    console.warn(
+      "[mcp] stdio stderr",
+      JSON.stringify({
+        command: safeCommand,
+        scope: scope === "global" ? "global" : `project:${scope.project}`,
+        message: sanitizeMcpDiagnostic(String(chunk)),
+      }),
+    );
+  });
+  stderr.on("error", (err: Error) => {
+    console.warn(
+      "[mcp] stdio stderr read failed",
+      JSON.stringify({ command: safeCommand, message: sanitizeMcpDiagnostic(err.message) }),
+    );
+  });
+}
+
+function sanitizeMcpDiagnostic(value: string): string {
+  const maxChars = 1_000;
+  const redacted = value
+    .replace(/(authorization\s*[:=]\s*bearer\s+)[^\s"',;]+/gi, "$1[REDACTED]")
+    .replace(
+      /((?:api[_-]?key|token|secret|password|passwd|pwd)\s*[:=]\s*)[^\s"',;]+/gi,
+      "$1[REDACTED]",
+    )
+    .replace(
+      /("(?:api[_-]?key|token|secret|password|passwd|pwd)"\s*:\s*")[^"]*(")/gi,
+      "$1[REDACTED]$2",
+    )
+    .replace(/([A-Za-z0-9_-]{8,}\.)[A-Za-z0-9_-]{8,}(\.[A-Za-z0-9_-]{8,})/g, "$1[REDACTED]$2");
+  if (redacted.length <= maxChars) return redacted;
+  return `${redacted.slice(0, maxChars)}… [truncated ${redacted.length - maxChars} chars]`;
 }
 
 async function recoverStaleSession(scope: Scope, name: string): Promise<boolean> {
@@ -526,8 +602,18 @@ async function disconnectEntry(entry: PoolEntry): Promise<void> {
   // the client never finished handshaking.
   // close() can be sync (void) or async (Promise<void>) depending on
   // the transport — Promise.resolve normalizes either to a thenable.
-  await Promise.resolve(client?.close()).catch(() => undefined);
-  await Promise.resolve(transport?.close()).catch(() => undefined);
+  await Promise.resolve(client?.close()).catch((err: unknown) => {
+    console.warn(
+      "[mcp] client close failed",
+      JSON.stringify({ server: entry.name, message: sanitizeMcpDiagnostic(String(err)) }),
+    );
+  });
+  await Promise.resolve(transport?.close()).catch((err: unknown) => {
+    console.warn(
+      "[mcp] transport close failed",
+      JSON.stringify({ server: entry.name, message: sanitizeMcpDiagnostic(String(err)) }),
+    );
+  });
 }
 
 interface OpenedConnection {
@@ -594,9 +680,9 @@ async function openConnection(cfg: McpServerConfig, scope: Scope): Promise<Opene
  * user's repo root); global entries inherit the pi-forge process
  * cwd. An explicit `cfg.cwd` always wins.
  *
- * **stderr.** Inherited so the operator can see startup failures /
- * tracebacks in the pi-forge log without having to pipe-and-pump
- * the child's stderr ourselves.
+ * **stderr.** Piped through pi-forge so startup failures / tracebacks
+ * remain visible in pod logs, but are size-limited and scrubbed for
+ * common secret shapes before logging.
  */
 async function openStdio(cfg: McpServerConfig, scope: Scope): Promise<OpenedConnection> {
   if (cfg.command === undefined || cfg.command.length === 0) {
@@ -615,8 +701,9 @@ async function openStdio(cfg: McpServerConfig, scope: Scope): Promise<OpenedConn
     args: cfg.args ?? [],
     env,
     ...(resolvedCwd !== undefined ? { cwd: resolvedCwd } : {}),
-    stderr: "inherit",
+    stderr: "pipe",
   });
+  attachStdioStderrLogger(transport, cfg.command, scope);
   const client = new Client({ name: "pi-forge", version: "1.0.0" }, { capabilities: {} });
   await client.connect(transport);
   return { client, transport, resolvedTransport: undefined };

--- a/packages/server/src/mcp/tool-bridge.ts
+++ b/packages/server/src/mcp/tool-bridge.ts
@@ -8,6 +8,10 @@ export interface McpResultTruncationSettings {
   maxChars: number;
 }
 
+export const MCP_TOOL_CALL_TIMEOUT_MS = 120_000;
+const MCP_DIAGNOSTIC_MAX_CHARS = 1_000;
+const MCP_DETAIL_MAX_CHARS = 10_000;
+
 /**
  * Translate a single MCP tool advertised by a connected MCP server
  * into a pi `ToolDefinition` the agent can call.
@@ -59,27 +63,47 @@ export function bridgeMcpTool(opts: {
       }
       try {
         const res = await callMcpTool(client, opts.toolName, params, signal);
-        return mcpResultToAgentResult(res);
+        return safelyConvertMcpResult(prefixedName, opts.serverName, opts.toolName, res);
       } catch (err) {
         if (
           !isAbortError(err) &&
           isStaleMcpSessionError(err) &&
           opts.recoverStaleSession !== undefined
         ) {
-          const recovered = await opts.recoverStaleSession().catch(() => false);
+          const recovered = await opts.recoverStaleSession().catch((recoverErr: unknown) => {
+            logMcpToolFailure({
+              serverName: opts.serverName,
+              toolName: opts.toolName,
+              phase: "reconnect",
+              error: recoverErr,
+            });
+            return false;
+          });
           const retryClient = opts.getClient();
           if (recovered && retryClient !== undefined) {
             try {
               const retryRes = await callMcpTool(retryClient, opts.toolName, params, signal);
-              return mcpResultToAgentResult(retryRes);
+              return safelyConvertMcpResult(prefixedName, opts.serverName, opts.toolName, retryRes);
             } catch (retryErr) {
+              logMcpToolFailure({
+                serverName: opts.serverName,
+                toolName: opts.toolName,
+                phase: "retry",
+                error: retryErr,
+              });
               return errorResult(
-                `MCP tool '${prefixedName}' threw after reconnect: ${errorMessage(retryErr)}`,
+                `MCP tool '${prefixedName}' failed after reconnect: ${errorMessage(retryErr)}`,
               );
             }
           }
         }
-        return errorResult(`MCP tool '${prefixedName}' threw: ${errorMessage(err)}`);
+        logMcpToolFailure({
+          serverName: opts.serverName,
+          toolName: opts.toolName,
+          phase: isAbortError(err) ? "abort" : "call",
+          error: err,
+        });
+        return errorResult(`MCP tool '${prefixedName}' failed: ${errorMessage(err)}`);
       }
     },
   } satisfies ToolDefinition;
@@ -91,29 +115,156 @@ async function callMcpTool(
   params: unknown,
   signal: AbortSignal | undefined,
 ): Promise<unknown> {
-  return await client.callTool(
-    {
-      name: toolName,
-      arguments: (params as Record<string, unknown>) ?? {},
+  const call = makeAbortableCallSignal(signal, MCP_TOOL_CALL_TIMEOUT_MS);
+  try {
+    const result = client.callTool(
+      {
+        name: toolName,
+        arguments: isRecord(params) ? params : {},
+      },
+      undefined,
+      { signal: call.signal },
+    );
+    return await Promise.race([result, call.abortPromise]);
+  } finally {
+    call.cleanup();
+  }
+}
+
+function safelyConvertMcpResult(
+  prefixedName: string,
+  serverName: string,
+  toolName: string,
+  res: unknown,
+): AgentToolResult<unknown> {
+  try {
+    return mcpResultToAgentResult(res);
+  } catch (err) {
+    logMcpToolFailure({ serverName, toolName, phase: "result_conversion", error: err });
+    return errorResult(
+      `MCP tool '${prefixedName}' returned a malformed result that pi-forge could not safely render: ${errorMessage(err)}`,
+    );
+  }
+}
+
+function makeAbortableCallSignal(
+  parent: AbortSignal | undefined,
+  timeoutMs: number,
+): { signal: AbortSignal; abortPromise: Promise<never>; cleanup: () => void } {
+  const controller = new AbortController();
+  let rejectAbort: (err: Error) => void = () => undefined;
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
+  });
+  const fail = (err: Error): void => {
+    controller.abort(err);
+    rejectAbort(err);
+  };
+  const timeout = setTimeout(() => {
+    fail(new Error(`MCP tool call timed out after ${timeoutMs} ms`));
+  }, timeoutMs);
+  const abort = (): void => {
+    const reason = parent?.reason;
+    fail(reason instanceof Error ? reason : new Error("MCP tool call aborted"));
+  };
+  if (parent?.aborted === true) abort();
+  else parent?.addEventListener("abort", abort, { once: true });
+  return {
+    signal: controller.signal,
+    abortPromise,
+    cleanup: () => {
+      clearTimeout(timeout);
+      parent?.removeEventListener("abort", abort);
     },
-    undefined,
-    signal !== undefined ? { signal } : undefined,
-  );
+  };
 }
 
 function errorResult(message: string): AgentToolResult<unknown> {
   return {
-    content: [{ type: "text", text: message }],
+    content: [{ type: "text", text: sanitizeDiagnostic(message, MCP_DIAGNOSTIC_MAX_CHARS) }],
     details: undefined,
   };
 }
 
 function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  if (err instanceof Error) {
+    const parts = [err.name, err.message].filter((p) => p.length > 0);
+    return sanitizeDiagnostic(parts.join(": "), MCP_DIAGNOSTIC_MAX_CHARS);
+  }
+  return sanitizeDiagnostic(safeStringify(err, MCP_DIAGNOSTIC_MAX_CHARS), MCP_DIAGNOSTIC_MAX_CHARS);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isAbortError(err: unknown): boolean {
   return err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
+}
+
+function logMcpToolFailure(opts: {
+  serverName: string;
+  toolName: string;
+  phase: "call" | "abort" | "reconnect" | "retry" | "result_conversion";
+  error: unknown;
+}): void {
+  const error = opts.error as { name?: unknown; code?: unknown; cause?: unknown };
+  const code =
+    typeof error?.code === "string" || typeof error?.code === "number" ? error.code : undefined;
+  const name = typeof error?.name === "string" ? error.name : undefined;
+  const cause = error?.cause instanceof Error ? errorMessage(error.cause) : undefined;
+  console.warn(
+    "[mcp] tool failure",
+    JSON.stringify({
+      server: opts.serverName,
+      tool: opts.toolName,
+      phase: opts.phase,
+      ...(name !== undefined ? { errorName: name } : {}),
+      ...(code !== undefined ? { code } : {}),
+      message: errorMessage(opts.error),
+      ...(cause !== undefined ? { cause } : {}),
+    }),
+  );
+}
+
+function safeStringify(value: unknown, maxChars: number): string {
+  const seen = new WeakSet<object>();
+  let text: string;
+  try {
+    text = JSON.stringify(value, (_key, nested) => {
+      if (typeof nested === "bigint") return nested.toString();
+      if (typeof nested === "object" && nested !== null) {
+        if (seen.has(nested)) return "[Circular]";
+        seen.add(nested);
+      }
+      return nested;
+    });
+  } catch (err) {
+    text = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+  }
+  if (text === undefined) text = String(value);
+  return sanitizeDiagnostic(text, maxChars);
+}
+
+function safeDetails(value: unknown): unknown {
+  if (value === undefined) return null;
+  return safeStringify(value, MCP_DETAIL_MAX_CHARS);
+}
+
+function sanitizeDiagnostic(value: string, maxChars: number): string {
+  const redacted = value
+    .replace(/(authorization\s*[:=]\s*bearer\s+)[^\s"',;]+/gi, "$1[REDACTED]")
+    .replace(
+      /((?:api[_-]?key|token|secret|password|passwd|pwd)\s*[:=]\s*)[^\s"',;]+/gi,
+      "$1[REDACTED]",
+    )
+    .replace(
+      /("(?:api[_-]?key|token|secret|password|passwd|pwd)"\s*:\s*")[^"]*(")/gi,
+      "$1[REDACTED]$2",
+    )
+    .replace(/([A-Za-z0-9_-]{8,}\.)[A-Za-z0-9_-]{8,}(\.[A-Za-z0-9_-]{8,})/g, "$1[REDACTED]$2");
+  if (redacted.length <= maxChars) return redacted;
+  return `${redacted.slice(0, maxChars)}… [truncated ${redacted.length - maxChars} chars]`;
 }
 
 function isStaleMcpSessionError(err: unknown): boolean {
@@ -177,7 +328,7 @@ export function mcpResultToAgentResult(res: unknown): AgentToolResult<unknown> {
       // drop would look like a successful no-op.
       content.push({
         type: "text",
-        text: `[${String(block.type ?? "unknown")}] ${JSON.stringify(block)}`,
+        text: `[${String(block.type ?? "unknown")}] ${safeStringify(block, MCP_DETAIL_MAX_CHARS)}`,
       });
     }
   }
@@ -186,7 +337,10 @@ export function mcpResultToAgentResult(res: unknown): AgentToolResult<unknown> {
     // include structuredContent if present so the agent has something
     // to work with.
     if (r.structuredContent !== undefined) {
-      content.push({ type: "text", text: JSON.stringify(r.structuredContent) });
+      content.push({
+        type: "text",
+        text: safeStringify(r.structuredContent, MCP_DETAIL_MAX_CHARS),
+      });
     } else {
       content.push({ type: "text", text: isError ? "[error] (no detail)" : "(empty result)" });
     }
@@ -194,7 +348,7 @@ export function mcpResultToAgentResult(res: unknown): AgentToolResult<unknown> {
   if (isError && content[0]?.type === "text") {
     content[0] = { type: "text", text: `[error] ${content[0].text}` };
   }
-  return { content: capTextContent(content), details: r.structuredContent ?? null };
+  return { content: capTextContent(content), details: safeDetails(r.structuredContent) };
 }
 
 /**

--- a/tests/test-mcp-failure-handling.ts
+++ b/tests/test-mcp-failure-handling.ts
@@ -1,0 +1,125 @@
+/**
+ * MCP failure-handling regression test.
+ *
+ * Exercises the pi-forge MCP bridge without a live MCP server so failures are
+ * deterministic: thrown tool calls are converted into visible tool errors,
+ * diagnostics are sanitized, and malformed/circular result payloads do not throw
+ * while being rendered for the agent.
+ */
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) console.log(`  PASS  ${label}`);
+  else {
+    failures += 1;
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+interface TextBlock {
+  type: "text";
+  text: string;
+}
+
+interface ToolBridgeModule {
+  bridgeMcpTool: (opts: {
+    serverName: string;
+    toolName: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    getClient: () => { callTool: (...args: unknown[]) => Promise<unknown> } | undefined;
+    recoverStaleSession?: () => Promise<boolean>;
+  }) => {
+    execute: (
+      toolCallId: string,
+      params: unknown,
+      signal: AbortSignal | undefined,
+      update: unknown,
+      context: unknown,
+    ) => Promise<{ content: TextBlock[]; details: unknown }>;
+  };
+  mcpResultToAgentResult: (res: unknown) => { content: TextBlock[]; details: unknown };
+}
+
+async function main(): Promise<void> {
+  const mod = (await import(
+    resolve(repoRoot, "packages/server/dist/mcp/tool-bridge.js")
+  )) as unknown as ToolBridgeModule;
+
+  // ---------- thrown call becomes sanitized tool result ----------
+  {
+    const tool = mod.bridgeMcpTool({
+      serverName: "secrets",
+      toolName: "explode",
+      description: "Throws with a secret-looking diagnostic.",
+      inputSchema: { type: "object", properties: {} },
+      getClient: () => ({
+        callTool: async () => {
+          throw new Error(
+            "upstream failed: Authorization: Bearer sk_live_secret token=abc123 password=hunter2",
+          );
+        },
+      }),
+    });
+    const result = await tool.execute("tcid-failure", {}, undefined, undefined, {});
+    const text = result.content[0]?.text ?? "";
+    assert(
+      "throw: returns visible MCP failure",
+      text.includes("MCP tool 'secrets__explode' failed"),
+      text,
+    );
+    assert(
+      "throw: bearer token redacted",
+      !text.includes("sk_live_secret") && text.includes("Bearer [REDACTED]"),
+      text,
+    );
+    assert(
+      "throw: token assignment redacted",
+      !text.includes("abc123") && text.includes("token=[REDACTED]"),
+      text,
+    );
+    assert(
+      "throw: password redacted",
+      !text.includes("hunter2") && text.includes("password=[REDACTED]"),
+      text,
+    );
+  }
+
+  // ---------- malformed/circular result is rendered safely ----------
+  {
+    const circular: Record<string, unknown> = { type: "resource", token: "super-secret-value" };
+    circular.self = circular;
+    const result = mod.mcpResultToAgentResult({ content: [circular], structuredContent: circular });
+    const text = result.content[0]?.text ?? "";
+    assert("circular result: returns a text block", result.content[0]?.type === "text", text);
+    assert("circular result: marks circular reference", text.includes("[Circular]"), text);
+    assert(
+      "circular result: sanitizes secret-looking keys",
+      !text.includes("super-secret-value"),
+      text,
+    );
+    assert(
+      "circular details: bounded string detail",
+      typeof result.details === "string",
+      String(result.details),
+    );
+  }
+
+  console.log(
+    failures === 0
+      ? "\n[test-mcp-failure-handling] PASS"
+      : `\n[test-mcp-failure-handling] FAIL — ${failures} assertion(s) failed`,
+  );
+  if (failures > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("[test-mcp-failure-handling] uncaught error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

MCP tool failures could be difficult to diagnose and, in some edge cases, risky for pod stability: thrown tool calls, stale/disconnected transports, malformed result payloads, noisy stdio stderr, or hung calls could escape with poor context or dump unsafe diagnostics. This PR hardens the MCP bridge so failures become visible tool results and sanitized server logs instead of unhandled crashes.

## Usage

No user-facing workflow changes. Operators can diagnose MCP issues from pod/server logs by searching for:

```bash
[mcp] connection failure
[mcp] tool failure
[mcp] stdio stderr
[mcp] client close failed
[mcp] transport close failed
```

MCP tool calls now have a hard 120s timeout. Risk/follow-up: if legitimate MCP tools need longer than 120s, this constant should become configurable in MCP settings or coordinated with broader SSE/worker timeout behavior.

## What changed (3 files)

- `packages/server/src/mcp/tool-bridge.ts` — wraps MCP tool calls with timeout/abort handling, converts call/retry/reconnect/result-conversion failures into sanitized visible tool results, safely stringifies malformed/circular/BigInt payloads, and bounds diagnostic/detail text.
- `packages/server/src/mcp/manager.ts` — sanitizes connection `lastError`, adds structured sanitized logging for connection/close failures, and pipes stdio stderr through bounded redacted logs instead of raw inherited stderr.
- `tests/test-mcp-failure-handling.ts` — adds regression coverage for thrown MCP calls becoming sanitized tool errors and circular/problematic payloads rendering without throwing.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `npx tsx tests/test-mcp-failure-handling.ts`
- [x] `npx tsx tests/test-mcp.ts`
- [x] `npx tsx tests/test-mcp-truncation.ts`
- [ ] CI green before merge
