### PR TITLE
chore(release): v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.5.2] — 2026-08-24
+
+### Added
+
+- **OTLP export diagnostics and private-endpoint TLS controls.** Operators can enable sanitized exporter status/error logs with `OTEL_DEBUG` and, for trusted self-signed endpoints, scope certificate-verification bypass to the OTLP exporter with `OTEL_EXPORTER_OTLP_TLS_REJECT_UNAUTHORIZED=false`.
+
+### Fixed
+
+- **Dashboard/app-portal sessions use the authenticated identity in telemetry.** Session attribution now propagates the verified proxy `sub` claim instead of falling back to the local admin username.
+
 ## [1.5.1] — 2026-08-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "workspaces": [
         "packages/*"
       ],
@@ -17290,7 +17290,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17362,7 +17362,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.10",
         "@earendil-works/pi-ai": "0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the v1.5.2 patch release from the changes merged since v1.5.1. This release contains the OTLP diagnostics/private-endpoint TLS controls and the dashboard/app-portal telemetry attribution fix from #414.

The release bump was generated with `scripts/bump-version.sh 1.5.2`; no tag is created by this PR.

## Usage

After this PR merges, tag the merge commit from an updated `main`:

```bash
git checkout main
git pull --ff-only
git tag v1.5.2
git push origin v1.5.2
```

The release workflow will build the multi-architecture image and create the GitHub release automatically.

## What changed (5 files)

- `CHANGELOG.md` — roll the OTLP diagnostics, scoped TLS control, and app-portal attribution notes into the dated v1.5.2 section.
- `package.json` — bump the root release version to 1.5.2.
- `packages/server/package.json` — bump the server workspace version to 1.5.2.
- `packages/client/package.json` — bump the client workspace version to 1.5.2.
- `package-lock.json` — synchronize the root and workspace lockfile versions.

## Test plan

- [x] `scripts/bump-version.sh 1.5.2`
- [x] `npx npm@latest approve-scripts --allow-scripts-pending` — no unreviewed install scripts
- [x] `npm run build`
- [x] `npm run check`
- [x] Verified root, server, client, and lockfile versions are all `1.5.2`
- [ ] CI green before merge
