### PR TITLE
chore(release): v1.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.4.8] — 2026-08-19
+
+### Added
+
+- **Skill and extension slash commands.** Prompt composition now supports slash command discovery and insertion for skills and extensions, including UI notifications and integration coverage.
+- **Session activity indicators.** The session list and streams now surface activity state so users can distinguish active, idle, and recently updated sessions.
+- **File tree excluded-folder toggles.** The file browser can show or hide excluded folders on demand while preserving workspace path safety.
+- **Env-backed MCP headers.** MCP server headers can reference environment-backed values so deployments can configure sensitive header values without storing raw secrets in forge data.
+- **Rootless Podman quickstart.** Container documentation now includes a rootless Podman compose quickstart and related deployment guidance.
+
+### Changed
+
+- **Dependabot update volume is capped.** Dependency update configuration now limits open version-update pull requests to reduce release noise.
+
+### Fixed
+
+- **Long-running SSE streams stay connected.** Stream handling now keeps extended agent output alive instead of timing out during long-running turns.
+- **MCP tool failures are isolated and reported safely.** MCP bridge handling now hardens tool failure paths so individual MCP failures do not destabilize the session stream.
+- **Sandboxed agents can read pi docs.** Tool sandbox policy now allows required read-only access to pi documentation paths used by project instructions.
+- **Theme contrast and inspector backgrounds are consistent.** Palette selection contrast and inspector surfaces now respect the active theme/background more reliably.
+
 ## [1.4.7] — 2026-07-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.4.7",
+      "version": "1.4.8",
       "workspaces": [
         "packages/*"
       ],
@@ -17096,7 +17096,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.4.7",
+      "version": "1.4.8",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17168,7 +17168,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.4.7",
+      "version": "1.4.8",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.10",
         "@earendil-works/pi-ai": "0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts the v1.4.8 release from `main`. Release notes were generated from changes since the previous release ref `v1.4.7` using `git log v1.4.7..HEAD` and `git diff --stat v1.4.7..HEAD`, then rolled into the dated changelog entry with `scripts/bump-version.sh 1.4.8`.

## Usage

No direct usage change for this PR. After merge, tag `v1.4.8` from updated `main` per the release workflow; this PR intentionally does not create the tag.

```bash
scripts/bump-version.sh 1.4.8
npx npm@latest approve-scripts --allow-scripts-pending
```

## What changed (5 files, +28/-7)

- `CHANGELOG.md` — adds the v1.4.8 release notes under a dated `## [1.4.8]` heading and leaves a fresh `## [Unreleased]` section.
- `package.json` — bumps the root package version to 1.4.8.
- `packages/server/package.json` — bumps the server workspace version to 1.4.8.
- `packages/client/package.json` — bumps the client workspace version to 1.4.8.
- `package-lock.json` — refreshes lockfile package versions for the root, server, and client workspaces.

## Test plan

- [x] `npx npm@latest approve-scripts --allow-scripts-pending` (no packages with unreviewed install scripts)
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run format:check` (covered by `npm run check`)
- [ ] CI green before merge
