### PR TITLE
chore: bump pi SDK packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@earendil-works/pi-agent-core": "0.84.3",
+        "@earendil-works/pi-ai": "0.84.3",
+        "@earendil-works/pi-coding-agent": "0.84.3",
         "@eslint/js": "^10.0.1",
         "@types/node": "^26.0.0",
         "concurrently": "^10.0.0",
@@ -2266,14 +2269,16 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
-      "integrity": "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg==",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.3.tgz",
+      "integrity": "sha512-VURr+xBRl3RxYcw3kT9Pn3yfi6LbRoCJgHF7h1mAblMjtLNV/MfG/RyF0uJizBAM886AEakSiw3j9c/aSngppg==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-telemetry": "^0.84.3",
+        "diff": "8.0.4",
         "ignore": "7.0.5",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "yaml": "2.9.0"
       },
       "engines": {
@@ -2290,22 +2295,21 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
-      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.3.tgz",
+      "integrity": "sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.3",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -2315,20 +2319,22 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
-      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.3.tgz",
+      "integrity": "sha512-Yr2p9PubrbFZmYEPYI+C8KmZP9xlFuLDnAG64RtU0ZDgrdiXYWa+y7WGyJO5OlqPliOkVCMd9IzVszO3/t0D0w==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.10",
-        "@earendil-works/pi-ai": "^0.80.10",
-        "@earendil-works/pi-tui": "^0.80.10",
+        "@earendil-works/pi-agent-core": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-client": "^0.84.3",
+        "@earendil-works/pi-protocol": "^0.84.3",
+        "@earendil-works/pi-tui": "^0.84.3",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
         "diff": "8.0.4",
-        "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
         "highlight.js": "10.7.3",
         "hosted-git-info": "9.0.3",
         "ignore": "7.0.5",
@@ -2336,12 +2342,12 @@
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
         "semver": "7.8.0",
-        "typebox": "1.1.38",
-        "undici": "8.5.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
         "yaml": "2.9.0"
       },
       "bin": {
-        "pi": "dist/cli.js"
+        "pi": "dist/bundle/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2786,13 +2792,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.3.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-telemetry": "^0.84.3",
+        "diff": "8.0.4",
         "ignore": "7.0.5",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "yaml": "2.9.0"
       },
       "engines": {
@@ -2800,21 +2808,20 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.3.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.3",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -2823,9 +2830,39 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.3.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.3"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.3.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.3.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.3.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -3038,26 +3075,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -3069,24 +3086,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -3334,15 +3333,15 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
@@ -3539,23 +3538,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
       "version": "10.6.2",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
@@ -3587,6 +3569,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
       "version": "10.7.3",
@@ -3744,15 +3735,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3798,13 +3780,10 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -3867,22 +3846,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -3904,9 +3867,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4019,15 +3982,15 @@
       "license": "0BSD"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -4114,22 +4077,13 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.3.tgz",
+      "integrity": "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g==",
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -5458,26 +5412,6 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
-    },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -8967,6 +8901,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-match-patch": {
@@ -13659,13 +13602,10 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -15911,9 +15851,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "license": "MIT"
     },
     "node_modules/typed-array-buffer": {
@@ -17364,9 +17304,9 @@
       "name": "@pi-forge/server",
       "version": "1.5.2",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "0.80.10",
-        "@earendil-works/pi-ai": "0.80.10",
-        "@earendil-works/pi-coding-agent": "0.80.10",
+        "@earendil-works/pi-agent-core": "0.84.3",
+        "@earendil-works/pi-ai": "0.84.3",
+        "@earendil-works/pi-coding-agent": "0.84.3",
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^10.0.0",
         "@fastify/rate-limit": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "uuid": ">=11.1.1"
   },
   "devDependencies": {
+    "@earendil-works/pi-agent-core": "0.84.3",
+    "@earendil-works/pi-ai": "0.84.3",
+    "@earendil-works/pi-coding-agent": "0.84.3",
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.0.0",
     "concurrently": "^10.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,9 +9,9 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.80.10",
-    "@earendil-works/pi-ai": "0.80.10",
-    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-agent-core": "0.84.3",
+    "@earendil-works/pi-ai": "0.84.3",
+    "@earendil-works/pi-coding-agent": "0.84.3",
     "@fastify/cors": "^11.0.1",
     "@fastify/multipart": "^10.0.0",
     "@fastify/rate-limit": "^11.0.0",

--- a/packages/server/src/routes/control.ts
+++ b/packages/server/src/routes/control.ts
@@ -563,7 +563,7 @@ export const controlRoutes: FastifyPluginAsync = async (fastify) => {
           // auth.json + models.json at session-create time; refresh it before
           // calling setModel so providers, models, and credentials added after
           // session creation are visible without restarting the session.
-          await live.session.modelRuntime.reloadConfig();
+          await live.session.modelRuntime.refresh();
           await syncStoredApiKeyToRuntime(live.session.modelRuntime, req.body.provider);
           await live.session.modelRuntime.refresh();
           // Wrap in withTimeout so a hung SDK setModel can't hold the

--- a/packages/server/src/routes/prompt.ts
+++ b/packages/server/src/routes/prompt.ts
@@ -369,7 +369,7 @@ async function validateModelForPrompt(live: LiveSession, reply: FastifyReply): P
     });
     return false;
   }
-  await live.session.modelRuntime.reloadConfig();
+  await live.session.modelRuntime.refresh();
   await syncStoredApiKeyToRuntime(live.session.modelRuntime, model.provider);
   if (!live.session.modelRuntime.hasConfiguredAuth(model.provider)) {
     await reply.code(400).send({

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -215,12 +215,12 @@ function publishActivity(
 /**
  * Built-in pi tools we activate on every session. Pi's SDK ships
  * seven `read | bash | edit | write | grep | find | ls` (see
- * `node_modules/@earendil-works/pi-coding-agent/dist/core/tools/index.d.ts`),
- * but only the first four are activated when `tools` is left
- * undefined. We enable all seven so the agent gets first-class
- * filesystem-read affordances (grep / find / ls) instead of
- * shelling out via bash for every directory listing or content
- * search — same UX the pi TUI ships with.
+ * `node_modules/@earendil-works/pi-coding-agent/dist/core/tools/index.d.ts`).
+ * SDK 0.84 also ships an optional Windows-only `powershell` tool, but
+ * pi-forge runs on Linux and intentionally does not expose it. We enable
+ * the Linux-compatible set so the agent gets first-class filesystem-read
+ * affordances (grep / find / ls) instead of shelling out via bash for every
+ * directory listing or content search — same UX the pi TUI ships with.
  *
  * Passing `tools: [...]` to `createAgentSession` ALSO filters
  * customTools (MCP) by name (see agent-session.js

--- a/tests/test-attachments.ts
+++ b/tests/test-attachments.ts
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
         prompt: (text: string, opts?: unknown) => Promise<void>;
         model: unknown;
         modelRuntime: {
-          reloadConfig: () => Promise<void>;
+          refresh: () => Promise<void>;
           setRuntimeApiKey: (provider: string, apiKey: string) => Promise<void>;
           removeRuntimeApiKey: (provider: string) => Promise<void>;
           hasConfiguredAuth: (provider: string) => boolean;
@@ -113,7 +113,7 @@ async function main(): Promise<void> {
     const fakeSession = {
       model: { provider: "test", id: "test-model" },
       modelRuntime: {
-        reloadConfig: async () => undefined,
+        refresh: async () => undefined,
         setRuntimeApiKey: async () => undefined,
         removeRuntimeApiKey: async () => undefined,
         hasConfiguredAuth: () => true,

--- a/tests/test-skill-commands.ts
+++ b/tests/test-skill-commands.ts
@@ -109,13 +109,13 @@ async function main(): Promise<void> {
 
     let promptText: string | undefined;
     let promptCalls = 0;
-    let reloadCalls = 0;
+    let refreshCalls = 0;
     const runtimeKeys: string[] = [];
     const fakeSession = {
       model: { provider: "test", id: "test-model" },
       modelRuntime: {
-        reloadConfig: async () => {
-          reloadCalls += 1;
+        refresh: async () => {
+          refreshCalls += 1;
         },
         setRuntimeApiKey: async (provider: string, apiKey: string) => {
           runtimeKeys.push(`${provider}:${apiKey}`);
@@ -150,8 +150,8 @@ async function main(): Promise<void> {
     );
     assert(
       "skill prompt runs normal runtime-auth preflight",
-      reloadCalls === 1 && runtimeKeys.includes("test:skill-test-key"),
-      JSON.stringify({ reloadCalls, runtimeKeys }),
+      refreshCalls === 1 && runtimeKeys.includes("test:skill-test-key"),
+      JSON.stringify({ refreshCalls, runtimeKeys }),
     );
     assert(
       "skill arguments forward through SDK-native slash command",

--- a/tests/test-tool-overrides.ts
+++ b/tests/test-tool-overrides.ts
@@ -116,10 +116,11 @@ async function main(): Promise<void> {
         builtin: { name: string; enabled: boolean }[];
         mcp: unknown[];
       };
-      // 7 SDK builtins + ask_user_question + todo + process (all three
-      // implemented in pi-forge but surfaced under "Built-in tools"
-      // so users can disable them from Settings → Tools). See
-      // packages/server/src/session-registry.ts BUILTIN_TOOL_NAMES.
+      // 7 Linux-compatible SDK builtins + ask_user_question + todo + process
+      // (all three implemented in pi-forge but surfaced under "Built-in tools"
+      // so users can disable them from Settings → Tools). The SDK also has an
+      // optional Windows-only powershell tool, intentionally not surfaced here.
+      // See packages/server/src/session-registry.ts BUILTIN_TOOL_NAMES.
       assert(
         "  ten builtins listed",
         body.builtin.length === 10,


### PR DESCRIPTION
## Summary

Bumps the pi SDK package trio used by the server from `0.80.10` to `0.84.3` and updates pi-forge for the small compatibility surface exposed by the newer SDK. The main API change affecting pi-forge is that live session model config refresh now uses `ModelRuntime.refresh()` instead of the removed `reloadConfig()` helper.

CI also typechecks root-level integration tests that import SDK types directly, so the SDK trio is declared at the root as dev dependencies in addition to the server runtime dependencies.

## Usage

No operator-facing usage changes. Existing sessions, prompts, model switching, MCP tools, and built-in Linux tools continue to work after reinstalling dependencies:

```bash
npm install
npm run build
```

The SDK's new optional Windows `powershell` tool is intentionally not surfaced by pi-forge because this app runs on Linux.

## What changed

- `package.json` / `package-lock.json` — add root dev dependencies for SDK packages used by integration-test type imports.
- `packages/server/package.json` / `package-lock.json` — bump `@earendil-works/pi-coding-agent`, `@earendil-works/pi-agent-core`, and `@earendil-works/pi-ai` from `0.80.10` to `0.84.3`.
- `packages/server/src/routes/control.ts` — refresh live session model runtime with `refresh()` before session-scoped model changes.
- `packages/server/src/routes/prompt.ts` — refresh live session model runtime with `refresh()` during prompt auth/model preflight.
- `packages/server/src/session-registry.ts` — document that the SDK exposes optional `powershell`, but keep pi-forge's Linux built-in allowlist unchanged.
- `tests/test-attachments.ts` / `tests/test-skill-commands.ts` — update fake model runtime stubs for the new refresh API.
- `tests/test-tool-overrides.ts` — keep the Tools settings expectation at the Linux-compatible built-in set and assert `powershell` remains absent.

## Test plan

- [x] `npm install --include=dev`
- [x] `npm run format`
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run test:ci` — all 57 tests passed
- [x] `npx tsx tests/test-tool-overrides.ts`
- [x] Manual: tested built-in tools, messages, MCP tool, and broader app flows after the bump
