### PR TITLE
feat: add runtime OTEL content capture setting

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -70,6 +70,7 @@ route handlers).
 | `tool-overrides.json` | Per-project tool enable/disable (built-ins + MCP) | `tool-overrides.ts` |
 | `prompts-overrides.json` | Per-project pi-prompt enable/disable patterns | `prompt-overrides.ts` |
 | `theme.json` | Global server-side UI color overrides | `theme-config.ts` |
+| `telemetry-settings.json` | Runtime OpenTelemetry content-capture override | `telemetry-settings.ts` |
 | `webhooks.json` | Webhook configs (HMAC secrets stored here — mode 0600) | `webhooks/store.ts` |
 | `webhook-deliveries.json` | Rolling delivery history (cap 100 / webhook) | `webhooks/store.ts` |
 | `session-orchestration.json` | Supervisor opt-in + supervisor↔worker links (mode 0600) | `orchestration/store.ts` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,7 +92,7 @@ or shell environment. The most-touched ones:
 | `OTEL_EXPORTER_OTLP_TLS_REJECT_UNAUTHORIZED` | `true` | Verify certificates for OTLP HTTPS connections. Set to `false` only for a trusted private endpoint with a self-signed certificate; this weakens TLS verification for the telemetry exporter. |
 | `OTEL_SERVICE_NAME` | `pi-forge` | OpenTelemetry resource service name. |
 | `OTEL_SERVICE_VERSION` | `unknown` | OpenTelemetry resource service version/release label. |
-| `OTEL_CAPTURE_CONTENT` | `false` | When true, exports full user/assistant message content and tool arguments/results. This can contain source code, credentials, personal data, and MCP responses; enable only with an approved data-retention policy. |
+| `OTEL_CAPTURE_CONTENT` | `false` | Initial/default value for telemetry content capture. The Settings → General pane can override this at runtime and persists the override in `FORGE_DATA_DIR/telemetry-settings.json`. When true, exports full user/assistant message content and tool arguments/results. This can contain source code, credentials, personal data, and MCP responses; enable only with an approved data-retention policy. |
 | `OTEL_DEBUG` | `false` | Log OTLP exporter configuration, batch attempts, results, durations, and sanitized errors to stdout. Span contents and header values are not logged. |
 | `TRUST_PROXY` | `false` | Set when behind a reverse proxy so `req.ip` is the real client (required for per-user login rate limits). |
 | `ORCHESTRATION_DISABLED` | `false` | Disable the chat-view `Orch` toggle and orchestration REST/tool surface. Orchestration is enabled by default; hard-disabled under `MINIMAL_UI` regardless. See [`orchestration.md`](./orchestration.md). |

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -75,6 +75,8 @@ export function App() {
   const active = useActiveProject();
   const activeProjectId = useProjectStore((s) => s.activeProjectId);
 
+  const telemetryCaptureContent = useUiConfigStore((s) => s.telemetryCaptureContent);
+
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
   const openActivityStream = useSessionStore((s) => s.openActivityStream);
   const closeActivityStream = useSessionStore((s) => s.closeActivityStream);
@@ -523,6 +525,14 @@ export function App() {
           <div className="hidden md:block">
             <GlobalSearchBar />
           </div>
+          {telemetryCaptureContent && (
+            <span
+              className="rounded-full bg-red-600 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white shadow-sm shadow-red-950/40"
+              title="OTEL_CAPTURE_CONTENT is on: message and tool content may be exported in telemetry."
+            >
+              OTEL content capture on
+            </span>
+          )}
           {/* MCP status badge stays visible in minimal — operators
               still want to see whether MCP servers are connected,
               they just can't reconfigure them from a locked-down

--- a/packages/client/src/components/ChatInput.tsx
+++ b/packages/client/src/components/ChatInput.tsx
@@ -253,6 +253,7 @@ export function ChatInput({ sessionId }: Props) {
   // direct shell. The agent's own `bash` tool is unaffected; the
   // restriction is on the *user* typing raw shell into chat.
   const minimalUi = useUiConfigStore((s) => s.minimal);
+  const telemetryCaptureContent = useUiConfigStore((s) => s.telemetryCaptureContent);
   const banner = useSessionStore((s) => s.bannerBySession[sessionId]);
   // Detect an in-progress auto-retry by the banner shape that
   // session-store sets in applyEvent for `auto_retry_start`. This lets
@@ -269,6 +270,11 @@ export function ChatInput({ sessionId }: Props) {
 
   const [text, setText] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [telemetryAck, setTelemetryAck] = useState(false);
+
+  useEffect(() => {
+    if (!telemetryCaptureContent) setTelemetryAck(false);
+  }, [telemetryCaptureContent]);
 
   // Todo toggle — appears in the top-right of the chat-input
   // header when the active session has at least one non-deleted
@@ -1368,6 +1374,12 @@ export function ChatInput({ sessionId }: Props) {
       }
       return;
     }
+    if (telemetryCaptureContent && !telemetryAck) {
+      setAttachmentError(
+        "Confirm telemetry content capture before sending. Check the acknowledgement box below the message.",
+      );
+      return;
+    }
     requestScrollToBottom(sessionId);
     setSubmitting(true);
     try {
@@ -1439,6 +1451,7 @@ export function ChatInput({ sessionId }: Props) {
       }
       setText("");
       clearAttachments();
+      setTelemetryAck(false);
       // Submitting clears history mode — the user's prompt is now
       // (or will shortly be) the newest entry, and pressing Up next
       // should land on it from a fresh empty draft.
@@ -2007,6 +2020,23 @@ export function ChatInput({ sessionId }: Props) {
             previewUrls={previewUrlsRef.current}
             onRemove={removeAttachment}
           />
+        )}
+        {telemetryCaptureContent && (text.trim().length > 0 || attachments.length > 0) && (
+          <label className="flex items-start gap-2 rounded-md border border-red-900/50 bg-red-950/25 px-3 py-2 text-xs text-red-200">
+            <input
+              type="checkbox"
+              checked={telemetryAck}
+              onChange={(e) => {
+                setTelemetryAck(e.target.checked);
+                if (e.target.checked) setAttachmentError(undefined);
+              }}
+              className="mt-0.5 h-4 w-4 accent-red-600"
+            />
+            <span>
+              I acknowledge that this message and related tool/model content will be included in
+              telemetry because OTEL_CAPTURE_CONTENT is enabled.
+            </span>
+          </label>
         )}
         <div className="flex items-end gap-2">
           {/* Files input — accepts everything. On desktop this is

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -258,7 +258,7 @@ export function SettingsPanel({ onClose, initialTab }: Props) {
           {tab === "webhooks" && <WebhooksTab onError={setError} />}
           {tab === "appearance" && <AppearanceTab />}
           {tab === "backup" && <BackupTab onError={setError} />}
-          {tab === "general" && <GeneralTab />}
+          {tab === "general" && <GeneralTab onError={setError} />}
         </div>
       </div>
     </div>
@@ -4500,7 +4500,7 @@ const MIN_PASSWORD_LENGTH = 8;
  * in those cases there is no local password to change or password
  * changes should be managed by LDAP.
  */
-function GeneralTab() {
+function GeneralTab({ onError }: { onError: (msg: string | undefined) => void }) {
   const version = useUiConfigStore((s) => s.version);
   const loaded = useUiConfigStore((s) => s.loaded);
   const passwordAuthEnabled = useUiConfigStore((s) => s.passwordAuthEnabled);
@@ -4577,8 +4577,96 @@ function GeneralTab() {
         </ul>
       </section>
 
+      <TelemetryCaptureSection onError={onError} />
+
       {showChangePassword && <ChangePasswordSection />}
     </div>
+  );
+}
+
+function TelemetryCaptureSection({ onError }: { onError: (msg: string | undefined) => void }) {
+  const captureContent = useUiConfigStore((s) => s.telemetryCaptureContent);
+  const setTelemetryCaptureContent = useUiConfigStore((s) => s.setTelemetryCaptureContent);
+  const [saving, setSaving] = useState(false);
+  const [savedFlash, setSavedFlash] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void api
+      .getTelemetrySettings()
+      .then((settings) => {
+        if (!cancelled) setTelemetryCaptureContent(settings.captureContent);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const code = err instanceof ApiError ? err.code : (err as Error).message;
+        onError(`Telemetry settings load failed: ${code}`);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [onError, setTelemetryCaptureContent]);
+
+  const setCaptureContent = async (enabled: boolean): Promise<void> => {
+    setSaving(true);
+    setSavedFlash(false);
+    onError(undefined);
+    try {
+      const next = await api.updateTelemetrySettings(enabled);
+      setTelemetryCaptureContent(next.captureContent);
+      setSavedFlash(true);
+      window.setTimeout(() => setSavedFlash(false), 2500);
+    } catch (err) {
+      const code = err instanceof ApiError ? err.code : (err as Error).message;
+      onError(`Telemetry settings update failed: ${code}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="space-y-3 border-t border-neutral-800 pt-5">
+      <div className="space-y-1">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          Telemetry content capture
+        </h3>
+        <p className="max-w-3xl text-xs text-neutral-500">
+          Controls OTEL_CAPTURE_CONTENT at runtime. When enabled, full user and assistant message
+          content plus tool inputs/results may be exported to OpenTelemetry.
+        </p>
+      </div>
+      <label className="flex max-w-3xl items-start gap-3 rounded-md border border-red-900/50 bg-red-950/20 p-3">
+        <input
+          type="checkbox"
+          checked={captureContent}
+          disabled={saving}
+          onChange={(e) => void setCaptureContent(e.target.checked)}
+          className="mt-0.5 h-4 w-4 accent-red-600 disabled:opacity-50"
+        />
+        <span className="space-y-1">
+          <span className="block text-sm font-medium text-neutral-100">
+            Include message and tool content in telemetry
+          </span>
+          <span className="block text-xs text-red-300/90">
+            Enable only with an approved data-retention policy. Captured content can include source
+            code, credentials, personal data, attachment text, and MCP/tool responses.
+          </span>
+        </span>
+      </label>
+      <div className="flex items-center gap-2 text-xs">
+        <span
+          className={`rounded-full px-2 py-0.5 font-semibold uppercase tracking-wide ${
+            captureContent
+              ? "bg-red-600 text-white"
+              : "bg-neutral-800 text-neutral-400 light:bg-neutral-200 light:text-neutral-700"
+          }`}
+        >
+          {captureContent ? "On" : "Off"}
+        </span>
+        {saving && <span className="text-neutral-500">saving…</span>}
+        {savedFlash && <span className="text-emerald-400">Saved.</span>}
+      </div>
+    </section>
   );
 }
 

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -29,6 +29,7 @@ import {
   type HealthResponse,
   SERVER_THEME_COLOR_KEYS,
   type SandboxSettingsResponse,
+  type TelemetrySettingsResponse,
   type ServerThemeConfigResponse,
   type ServerThemeColors,
   type UiConfigResponse,
@@ -218,6 +219,8 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
   // builds kept orchestration behind an explicit opt-in flag.
   const orchestrationEnabled =
     typeof value.orchestrationEnabled === "boolean" ? value.orchestrationEnabled : false;
+  const telemetryCaptureContent =
+    typeof value.telemetryCaptureContent === "boolean" ? value.telemetryCaptureContent : false;
   const authBannerText =
     typeof value.authBannerText === "string" ? value.authBannerText : undefined;
   const authBannerHtml = typeof value.authBannerHtml === "boolean" ? value.authBannerHtml : false;
@@ -235,6 +238,7 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
     passwordAuthEnabled,
     ldapEnabled,
     orchestrationEnabled,
+    telemetryCaptureContent,
     serverTheme:
       value.serverTheme === undefined ? undefined : vServerThemeConfig(value.serverTheme, status),
     authBannerText,
@@ -245,6 +249,13 @@ function vUiConfig(value: unknown, status: number): UiConfigResponse {
     appLogoDarkUrl,
     appLogoLightUrl,
   };
+}
+
+function vTelemetrySettings(value: unknown, status: number): TelemetrySettingsResponse {
+  if (!isObject(value) || typeof value.captureContent !== "boolean") {
+    fail(status, "expected TelemetrySettingsResponse");
+  }
+  return { captureContent: value.captureContent };
 }
 
 function vSandboxSettings(value: unknown, status: number): SandboxSettingsResponse {
@@ -2018,6 +2029,12 @@ export const api = {
   updateSettings: (patch: Record<string, unknown>) =>
     request("/api/v1/config/settings", vSettings, { method: "PUT", body: patch }),
   getSandboxSettings: () => request("/api/v1/config/sandbox", vSandboxSettings),
+  getTelemetrySettings: () => request("/api/v1/config/telemetry", vTelemetrySettings),
+  updateTelemetrySettings: (captureContent: boolean) =>
+    request("/api/v1/config/telemetry", vTelemetrySettings, {
+      method: "PUT",
+      body: { captureContent },
+    }),
   updateSandboxSettings: (toolEnv: Record<string, string>) =>
     request("/api/v1/config/sandbox", vSandboxSettings, {
       method: "PUT",

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -297,6 +297,10 @@ export interface SandboxSettingsResponse {
   toolEnv: Record<string, string>;
 }
 
+export interface TelemetrySettingsResponse {
+  captureContent: boolean;
+}
+
 export interface AuthColorScheme {
   pageBackground: string;
   cardBackground: string;
@@ -334,6 +338,8 @@ export interface UiConfigResponse {
    * render at all. Defaults to false on older servers (forward-compatible).
    */
   orchestrationEnabled: boolean;
+  /** True when OpenTelemetry content capture is enabled at runtime. */
+  telemetryCaptureContent: boolean;
   /** Global server-side color overrides for broad UI surfaces. */
   serverTheme: ServerThemeConfigResponse | undefined;
   /** Optional public banner shown on the login screen. */

--- a/packages/client/src/store/ui-config-store.ts
+++ b/packages/client/src/store/ui-config-store.ts
@@ -44,6 +44,8 @@ interface UiConfigState {
    * expose the field keep the old hidden posture.
    */
   orchestrationEnabled: boolean;
+  /** True when OpenTelemetry content capture is enabled at runtime. */
+  telemetryCaptureContent: boolean;
   /** Global server-side color overrides for broad UI surfaces. */
   serverTheme: ServerThemeConfigResponse | undefined;
   /** Optional public banner shown below the login prompt. */
@@ -64,6 +66,7 @@ interface UiConfigState {
   error: string | undefined;
   load: () => Promise<void>;
   setServerTheme: (theme: ServerThemeConfigResponse) => void;
+  setTelemetryCaptureContent: (enabled: boolean) => void;
 }
 
 export const useUiConfigStore = create<UiConfigState>((set) => ({
@@ -74,6 +77,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
   passwordAuthEnabled: true,
   ldapEnabled: false,
   orchestrationEnabled: false,
+  telemetryCaptureContent: false,
   serverTheme: undefined,
   authBannerText: undefined,
   authBannerHtml: false,
@@ -87,6 +91,9 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
     applyServerTheme(theme);
     set({ serverTheme: theme });
   },
+  setTelemetryCaptureContent: (enabled) => {
+    set({ telemetryCaptureContent: enabled });
+  },
   load: async () => {
     try {
       const cfg = await api.uiConfig();
@@ -99,6 +106,7 @@ export const useUiConfigStore = create<UiConfigState>((set) => ({
         passwordAuthEnabled: cfg.passwordAuthEnabled,
         ldapEnabled: cfg.ldapEnabled,
         orchestrationEnabled: cfg.orchestrationEnabled,
+        telemetryCaptureContent: cfg.telemetryCaptureContent,
         serverTheme: cfg.serverTheme,
         authBannerText: cfg.authBannerText,
         authBannerHtml: cfg.authBannerHtml,

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -50,6 +50,7 @@ import {
   validateSandboxToolEnv,
   writeSandboxSettings,
 } from "../sandbox-settings.js";
+import { readTelemetrySettings, writeTelemetrySettings } from "../telemetry-settings.js";
 import {
   DEFAULT_THEME_COLORS,
   readThemeConfig,
@@ -99,6 +100,15 @@ const sandboxSettingsSchema = {
     gid: { type: "integer" },
     home: { type: "string" },
     toolEnv: { type: "object", additionalProperties: { type: "string" } },
+  },
+} as const;
+
+const telemetrySettingsSchema = {
+  type: "object",
+  required: ["captureContent"],
+  additionalProperties: false,
+  properties: {
+    captureContent: { type: "boolean" },
   },
 } as const;
 
@@ -453,6 +463,52 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
           home: config.agentToolSandbox.home,
           toolEnv: settings.toolEnv,
         };
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  // ---------------------- telemetry settings ----------------------
+  fastify.get(
+    "/config/telemetry",
+    {
+      schema: {
+        description:
+          "Read runtime telemetry settings. captureContent controls whether message/tool content is exported to OpenTelemetry.",
+        tags: ["config"],
+        response: { 200: telemetrySettingsSchema, 500: errorSchema },
+      },
+    },
+    async (_req, reply) => {
+      try {
+        return await readTelemetrySettings();
+      } catch (err) {
+        return internalError(reply, err);
+      }
+    },
+  );
+
+  fastify.put<{ Body: { captureContent: boolean } }>(
+    "/config/telemetry",
+    {
+      schema: {
+        description:
+          "Replace runtime telemetry settings. Enabling captureContent exports full message and tool content and may include sensitive data.",
+        tags: ["config"],
+        body: telemetrySettingsSchema,
+        response: { 200: telemetrySettingsSchema, 400: errorSchema, 500: errorSchema },
+      },
+    },
+    async (req, reply) => {
+      if (typeof req.body.captureContent !== "boolean") {
+        return reply.code(400).send({
+          error: "invalid_telemetry_settings",
+          message: "captureContent must be a boolean",
+        });
+      }
+      try {
+        return await writeTelemetrySettings({ captureContent: req.body.captureContent });
       } catch (err) {
         return internalError(reply, err);
       }

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -8,6 +8,7 @@ import { config, passwordAuthEnabled } from "../config.js";
 import { logoUrls } from "../logo-cache.js";
 import { isOrchestrationEnabled } from "../orchestration/config.js";
 import { DEFAULT_THEME_COLORS, readThemeConfig, THEME_COLOR_KEYS } from "../theme-config.js";
+import { readTelemetrySettings } from "../telemetry-settings.js";
 
 /**
  * Read the server's own package.json once at module load. Used by the
@@ -126,6 +127,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
               "passwordAuthEnabled",
               "ldapEnabled",
               "orchestrationEnabled",
+              "telemetryCaptureContent",
               "serverTheme",
               "authBannerHtml",
             ],
@@ -158,6 +160,8 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
               // by default, but false when disabled by instance config
               // OR when MINIMAL_UI is true (MINIMAL_UI is a hard gate).
               orchestrationEnabled: { type: "boolean" },
+              // True when OpenTelemetry content capture is enabled at runtime.
+              telemetryCaptureContent: { type: "boolean" },
               // Global server-side color overrides for broad UI surfaces.
               serverTheme: themeConfigSchema,
               // Public login-screen customization. Banner text and
@@ -199,6 +203,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async () => {
       const serverTheme = await readThemeConfig();
+      const telemetrySettings = await readTelemetrySettings();
       const logos = logoUrls();
       return {
         minimal: config.minimalUi,
@@ -207,6 +212,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
         passwordAuthEnabled: passwordAuthEnabled(),
         ldapEnabled: config.auth.ldap.enabled,
         orchestrationEnabled: isOrchestrationEnabled(),
+        telemetryCaptureContent: telemetrySettings.captureContent,
         serverTheme: { ...serverTheme, defaults: DEFAULT_THEME_COLORS },
         authBannerText: config.authBannerText,
         authBannerHtml: config.authBannerHtml,

--- a/packages/server/src/telemetry-settings.ts
+++ b/packages/server/src/telemetry-settings.ts
@@ -1,0 +1,77 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { config } from "./config.js";
+import { makeLock } from "./concurrency.js";
+
+const TELEMETRY_SETTINGS_FILE = (): string => join(config.forgeDataDir, "telemetry-settings.json");
+
+export interface TelemetrySettings {
+  captureContent: boolean;
+}
+
+const lock = makeLock();
+let captureContent = loadInitialCaptureContent();
+
+function normalizeCaptureContent(input: unknown): boolean | undefined {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return undefined;
+  const raw = (input as { captureContent?: unknown }).captureContent;
+  return typeof raw === "boolean" ? raw : undefined;
+}
+
+function loadInitialCaptureContent(): boolean {
+  const path = TELEMETRY_SETTINGS_FILE();
+  if (!existsSync(path)) return config.telemetry.captureContent;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    return normalizeCaptureContent(parsed) ?? config.telemetry.captureContent;
+  } catch {
+    return config.telemetry.captureContent;
+  }
+}
+
+async function ensureDataDir(): Promise<void> {
+  await mkdir(config.forgeDataDir, { recursive: true });
+}
+
+async function atomicWriteJson(path: string, data: unknown): Promise<void> {
+  await ensureDataDir();
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
+}
+
+export function isTelemetryContentCaptureEnabled(): boolean {
+  return captureContent;
+}
+
+export async function readTelemetrySettings(): Promise<TelemetrySettings> {
+  return lock(async () => {
+    try {
+      const raw = await readFile(TELEMETRY_SETTINGS_FILE(), "utf8");
+      const parsed = JSON.parse(raw) as unknown;
+      captureContent = normalizeCaptureContent(parsed) ?? config.telemetry.captureContent;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      captureContent = config.telemetry.captureContent;
+    }
+    return { captureContent };
+  });
+}
+
+export async function writeTelemetrySettings(
+  settings: TelemetrySettings,
+): Promise<TelemetrySettings> {
+  const safe: TelemetrySettings = { captureContent: settings.captureContent };
+  await lock(async () => {
+    await atomicWriteJson(TELEMETRY_SETTINGS_FILE(), safe);
+    captureContent = safe.captureContent;
+  });
+  return safe;
+}

--- a/packages/server/src/telemetry.ts
+++ b/packages/server/src/telemetry.ts
@@ -10,6 +10,7 @@ import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import { config } from "./config.js";
+import { isTelemetryContentCaptureEnabled } from "./telemetry-settings.js";
 
 const TRACER_NAME = "pi-forge.sessions";
 const MAX_CAPTURE_CHARS = 1_000_000;
@@ -323,7 +324,7 @@ export function createSessionTelemetry(opts: SessionTelemetryOptions): SessionTe
                     "gen_ai.request.model": model.id,
                     "langfuse.observation.model": model.id,
                   }),
-              ...(config.telemetry.captureContent && observationInput !== undefined
+              ...(isTelemetryContentCaptureEnabled() && observationInput !== undefined
                 ? { "langfuse.observation.input": stringify(observationInput) }
                 : {}),
             },
@@ -331,7 +332,7 @@ export function createSessionTelemetry(opts: SessionTelemetryOptions): SessionTe
           spanContext(turnSpan),
         );
         messageSpans.set(messageKey(event.message), span);
-        if (config.telemetry.captureContent && role === "user") {
+        if (isTelemetryContentCaptureEnabled() && role === "user") {
           turnSpan?.setAttribute(
             "langfuse.observation.input",
             stringify(messageContent(event.message)),
@@ -344,7 +345,7 @@ export function createSessionTelemetry(opts: SessionTelemetryOptions): SessionTe
         const role = messageRole(event.message);
         const span = messageSpans.get(messageKey(event.message));
         if (span === undefined) return;
-        if (config.telemetry.captureContent) {
+        if (isTelemetryContentCaptureEnabled()) {
           span.setAttribute(
             "langfuse.observation.output",
             stringify(messageContent(event.message)),
@@ -434,7 +435,7 @@ export function createSessionTelemetry(opts: SessionTelemetryOptions): SessionTe
               "gen_ai.operation.name": "execute_tool",
               "gen_ai.tool.name": event.toolName,
               "pi.tool.type": isMcp ? "mcp" : "builtin",
-              ...(config.telemetry.captureContent
+              ...(isTelemetryContentCaptureEnabled()
                 ? { "langfuse.observation.input": stringify(event.args) }
                 : {}),
             },
@@ -448,7 +449,7 @@ export function createSessionTelemetry(opts: SessionTelemetryOptions): SessionTe
       if (event.type === "tool_execution_end") {
         const span = toolSpans.get(event.toolCallId);
         if (span === undefined) return;
-        if (config.telemetry.captureContent) {
+        if (isTelemetryContentCaptureEnabled()) {
           span.setAttribute("langfuse.observation.output", stringify(event.result));
         }
         if (event.isError) span.setStatus({ code: SpanStatusCode.ERROR, message: "tool failed" });

--- a/tests/test-config.ts
+++ b/tests/test-config.ts
@@ -309,7 +309,37 @@ async function main(): Promise<void> {
       assert("null patch leaves defaultModel intact", m3.defaultModel === "claude-haiku-4-5");
     }
 
-    // 7. /config/skills — needs a real project (route validates projectId).
+    // 7. /config/telemetry — runtime OTEL content capture toggle.
+    {
+      const initial = await jget(base, "/api/v1/config/telemetry");
+      assert("GET /config/telemetry initial → 200", initial.status === 200);
+      assert(
+        "  captureContent defaults false",
+        (initial.body as { captureContent: boolean }).captureContent === false,
+      );
+
+      const enabled = await jsend(base, "PUT", "/api/v1/config/telemetry", {
+        captureContent: true,
+      });
+      assert("PUT /config/telemetry true → 200", enabled.status === 200);
+      assert(
+        "  body.captureContent === true",
+        (enabled.body as { captureContent: boolean }).captureContent === true,
+      );
+
+      const reloaded = await jget(base, "/api/v1/config/telemetry");
+      assert(
+        "GET /config/telemetry reflects persisted toggle",
+        (reloaded.body as { captureContent: boolean }).captureContent === true,
+      );
+
+      const bad = await jsend(base, "PUT", "/api/v1/config/telemetry", {
+        captureContent: "yes",
+      });
+      assert("PUT /config/telemetry rejects non-boolean", bad.status === 400);
+    }
+
+    // 8. /config/skills — needs a real project (route validates projectId).
     //    Create a project, then a project-local SKILL.md, then list +
     //    toggle.
     let projectId: string;

--- a/tests/test-telemetry.ts
+++ b/tests/test-telemetry.ts
@@ -28,6 +28,9 @@ try {
   const identities = (await import(
     resolve("packages/server/dist/session-identity.js")
   )) as typeof import("../packages/server/src/session-identity.js");
+  const telemetrySettings = (await import(
+    resolve("packages/server/dist/telemetry-settings.js")
+  )) as typeof import("../packages/server/src/telemetry-settings.js");
   const exporter = new InMemorySpanExporter();
   telemetry.initializeTelemetry(exporter);
 
@@ -196,6 +199,42 @@ try {
       userMessage?.spanContext().traceId === turn.spanContext().traceId,
   );
 
+  await telemetrySettings.writeTelemetrySettings({ captureContent: false });
+  assert(
+    "runtime telemetry setting can disable content capture",
+    telemetrySettings.isTelemetryContentCaptureEnabled() === false,
+  );
+  const redactedTracker = telemetry.createSessionTelemetry({
+    sessionId: "session-redacted",
+    projectId: "project-456",
+    username: "alice@example.com",
+    mcpToolNames: new Set(),
+    model: () => ({ provider: "anthropic", id: "claude-test" }),
+  });
+  const emitRedacted = (event: unknown): void => redactedTracker.handle(event as AgentSessionEvent);
+  emitRedacted({ type: "agent_start" });
+  emitRedacted({
+    type: "message_start",
+    message: { role: "user", content: "do not capture", timestamp: 3 },
+  });
+  emitRedacted({
+    type: "message_end",
+    message: { role: "user", content: "do not capture", timestamp: 3 },
+  });
+  emitRedacted({ type: "agent_end", messages: [] });
+  await telemetry.flushTelemetry();
+  const redactedUser = exporter
+    .getFinishedSpans()
+    .filter(
+      (span) => span.attributes["langfuse.session.id"] === "alice@example.com:session-redacted",
+    )
+    .find((span) => span.name === "pi.message.user");
+  assert(
+    "content capture excludes user data when disabled at runtime",
+    redactedUser !== undefined &&
+      redactedUser.attributes["langfuse.observation.input"] === undefined,
+  );
+
   await identities.rememberSessionUsername("session-123", "alice@example.com");
   assert(
     "session username survives identity lookup",
@@ -205,6 +244,21 @@ try {
     await readFile(resolve(temp, "session-users.json"), "utf8"),
   ) as Record<string, string>;
   assert("session username is persisted", persisted["session-123"] === "alice@example.com");
+
+  const appSource = await readFile(resolve("packages/client/src/App.tsx"), "utf8");
+  assert(
+    "app banner warns when telemetry content capture is on",
+    appSource.includes("OTEL content capture on"),
+  );
+  const chatInputSource = await readFile(
+    resolve("packages/client/src/components/ChatInput.tsx"),
+    "utf8",
+  );
+  assert(
+    "chat input requires telemetry capture acknowledgement",
+    chatInputSource.includes("I acknowledge that this message") &&
+      chatInputSource.includes("Confirm telemetry content capture before sending"),
+  );
 } finally {
   await rm(temp, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

Adds a runtime setting for `OTEL_CAPTURE_CONTENT` so operators can enable or disable telemetry content capture from the browser Settings pane, including sandbox deployments. When capture content is enabled, the app header shows a red warning pill and chat submission requires the user to check an acknowledgement box before sending message content.

## Usage

Start with content capture disabled (default or explicit):

```bash
OTEL_CAPTURE_CONTENT=false npm run dev:remote
```

Then open Settings → General → Telemetry content capture and toggle **Include message and tool content in telemetry**. The setting persists in `FORGE_DATA_DIR/telemetry-settings.json` and overrides the startup env default at runtime.

## What changed

- `packages/server/src/telemetry-settings.ts` — new atomic persisted runtime setting for telemetry content capture.
- `packages/server/src/routes/config.ts` — adds `GET/PUT /api/v1/config/telemetry`.
- `packages/server/src/routes/health.ts` — exposes current capture state through `/api/v1/ui-config`.
- `packages/server/src/telemetry.ts` — reads the runtime toggle when deciding whether to attach message/tool content to spans.
- `packages/client/src/components/SettingsPanel.tsx` — adds Settings → General telemetry capture toggle and warning copy.
- `packages/client/src/App.tsx` — shows a red header pill while capture content is enabled.
- `packages/client/src/components/ChatInput.tsx` — requires acknowledgement checkbox before prompt/steer submission when capture content is enabled.
- `packages/client/src/lib/api-client/*` and `packages/client/src/store/ui-config-store.ts` — client API/types/store wiring for the new setting.
- `docs/configuration.md`, `docs/agent/config.md` — documents the persisted runtime override.
- `tests/test-config.ts`, `tests/test-telemetry.ts` — route/runtime behavior and UI-source assertions.

## Test plan

- [x] `npm run format`
- [x] `npm run build`
- [x] `NODE_OPTIONS=--max-old-space-size=4096 npm run check`
- [x] `npx tsx tests/test-config.ts`
- [x] `npx tsx tests/test-telemetry.ts`
- [x] `npx tsx tests/test-sandbox-settings.ts`
- [x] `npm run test:ci` — all 57 tests passed
- [x] Manual: started `OTEL_CAPTURE_CONTENT=false npm run dev:remote`, enabled capture content from Settings, verified warning pill and submit acknowledgement behavior in browser
