### PR TITLE
feat: support dashboard proxy SSO

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -51,6 +51,21 @@ FORGE_DATA_HOST_PATH=~/.pi-forge-docker
 UI_PASSWORD=
 API_KEY=
 
+# ---- Dashboard path proxy / SSO ----
+# When pi-forge is embedded behind the dashboard app proxy at /apps/pi-forge/:
+# - build the client with this Vite base path
+# - set DASHBOARD_IDENTITY_SECRET to the same per-app secret configured in
+#   the dashboard catalog for pi-forge
+# - keep issuer/audience aligned with the dashboard proxy identity envelope
+# - optionally restrict signed dashboard identities to one or more groups.
+#   JSON array is safest for LDAP DNs because DNs contain commas. If unset,
+#   dashboard identity group enforcement falls back to LDAP_REQUIRED_GROUP_DN.
+VITE_BASE_PATH=/apps/pi-forge/
+DASHBOARD_IDENTITY_SECRET=
+DASHBOARD_IDENTITY_ISSUER=internal-dashboard
+DASHBOARD_IDENTITY_AUDIENCE=pi-forge
+DASHBOARD_IDENTITY_ALLOWED_GROUPS=["CN=Developers,OU=Groups,DC=company,DC=local"]
+
 # ---- Reverse proxy / logging ----
 # Set to `true` when running behind nginx / Caddy / Traefik so req.ip
 # reflects the real client IP — required for the login rate limit.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,10 +77,13 @@ COPY packages/client/package.json packages/client/
 # `npm ci --workspaces` honours the root lockfile across all packages.
 RUN npm ci --workspaces --include-workspace-root
 
-# Now bring in the source and build.
+# Now bring in the source and build. VITE_BASE_PATH is a build-time Vite
+# setting; set it when producing an image intended to run under a path proxy
+# such as /apps/pi-forge/.
 COPY . .
 
-RUN npm run build
+ARG VITE_BASE_PATH=/
+RUN VITE_BASE_PATH="$VITE_BASE_PATH" npm run build
 
 # ---------- runtime ----------
 FROM node-python-base AS runtime

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,6 +18,8 @@ services:
         # non-default pi-tools IDs (see ../docs/agent-tool-sandbox.md).
         PTOOLS_UID: ${AGENT_TOOL_UID:-1001}
         PTOOLS_GID: ${AGENT_TOOL_GID:-1001}
+        # Build-time Vite base for path-proxied deployments.
+        VITE_BASE_PATH: ${VITE_BASE_PATH:-/}
     image: pi-forge:latest
     container_name: ${CONTAINER_NAME:-pi-forge}
     restart: unless-stopped
@@ -44,6 +46,12 @@ services:
       # Auth — read from .env. Both empty = auth disabled.
       UI_PASSWORD: ${UI_PASSWORD:-}
       API_KEY: ${API_KEY:-}
+      # Dashboard path-proxy SSO. Leave DASHBOARD_IDENTITY_SECRET empty when
+      # not embedding behind the dashboard proxy.
+      DASHBOARD_IDENTITY_SECRET: ${DASHBOARD_IDENTITY_SECRET:-}
+      DASHBOARD_IDENTITY_ISSUER: ${DASHBOARD_IDENTITY_ISSUER:-internal-dashboard}
+      DASHBOARD_IDENTITY_AUDIENCE: ${DASHBOARD_IDENTITY_AUDIENCE:-pi-forge}
+      DASHBOARD_IDENTITY_ALLOWED_GROUPS: ${DASHBOARD_IDENTITY_ALLOWED_GROUPS:-}
       # Logging + reverse-proxy hint.
       LOG_LEVEL: ${LOG_LEVEL:-info}
       TRUST_PROXY: ${TRUST_PROXY:-false}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,14 @@ or shell environment. The most-touched ones:
 | `LDAP_GROUP_ATTRIBUTE` | `memberOf` | User attribute checked for group DNs. Change only for directories that expose group membership under a different attribute. |
 | `LDAP_TIMEOUT_MS` | `5000` | LDAP connect/operation timeout in milliseconds. |
 | `LDAP_TLS_REJECT_UNAUTHORIZED` | `true` | Reject untrusted TLS certificates for `ldaps://` connections. Set `false` only for local/self-signed testing. |
+| `VITE_BASE_PATH` | `/` | Build-time Vite base path. Set to `/apps/pi-forge/` when building an image/client bundle embedded behind the dashboard app proxy. |
+| `DASHBOARD_IDENTITY_SECRET` | (unset) | Enables dashboard SSO by verifying the dashboard proxy's signed `X-Dashboard-Identity` / `X-Dashboard-Signature` envelope. Must match pi-forge's per-app `identitySecret` in the dashboard catalog. |
+| `DASHBOARD_IDENTITY_SECRET_FILE` | (unset) | File containing the dashboard identity HMAC secret. Takes precedence over `DASHBOARD_IDENTITY_SECRET`. |
+| `DASHBOARD_IDENTITY_ISSUER` | `internal-dashboard` | Expected `iss` in signed dashboard identity envelopes. Must match the dashboard's `DASHBOARD_IDENTITY_ISSUER`. |
+| `DASHBOARD_IDENTITY_AUDIENCE` | `pi-forge` | Expected `aud` and `app` in signed dashboard identity envelopes. `DASHBOARD_APP_ID` is accepted as a legacy/alternate source when this is unset. |
+| `DASHBOARD_IDENTITY_MAX_FUTURE_IAT_SKEW_SECONDS` | `60` | Allowed clock skew for future `iat` values in dashboard identity envelopes. |
+| `DASHBOARD_IDENTITY_MAX_AGE_SECONDS` | `300` | Maximum dashboard identity age and maximum `exp - iat` lifetime. Keeps replay windows short even if the proxy signs a longer-lived envelope. |
+| `DASHBOARD_IDENTITY_ALLOWED_GROUPS` | (unset) | Optional dashboard SSO group allowlist. Use a JSON string array for LDAP DNs, e.g. `["CN=Developers,OU=Groups,DC=company,DC=local"]`; semicolon/newline-separated values are also accepted. If unset, falls back to `LDAP_REQUIRED_GROUP_DN`. |
 | `MINIMAL_UI` | `false` | Hide terminal / git / last-turn / providers / agent-settings panels. Frontend gate; server routes unchanged. ALSO hard-disables webhook configuration, session orchestration, and the quick-actions runner. |
 | `AUTH_BANNER_TEXT` | (unset) | Optional public banner shown below the login prompt. Literal newlines/carriage returns are preserved; `\\n` and `\\r` escapes are decoded for single-line env/CLI surfaces. Do not put secrets here: it is exposed by public `/api/v1/ui-config`. |
 | `AUTH_BANNER_HTML` | `false` | When true, renders `AUTH_BANNER_TEXT` as sanitized HTML instead of plain text. Scripts, styles, event handlers, and unsafe links are stripped client-side. Leave false unless you need links or simple formatting. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -157,6 +157,51 @@ In Traefik's static config, lift
 `3600s` so SSE streams aren't terminated at the default 60 s.
 WebSocket upgrades are handled transparently.
 
+## Dashboard app-proxy embedding
+
+Pi-forge can run as an iframe app behind the dashboard's path proxy, for example
+at `/apps/pi-forge/`. In that topology the dashboard authenticates the browser,
+strips the `/apps/pi-forge/` prefix before forwarding, and injects signed
+identity headers. Build pi-forge with the same base path and configure the
+server to verify the dashboard envelope:
+
+```env
+# Build-time Vite setting; rebuild the image/client after changing it.
+VITE_BASE_PATH=/apps/pi-forge/
+
+# Runtime server settings. The secret must match pi-forge's dashboard catalog
+# identitySecret; issuer/audience must match the dashboard proxy payload.
+DASHBOARD_IDENTITY_SECRET=<matching-per-app-secret>
+DASHBOARD_IDENTITY_ISSUER=internal-dashboard
+DASHBOARD_IDENTITY_AUDIENCE=pi-forge
+
+# Optional downstream group enforcement. Use JSON for LDAP DNs because DNs
+# contain commas. If unset, pi-forge falls back to LDAP_REQUIRED_GROUP_DN.
+DASHBOARD_IDENTITY_ALLOWED_GROUPS=["CN=Developers,OU=Groups,DC=company,DC=local"]
+```
+
+Dashboard catalog shape:
+
+```json
+{
+  "id": "pi-forge",
+  "path": "/apps/pi-forge/",
+  "upstream": "http://pi-forge:3000/",
+  "healthCheckPath": "/api/v1/health"
+}
+```
+
+Notes:
+
+- Keep the upstream network private; dashboard identity headers are trusted only
+  when users cannot bypass the dashboard and hit pi-forge directly.
+- Cached same-origin logos (`/cache/logos/...`), API/SSE calls, downloads,
+  Swagger docs, PWA assets, and terminal WebSocket URLs are base-path aware when
+  the client is built with `VITE_BASE_PATH=/apps/pi-forge/`.
+- The terminal uses WebSocket upgrade. The dashboard app proxy must forward
+  WebSockets for `/apps/pi-forge/api/v1/terminal` if you want embedded terminal
+  support.
+
 ## Network-deploy env-var overrides
 
 Full reference: [`configuration.md`](./configuration.md#environment-variables).

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -18,13 +18,13 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="pi" />
-    <link rel="icon" type="image/svg+xml" href="/icons/icon.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%icons/icon.svg" />
     <!-- iOS Safari "Add to Home Screen" picks an apple-touch-icon link
          and prefers PNG; SVG works on modern iOS but renders fuzzy on
          the home screen. The 192/512 rasters here are the same ones
          the manifest advertises. -->
-    <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192.png" />
-    <link rel="apple-touch-icon" sizes="512x512" href="/icons/icon-512.png" />
+    <link rel="apple-touch-icon" sizes="192x192" href="%BASE_URL%icons/icon-192.png" />
+    <link rel="apple-touch-icon" sizes="512x512" href="%BASE_URL%icons/icon-512.png" />
     <title>pi-forge</title>
   </head>
   <body class="bg-neutral-950 text-neutral-100 antialiased">

--- a/packages/client/public/offline.html
+++ b/packages/client/public/offline.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Offline — pi-forge</title>
     <meta name="theme-color" content="#0a0a0a" />
-    <link rel="icon" type="image/svg+xml" href="/icons/icon.svg" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><g fill="%23ffffff"><polygon points="28,25 8,50 28,75 36,75 16,50 36,25"/><polygon points="72,25 92,50 72,75 64,75 84,50 64,25"/><rect x="34" y="35" width="32" height="8"/><rect x="39" y="42" width="7" height="28"/><rect x="54" y="42" width="7" height="28"/></g></svg>'
+    />
     <style>
       :root {
         color-scheme: dark;
@@ -47,9 +51,10 @@
         gap: 0.5rem;
         margin-bottom: 0.75rem;
       }
-      .brand img {
+      .brand svg {
         width: 1.75rem;
         height: 1.75rem;
+        color: #ffffff;
       }
       .brand h1 {
         margin: 0;
@@ -114,7 +119,15 @@
     <main>
       <div class="card" role="alertdialog" aria-labelledby="title">
         <div class="brand">
-          <img src="/icons/icon.svg" alt="" aria-hidden="true" />
+          <svg viewBox="0 0 100 100" aria-hidden="true">
+            <g fill="currentColor">
+              <polygon points="28,25 8,50 28,75 36,75 16,50 36,25" />
+              <polygon points="72,25 92,50 72,75 64,75 84,50 64,25" />
+              <rect x="34" y="35" width="32" height="8" />
+              <rect x="39" y="42" width="7" height="28" />
+              <rect x="54" y="42" width="7" height="28" />
+            </g>
+          </svg>
           <h1>pi-forge</h1>
         </div>
         <h2 id="title">You're offline.</h2>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -33,6 +33,7 @@ import { SearchPanel } from "./components/SearchPanel";
 import { ContextInspectorPanel } from "./components/ContextInspectorPanel";
 import { ResizableDivider } from "./components/ResizableDivider";
 import { useGitStatus } from "./hooks/useGitStatus";
+import { appUrl } from "./lib/base-path";
 import { themeDef, useThemeStore } from "./lib/theme";
 
 type RightPaneTab = "files" | "search" | "changes" | "git" | "context" | "processes";
@@ -447,7 +448,7 @@ export function App() {
               the parent gap-3 used between brand and project picker). */}
           <div className="flex shrink-0 items-center gap-1.5 whitespace-nowrap">
             <img
-              src={appLogoUrl ?? "/icons/icon.svg"}
+              src={appLogoUrl ?? appUrl("/icons/icon.svg")}
               alt=""
               className="max-h-8 max-w-28 shrink-0 object-contain"
               aria-hidden="true"

--- a/packages/client/src/components/ChangePasswordScreen.tsx
+++ b/packages/client/src/components/ChangePasswordScreen.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type FormEvent } from "react";
 import { authColorStyle } from "../lib/auth-colors";
+import { appUrl } from "../lib/base-path";
 import { useAuthStore } from "../store/auth-store";
 import { useUiConfigStore } from "../store/ui-config-store";
 
@@ -62,7 +63,7 @@ export function ChangePasswordScreen() {
         <header className="space-y-1">
           <div className="flex items-center gap-2">
             <img
-              src={authLogoUrl ?? "/icons/icon.svg"}
+              src={authLogoUrl ?? appUrl("/icons/icon.svg")}
               alt=""
               className="max-h-6 max-w-24 object-contain"
               aria-hidden="true"

--- a/packages/client/src/components/LoginScreen.tsx
+++ b/packages/client/src/components/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type FormEvent } from "react";
 import { authColorStyle } from "../lib/auth-colors";
+import { appUrl } from "../lib/base-path";
 import { useAuthStore } from "../store/auth-store";
 import { useUiConfigStore } from "../store/ui-config-store";
 
@@ -108,7 +109,7 @@ export function LoginScreen() {
           <header className="space-y-1">
             <div className="flex items-center gap-2">
               <img
-                src={authLogoUrl ?? "/icons/icon.svg"}
+                src={authLogoUrl ?? appUrl("/icons/icon.svg")}
                 alt=""
                 className="max-h-6 max-w-24 object-contain"
                 aria-hidden="true"

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { appUrl } from "../lib/base-path";
 import {
   api,
   ApiError,
@@ -219,8 +220,8 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
                 const stored = getStoredToken();
                 const url =
                   stored !== undefined
-                    ? `/api/docs?token=${encodeURIComponent(stored.token)}`
-                    : "/api/docs";
+                    ? appUrl(`/api/docs?token=${encodeURIComponent(stored.token)}`)
+                    : appUrl("/api/docs");
                 window.open(url, "_blank", "noopener,noreferrer");
               }}
               className="rounded border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:border-neutral-500"

--- a/packages/client/src/components/TerminalPanel.tsx
+++ b/packages/client/src/components/TerminalPanel.tsx
@@ -7,6 +7,7 @@ import "@xterm/xterm/css/xterm.css";
 import { useTerminalStore, type TerminalTab } from "../store/terminal-store";
 import { useActiveProject, useProjectStore } from "../store/project-store";
 import { getStoredToken } from "../lib/auth-client";
+import { appUrl } from "../lib/base-path";
 import { readCssVar, useThemeStore } from "../lib/theme";
 
 /**
@@ -630,9 +631,9 @@ function attachWebSocket(
   // Pass the stable client tabId so the server can reattach to the
   // existing PTY (with its rolling output buffer replayed) on
   // reconnect / page reload, instead of spawning a fresh shell.
-  const url = `${proto}://${window.location.host}/api/v1/terminal?projectId=${encodeURIComponent(
-    projectId,
-  )}&tabId=${encodeURIComponent(tabId)}${tokenQs}`;
+  const url = `${proto}://${window.location.host}${appUrl(
+    `/api/v1/terminal?projectId=${encodeURIComponent(projectId)}&tabId=${encodeURIComponent(tabId)}${tokenQs}`,
+  )}`;
   const ws = new WebSocket(url);
   ws.binaryType = "arraybuffer";
 

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -673,10 +673,10 @@
    image with `filter: invert(1)` turns pure-white pixels into pure
    black, which is exactly the black variant we need for the light
    theme. Avoids shipping a parallel asset file or threading a
-   theme-aware `src` swap through every `<img>` usage. Scoped to
-   the existing icon src attribute so it can't accidentally invert
-   any other image. */
-[data-theme="light"] img[src="/icons/icon.svg"] {
+   theme-aware `src` swap through every `<img>` usage. Match by suffix
+   so deployments under a Vite base path like `/apps/pi-forge/` still
+   recolor the fallback icon. */
+[data-theme="light"] img[src$="/icons/icon.svg"] {
   filter: invert(1);
 }
 

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -1,5 +1,6 @@
 import { createSHA256 } from "hash-wasm";
 import { clearStoredToken, getStoredToken } from "../auth-client";
+import { appUrl } from "../base-path";
 import {
   ApiError,
   UNAUTHORIZED_EVENT,
@@ -112,6 +113,12 @@ function vAuthStatus(value: unknown, status: number): AuthStatusResponse {
   return {
     authEnabled: value.authEnabled,
     ldapEnabled: typeof value.ldapEnabled === "boolean" ? value.ldapEnabled : false,
+    dashboardIdentityEnabled:
+      typeof value.dashboardIdentityEnabled === "boolean" ? value.dashboardIdentityEnabled : false,
+    dashboardIdentityAuthenticated:
+      typeof value.dashboardIdentityAuthenticated === "boolean"
+        ? value.dashboardIdentityAuthenticated
+        : false,
   };
 }
 
@@ -1605,7 +1612,7 @@ async function request<T>(
 
   let res: Response;
   try {
-    res = await fetch(path, init);
+    res = await fetch(appUrl(path), init);
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") throw err;
     throw new ApiError(0, "network_error", (err as Error).message);
@@ -1771,7 +1778,7 @@ export const api = {
       body: JSON.stringify(body),
     };
     if (signal !== undefined) init.signal = signal;
-    const res = await fetch("/api/v1/projects/clone", init);
+    const res = await fetch(appUrl("/api/v1/projects/clone"), init);
     if (res.status === 401) {
       clearStoredToken();
       window.dispatchEvent(new Event(UNAUTHORIZED_EVENT));
@@ -2147,7 +2154,9 @@ export const api = {
   /** Returns the absolute URL of the streaming log endpoint —
    *  callers use it with EventSource or fetch+ReadableStream. */
   processLogFileUrl: (sessionId: string, processId: string, stream: "stdout" | "stderr") =>
-    `/api/v1/sessions/${encodeURIComponent(sessionId)}/processes/${encodeURIComponent(processId)}/logs/file?stream=${stream}`,
+    appUrl(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/processes/${encodeURIComponent(processId)}/logs/file?stream=${stream}`,
+    ),
   killProcess: (sessionId: string, processId: string) =>
     request(
       `/api/v1/sessions/${encodeURIComponent(sessionId)}/processes/${encodeURIComponent(processId)}/kill`,
@@ -2470,7 +2479,7 @@ export const api = {
     const headers: Record<string, string> = {};
     const stored = getStoredToken();
     if (stored !== undefined) headers.Authorization = `Bearer ${stored.token}`;
-    const res = await fetch("/api/v1/config/export", { headers });
+    const res = await fetch(appUrl("/api/v1/config/export"), { headers });
     if (res.status === 401) {
       clearStoredToken();
       window.dispatchEvent(new Event(UNAUTHORIZED_EVENT));
@@ -2540,7 +2549,7 @@ export const api = {
     const headers: Record<string, string> = {};
     const stored = getStoredToken();
     if (stored !== undefined) headers.Authorization = `Bearer ${stored.token}`;
-    const res = await fetch("/api/v1/config/skills/export", { headers });
+    const res = await fetch(appUrl("/api/v1/config/skills/export"), { headers });
     if (res.status === 401) {
       clearStoredToken();
       window.dispatchEvent(new Event(UNAUTHORIZED_EVENT));
@@ -2579,7 +2588,7 @@ export const api = {
     const stored = getStoredToken();
     if (stored !== undefined) headers.Authorization = `Bearer ${stored.token}`;
     const res = await fetch(
-      `/api/v1/sessions/${encodeURIComponent(sessionId)}/export?format=${format}`,
+      appUrl(`/api/v1/sessions/${encodeURIComponent(sessionId)}/export?format=${format}`),
       { headers },
     );
     if (res.status === 401) {
@@ -2700,7 +2709,7 @@ export const api = {
     const headers: Record<string, string> = {};
     const stored = getStoredToken();
     if (stored !== undefined) headers.Authorization = `Bearer ${stored.token}`;
-    const res = await fetch(`/api/v1/files/download?${qs.toString()}`, { headers });
+    const res = await fetch(appUrl(`/api/v1/files/download?${qs.toString()}`), { headers });
     if (res.status === 401) {
       clearStoredToken();
       window.dispatchEvent(new Event(UNAUTHORIZED_EVENT));

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -26,6 +26,8 @@ export class ApiError extends Error {
 export interface AuthStatusResponse {
   authEnabled: boolean;
   ldapEnabled: boolean;
+  dashboardIdentityEnabled: boolean;
+  dashboardIdentityAuthenticated: boolean;
 }
 
 export interface LoginResponse {

--- a/packages/client/src/lib/base-path.ts
+++ b/packages/client/src/lib/base-path.ts
@@ -1,0 +1,24 @@
+const RAW_BASE = import.meta.env?.BASE_URL ?? "/";
+
+/**
+ * Vite exposes the deployment base as import.meta.env.BASE_URL. In the
+ * dashboard iframe deployment this is something like `/apps/pi-forge/`; in
+ * normal local/dev deployments it is `/`. Keep URL construction centralized so
+ * API, SSE, WebSocket, docs, and download URLs all honor the same prefix.
+ */
+export const appBasePath = RAW_BASE.endsWith("/") ? RAW_BASE.slice(0, -1) : RAW_BASE;
+
+export function appUrl(path: string): string {
+  const suffix = path.startsWith("/") ? path : `/${path}`;
+  return `${appBasePath}${suffix}`;
+}
+
+export function appResourceUrl(url: string | undefined): string | undefined {
+  if (url === undefined) return undefined;
+  // Leave absolute and browser-native resource URLs alone. Prefix only
+  // origin-root-relative server URLs such as /cache/logos/... so they stay
+  // inside a path-proxied deployment like /apps/pi-forge/.
+  if (/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(url)) return url;
+  if (url.startsWith("/")) return appUrl(url);
+  return url;
+}

--- a/packages/client/src/lib/sse-client.ts
+++ b/packages/client/src/lib/sse-client.ts
@@ -1,5 +1,6 @@
 import { ApiError, UNAUTHORIZED_EVENT } from "./api-client";
 import { clearStoredToken, getStoredToken } from "./auth-client";
+import { appUrl } from "./base-path";
 
 /**
  * Minimal SSE reader that uses fetch + ReadableStream so we can send the
@@ -91,7 +92,7 @@ async function runOneAttempt<T extends { type: string }>(
 
   let res: Response;
   try {
-    res = await fetch(path, init);
+    res = await fetch(appUrl(path), init);
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") return "aborted";
     throw new ApiError(0, "network_error", (err as Error).message);

--- a/packages/client/src/store/auth-store.ts
+++ b/packages/client/src/store/auth-store.ts
@@ -40,11 +40,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   changePasswordPending: false,
   bootstrap: async () => {
     try {
-      const { authEnabled, ldapEnabled } = await api.authStatus();
-      if (!authEnabled) {
+      const { authEnabled, ldapEnabled, dashboardIdentityAuthenticated } = await api.authStatus();
+      if (!authEnabled || dashboardIdentityAuthenticated) {
         set({
           ready: true,
-          authRequired: false,
+          authRequired: authEnabled && !dashboardIdentityAuthenticated,
           ldapEnabled,
           isAuthenticated: true,
           mustChangePassword: false,

--- a/packages/client/src/store/ui-config-store.ts
+++ b/packages/client/src/store/ui-config-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { api, ApiError, type ServerThemeConfigResponse } from "../lib/api-client";
 import type { AuthColorScheme } from "../lib/api-client/types";
+import { appResourceUrl } from "../lib/base-path";
 import { applyServerTheme } from "../lib/server-theme";
 
 /**
@@ -103,9 +104,9 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
         authBannerHtml: cfg.authBannerHtml,
         logoUrlMode: cfg.logoUrlMode,
         authColorScheme: cfg.authColorScheme,
-        authLogoUrl: cfg.authLogoUrl,
-        appLogoDarkUrl: cfg.appLogoDarkUrl,
-        appLogoLightUrl: cfg.appLogoLightUrl,
+        authLogoUrl: appResourceUrl(cfg.authLogoUrl),
+        appLogoDarkUrl: appResourceUrl(cfg.appLogoDarkUrl),
+        appLogoLightUrl: appResourceUrl(cfg.appLogoLightUrl),
         error: undefined,
       });
     } catch (err) {

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -27,7 +27,12 @@ function devApiTarget(): string {
   return `http://${host}:${port}`;
 }
 
+const basePath = process.env.VITE_BASE_PATH ?? "/";
+const basePathNoTrailingSlash = basePath.endsWith("/") ? basePath.slice(0, -1) : basePath;
+const baseAsset = (path: string): string => `${basePathNoTrailingSlash}${path}`;
+
 export default defineConfig({
+  base: basePath,
   plugins: [
     react(),
     tailwindcss(),
@@ -59,8 +64,8 @@ export default defineConfig({
         // (which would require a rebuild per user preference).
         background_color: "#0a0a0a",
         display: "standalone",
-        start_url: "/",
-        scope: "/",
+        start_url: basePath,
+        scope: basePath,
         orientation: "any",
         lang: "en",
         // App-store-style categorization. Surfaced by Chrome's
@@ -79,25 +84,25 @@ export default defineConfig({
         // installs; the rasters above also serve that path.
         icons: [
           {
-            src: "/icons/icon-192.png",
+            src: baseAsset("/icons/icon-192.png"),
             sizes: "192x192",
             type: "image/png",
             purpose: "any",
           },
           {
-            src: "/icons/icon-512.png",
+            src: baseAsset("/icons/icon-512.png"),
             sizes: "512x512",
             type: "image/png",
             purpose: "any",
           },
           {
-            src: "/icons/icon-maskable-512.png",
+            src: baseAsset("/icons/icon-maskable-512.png"),
             sizes: "512x512",
             type: "image/png",
             purpose: "maskable",
           },
           {
-            src: "/icons/icon.svg",
+            src: baseAsset("/icons/icon.svg"),
             sizes: "any",
             type: "image/svg+xml",
             purpose: "any",
@@ -118,12 +123,13 @@ export default defineConfig({
         // branded /offline.html instead — usable, in-theme, with a
         // reload button — rather than the browser's chromeless
         // "no-internet" page or the SPA shell with a red error banner.
-        navigateFallback: "/index.html",
-        navigateFallbackDenylist: [/^\/api\//],
+        navigateFallback: baseAsset("/index.html"),
+        navigateFallbackDenylist: [/^\/api\//, /^\/apps\/[^/]+\/api\//],
         globPatterns: ["**/*.{js,css,html,svg,png,ico,webmanifest}"],
         runtimeCaching: [
           {
-            urlPattern: ({ url }) => url.pathname.startsWith("/api/v1/"),
+            urlPattern: ({ url }) =>
+              url.pathname.startsWith(baseAsset("/api/v1/")) || url.pathname.startsWith("/api/v1/"),
             handler: "NetworkOnly",
           },
           {
@@ -142,7 +148,7 @@ export default defineConfig({
             options: {
               cacheName: "pi-navigation",
               networkTimeoutSeconds: 3,
-              precacheFallback: { fallbackURL: "/offline.html" },
+              precacheFallback: { fallbackURL: baseAsset("/offline.html") },
             },
           },
         ],
@@ -176,6 +182,21 @@ export default defineConfig({
     // Production / built bundle is unaffected — this is dev-server only.
     allowedHosts: parseAllowedHosts(process.env.VITE_DEV_ALLOWED_HOSTS),
     proxy: {
+      ...(basePathNoTrailingSlash.length > 0
+        ? {
+            [baseAsset("/api")]: {
+              target: devApiTarget(),
+              changeOrigin: true,
+              rewrite: (path) => path.slice(basePathNoTrailingSlash.length),
+              ws: true,
+            },
+            [baseAsset("/cache")]: {
+              target: devApiTarget(),
+              changeOrigin: true,
+              rewrite: (path) => path.slice(basePathNoTrailingSlash.length),
+            },
+          }
+        : {}),
       "/api": {
         // Root `npm run dev` / `dev:remote` pass the API server port through
         // PORT (default 3100). Mirror that default here instead of hardcoding

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
+import type { IncomingHttpHeaders } from "node:http";
 import { chmodSync, existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { randomBytes, scrypt as scryptCb, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, scrypt as scryptCb, timingSafeEqual } from "node:crypto";
 import { promisify } from "node:util";
 import jwt from "jsonwebtoken";
 import { config } from "./config.js";
@@ -38,6 +39,17 @@ export interface JwtPayload {
 export interface IssuedToken {
   token: string;
   expiresAt: string;
+}
+
+export interface DashboardIdentityPayload {
+  iss: string;
+  aud: string;
+  sub: string;
+  email?: string;
+  groups: string[];
+  app: string;
+  iat: number;
+  exp: number;
 }
 
 export type PasswordSource = "stored" | "env" | "none";
@@ -133,6 +145,73 @@ export function verifyApiKey(presented: string): boolean {
   const expected = config.auth.apiKey;
   if (expected === undefined) return false;
   return constantTimeStringEqual(presented, expected);
+}
+
+export function verifyDashboardIdentity(
+  headers: IncomingHttpHeaders,
+): DashboardIdentityPayload | undefined {
+  const secret = config.auth.dashboardIdentity.secret;
+  if (secret === undefined) return undefined;
+  const encoded = singleHeader(headers["x-dashboard-identity"]);
+  const signature = singleHeader(headers["x-dashboard-signature"]);
+  if (encoded === undefined || signature === undefined) return undefined;
+
+  const expected = createHmac("sha256", secret).update(encoded).digest("hex");
+  if (!constantTimeStringEqual(signature, expected)) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const payload = parsed as Record<string, unknown>;
+  if (payload.iss !== config.auth.dashboardIdentity.issuer) return undefined;
+  if (payload.aud !== config.auth.dashboardIdentity.audience) return undefined;
+  if (payload.app !== config.auth.dashboardIdentity.audience) return undefined;
+  if (typeof payload.sub !== "string" || payload.sub.length === 0) return undefined;
+  if (typeof payload.iat !== "number" || typeof payload.exp !== "number") return undefined;
+  if (!Number.isFinite(payload.iat) || !Number.isFinite(payload.exp)) return undefined;
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp <= now) return undefined;
+  if (payload.iat > now + config.auth.dashboardIdentity.maxFutureIatSkewSeconds) return undefined;
+  if (payload.iat < now - config.auth.dashboardIdentity.maxAgeSeconds) return undefined;
+  if (payload.exp - payload.iat > config.auth.dashboardIdentity.maxAgeSeconds) return undefined;
+  if (
+    !Array.isArray(payload.groups) ||
+    !payload.groups.every((group) => typeof group === "string")
+  ) {
+    return undefined;
+  }
+  const configuredGroups = config.auth.dashboardIdentity.allowedGroups;
+  if (configuredGroups.length > 0) {
+    const userGroups = new Set(payload.groups.map((group) => group.toLocaleLowerCase("en-US")));
+    const allowed = configuredGroups.some((group) =>
+      userGroups.has(group.toLocaleLowerCase("en-US")),
+    );
+    if (!allowed) return undefined;
+  }
+  if (payload.email !== undefined && typeof payload.email !== "string") return undefined;
+  const result: DashboardIdentityPayload = {
+    iss: payload.iss,
+    aud: payload.aud,
+    sub: payload.sub,
+    groups: payload.groups,
+    app: payload.app,
+    iat: payload.iat,
+    exp: payload.exp,
+  };
+  if (payload.email !== undefined) result.email = payload.email;
+  return result;
+}
+
+export function dashboardIdentityConfigured(): boolean {
+  return config.auth.dashboardIdentity.secret !== undefined;
+}
+
+function singleHeader(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
 }
 
 export function loginLockoutKey(username: string | undefined): string {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -41,6 +41,31 @@ function readStringList(key: string): string[] {
     .filter((s) => s.length > 0);
 }
 
+function readDashboardAllowedGroups(key: string, fallbackKey?: string): string[] {
+  const v = readEnv(key) ?? (fallbackKey === undefined ? undefined : readEnv(fallbackKey));
+  if (v === undefined) return [];
+  const trimmed = v.trim();
+  if (trimmed.length === 0) return [];
+  if (trimmed.startsWith("[")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      throw new Error(`config: ${key} JSON value must be an array of strings`);
+    }
+    if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
+      throw new Error(`config: ${key} JSON value must be an array of strings`);
+    }
+    return parsed.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+  }
+  // LDAP DNs commonly contain commas, so this advanced allowlist uses
+  // newline/semicolon delimiters instead of readStringList's comma split.
+  return trimmed
+    .split(/[;\n\r]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 function readUsername(key: string, fallback: string): string {
   const value = readEnv(key) ?? fallback;
   const trimmed = value.trim();
@@ -274,6 +299,10 @@ const UI_PASSWORD = UI_PASSWORD_FILE
   ? readSecretFile(UI_PASSWORD_FILE, "UI_PASSWORD_FILE")
   : readEnv("UI_PASSWORD");
 const API_KEY = readEnv("API_KEY");
+const DASHBOARD_IDENTITY_SECRET_FILE = readEnv("DASHBOARD_IDENTITY_SECRET_FILE");
+const DASHBOARD_IDENTITY_SECRET = DASHBOARD_IDENTITY_SECRET_FILE
+  ? readSecretFile(DASHBOARD_IDENTITY_SECRET_FILE, "DASHBOARD_IDENTITY_SECRET_FILE")
+  : readEnv("DASHBOARD_IDENTITY_SECRET");
 const LOCAL_ADMIN_USERNAME = readUsername("FORGE_LOCAL_ADMIN_USERNAME", "admin");
 const CORS_ORIGIN = readEnv("CORS_ORIGIN");
 const PASSWORD_HASH_FILE = join(FORGE_DATA_DIR, "password-hash");
@@ -502,6 +531,17 @@ export const config = Object.freeze({
     uiPasswordFile: UI_PASSWORD_FILE,
     jwtSecret: JWT_SECRET,
     apiKey: API_KEY,
+    dashboardIdentity: Object.freeze({
+      secret: DASHBOARD_IDENTITY_SECRET,
+      secretFile: DASHBOARD_IDENTITY_SECRET_FILE,
+      issuer: readEnv("DASHBOARD_IDENTITY_ISSUER") ?? "internal-dashboard",
+      audience: readEnv("DASHBOARD_IDENTITY_AUDIENCE") ?? readEnv("DASHBOARD_APP_ID") ?? "pi-forge",
+      maxFutureIatSkewSeconds: readInt("DASHBOARD_IDENTITY_MAX_FUTURE_IAT_SKEW_SECONDS", 60),
+      maxAgeSeconds: readInt("DASHBOARD_IDENTITY_MAX_AGE_SECONDS", 5 * 60),
+      allowedGroups: Object.freeze(
+        readDashboardAllowedGroups("DASHBOARD_IDENTITY_ALLOWED_GROUPS", "LDAP_REQUIRED_GROUP_DN"),
+      ),
+    }),
     localAdminUsername: LOCAL_ADMIN_USERNAME,
     ldap: Object.freeze({
       enabled: LDAP_ENABLED,
@@ -648,6 +688,7 @@ export function authEnabled(): boolean {
   return (
     config.auth.uiPassword !== undefined ||
     config.auth.apiKey !== undefined ||
+    config.auth.dashboardIdentity.secret !== undefined ||
     config.auth.ldap.enabled ||
     existsSync(config.auth.passwordHashFile)
   );

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,7 +11,7 @@ import websocket from "@fastify/websocket";
 import multipart from "@fastify/multipart";
 import { config, authEnabled } from "./config.js";
 import { installDiagnostics } from "./diagnostics.js";
-import { extractBearer, verifyApiKey, verifyToken } from "./auth.js";
+import { extractBearer, verifyApiKey, verifyDashboardIdentity, verifyToken } from "./auth.js";
 import { healthRoutes } from "./routes/health.js";
 import { authRoutes } from "./routes/auth.js";
 import { projectRoutes } from "./routes/projects.js";
@@ -226,10 +226,13 @@ export async function buildServer(): Promise<FastifyInstance> {
   //   - worker-src 'self' blob: — Vite PWA service worker.
   //   - object-src 'none', base-uri 'self', frame-ancestors 'none' —
   //     defense in depth against legacy / clickjacking surfaces.
-  fastify.addHook("onSend", async (_req, reply) => {
+  fastify.addHook("onSend", async (req, reply, payload) => {
     reply.header("X-Content-Type-Options", "nosniff");
     reply.header("Referrer-Policy", "strict-origin-when-cross-origin");
-    reply.header("X-Frame-Options", "DENY");
+    reply.header(
+      "X-Frame-Options",
+      config.auth.dashboardIdentity.secret !== undefined ? "SAMEORIGIN" : "DENY",
+    );
     // HSTS is harmless on plain HTTP (browsers ignore it without TLS),
     // useful behind a TLS proxy. 180 days is a balance: long enough to
     // matter, short enough that an operator can recover from accidentally
@@ -251,9 +254,34 @@ export async function buildServer(): Promise<FastifyInstance> {
         "worker-src 'self' blob:",
         "object-src 'none'",
         "base-uri 'self'",
-        "frame-ancestors 'none'",
+        config.auth.dashboardIdentity.secret !== undefined
+          ? "frame-ancestors 'self'"
+          : "frame-ancestors 'none'",
       ].join("; "),
     );
+
+    const forwardedPrefix =
+      typeof req.headers["x-forwarded-prefix"] === "string"
+        ? req.headers["x-forwarded-prefix"].replace(/\/$/, "")
+        : undefined;
+    const path = req.url.split("?")[0] ?? req.url;
+    if (
+      forwardedPrefix !== undefined &&
+      forwardedPrefix.startsWith("/") &&
+      (path === "/api/docs" || path.startsWith("/api/docs/"))
+    ) {
+      const contentType = reply.getHeader("content-type")?.toString() ?? "";
+      if (
+        (contentType.includes("text/html") || contentType.includes("javascript")) &&
+        (typeof payload === "string" || Buffer.isBuffer(payload))
+      ) {
+        return payload
+          .toString()
+          .replace(/(["'`])\/api\/docs/g, `$1${forwardedPrefix}/api/docs`)
+          .replace(/(["'`])\/api\/v1\//g, `$1${forwardedPrefix}/api/v1/`);
+      }
+    }
+    return payload;
   });
 
   // WebSocket support for the integrated terminal (Phase 11). Must be
@@ -322,15 +350,33 @@ export async function buildServer(): Promise<FastifyInstance> {
         url.searchParams.delete("token");
         window.history.replaceState({}, document.title, url.toString());
       }
+      var docsIndex = window.location.pathname.indexOf("/api/docs");
+      var basePrefix = docsIndex > 0 ? window.location.pathname.slice(0, docsIndex) : "";
+      function rewriteRootApiUrl(raw) {
+        if (!basePrefix || !raw) return raw;
+        var u = new URL(raw, window.location.href);
+        if (u.origin !== window.location.origin) return raw;
+        var apiPath = u.pathname.indexOf("/api/v1/") === 0 || u.pathname.indexOf("/api/docs") === 0;
+        if (!apiPath || u.pathname.indexOf(basePrefix + "/") === 0) return raw;
+        u.pathname = basePrefix + u.pathname;
+        return raw.indexOf(window.location.origin) === 0
+          ? u.toString()
+          : u.pathname + u.search + u.hash;
+      }
       var token =
         sessionStorage.getItem("pi-forge/docs-token") ||
         localStorage.getItem("pi-forge/auth-token");
-      if (token && window.fetch) {
+      if (window.fetch) {
         var origFetch = window.fetch.bind(window);
         window.fetch = function (input, init) {
           init = init || {};
-          var url2 = typeof input === "string" ? input : input.url;
-          if (url2 && url2.indexOf("/api/v1/") !== -1) {
+          var rawUrl = typeof input === "string" ? input : input.url;
+          var rewritten = rewriteRootApiUrl(rawUrl);
+          if (rewritten !== rawUrl) {
+            input = typeof input === "string" ? rewritten : new Request(rewritten, input);
+          }
+          var url2 = rewritten || rawUrl;
+          if (token && url2 && url2.indexOf("/api/v1/") !== -1) {
             init.headers = new Headers(init.headers || {});
             if (!init.headers.has("Authorization")) {
               init.headers.set("Authorization", "Bearer " + token);
@@ -405,6 +451,8 @@ export async function buildServer(): Promise<FastifyInstance> {
     const routeConfig = req.routeOptions?.config;
     if (routeConfig?.public === true) return;
     if (!authEnabled()) return;
+
+    if (verifyDashboardIdentity(req.headers) !== undefined) return;
 
     const presented = extractBearer(req.headers.authorization);
     if (presented === undefined) {

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import type { FastifyPluginAsync } from "fastify";
 import { config, authEnabled } from "../config.js";
 import {
+  dashboardIdentityConfigured,
   extractBearer,
   generateToken,
   getLoginLockoutState,
@@ -9,6 +10,7 @@ import {
   persistPassword,
   recordLoginFailure,
   resetLoginFailures,
+  verifyDashboardIdentity,
   verifyPasswordWithSource,
   verifyToken,
 } from "../auth.js";
@@ -40,16 +42,28 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
         response: {
           200: {
             type: "object",
-            required: ["authEnabled", "ldapEnabled"],
+            required: [
+              "authEnabled",
+              "ldapEnabled",
+              "dashboardIdentityEnabled",
+              "dashboardIdentityAuthenticated",
+            ],
             properties: {
               authEnabled: { type: "boolean" },
               ldapEnabled: { type: "boolean" },
+              dashboardIdentityEnabled: { type: "boolean" },
+              dashboardIdentityAuthenticated: { type: "boolean" },
             },
           },
         },
       },
     },
-    async () => ({ authEnabled: authEnabled(), ldapEnabled: config.auth.ldap.enabled }),
+    async (req) => ({
+      authEnabled: authEnabled(),
+      ldapEnabled: config.auth.ldap.enabled,
+      dashboardIdentityEnabled: dashboardIdentityConfigured(),
+      dashboardIdentityAuthenticated: verifyDashboardIdentity(req.headers) !== undefined,
+    }),
   );
 
   fastify.post<{ Body: LoginBody }>(

--- a/packages/server/src/routes/terminal.ts
+++ b/packages/server/src/routes/terminal.ts
@@ -2,7 +2,7 @@ import { stat } from "node:fs/promises";
 import { join } from "node:path";
 import type { FastifyPluginAsync, FastifyRequest } from "fastify";
 import type { WebSocket } from "ws";
-import { extractBearer, verifyApiKey, verifyToken } from "../auth.js";
+import { extractBearer, verifyApiKey, verifyDashboardIdentity, verifyToken } from "../auth.js";
 import { authEnabled, config } from "../config.js";
 import { getProject } from "../project-manager.js";
 import { attachSink, findPtyByTabId, killPty, spawnPty } from "../pty-manager.js";
@@ -135,6 +135,7 @@ async function findVenvActivate(cwd: string): Promise<string | undefined> {
 
 function authorize(req: FastifyRequest): boolean {
   if (!authEnabled()) return true;
+  if (verifyDashboardIdentity(req.headers) !== undefined) return true;
   const headerToken = extractBearer(req.headers.authorization);
   const queryToken =
     typeof (req.query as { token?: unknown } | undefined)?.token === "string"

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -21,7 +21,7 @@
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
-import { randomBytes } from "node:crypto";
+import { createHmac, randomBytes } from "node:crypto";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -627,6 +627,133 @@ async function scenarioLoginAttemptLockout(): Promise<void> {
   }
 }
 
+function dashboardHeaders(
+  secret: string,
+  overrides: Partial<{
+    iss: string;
+    aud: string;
+    sub: string;
+    groups: string[];
+    app: string;
+    iat: number;
+    exp: number;
+  }> = {},
+): Record<string, string> {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: "internal-dashboard",
+    aud: "pi-forge",
+    sub: "alice",
+    groups: ["cn=devs,ou=groups,dc=example,dc=com"],
+    app: "pi-forge",
+    iat: now,
+    exp: now + 60,
+    ...overrides,
+  };
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac("sha256", secret).update(encoded).digest("hex");
+  return {
+    "X-Dashboard-Identity": encoded,
+    "X-Dashboard-Signature": signature,
+  };
+}
+
+async function scenarioDashboardIdentity(): Promise<void> {
+  console.log("\n[scenario H] dashboard identity SSO");
+  const secret = randomBytes(32).toString("hex");
+  const srv = await startServer({
+    DASHBOARD_IDENTITY_SECRET: secret,
+    LDAP_REQUIRED_GROUP_DN: "cn=devs,ou=groups,dc=example,dc=com",
+    UI_PASSWORD: undefined,
+    API_KEY: undefined,
+  });
+  try {
+    const status = await fetch(`${srv.base}/api/v1/auth/status`, {
+      headers: dashboardHeaders(secret),
+    });
+    assert("auth/status with dashboard headers → 200", status.status === 200);
+    const statusBody = (await status.json()) as {
+      authEnabled: boolean;
+      dashboardIdentityEnabled: boolean;
+      dashboardIdentityAuthenticated: boolean;
+    };
+    assert("auth/status reports auth enabled", statusBody.authEnabled === true);
+    assert(
+      "auth/status reports dashboard identity enabled",
+      statusBody.dashboardIdentityEnabled === true,
+    );
+    assert(
+      "auth/status reports dashboard identity authenticated via LDAP_REQUIRED_GROUP_DN fallback",
+      statusBody.dashboardIdentityAuthenticated === true,
+    );
+
+    const noHeaders = await fetch(`${srv.base}/api/v1/__protected_probe`);
+    assert("protected probe without dashboard headers → 401", noHeaders.status === 401);
+
+    const withHeaders = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: dashboardHeaders(secret),
+    });
+    assert(
+      "protected probe with valid dashboard headers → 404 (passes auth)",
+      withHeaders.status === 404,
+    );
+
+    const wrongSignature = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: dashboardHeaders(`${secret}-wrong`),
+    });
+    assert("protected probe with wrong signature → 401", wrongSignature.status === 401);
+
+    const wrongAudience = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: dashboardHeaders(secret, { aud: "other-app" }),
+    });
+    assert("protected probe with wrong audience → 401", wrongAudience.status === 401);
+
+    const wrongApp = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: dashboardHeaders(secret, { app: "other-app" }),
+    });
+    assert("protected probe with wrong app → 401", wrongApp.status === 401);
+
+    const expired = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: dashboardHeaders(secret, { iat: Math.floor(Date.now() / 1000) - 120, exp: 1 }),
+    });
+    assert("protected probe with expired identity → 401", expired.status === 401);
+
+    const futureIat = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: dashboardHeaders(secret, {
+        iat: Math.floor(Date.now() / 1000) + 120,
+        exp: Math.floor(Date.now() / 1000) + 180,
+      }),
+    });
+    assert("protected probe with future iat → 401", futureIat.status === 401);
+
+    const staleIat = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: dashboardHeaders(secret, {
+        iat: Math.floor(Date.now() / 1000) - 10 * 60,
+        exp: Math.floor(Date.now() / 1000) + 60,
+      }),
+    });
+    assert("protected probe with stale iat → 401", staleIat.status === 401);
+
+    const excessiveLifetime = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: dashboardHeaders(secret, {
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 10 * 60,
+      }),
+    });
+    assert(
+      "protected probe with excessive identity lifetime → 401",
+      excessiveLifetime.status === 401,
+    );
+
+    const wrongGroup = await fetch(`${srv.base}/api/v1/__protected_probe`, {
+      headers: dashboardHeaders(secret, { groups: ["cn=other,ou=groups,dc=example,dc=com"] }),
+    });
+    assert("protected probe with unallowed group → 401", wrongGroup.status === 401);
+  } finally {
+    await srv.stop();
+  }
+}
+
 async function main(): Promise<void> {
   await scenarioPasswordAndJwt();
   await scenarioLoginInactivityTimeout();
@@ -637,6 +764,7 @@ async function main(): Promise<void> {
   await scenarioLdapEnabledWithoutLocalPassword();
   await scenarioLdapAdminUsesLocalPassword();
   await scenarioCustomLocalAdminUsername();
+  await scenarioDashboardIdentity();
 
   if (failures > 0) {
     console.log(`\n[test-auth] FAIL — ${failures} assertion(s) failed`);


### PR DESCRIPTION
## Summary
- add Vite/base-path URL handling so pi-forge can run under `/apps/pi-forge/`
- verify dashboard `X-Dashboard-Identity` / `X-Dashboard-Signature` headers and bypass the login screen for authenticated dashboard users
- support dashboard identity age, issuer/audience/app, and optional group validation with `LDAP_REQUIRED_GROUP_DN` fallback
- make Swagger docs, cached logo URLs, downloads, SSE, WebSocket terminal URLs, PWA assets, and Docker/deployment docs path-proxy aware

## Validation
- `npm run check`
- `VITE_BASE_PATH=/apps/pi-forge/ npm run build --workspace packages/client`
- `npm test -- --ci` (all 56 tests passed)
- local dashboard proxy simulator on `:5173` forwarding to pi-forge on `:3100` validated app shell, API, auth status, manifest, Swagger assets/OpenAPI JSON, project/session APIs, SSE, file download, config export, and terminal WebSocket echo
