### PR TITLE
fix: resolve dashboard app path at runtime

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -60,10 +60,9 @@ API_KEY=
 # - optionally restrict signed dashboard identities to one or more groups.
 #   JSON array is safest for LDAP DNs because DNs contain commas. If unset,
 #   dashboard identity group enforcement falls back to LDAP_REQUIRED_GROUP_DN.
-VITE_BASE_PATH=/apps/pi-forge/
 DASHBOARD_IDENTITY_SECRET=
 DASHBOARD_IDENTITY_ISSUER=internal-dashboard
-DASHBOARD_IDENTITY_AUDIENCE=pi-forge
+DASHBOARD_APP_ID=pi-forge
 DASHBOARD_IDENTITY_ALLOWED_GROUPS=["CN=Developers,OU=Groups,DC=company,DC=local"]
 
 # ---- Reverse proxy / logging ----

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,13 +77,12 @@ COPY packages/client/package.json packages/client/
 # `npm ci --workspaces` honours the root lockfile across all packages.
 RUN npm ci --workspaces --include-workspace-root
 
-# Now bring in the source and build. VITE_BASE_PATH is a build-time Vite
-# setting; set it when producing an image intended to run under a path proxy
-# such as /apps/pi-forge/.
+# Now bring in the source and build. Dashboard path-prefix deployments use
+# X-Forwarded-Prefix at runtime, so the image can be built once with Vite's
+# default root base and reused behind different app-proxy paths.
 COPY . .
 
-ARG VITE_BASE_PATH=/
-RUN VITE_BASE_PATH="$VITE_BASE_PATH" npm run build
+RUN npm run build
 
 # ---------- runtime ----------
 FROM node-python-base AS runtime

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,8 +18,6 @@ services:
         # non-default pi-tools IDs (see ../docs/agent-tool-sandbox.md).
         PTOOLS_UID: ${AGENT_TOOL_UID:-1001}
         PTOOLS_GID: ${AGENT_TOOL_GID:-1001}
-        # Build-time Vite base for path-proxied deployments.
-        VITE_BASE_PATH: ${VITE_BASE_PATH:-/}
     image: pi-forge:latest
     container_name: ${CONTAINER_NAME:-pi-forge}
     restart: unless-stopped
@@ -50,7 +48,7 @@ services:
       # not embedding behind the dashboard proxy.
       DASHBOARD_IDENTITY_SECRET: ${DASHBOARD_IDENTITY_SECRET:-}
       DASHBOARD_IDENTITY_ISSUER: ${DASHBOARD_IDENTITY_ISSUER:-internal-dashboard}
-      DASHBOARD_IDENTITY_AUDIENCE: ${DASHBOARD_IDENTITY_AUDIENCE:-pi-forge}
+      DASHBOARD_APP_ID: ${DASHBOARD_APP_ID:-pi-forge}
       DASHBOARD_IDENTITY_ALLOWED_GROUPS: ${DASHBOARD_IDENTITY_ALLOWED_GROUPS:-}
       # Logging + reverse-proxy hint.
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,11 +68,12 @@ or shell environment. The most-touched ones:
 | `LDAP_GROUP_ATTRIBUTE` | `memberOf` | User attribute checked for group DNs. Change only for directories that expose group membership under a different attribute. |
 | `LDAP_TIMEOUT_MS` | `5000` | LDAP connect/operation timeout in milliseconds. |
 | `LDAP_TLS_REJECT_UNAUTHORIZED` | `true` | Reject untrusted TLS certificates for `ldaps://` connections. Set `false` only for local/self-signed testing. |
-| `VITE_BASE_PATH` | `/` | Build-time Vite base path. Set to `/apps/pi-forge/` when building an image/client bundle embedded behind the dashboard app proxy. |
+| `VITE_BASE_PATH` | `/` | Optional build-time Vite base path for static hosting. Dashboard app-proxy deployments should normally leave this as `/` and rely on runtime `X-Forwarded-Prefix` instead. |
 | `DASHBOARD_IDENTITY_SECRET` | (unset) | Enables dashboard SSO by verifying the dashboard proxy's signed `X-Dashboard-Identity` / `X-Dashboard-Signature` envelope. Must match pi-forge's per-app `identitySecret` in the dashboard catalog. |
 | `DASHBOARD_IDENTITY_SECRET_FILE` | (unset) | File containing the dashboard identity HMAC secret. Takes precedence over `DASHBOARD_IDENTITY_SECRET`. |
 | `DASHBOARD_IDENTITY_ISSUER` | `internal-dashboard` | Expected `iss` in signed dashboard identity envelopes. Must match the dashboard's `DASHBOARD_IDENTITY_ISSUER`. |
-| `DASHBOARD_IDENTITY_AUDIENCE` | `pi-forge` | Expected `aud` and `app` in signed dashboard identity envelopes. `DASHBOARD_APP_ID` is accepted as a legacy/alternate source when this is unset. |
+| `DASHBOARD_APP_ID` | `pi-forge` | Expected `aud` and `app` in signed dashboard identity envelopes. Set this to the dashboard catalog app id for pi-forge. |
+| `DASHBOARD_IDENTITY_AUDIENCE` | (unset) | Deprecated compatibility alias for `DASHBOARD_APP_ID`; used only when `DASHBOARD_APP_ID` is unset. |
 | `DASHBOARD_IDENTITY_MAX_FUTURE_IAT_SKEW_SECONDS` | `60` | Allowed clock skew for future `iat` values in dashboard identity envelopes. |
 | `DASHBOARD_IDENTITY_MAX_AGE_SECONDS` | `300` | Maximum dashboard identity age and maximum `exp - iat` lifetime. Keeps replay windows short even if the proxy signs a longer-lived envelope. |
 | `DASHBOARD_IDENTITY_ALLOWED_GROUPS` | (unset) | Optional dashboard SSO group allowlist. Use a JSON string array for LDAP DNs, e.g. `["CN=Developers,OU=Groups,DC=company,DC=local"]`; semicolon/newline-separated values are also accepted. If unset, falls back to `LDAP_REQUIRED_GROUP_DN`. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -162,18 +162,17 @@ WebSocket upgrades are handled transparently.
 Pi-forge can run as an iframe app behind the dashboard's path proxy, for example
 at `/apps/pi-forge/`. In that topology the dashboard authenticates the browser,
 strips the `/apps/pi-forge/` prefix before forwarding, and injects signed
-identity headers. Build pi-forge with the same base path and configure the
-server to verify the dashboard envelope:
+identity headers. Configure the server to verify the dashboard envelope. The
+served app shell uses the proxy's `X-Forwarded-Prefix` header to add the mount
+path at request time, so a normal `/` client build can be reused across dashboard
+paths:
 
 ```env
-# Build-time Vite setting; rebuild the image/client after changing it.
-VITE_BASE_PATH=/apps/pi-forge/
-
 # Runtime server settings. The secret must match pi-forge's dashboard catalog
-# identitySecret; issuer/audience must match the dashboard proxy payload.
+# identitySecret; issuer/app id must match the dashboard proxy payload.
 DASHBOARD_IDENTITY_SECRET=<matching-per-app-secret>
 DASHBOARD_IDENTITY_ISSUER=internal-dashboard
-DASHBOARD_IDENTITY_AUDIENCE=pi-forge
+DASHBOARD_APP_ID=pi-forge
 
 # Optional downstream group enforcement. Use JSON for LDAP DNs because DNs
 # contain commas. If unset, pi-forge falls back to LDAP_REQUIRED_GROUP_DN.
@@ -195,12 +194,44 @@ Notes:
 
 - Keep the upstream network private; dashboard identity headers are trusted only
   when users cannot bypass the dashboard and hit pi-forge directly.
+- The dashboard proxy must strip `/apps/pi-forge` before forwarding and send
+  `X-Forwarded-Prefix: /apps/pi-forge`. If it forwards the full prefixed path
+  upstream, the SPA fallback may answer asset requests with `index.html`, which
+  browsers reject as JavaScript/CSS because of MIME `nosniff`.
 - Cached same-origin logos (`/cache/logos/...`), API/SSE calls, downloads,
   Swagger docs, PWA assets, and terminal WebSocket URLs are base-path aware when
-  the client is built with `VITE_BASE_PATH=/apps/pi-forge/`.
+  the dashboard proxy sends `X-Forwarded-Prefix`.
 - The terminal uses WebSocket upgrade. The dashboard app proxy must forward
   WebSockets for `/apps/pi-forge/api/v1/terminal` if you want embedded terminal
   support.
+
+To test the runtime path behavior locally:
+
+```bash
+npm run build
+
+# Terminal 1: run pi-forge with the normal `/` client build.
+PORT=3100 \
+SERVE_CLIENT=true \
+DASHBOARD_IDENTITY_SECRET=dev-dashboard-identity-secret-32-bytes-min \
+DASHBOARD_IDENTITY_ISSUER=internal-dashboard \
+DASHBOARD_APP_ID=pi-forge \
+node packages/server/dist/index.js
+
+# Terminal 2: run a path-stripping dashboard proxy simulator and assertions.
+PROXY_PORT=5173 \
+TARGET_PORT=3100 \
+APP_PREFIX=/apps/pi-forge \
+DASHBOARD_IDENTITY_SECRET=dev-dashboard-identity-secret-32-bytes-min \
+DASHBOARD_IDENTITY_ISSUER=internal-dashboard \
+DASHBOARD_APP_ID=pi-forge \
+node scripts/dashboard-proxy-smoke-test.mjs
+```
+
+The smoke test fails if `/apps/pi-forge/` does not rewrite asset URLs, if JS/CSS
+assets return `text/html`, if the manifest scope is wrong, or if signed dashboard
+identity is not accepted. Use `node scripts/dashboard-proxy-smoke-test.mjs --serve`
+to leave the simulator running for browser testing.
 
 ## Network-deploy env-var overrides
 

--- a/packages/client/src/lib/base-path.ts
+++ b/packages/client/src/lib/base-path.ts
@@ -1,17 +1,32 @@
-const RAW_BASE = import.meta.env?.BASE_URL ?? "/";
+const RAW_BUILD_BASE = import.meta.env?.BASE_URL ?? "/";
+
+function normalizedBase(value: string): string {
+  if (value === "/") return "";
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function runtimeBasePath(): string | undefined {
+  if (typeof document === "undefined" || typeof document.querySelector !== "function") {
+    return undefined;
+  }
+  const value = document.querySelector<HTMLMetaElement>('meta[name="pi-forge-base-path"]')?.content;
+  return value && value.length > 0 ? value : undefined;
+}
 
 /**
- * Vite exposes the deployment base as import.meta.env.BASE_URL. In the
- * dashboard iframe deployment this is something like `/apps/pi-forge/`; in
- * normal local/dev deployments it is `/`. Keep URL construction centralized so
- * API, SSE, WebSocket, docs, and download URLs all honor the same prefix.
+ * Prefer the server-injected runtime base path (derived from
+ * X-Forwarded-Prefix) so one normal `/` build can run under a dashboard path
+ * proxy like `/apps/pi-forge/`. Fall back to Vite's build-time base for static
+ * hosts that still choose to bake the base path into the client bundle.
  */
-export const appBasePath = RAW_BASE.endsWith("/") ? RAW_BASE.slice(0, -1) : RAW_BASE;
+export const appBasePath = normalizedBase(runtimeBasePath() ?? RAW_BUILD_BASE);
 
 export function appUrl(path: string): string {
   const suffix = path.startsWith("/") ? path : `/${path}`;
   return `${appBasePath}${suffix}`;
 }
+
+export const serviceWorkerRuntimeCompatible = appBasePath === normalizedBase(RAW_BUILD_BASE);
 
 export function appResourceUrl(url: string | undefined): string | undefined {
   if (url === undefined) return undefined;

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { registerSW } from "virtual:pwa-register";
 import { App } from "./App";
 import "./index.css";
+import { appBasePath, serviceWorkerRuntimeCompatible } from "./lib/base-path";
 import { bootTheme } from "./lib/theme";
 
 // Apply the persisted theme BEFORE React mounts so the first paint
@@ -13,8 +14,31 @@ import { bootTheme } from "./lib/theme";
 bootTheme();
 
 // Auto-register the service worker (vite-plugin-pwa). `autoUpdate` mode
-// silently swaps in new shells on the next reload — no banner needed.
-registerSW({ immediate: true });
+// silently swaps in new shells on the next reload — no banner needed. Skip
+// registration when the server injected a runtime base path that differs from
+// the build-time Vite base; vite-plugin-pwa bakes the service worker URL/scope
+// at build time, so a root build running under /apps/pi-forge/ would otherwise
+// try to register /sw.js at the dashboard origin root.
+if (serviceWorkerRuntimeCompatible) {
+  registerSW({ immediate: true });
+} else if ("serviceWorker" in navigator) {
+  void navigator.serviceWorker.getRegistrations().then(async (registrations) => {
+    const appScope = new URL(`${appBasePath || "/"}`, window.location.origin).href;
+    const staleRegistrations = registrations.filter((registration) =>
+      registration.scope.startsWith(appScope),
+    );
+    if (staleRegistrations.length === 0) return;
+    await Promise.all(staleRegistrations.map((registration) => registration.unregister()));
+    // If a stale service worker controlled this load, a single soft reload
+    // moves the page onto network-served runtime-prefixed assets. Session
+    // storage avoids an accidental reload loop if a browser delays teardown.
+    const reloadKey = "pi-forge-stale-sw-reloaded";
+    if (navigator.serviceWorker.controller !== null && sessionStorage.getItem(reloadKey) !== "1") {
+      sessionStorage.setItem(reloadKey, "1");
+      window.location.reload();
+    }
+  });
+}
 
 /**
  * Dev-time error boundary that renders the error visibly on the page when

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -543,7 +543,7 @@ export const config = Object.freeze({
       secret: DASHBOARD_IDENTITY_SECRET,
       secretFile: DASHBOARD_IDENTITY_SECRET_FILE,
       issuer: readEnv("DASHBOARD_IDENTITY_ISSUER") ?? "internal-dashboard",
-      audience: readEnv("DASHBOARD_IDENTITY_AUDIENCE") ?? readEnv("DASHBOARD_APP_ID") ?? "pi-forge",
+      audience: readEnv("DASHBOARD_APP_ID") ?? readEnv("DASHBOARD_IDENTITY_AUDIENCE") ?? "pi-forge",
       maxFutureIatSkewSeconds: readInt("DASHBOARD_IDENTITY_MAX_FUTURE_IAT_SKEW_SECONDS", 60),
       maxAgeSeconds: readInt("DASHBOARD_IDENTITY_MAX_AGE_SECONDS", 5 * 60),
       allowedGroups: Object.freeze(

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import Fastify, { type FastifyInstance, type FastifyRequest } from "fastify";
 import cors from "@fastify/cors";
@@ -95,6 +96,61 @@ function imgSrcCsp(): string {
     }
   }
   return `img-src ${[...sources].join(" ")}`;
+}
+
+function forwardedPrefix(headers: FastifyRequest["headers"]): string | undefined {
+  const raw = headers["x-forwarded-prefix"];
+  if (typeof raw !== "string") return undefined;
+  const prefix = raw.replace(/\/$/, "");
+  return prefix.startsWith("/") && prefix.length > 0 ? prefix : undefined;
+}
+
+function prefixRootUrl(prefix: string, value: string): string {
+  if (!value.startsWith("/")) return value;
+  if (value === prefix || value.startsWith(`${prefix}/`)) return value;
+  return `${prefix}${value}`;
+}
+
+function rewriteRuntimeHtmlBase(html: string, prefix: string): string {
+  const meta = `<meta name="pi-forge-base-path" content="${prefix}" />`;
+  const withMeta = html.includes('name="pi-forge-base-path"')
+    ? html
+    : html.replace("</head>", `    ${meta}\n  </head>`);
+  return withMeta
+    .replace(
+      /(\s(?:src|href)=")\/(assets|icons|manifest\.webmanifest|offline\.html)/g,
+      `$1${prefix}/$2`,
+    )
+    .replace(/(["'`])\/api\/docs/g, `$1${prefix}/api/docs`)
+    .replace(/(["'`])\/api\/v1\//g, `$1${prefix}/api/v1/`);
+}
+
+async function clientIndexHtml(headers: FastifyRequest["headers"]): Promise<string> {
+  const html = await readFile(join(config.clientDistPath, "index.html"), "utf8");
+  const prefix = forwardedPrefix(headers);
+  return prefix === undefined ? html : rewriteRuntimeHtmlBase(html, prefix);
+}
+
+function rewriteRuntimeManifest(manifest: string, prefix: string): string {
+  try {
+    const parsed = JSON.parse(manifest) as {
+      start_url?: string;
+      scope?: string;
+      icons?: { src?: string }[];
+      [key: string]: unknown;
+    };
+    if (typeof parsed.start_url === "string")
+      parsed.start_url = prefixRootUrl(prefix, parsed.start_url);
+    if (typeof parsed.scope === "string") parsed.scope = prefixRootUrl(prefix, parsed.scope);
+    if (Array.isArray(parsed.icons)) {
+      for (const icon of parsed.icons) {
+        if (typeof icon.src === "string") icon.src = prefixRootUrl(prefix, icon.src);
+      }
+    }
+    return JSON.stringify(parsed);
+  } catch {
+    return manifest;
+  }
 }
 
 export async function buildServer(): Promise<FastifyInstance> {
@@ -266,25 +322,21 @@ export async function buildServer(): Promise<FastifyInstance> {
       ].join("; "),
     );
 
-    const forwardedPrefix =
-      typeof req.headers["x-forwarded-prefix"] === "string"
-        ? req.headers["x-forwarded-prefix"].replace(/\/$/, "")
-        : undefined;
-    const path = req.url.split("?")[0] ?? req.url;
-    if (
-      forwardedPrefix !== undefined &&
-      forwardedPrefix.startsWith("/") &&
-      (path === "/api/docs" || path.startsWith("/api/docs/"))
-    ) {
+    const prefix = forwardedPrefix(req.headers);
+    if (prefix !== undefined && (typeof payload === "string" || Buffer.isBuffer(payload))) {
+      const path = req.url.split("?")[0] ?? req.url;
       const contentType = reply.getHeader("content-type")?.toString() ?? "";
+      if (contentType.includes("text/html")) {
+        return rewriteRuntimeHtmlBase(payload.toString(), prefix);
+      }
+      if (path === "/manifest.webmanifest" || contentType.includes("manifest+json")) {
+        return rewriteRuntimeManifest(payload.toString(), prefix);
+      }
       if (
-        (contentType.includes("text/html") || contentType.includes("javascript")) &&
-        (typeof payload === "string" || Buffer.isBuffer(payload))
+        (path === "/api/docs" || path.startsWith("/api/docs/")) &&
+        contentType.includes("javascript")
       ) {
-        return payload
-          .toString()
-          .replace(/(["'`])\/api\/docs/g, `$1${forwardedPrefix}/api/docs`)
-          .replace(/(["'`])\/api\/v1\//g, `$1${forwardedPrefix}/api/v1/`);
+        return rewriteRuntimeHtmlBase(payload.toString(), prefix);
       }
     }
     return payload;
@@ -551,12 +603,28 @@ export async function buildServer(): Promise<FastifyInstance> {
       }
     });
 
-    await fastify.register(fastifyStatic, {
-      root: config.clientDistPath,
-      index: "index.html",
+    fastify.get("/", async (req, reply) =>
+      reply
+        .code(200)
+        .type("text/html")
+        .send(await clientIndexHtml(req.headers)),
+    );
+
+    fastify.get("/manifest.webmanifest", async (req, reply) => {
+      const manifest = await readFile(join(config.clientDistPath, "manifest.webmanifest"), "utf8");
+      const prefix = forwardedPrefix(req.headers);
+      return reply
+        .code(200)
+        .type("application/manifest+json")
+        .send(prefix === undefined ? manifest : rewriteRuntimeManifest(manifest, prefix));
     });
 
-    fastify.setNotFoundHandler((req, reply) => {
+    await fastify.register(fastifyStatic, {
+      root: config.clientDistPath,
+      index: false,
+    });
+
+    fastify.setNotFoundHandler(async (req, reply) => {
       const path = req.url.split("?")[0] ?? req.url;
       // The API surface explicitly 404s — never fall through to the SPA.
       if (path.startsWith("/api/")) {
@@ -571,7 +639,10 @@ export async function buildServer(): Promise<FastifyInstance> {
       if (req.method !== "GET" || looksLikeAsset) {
         return reply.code(404).send({ error: "not_found" });
       }
-      return reply.code(200).type("text/html").sendFile("index.html");
+      return reply
+        .code(200)
+        .type("text/html")
+        .send(await clientIndexHtml(req.headers));
     });
 
     fastify.log.info({ root: config.clientDistPath }, "serving client from disk");

--- a/scripts/dashboard-proxy-smoke-test.mjs
+++ b/scripts/dashboard-proxy-smoke-test.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+import { createHmac } from "node:crypto";
+import http from "node:http";
+import net from "node:net";
+
+const serveOnly = process.argv.includes("--serve");
+const listenHost = process.env.PROXY_HOST ?? "127.0.0.1";
+const listenPort = Number(process.env.PROXY_PORT ?? "5173");
+const targetHost = process.env.TARGET_HOST ?? "127.0.0.1";
+const targetPort = Number(process.env.TARGET_PORT ?? "3100");
+const prefix = (process.env.APP_PREFIX ?? "/apps/pi-forge").replace(/\/$/, "");
+const secret =
+  process.env.DASHBOARD_IDENTITY_SECRET ?? "dev-dashboard-identity-secret-32-bytes-min";
+const issuer = process.env.DASHBOARD_IDENTITY_ISSUER ?? "internal-dashboard";
+const appId = process.env.DASHBOARD_APP_ID ?? "pi-forge";
+const username = process.env.DASHBOARD_USER ?? "dev-user";
+const email = process.env.DASHBOARD_EMAIL ?? "dev-user@example.test";
+const groups = (process.env.DASHBOARD_GROUPS ?? "cn=devs,ou=groups,dc=example,dc=com")
+  .split(";")
+  .map((group) => group.trim())
+  .filter(Boolean);
+
+const stripHeaders = new Set([
+  "forwarded",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-port",
+  "x-forwarded-proto",
+  "x-forwarded-prefix",
+  "x-real-ip",
+  "x-dashboard-user",
+  "x-dashboard-display-name",
+  "x-dashboard-email",
+  "x-dashboard-groups",
+  "x-dashboard-app-id",
+  "x-dashboard-identity",
+  "x-dashboard-signature",
+]);
+
+function identityHeaders(req) {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: issuer,
+    aud: appId,
+    sub: username,
+    email,
+    groups,
+    app: appId,
+    iat: now,
+    exp: now + 60,
+  };
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac("sha256", secret).update(encoded).digest("hex");
+  return {
+    "x-dashboard-user": username,
+    "x-dashboard-display-name": username,
+    "x-dashboard-email": email,
+    "x-dashboard-groups": JSON.stringify(groups),
+    "x-dashboard-app-id": appId,
+    "x-dashboard-identity": encoded,
+    "x-dashboard-signature": signature,
+    "x-forwarded-for": req.socket.remoteAddress ?? "127.0.0.1",
+    "x-forwarded-host": req.headers.host ?? `127.0.0.1:${listenPort}`,
+    "x-forwarded-proto": "http",
+    "x-forwarded-prefix": prefix,
+  };
+}
+
+function rewriteUrl(url) {
+  if (url === prefix) return "/";
+  if (url.startsWith(`${prefix}/`)) return url.slice(prefix.length) || "/";
+  return undefined;
+}
+
+function proxyHeaders(req) {
+  const headers = { ...req.headers };
+  for (const header of stripHeaders) delete headers[header];
+  headers.host = `${targetHost}:${targetPort}`;
+  Object.assign(headers, identityHeaders(req));
+  return headers;
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url === "/" || req.url === "") {
+    res.writeHead(302, { Location: `${prefix}/` });
+    res.end();
+    return;
+  }
+
+  const rewritten = rewriteUrl(req.url ?? "/");
+  if (rewritten === undefined) {
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end(`not proxied by dashboard simulator: ${req.url}\n`);
+    return;
+  }
+
+  const upstream = http.request(
+    {
+      host: targetHost,
+      port: targetPort,
+      method: req.method,
+      path: rewritten,
+      headers: proxyHeaders(req),
+    },
+    (upstreamRes) => {
+      const headers = { ...upstreamRes.headers };
+      const setCookie = headers["set-cookie"];
+      if (setCookie) {
+        headers["set-cookie"] = (Array.isArray(setCookie) ? setCookie : [setCookie]).map(
+          (cookie) => {
+            const noDomain = cookie.replace(/;\s*Domain=[^;]*/gi, "");
+            return /;\s*Path=/i.test(noDomain)
+              ? noDomain.replace(/;\s*Path=[^;]*/i, `; Path=${prefix}/`)
+              : `${noDomain}; Path=${prefix}/`;
+          },
+        );
+      }
+      res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.statusMessage, headers);
+      upstreamRes.pipe(res);
+    },
+  );
+  upstream.on("error", (err) => {
+    res.writeHead(502, { "content-type": "text/plain" });
+    res.end(`upstream error: ${err.message}\n`);
+  });
+  req.pipe(upstream);
+});
+
+server.on("upgrade", (req, socket, head) => {
+  const rewritten = rewriteUrl(req.url ?? "/");
+  if (rewritten === undefined) {
+    socket.end("HTTP/1.1 404 Not Found\r\n\r\n");
+    return;
+  }
+  const upstream = net.connect(targetPort, targetHost, () => {
+    const headers = proxyHeaders(req);
+    headers.connection = "Upgrade";
+    headers.upgrade = req.headers.upgrade ?? "websocket";
+    const lines = [`${req.method} ${rewritten} HTTP/${req.httpVersion}`];
+    for (const [key, value] of Object.entries(headers)) {
+      if (Array.isArray(value)) for (const item of value) lines.push(`${key}: ${item}`);
+      else if (value !== undefined) lines.push(`${key}: ${value}`);
+    }
+    upstream.write(`${lines.join("\r\n")}\r\n\r\n`);
+    if (head.length > 0) upstream.write(head);
+    socket.pipe(upstream).pipe(socket);
+  });
+  upstream.on("error", () => socket.destroy());
+});
+
+function listen() {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(listenPort, listenHost, () => {
+      server.off("error", reject);
+      const displayHost = listenHost === "0.0.0.0" ? "127.0.0.1" : listenHost;
+      console.log(
+        `[dashboard-proxy-smoke] http://${displayHost}:${listenPort}${prefix}/ -> http://${targetHost}:${targetPort}/`,
+      );
+      resolve();
+    });
+  });
+}
+
+async function assertOk(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function smokeTest() {
+  const base = `http://127.0.0.1:${listenPort}${prefix}`;
+  const htmlRes = await fetch(`${base}/`);
+  const html = await htmlRes.text();
+  await assertOk(htmlRes.ok, `app shell returned ${htmlRes.status}`);
+  await assertOk(
+    html.includes(`name="pi-forge-base-path" content="${prefix}"`),
+    "app shell is missing runtime base-path meta tag",
+  );
+
+  const assetRefs = [...html.matchAll(/(?:src|href)="([^"]*\/assets\/[^"]+)"/g)].map(
+    (match) => match[1],
+  );
+  await assertOk(assetRefs.length > 0, "app shell did not reference built assets");
+  await assertOk(
+    assetRefs.every((ref) => ref.startsWith(`${prefix}/assets/`)),
+    `asset refs were not runtime-prefixed: ${assetRefs.join(", ")}`,
+  );
+
+  for (const ref of assetRefs) {
+    const res = await fetch(new URL(ref, base));
+    const contentType = res.headers.get("content-type") ?? "";
+    await assertOk(res.ok, `${ref} returned ${res.status}`);
+    if (ref.endsWith(".js"))
+      await assertOk(/javascript|ecmascript/.test(contentType), `${ref} returned ${contentType}`);
+    if (ref.endsWith(".css"))
+      await assertOk(contentType.includes("text/css"), `${ref} returned ${contentType}`);
+  }
+
+  const authStatus = await (await fetch(`${base}/api/v1/auth/status`)).json();
+  await assertOk(
+    authStatus.dashboardIdentityAuthenticated === true,
+    "dashboard identity was not accepted",
+  );
+
+  const manifest = await (await fetch(`${base}/manifest.webmanifest`)).json();
+  await assertOk(
+    manifest.start_url === `${prefix}/`,
+    `manifest start_url was ${manifest.start_url}`,
+  );
+  await assertOk(manifest.scope === `${prefix}/`, `manifest scope was ${manifest.scope}`);
+
+  console.log(
+    `[dashboard-proxy-smoke] OK: runtime prefix ${prefix} assets, manifest, and SSO all passed`,
+  );
+}
+
+await listen();
+if (serveOnly) {
+  console.log("[dashboard-proxy-smoke] --serve mode; press Ctrl+C to stop");
+} else {
+  try {
+    await smokeTest();
+  } finally {
+    server.close();
+  }
+}


### PR DESCRIPTION
## Summary

- resolve the dashboard app mount path at runtime from `X-Forwarded-Prefix`
- rewrite served `index.html` and `manifest.webmanifest` so a normal `/` build works at `/apps/pi-forge/`
- inject a runtime base-path meta tag consumed by the client URL helper
- disable service-worker registration when runtime and build-time bases differ
- make `DASHBOARD_APP_ID` the primary env var, with `DASHBOARD_IDENTITY_AUDIENCE` as a deprecated fallback
- add a checked-in dashboard proxy smoke test that signs identity headers and verifies assets, MIME types, manifest scope, and SSO
- remove Docker/dashboard examples that required build-time `VITE_BASE_PATH`

## Why

In production the app shell was still referencing `/assets/index...`, so the dashboard portal could return HTML for JS/CSS asset requests. With `nosniff`, browsers reject those `text/html` responses as scripts/styles and show a white page.

This fixes that by making pi-forge rewrite the app shell at request time using the proxy-provided mount prefix, instead of requiring a separate build per dashboard path.

## Validation

```bash
npm run check
npm run build
```

Runtime dashboard proxy smoke test against a normal `/` build:

```bash
# Terminal 1
PORT=3100 \
SERVE_CLIENT=true \
DASHBOARD_IDENTITY_SECRET=dev-dashboard-identity-secret-32-bytes-min \
DASHBOARD_IDENTITY_ISSUER=internal-dashboard \
DASHBOARD_APP_ID=pi-forge \
node packages/server/dist/index.js

# Terminal 2
PROXY_PORT=5173 \
TARGET_PORT=3100 \
APP_PREFIX=/apps/pi-forge \
DASHBOARD_IDENTITY_SECRET=dev-dashboard-identity-secret-32-bytes-min \
DASHBOARD_IDENTITY_ISSUER=internal-dashboard \
DASHBOARD_APP_ID=pi-forge \
node scripts/dashboard-proxy-smoke-test.mjs
```

Observed:

```txt
[dashboard-proxy-smoke] OK: runtime prefix /apps/pi-forge assets, manifest, and SSO all passed
```
