### PR TITLE
fix: preserve MCP transport request headers

### DIFF
--- a/packages/server/src/mcp/manager.ts
+++ b/packages/server/src/mcp/manager.ts
@@ -798,9 +798,13 @@ function makeFetchWithMcpHeaders(
   if (headers === undefined) return baseFetch;
   return async (input, init) => {
     const resolved = resolveMcpHeaders(headers);
+    const mergedHeaders = new Headers(init?.headers);
+    for (const [name, value] of Object.entries(resolved ?? {})) {
+      mergedHeaders.set(name, value);
+    }
     return await baseFetch(input, {
       ...init,
-      headers: { ...((init?.headers as Record<string, string>) ?? {}), ...(resolved ?? {}) },
+      headers: mergedHeaders,
     });
   };
 }

--- a/tests/test-mcp.ts
+++ b/tests/test-mcp.ts
@@ -45,6 +45,8 @@ interface FixtureServer {
   url: string;
   /** Counts tool invocations since spawn — handy for probe assertions. */
   callCount: () => number;
+  /** Captured Content-Type headers from JSON-RPC POST /messages requests. */
+  postContentTypes: () => string[];
   /** Simulates an MCP server restart that drops known session ids while keeping the URL stable. */
   dropSessions: () => Promise<void>;
   close: () => Promise<void>;
@@ -105,6 +107,7 @@ async function spawnFixtureServer(opts?: {
   // without breaking the prior one). Real production servers do this
   // — Case F (probe) exercises the reconnect path.
   const sessions = new Map<string, SSEServerTransport>();
+  const postContentTypes: string[] = [];
 
   const httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
     void (async () => {
@@ -128,6 +131,7 @@ async function spawnFixtureServer(opts?: {
           return;
         }
         if (req.method === "POST" && url.pathname === "/messages") {
+          postContentTypes.push(req.headers["content-type"] ?? "");
           const sessionId = url.searchParams.get("sessionId") ?? "";
           const transport = sessions.get(sessionId);
           if (transport === undefined) {
@@ -168,6 +172,7 @@ async function spawnFixtureServer(opts?: {
   return {
     url,
     callCount: () => calls,
+    postContentTypes: () => [...postContentTypes],
     dropSessions: async () => {
       const oldSessions = Array.from(sessions.values());
       sessions.clear();
@@ -381,6 +386,25 @@ async function main(): Promise<void> {
       assert(
         "headers: env-backed value resolves and connects",
         manager.getStatus().find((s) => s.name === "headered")?.state === "connected",
+      );
+      const headeredTools = manager.customToolsForProject("any-project-id");
+      const headeredEcho = headeredTools.find((t) => t.name === "headered__echo");
+      assert("headers: env-backed echo tool present", headeredEcho !== undefined);
+      if (headeredEcho !== undefined) {
+        await headeredEcho.execute(
+          "tcid-headered",
+          { text: "content-type-check" },
+          undefined,
+          undefined,
+          {} as Parameters<typeof headeredEcho.execute>[4],
+        );
+      }
+      assert(
+        "headers: JSON-RPC POST keeps application/json content-type",
+        headerFixture
+          .postContentTypes()
+          .some((value) => value.toLowerCase().startsWith("application/json")),
+        JSON.stringify(headerFixture.postContentTypes()),
       );
       delete process.env.TEST_MCP_HEADER_TOKEN;
       await manager.probe("global", "headered");


### PR DESCRIPTION
## Summary

PR #404 introduced env-backed MCP remote headers by wrapping the MCP SDK transport fetch function. The first implementation merged headers with object spread, which fails when the SDK passes a `Headers` instance. That dropped SDK-set transport headers such as `content-type: application/json`; with a string body, fetch could then default the JSON-RPC POST to `text/plain`.

This PR preserves the SDK/transport default headers by constructing a `Headers` object from `init.headers` and then setting the resolved user-configured MCP headers on top.

## Usage

No operator-facing usage change. Env-backed headers continue to use the PR #404 form:

```json
{
  "headers": {
    "Authorization": { "env": "MY_MCP_TOKEN" }
  }
}
```

## What changed (2 files)

- `packages/server/src/mcp/manager.ts` — preserves SDK-provided `Headers` instances when applying resolved MCP literal/env headers.
- `tests/test-mcp.ts` — records fixture JSON-RPC POST content-types and asserts env-backed header tool calls keep `application/json`.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `npx tsx tests/test-mcp.ts`
- [x] `npx tsx tests/test-mcp-truncation.ts`
- [ ] CI green before merge
