### PR TITLE
fix: avoid auth file reads in sandbox model runtime

### DIFF
--- a/packages/server/src/config-manager.ts
+++ b/packages/server/src/config-manager.ts
@@ -15,7 +15,10 @@ import {
 import {
   getSupportedThinkingLevels,
   type Api,
+  type AuthOperationOptions,
   type Credential,
+  type CredentialInfo,
+  type CredentialStore,
   type Model,
   type ModelThinkingLevel,
 } from "@earendil-works/pi-ai";
@@ -346,13 +349,85 @@ async function readAuthJson(): Promise<AuthJson> {
   return data as AuthJson;
 }
 
+async function readAuthJsonForSession(): Promise<AuthJson> {
+  try {
+    return await readAuthJson();
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EACCES" || code === "EPERM") {
+      console.warn(
+        `[config] ${AUTH_FILE()} is not readable; continuing session model runtime without auth.json credentials`,
+      );
+      return {};
+    }
+    throw err;
+  }
+}
+
 async function writeAuthJson(data: AuthJson): Promise<void> {
   await atomicWriteJson(AUTH_FILE(), data);
 }
 
 async function liveModelRuntime(): Promise<ModelRuntime> {
   await migrateLegacyModelsJsonIfNeeded();
-  return ModelRuntime.create({ authPath: AUTH_FILE(), modelsPath: MODELS_FILE() });
+  return ModelRuntime.create({
+    credentials: new SnapshotCredentialStore(await readAuthJsonForSession()),
+    modelsPath: MODELS_FILE(),
+  });
+}
+
+class SnapshotCredentialStore implements CredentialStore {
+  private readonly credentials: Map<string, Credential>;
+
+  constructor(data: AuthJson) {
+    this.credentials = new Map(Object.entries(data));
+  }
+
+  async read(providerId: string, _options?: AuthOperationOptions): Promise<Credential | undefined> {
+    return this.credentials.get(providerId);
+  }
+
+  async list(_options?: AuthOperationOptions): Promise<readonly CredentialInfo[]> {
+    return Array.from(this.credentials.entries()).map(([providerId, credential]) => ({
+      providerId,
+      type: credential.type,
+    }));
+  }
+
+  async modify(
+    providerId: string,
+    fn: (current: Credential | undefined) => Promise<Credential | undefined>,
+    _options?: AuthOperationOptions,
+  ): Promise<Credential | undefined> {
+    const next = await fn(this.credentials.get(providerId));
+    if (next !== undefined) this.credentials.set(providerId, next);
+    return next;
+  }
+
+  async delete(providerId: string, _options?: AuthOperationOptions): Promise<void> {
+    this.credentials.delete(providerId);
+  }
+}
+
+/**
+ * Create a session-scoped ModelRuntime from config files the server reads up
+ * front, without leaving the SDK on its default file-backed auth store.
+ *
+ * This matters in sandbox mode: `${PI_CONFIG_DIR}/auth.json`, `models.json`,
+ * and `settings.json` can intentionally stay unreadable to the lower-privileged
+ * tool identity, while the server process reads config and brokers model
+ * requests. Recent SDK/runtime paths may resolve request auth lazily during a
+ * model turn; a file-backed auth store can therefore surface EACCES from the hot
+ * model path even when credentials live in `models.json`. Sessions only need the
+ * auth.json credentials as they existed at creation/resume time, and config
+ * routes remain the owner of persistent auth.json writes.
+ */
+export async function createSessionModelRuntime(): Promise<ModelRuntime> {
+  await migrateLegacyModelsJsonIfNeeded();
+  return ModelRuntime.create({
+    credentials: new SnapshotCredentialStore(await readAuthJsonForSession()),
+    modelsPath: MODELS_FILE(),
+  });
 }
 
 /**

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -16,9 +16,9 @@ import { createSandboxedToolDefinitions } from "./agent-tool-overrides.js";
 import { config } from "./config.js";
 import { makeDedupe, makeLock } from "./concurrency.js";
 import {
+  createSessionModelRuntime,
   effectivePromptsForProject,
   effectiveSkillsForProject,
-  migrateLegacyModelsJsonIfNeeded,
 } from "./config-manager.js";
 import { readProjects } from "./project-manager.js";
 import { filterEnabledTools, readToolOverrides } from "./tool-overrides.js";
@@ -858,12 +858,13 @@ export async function createSession(
     settingsManager,
     projectId,
   );
-  await migrateLegacyModelsJsonIfNeeded();
+  const modelRuntime = await createSessionModelRuntime();
   const { session } = await createAgentSession({
     cwd: workspacePath,
     sessionManager,
     settingsManager,
     resourceLoader,
+    modelRuntime,
     agentDir: config.piConfigDir,
     customTools: effectiveCustomTools,
     tools: await buildToolsAllowlist(effectiveCustomTools, projectId, workspacePath),
@@ -1224,12 +1225,13 @@ export async function resumeSession(
       settingsManager,
       projectId,
     );
-    await migrateLegacyModelsJsonIfNeeded();
+    const modelRuntime = await createSessionModelRuntime();
     const { session } = await createAgentSession({
       cwd: workspacePath,
       sessionManager,
       settingsManager,
       resourceLoader,
+      modelRuntime,
       agentDir: config.piConfigDir,
       customTools: effectiveCustomTools,
       tools: await buildToolsAllowlist(effectiveCustomTools, projectId, workspacePath),
@@ -1939,12 +1941,13 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
     settingsManager,
     source.projectId,
   );
-  await migrateLegacyModelsJsonIfNeeded();
+  const modelRuntime = await createSessionModelRuntime();
   const { session } = await createAgentSession({
     cwd: source.workspacePath,
     sessionManager,
     settingsManager,
     resourceLoader,
+    modelRuntime,
     agentDir: config.piConfigDir,
     customTools: effectiveCustomTools,
     tools: await buildToolsAllowlist(effectiveCustomTools, source.projectId, source.workspacePath),
@@ -2060,12 +2063,13 @@ async function forkSessionLocked(sessionId: string, entryId: string): Promise<Li
         restoredSettingsManager,
         source.projectId,
       );
-      await migrateLegacyModelsJsonIfNeeded();
+      const restoredModelRuntime = await createSessionModelRuntime();
       const { session: restoredSession } = await createAgentSession({
         cwd: source.workspacePath,
         sessionManager: restoredManager,
         settingsManager: restoredSettingsManager,
         resourceLoader: restoredResourceLoader,
+        modelRuntime: restoredModelRuntime,
         agentDir: config.piConfigDir,
         customTools: restoredEffectiveCustomTools,
         tools: await buildToolsAllowlist(
@@ -2193,12 +2197,13 @@ export async function rebuildAgentSessionForTools(
     settingsManager,
     live.projectId,
   );
-  await migrateLegacyModelsJsonIfNeeded();
+  const modelRuntime = await createSessionModelRuntime();
   const { session: newSession } = await createAgentSession({
     cwd: live.workspacePath,
     sessionManager,
     settingsManager,
     resourceLoader,
+    modelRuntime,
     agentDir: config.piConfigDir,
     customTools: effectiveCustomTools,
     tools: await buildToolsAllowlist(effectiveCustomTools, live.projectId, live.workspacePath),


### PR DESCRIPTION
## Summary

Sandbox mode intentionally keeps pi SDK config files such as `${PI_CONFIG_DIR}/auth.json`, `models.json`, and `settings.json` protected from the lower-privileged tool identity. In newer pi SDK model-runtime paths, the default file-backed credential store can still lazily touch `auth.json` during model/runtime auth resolution. That can fail with:

```text
EACCES: permission denied, open '/home/pi/.pi/auth.json'
```

This PR keeps session/provider model runtimes from using the SDK default file-backed `auth.json` store. pi-forge now snapshots readable `auth.json` credentials up front; if `auth.json` is unreadable, it treats it as empty for session runtime purposes while still consuming provider config and inline `apiKey` values from `models.json`.

## Usage

No operator-facing config changes are required. Existing sandbox deployments with provider credentials in `models.json` should continue to work even when `auth.json` is not readable by the sandbox/tool identity.

## What changed (2 files, +87/-7)

- `packages/server/src/config-manager.ts` — added a `CredentialStore` snapshot implementation for session/provider model runtimes and tolerant `EACCES`/`EPERM` handling for unreadable `auth.json`.
- `packages/server/src/session-registry.ts` — wires every `createAgentSession()` path through the session-scoped model runtime instead of letting the SDK construct its default file-backed auth store.

## Test plan

- [x] `npx tsc -p packages/server/tsconfig.json --noEmit`
- [x] `npx eslint packages/server/src/config-manager.ts packages/server/src/session-registry.ts`
- [x] `npx prettier --check packages/server/src/config-manager.ts packages/server/src/session-registry.ts`
- [x] `npm -w @pi-forge/server run build`
- [x] Manual inline repro: unreadable `auth.json` + readable `models.json` no longer fails session/provider runtime creation
- [x] `npx tsx tests/test-agent-tool-sandbox.ts`
- [ ] CI green before merge
