### PR TITLE
fix: improve OTLP diagnostics and proxy attribution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,7 @@ or shell environment. The most-touched ones:
 | `OTEL_SERVICE_NAME` | `pi-forge` | OpenTelemetry resource service name. |
 | `OTEL_SERVICE_VERSION` | `unknown` | OpenTelemetry resource service version/release label. |
 | `OTEL_CAPTURE_CONTENT` | `false` | When true, exports full user/assistant message content and tool arguments/results. This can contain source code, credentials, personal data, and MCP responses; enable only with an approved data-retention policy. |
+| `OTEL_DEBUG` | `false` | Log OTLP exporter configuration, batch attempts, results, durations, and sanitized errors to stdout. Span contents and header values are not logged. |
 | `TRUST_PROXY` | `false` | Set when behind a reverse proxy so `req.ip` is the real client (required for per-user login rate limits). |
 | `ORCHESTRATION_DISABLED` | `false` | Disable the chat-view `Orch` toggle and orchestration REST/tool surface. Orchestration is enabled by default; hard-disabled under `MINIMAL_UI` regardless. See [`orchestration.md`](./orchestration.md). |
 | `ORCHESTRATION_ENABLED` | `true` | Legacy compatibility switch. `false` disables orchestration; `true`/unset keep the default enabled behavior. Prefer `ORCHESTRATION_DISABLED=true` for new deployments. |
@@ -141,6 +142,12 @@ For a trusted private OTLP endpoint with a self-signed certificate, set
 the telemetry exporter's HTTP agent, but it still permits man-in-the-middle
 attacks against exported telemetry; installing the endpoint's CA certificate is
 preferred.
+
+To troubleshoot export failures in pod logs without printing span contents or
+header values, set `OTEL_DEBUG=true`. Debug lines are prefixed with
+`[telemetry:debug]` and report whether telemetry is disabled due to a missing
+endpoint, plus the sanitized endpoint, TLS verification setting, batch size,
+duration, and exporter error message.
 
 Langfuse example:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,6 +89,7 @@ or shell environment. The most-touched ones:
 | `AUTH_COLOR_SCHEME` | (unset) | Optional comma-separated list of exactly 8 hex colors for login/auth pages only: page background, card background, border, text, muted text, button background, button text, button hover background. Example: `#ffffff,#2563eb,#1d4ed8,#ffffff,#dbeafe,#2563eb,#ffffff,#1d4ed8`. Only `#rgb` and `#rrggbb` forms are accepted; invalid values fail startup rather than becoming CSS. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | (unset) | Enables OpenTelemetry trace export over OTLP/HTTP. For Langfuse use `https://<region>.cloud.langfuse.com/api/public/otel`; pi-forge appends `/v1/traces`. |
 | `OTEL_EXPORTER_OTLP_HEADERS` | (unset) | Comma-separated exporter headers. Langfuse requires `Authorization=Basic <base64-public-key:secret-key>,x-langfuse-ingestion-version=4`. Treat this value as a secret. |
+| `OTEL_EXPORTER_OTLP_TLS_REJECT_UNAUTHORIZED` | `true` | Verify certificates for OTLP HTTPS connections. Set to `false` only for a trusted private endpoint with a self-signed certificate; this weakens TLS verification for the telemetry exporter. |
 | `OTEL_SERVICE_NAME` | `pi-forge` | OpenTelemetry resource service name. |
 | `OTEL_SERVICE_VERSION` | `unknown` | OpenTelemetry resource service version/release label. |
 | `OTEL_CAPTURE_CONTENT` | `false` | When true, exports full user/assistant message content and tool arguments/results. This can contain source code, credentials, personal data, and MCP responses; enable only with an approved data-retention policy. |
@@ -132,7 +133,14 @@ message, and tool execution. MCP calls are emitted as tool observations with
 Pi UUID remains available as `pi.session.id`. Session ownership is persisted in
 `${FORGE_DATA_DIR}/session-users.json` (mode 0600), so attribution survives a
 server restart. Local-password, API-key, and unauthenticated use map to
-`FORGE_LOCAL_ADMIN_USERNAME`; LDAP sessions use the authenticated LDAP login.
+`FORGE_LOCAL_ADMIN_USERNAME`; LDAP sessions use the authenticated LDAP login,
+and dashboard/app-portal SSO sessions use the verified identity's `sub` claim.
+
+For a trusted private OTLP endpoint with a self-signed certificate, set
+`OTEL_EXPORTER_OTLP_TLS_REJECT_UNAUTHORIZED=false`. This exception is scoped to
+the telemetry exporter's HTTP agent, but it still permits man-in-the-middle
+attacks against exported telemetry; installing the endpoint's CA certificate is
+preferred.
 
 Langfuse example:
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -317,6 +317,14 @@ const FLAGS: readonly FlagDef[] = [
     sensitive: true,
   },
   {
+    name: "otel-exporter-otlp-tls-reject-unauthorized",
+    env: "OTEL_EXPORTER_OTLP_TLS_REJECT_UNAUTHORIZED",
+    type: "boolean",
+    group: "telemetry",
+    desc: "Verify OTLP HTTPS certificates; set false only for trusted private endpoints",
+    defaultText: "true",
+  },
+  {
     name: "otel-service-name",
     env: "OTEL_SERVICE_NAME",
     type: "string",

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -348,6 +348,14 @@ const FLAGS: readonly FlagDef[] = [
     desc: "Export message content and tool inputs/results (may contain sensitive user data)",
     defaultText: "false",
   },
+  {
+    name: "otel-debug",
+    env: "OTEL_DEBUG",
+    type: "boolean",
+    group: "telemetry",
+    desc: "Log OTLP export attempts, results, and errors to stdout without span contents",
+    defaultText: "false",
+  },
   // features
   {
     name: "log-level",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -393,6 +393,7 @@ export const config = Object.freeze({
     serviceName: readEnv("OTEL_SERVICE_NAME") ?? "pi-forge",
     serviceVersion: readEnv("OTEL_SERVICE_VERSION") ?? "unknown",
     captureContent: readBool("OTEL_CAPTURE_CONTENT", false),
+    debug: readBool("OTEL_DEBUG", false),
   }),
   isTest: (readEnv("NODE_ENV") ?? "") === "test",
   isProduction: (readEnv("NODE_ENV") ?? "") === "production",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -389,6 +389,7 @@ export const config = Object.freeze({
   telemetry: Object.freeze({
     otlpEndpoint: readHttpUrl("OTEL_EXPORTER_OTLP_ENDPOINT"),
     otlpHeaders: readEnv("OTEL_EXPORTER_OTLP_HEADERS"),
+    otlpTlsRejectUnauthorized: readBool("OTEL_EXPORTER_OTLP_TLS_REJECT_UNAUTHORIZED", true),
     serviceName: readEnv("OTEL_SERVICE_NAME") ?? "pi-forge",
     serviceVersion: readEnv("OTEL_SERVICE_VERSION") ?? "unknown",
     captureContent: readBool("OTEL_CAPTURE_CONTENT", false),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -513,7 +513,11 @@ export async function buildServer(): Promise<FastifyInstance> {
       return;
     }
 
-    if (verifyDashboardIdentity(req.headers) !== undefined) return;
+    const dashboardIdentity = verifyDashboardIdentity(req.headers);
+    if (dashboardIdentity !== undefined) {
+      req.authUsername = dashboardIdentity.sub;
+      return;
+    }
 
     const presented = extractBearer(req.headers.authorization);
     if (presented === undefined) {

--- a/packages/server/src/telemetry.ts
+++ b/packages/server/src/telemetry.ts
@@ -36,18 +36,25 @@ export function telemetryTraceEndpoint(endpoint: string): string {
   return trimmed.endsWith("/v1/traces") ? trimmed : `${trimmed}/v1/traces`;
 }
 
+export function telemetryExporterOptions(
+  endpoint: string,
+): NonNullable<ConstructorParameters<typeof OTLPTraceExporter>[0]> {
+  return {
+    url: telemetryTraceEndpoint(endpoint),
+    headers: parseHeaders(config.telemetry.otlpHeaders),
+    ...(config.telemetry.otlpTlsRejectUnauthorized
+      ? {}
+      : { httpAgentOptions: { rejectUnauthorized: false } }),
+  };
+}
+
 export function initializeTelemetry(exporterOverride?: SpanExporter): void {
   if (initialized) return;
   initialized = true;
   const endpoint = config.telemetry.otlpEndpoint;
   if (endpoint === undefined && exporterOverride === undefined) return;
 
-  const exporter =
-    exporterOverride ??
-    new OTLPTraceExporter({
-      url: telemetryTraceEndpoint(endpoint!),
-      headers: parseHeaders(config.telemetry.otlpHeaders),
-    });
+  const exporter = exporterOverride ?? new OTLPTraceExporter(telemetryExporterOptions(endpoint!));
   provider = new NodeTracerProvider({
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: config.telemetry.serviceName,

--- a/packages/server/src/telemetry.ts
+++ b/packages/server/src/telemetry.ts
@@ -1,7 +1,11 @@
 import { context, SpanStatusCode, trace, type Context, type Span } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { resourceFromAttributes } from "@opentelemetry/resources";
-import { BatchSpanProcessor, type SpanExporter } from "@opentelemetry/sdk-trace-base";
+import {
+  BatchSpanProcessor,
+  type ReadableSpan,
+  type SpanExporter,
+} from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
@@ -48,13 +52,108 @@ export function telemetryExporterOptions(
   };
 }
 
+type TelemetryDebugLog = (message: string) => void;
+
+function diagnosticEndpoint(endpoint: string): string {
+  try {
+    const parsed = new URL(telemetryTraceEndpoint(endpoint));
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return "(invalid endpoint)";
+  }
+}
+
+function errorSummary(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const code = (error as NodeJS.ErrnoException).code;
+  return `${error.name}${code === undefined ? "" : ` [${code}]`}: ${error.message}`;
+}
+
+export function telemetryDebugExporter(
+  delegate: SpanExporter,
+  endpoint: string,
+  tlsRejectUnauthorized: boolean,
+  log: TelemetryDebugLog = (message) => console.log(message),
+): SpanExporter {
+  const safeEndpoint = diagnosticEndpoint(endpoint);
+  const write = (message: string): void => {
+    try {
+      log(`[telemetry:debug] ${message}`);
+    } catch {
+      // Diagnostic output must never interrupt trace export.
+    }
+  };
+
+  write(
+    `OTLP exporter configured endpoint=${safeEndpoint} tlsRejectUnauthorized=${String(tlsRejectUnauthorized)}`,
+  );
+
+  return {
+    export(spans: ReadableSpan[], resultCallback: Parameters<SpanExporter["export"]>[1]): void {
+      const startedAt = Date.now();
+      write(`export started spans=${spans.length}`);
+      try {
+        delegate.export(spans, (result) => {
+          const elapsedMs = Date.now() - startedAt;
+          if (Number(result.code) === 0) {
+            write(`export succeeded spans=${spans.length} durationMs=${elapsedMs}`);
+          } else {
+            write(
+              `export failed spans=${spans.length} durationMs=${elapsedMs} error=${errorSummary(result.error)}`,
+            );
+          }
+          resultCallback(result);
+        });
+      } catch (error) {
+        write(`export threw spans=${spans.length} error=${errorSummary(error)}`);
+        throw error;
+      }
+    },
+    async forceFlush(): Promise<void> {
+      write("force flush started");
+      try {
+        await delegate.forceFlush?.();
+        write("force flush completed");
+      } catch (error) {
+        write(`force flush failed error=${errorSummary(error)}`);
+        throw error;
+      }
+    },
+    async shutdown(): Promise<void> {
+      write("exporter shutdown started");
+      try {
+        await delegate.shutdown();
+        write("exporter shutdown completed");
+      } catch (error) {
+        write(`exporter shutdown failed error=${errorSummary(error)}`);
+        throw error;
+      }
+    },
+  };
+}
+
 export function initializeTelemetry(exporterOverride?: SpanExporter): void {
   if (initialized) return;
   initialized = true;
   const endpoint = config.telemetry.otlpEndpoint;
-  if (endpoint === undefined && exporterOverride === undefined) return;
+  if (endpoint === undefined && exporterOverride === undefined) {
+    if (config.telemetry.debug) {
+      console.log("[telemetry:debug] telemetry disabled: OTEL_EXPORTER_OTLP_ENDPOINT is unset");
+    }
+    return;
+  }
 
-  const exporter = exporterOverride ?? new OTLPTraceExporter(telemetryExporterOptions(endpoint!));
+  let exporter = exporterOverride;
+  if (exporter === undefined) {
+    const otlpExporter = new OTLPTraceExporter(telemetryExporterOptions(endpoint!));
+    exporter = config.telemetry.debug
+      ? telemetryDebugExporter(otlpExporter, endpoint!, config.telemetry.otlpTlsRejectUnauthorized)
+      : otlpExporter;
+  }
   provider = new NodeTracerProvider({
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: config.telemetry.serviceName,

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -22,7 +22,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
 import { createHmac, randomBytes } from "node:crypto";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -118,6 +118,8 @@ async function startServer(
       LOG_LEVEL: "warn",
       NODE_ENV: "test",
       FORGE_DATA_DIR: dataDir,
+      PI_CONFIG_DIR: join(dataDir, "pi-config"),
+      SESSION_DIR: join(dataDir, "sessions"),
       WORKSPACE_PATH: workspacePath,
     },
     stdio: ["ignore", "pipe", "pipe"],
@@ -696,6 +698,31 @@ async function scenarioDashboardIdentity(): Promise<void> {
     assert(
       "protected probe with valid dashboard headers → 404 (passes auth)",
       withHeaders.status === 404,
+    );
+
+    const projectPath = join(srv.dataDir, "workspace", "dashboard-project");
+    await mkdir(projectPath, { recursive: true });
+    const createProjectResponse = await jsonPost(
+      `${srv.base}/api/v1/projects`,
+      { name: "Dashboard project", path: projectPath },
+      dashboardHeaders(secret),
+    );
+    assert("dashboard identity can create a project", createProjectResponse.status === 201);
+    const project = (await createProjectResponse.json()) as { id: string };
+    const createSessionResponse = await jsonPost(
+      `${srv.base}/api/v1/sessions`,
+      { projectId: project.id },
+      dashboardHeaders(secret, { sub: "portal-user" }),
+    );
+    assert("dashboard identity can create a session", createSessionResponse.status === 201);
+    const session = (await createSessionResponse.json()) as { sessionId: string };
+    const sessionUsers = JSON.parse(
+      await readFile(join(srv.dataDir, "session-users.json"), "utf8"),
+    ) as Record<string, string>;
+    assert(
+      "dashboard identity sub is persisted as the session username",
+      sessionUsers[session.sessionId] === "portal-user",
+      `got ${String(sessionUsers[session.sessionId])}`,
     );
 
     const wrongSignature = await fetch(`${srv.base}/api/v1/__protected_probe`, {

--- a/tests/test-telemetry.ts
+++ b/tests/test-telemetry.ts
@@ -10,6 +10,7 @@ process.env.FORGE_DATA_DIR = temp;
 process.env.WORKSPACE_PATH = temp;
 process.env.PI_CONFIG_DIR = join(temp, "pi-config");
 process.env.OTEL_CAPTURE_CONTENT = "true";
+process.env.OTEL_EXPORTER_OTLP_TLS_REJECT_UNAUTHORIZED = "false";
 
 let failures = 0;
 function assert(label: string, ok: boolean, detail?: string): void {
@@ -34,6 +35,14 @@ try {
     "OTLP base endpoint gets traces suffix",
     telemetry.telemetryTraceEndpoint("https://cloud.langfuse.com/api/public/otel/") ===
       "https://cloud.langfuse.com/api/public/otel/v1/traces",
+  );
+  const exporterOptions = telemetry.telemetryExporterOptions("https://otel.example.com");
+  const agentOptions = exporterOptions.httpAgentOptions as
+    | { rejectUnauthorized?: boolean }
+    | undefined;
+  assert(
+    "OTLP TLS verification can be disabled without changing process-wide TLS",
+    typeof agentOptions === "object" && agentOptions.rejectUnauthorized === false,
   );
   assert(
     "username is included in telemetry session id",

--- a/tests/test-telemetry.ts
+++ b/tests/test-telemetry.ts
@@ -2,7 +2,7 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { InMemorySpanExporter } from "@opentelemetry/sdk-trace-base";
+import { InMemorySpanExporter, type SpanExporter } from "@opentelemetry/sdk-trace-base";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 
 const temp = await mkdtemp(join(tmpdir(), "pi-forge-telemetry-"));
@@ -44,6 +44,54 @@ try {
     "OTLP TLS verification can be disabled without changing process-wide TLS",
     typeof agentOptions === "object" && agentOptions.rejectUnauthorized === false,
   );
+
+  const debugLines: string[] = [];
+  const failingExporter: SpanExporter = {
+    export(_spans, resultCallback): void {
+      const error = Object.assign(new Error("self-signed certificate"), {
+        code: "DEPTH_ZERO_SELF_SIGNED_CERT",
+      });
+      resultCallback({ code: 1, error });
+    },
+    shutdown(): Promise<void> {
+      return Promise.resolve();
+    },
+  };
+  const debugExporter = telemetry.telemetryDebugExporter(
+    failingExporter,
+    "https://user:password@otel.example.com/v1/traces?token=secret",
+    false,
+    (line) => debugLines.push(line),
+  );
+  debugExporter.export(
+    [{ name: "private prompt", attributes: { secret: "private span content" } } as never],
+    () => undefined,
+  );
+  assert(
+    "OTEL debug output reports sanitized exporter failures",
+    debugLines.some(
+      (line) =>
+        line.includes("endpoint=https://otel.example.com/v1/traces") &&
+        line.includes("tlsRejectUnauthorized=false"),
+    ) &&
+      debugLines.some(
+        (line) =>
+          line.includes("export failed spans=1") &&
+          line.includes("DEPTH_ZERO_SELF_SIGNED_CERT") &&
+          line.includes("self-signed certificate"),
+      ),
+  );
+  assert(
+    "OTEL debug output excludes endpoint credentials and span contents",
+    debugLines.every(
+      (line) =>
+        !line.includes("password") &&
+        !line.includes("token=secret") &&
+        !line.includes("private prompt") &&
+        !line.includes("private span content"),
+    ),
+  );
+
   assert(
     "username is included in telemetry session id",
     telemetry.formatTelemetrySessionId("alice@example.com", "session-123") ===


### PR DESCRIPTION
## Summary

App-portal/dashboard SSO requests were authenticated successfully but did not propagate the verified identity into `req.authUsername`, so new session telemetry fell back to the local admin username. OTLP HTTPS export also had no exporter-scoped escape hatch for trusted self-signed endpoints and provided too little information when exports failed.

This PR attributes new app-portal sessions to the verified `sub` claim, adds an exporter-scoped TLS verification setting, and adds opt-in, privacy-conscious OTLP diagnostics for pod logs.

## Usage

Enable sanitized OTLP diagnostics in pod stdout:

```bash
OTEL_DEBUG=true
```

Logs are prefixed with `[telemetry:debug]` and include whether the endpoint is missing, the sanitized endpoint, TLS verification state, batch size, duration, and export result/error. Header values, endpoint credentials/query parameters, and span contents are not logged.

For a trusted private OTLP endpoint using a self-signed certificate:

```bash
OTEL_EXPORTER_OTLP_TLS_REJECT_UNAUTHORIZED=false
```

This disables certificate verification only for the OTLP exporter's HTTP agent. Installing the endpoint CA remains the preferred production configuration.

Dashboard/app-portal SSO attribution is automatic for newly created or resumed sessions and uses the verified identity's `sub` claim. Existing session mappings already persisted as `admin` are not rewritten automatically.

## What changed (7 files)

- `packages/server/src/index.ts` — propagate verified dashboard/app-portal `sub` into `req.authUsername`.
- `packages/server/src/config.ts` — add centralized parsing for OTLP TLS verification and debug settings.
- `packages/server/src/cli.ts` — add matching `--otel-exporter-otlp-tls-reject-unauthorized` and `--otel-debug` flags.
- `packages/server/src/telemetry.ts` — scope `rejectUnauthorized` to the OTLP HTTP exporter and add sanitized exporter lifecycle/result diagnostics.
- `tests/test-auth.ts` — verify app-portal identity is persisted as the session username.
- `tests/test-telemetry.ts` — verify scoped TLS options, failure diagnostics, and redaction of credentials/span contents.
- `docs/configuration.md` — document both settings, security trade-offs, and app-portal attribution.

## Test plan

- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run test:ci` — all 57 tests passed
- [x] Dedicated review of TLS scoping and proxy identity propagation
- [x] Dedicated review of debug logging privacy and exporter delegation; its missing-endpoint observation was addressed before the final commit/test run
- [ ] CI green before merge
