### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.5.0] — 2026-08-19
+
 ## [1.4.9] — 2026-08-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.4.9",
+      "version": "1.5.0",
       "workspaces": [
         "packages/*"
       ],
@@ -17096,7 +17096,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.4.9",
+      "version": "1.5.0",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17168,7 +17168,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.4.9",
+      "version": "1.5.0",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.10",
         "@earendil-works/pi-ai": "0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps pi-forge from v1.4.9 to v1.5.0 using the release tooling. This is an empty release cut from the current v1.4.9 tag, so the changelog contains the dated v1.5.0 heading with no release entries.

## Usage

No direct user-facing usage changes. After merge, tag main with:

```bash
git tag v1.5.0
git push origin v1.5.0
```

## What changed (5 files)

- `package.json` — bumped the root package version to `1.5.0`.
- `packages/server/package.json` — kept the server workspace version in lockstep.
- `packages/client/package.json` — kept the client workspace version in lockstep.
- `package-lock.json` — refreshed lockfile package versions for npm CI consistency.
- `CHANGELOG.md` — rolled `## [Unreleased]` into a dated `## [1.5.0]` release heading.

## Test plan

- [x] `scripts/bump-version.sh 1.5.0 --allow-empty`
- [x] `npx npm@latest approve-scripts --allow-scripts-pending`
- [ ] CI green before merge
