### PR TITLE
chore(release): v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.5.1] — 2026-08-20
+
+### Fixed
+
+- **Dashboard app-proxy runtime paths.** Pi-forge now resolves dashboard mount paths from `X-Forwarded-Prefix` at request time, so a normal `/` build works behind `/apps/pi-forge/` without serving JS/CSS as HTML. Dashboard SSO configuration now uses `DASHBOARD_APP_ID` as the primary app id setting.
+
 ## [1.5.0] — 2026-08-19
 
 ## [1.4.9] — 2026-08-19

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "workspaces": [
         "packages/*"
       ],
@@ -17290,7 +17290,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17362,7 +17362,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.10",
         "@earendil-works/pi-ai": "0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump root, client, and server package versions to `1.5.1`
- update `package-lock.json`
- add `CHANGELOG.md` entry for the dashboard runtime path fix

## Validation

```bash
npm run check
npm run build
```
