### PR TITLE
chore(release): v1.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.4.9] — 2026-08-19
+
+### Fixed
+
+- **Configured MCP headers preserve SDK JSON transport headers.** MCP requests now merge user-configured headers without dropping SDK-provided transport headers such as `content-type: application/json`.
+
 ## [1.4.8] — 2026-08-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "workspaces": [
         "packages/*"
       ],
@@ -17096,7 +17096,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17168,7 +17168,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.10",
         "@earendil-works/pi-ai": "0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts v1.4.9 from `main` after v1.4.8. Release notes were generated from changes present on the release base since `v1.4.8`: one follow-up fix, `5acc44a fix: preserve MCP transport request headers (#407)`, which keeps configured MCP headers from dropping SDK transport headers such as `content-type: application/json`.

## Usage

No direct user-facing usage change for the release cut. After this PR merges, tag `v1.4.9` from `main` to trigger the release workflow.

```bash
git checkout main
git pull --ff-only
git tag v1.4.9
git push origin v1.4.9
```

## What changed (5 files, +13/-7)

- `CHANGELOG.md` — promoted the v1.4.9 release notes from `## [Unreleased]` with the MCP header preservation fix.
- `package.json` — bumped the root package version to `1.4.9` via `scripts/bump-version.sh`.
- `packages/client/package.json` — bumped the client workspace version to `1.4.9` via `scripts/bump-version.sh`.
- `packages/server/package.json` — bumped the server workspace version to `1.4.9` via `scripts/bump-version.sh`.
- `package-lock.json` — refreshed lockfile version metadata for `1.4.9` via the release bump script.

## Test plan

- [x] `git log --oneline --decorate --grep='chore(release):' --max-count=5`
- [x] `git tag --sort=-version:refname | head`
- [x] `git log --oneline v1.4.8..HEAD`
- [x] `git diff --stat v1.4.8..HEAD`
- [x] `scripts/bump-version.sh 1.4.9`
- [x] `npx npm@latest approve-scripts --allow-scripts-pending` (reported no packages with unreviewed install scripts)
- [x] `npm run build` (passed after installing dev dependencies in the worktree with `npm install --include=dev`; first attempt failed because local npm config omitted dev dependencies)
- [x] `npm run check`
- [ ] CI green before merge
