### PR TITLE
fix: tolerate unreadable auth summary

### DIFF
--- a/packages/server/src/config-manager.ts
+++ b/packages/server/src/config-manager.ts
@@ -349,15 +349,13 @@ async function readAuthJson(): Promise<AuthJson> {
   return data as AuthJson;
 }
 
-async function readAuthJsonForSession(): Promise<AuthJson> {
+async function readAuthJsonIfReadable(): Promise<AuthJson> {
   try {
     return await readAuthJson();
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "EACCES" || code === "EPERM") {
-      console.warn(
-        `[config] ${AUTH_FILE()} is not readable; continuing session model runtime without auth.json credentials`,
-      );
+      console.warn(`[config] ${AUTH_FILE()} is not readable; treating auth.json as empty`);
       return {};
     }
     throw err;
@@ -371,7 +369,7 @@ async function writeAuthJson(data: AuthJson): Promise<void> {
 async function liveModelRuntime(): Promise<ModelRuntime> {
   await migrateLegacyModelsJsonIfNeeded();
   return ModelRuntime.create({
-    credentials: new SnapshotCredentialStore(await readAuthJsonForSession()),
+    credentials: new SnapshotCredentialStore(await readAuthJsonIfReadable()),
     modelsPath: MODELS_FILE(),
   });
 }
@@ -425,7 +423,7 @@ class SnapshotCredentialStore implements CredentialStore {
 export async function createSessionModelRuntime(): Promise<ModelRuntime> {
   await migrateLegacyModelsJsonIfNeeded();
   return ModelRuntime.create({
-    credentials: new SnapshotCredentialStore(await readAuthJsonForSession()),
+    credentials: new SnapshotCredentialStore(await readAuthJsonIfReadable()),
     modelsPath: MODELS_FILE(),
   });
 }
@@ -444,7 +442,7 @@ export async function liveModelRegistry(): Promise<ModelRegistry> {
 
 export async function readAuthSummary(): Promise<AuthSummary> {
   const providers: Record<string, AuthEntry> = {};
-  for (const [provider, credential] of Object.entries(await readAuthJson())) {
+  for (const [provider, credential] of Object.entries(await readAuthJsonIfReadable())) {
     providers[provider] = {
       configured: true,
       source: "stored",
@@ -481,7 +479,7 @@ export async function syncStoredApiKeyToRuntime(
   runtime: ModelRuntimeInstance,
   provider: string,
 ): Promise<void> {
-  const credential = (await readAuthJson())[provider];
+  const credential = (await readAuthJsonIfReadable())[provider];
   if (credential?.type === "api_key" && typeof credential.key === "string") {
     await runtime.setRuntimeApiKey(provider, credential.key);
   } else {


### PR DESCRIPTION
## Summary

Follow-up to #420. The Providers settings tab loads both `/config/providers` and `/config/auth` in one `Promise.all`. #420 fixed the model/provider runtime path, but `/config/auth` still read `${PI_CONFIG_DIR}/auth.json` directly for the presence-only summary. In sandbox deployments where that file is intentionally unreadable, the tab could still show the same fetch failure:

```text
EACCES: permission denied, open '/home/pi/.pi/agent/auth.json'
```

This PR extends the best-effort unreadable-auth behavior to the presence summary and the set-model runtime sync path. If `auth.json` is unreadable, pi-forge treats it as empty for read/runtime purposes while continuing to use provider credentials from readable `models.json`.

## Usage

No config changes required. Sandbox deployments can keep `${PI_CONFIG_DIR}/auth.json` protected. Providers configured with inline `apiKey` in `models.json` should still list and connect.

## What changed (1 file, +6/-8)

- `packages/server/src/config-manager.ts` — generalizes the unreadable-auth helper, uses it for `readAuthSummary()`, and avoids failing `syncStoredApiKeyToRuntime()` when `auth.json` is protected.

## Test plan

- [x] `npx tsc -p packages/server/tsconfig.json --noEmit`
- [x] `npx eslint packages/server/src/config-manager.ts`
- [x] `npx prettier --check packages/server/src/config-manager.ts`
- [x] `npm -w @pi-forge/server run build`
- [x] Manual inline repro: chmod `000` auth.json, then verify `createSessionModelRuntime()`, `liveProvidersListing()`, and `readAuthSummary()` all complete
- [ ] CI green before merge
