### PR TITLE
chore(release): v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.5.3] — 2026-08-26
+
+### Added
+
+- **Configurable web UI branding.** Operators can customize the browser title, install/offline app name, and sidebar/header brand label through server configuration exposed safely to the client.
+- **Runtime OTEL content capture controls.** Administrators can inspect and toggle OpenTelemetry content-capture settings at runtime from the settings UI and config API, with health/config endpoints reporting the effective state.
+
+### Changed
+
+- **Dependency updates for v1.5.3.** Updated the pinned pi SDK trio to 0.84.3 and adjusted session/tool integrations for the refreshed SDK behavior.
+
 ## [1.5.2] — 2026-08-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "workspaces": [
         "packages/*"
       ],
@@ -17230,7 +17230,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17302,7 +17302,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.84.3",
         "@earendil-works/pi-ai": "0.84.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the v1.5.3 release bump from current `main`. This updates the workspace package versions in lockstep and rolls the changelog forward with release notes generated from changes since v1.5.2.

This PR intentionally does not include the separate vulnerability-fix branch/worktree.

## Usage

No direct user-facing usage change. After merge, tag from `main`:

```bash
git checkout main && git pull --ff-only
git tag v1.5.3
git push origin v1.5.3
```

## What changed (5 files, +18/-7)

- `CHANGELOG.md` — added the `## [1.5.3] — 2026-08-26` release heading and notes.
- `package.json` — bumped root package version to `1.5.3`.
- `packages/client/package.json` — bumped client package version to `1.5.3`.
- `packages/server/package.json` — bumped server package version to `1.5.3`.
- `package-lock.json` — refreshed lockfile package version metadata only.

## Test plan

- [x] `npm install --include=dev`
- [x] `npx npm@latest approve-scripts --allow-scripts-pending`
- [x] `npm run format`
- [x] `npm run build`
- [x] `npm run check`
- [x] `npx tsx tests/test-publish-package.ts`
- [x] `git diff --cached --check`
- [ ] CI green before merge
