### PR TITLE
fix: correct tool batch child error status

### DIFF
--- a/packages/client/src/components/ChatView.tsx
+++ b/packages/client/src/components/ChatView.tsx
@@ -47,6 +47,7 @@ import { QuickActionRunCard } from "./QuickActionRunCard";
 import { useQuickActionRunsStore, type QuickActionRun } from "../store/quick-actions-store";
 import { placeChatTimelineItems, type ChatTimelinePosition } from "../lib/chat-timeline";
 import { parseSubagentDetails, type SubagentResult } from "../lib/subagent-parser";
+import { getToolBatchStatus } from "../lib/tool-call-batch-status";
 import { OrchestrationPanel } from "./OrchestrationPanel";
 import { useUiConfigStore } from "../store/ui-config-store";
 import {
@@ -1861,14 +1862,15 @@ function toolPreviewFromArgs(name: string, args: unknown): string | undefined {
 function ToolCallBatchCard({ entries }: { entries: ToolBatchEntry[] }) {
   const toolEntries = entries.filter((entry) => entry.kind === "tool");
   const toolCount = toolEntries.length;
-  const inFlight = toolEntries.filter((e) => e.result === undefined).length;
-  const errored = toolEntries.some((e) => e.result?.isError === true);
+  const { inFlightCount, failedChildCount, hasChildFailures, hasAggregateError } =
+    getToolBatchStatus(toolEntries);
   const counts = new Map<string, number>();
   for (const e of toolEntries) {
     const name = String(e.block.name ?? "tool");
     counts.set(name, (counts.get(name) ?? 0) + 1);
   }
   const countSummary = [...counts].map(([name, count]) => `${name} ×${count}`).join(" · ");
+  const failedChildLabel = `${failedChildCount} ${failedChildCount === 1 ? "child" : "children"} failed`;
   const previews = toolEntries
     .map((e) => {
       const name = String(e.block.name ?? "tool");
@@ -1897,12 +1899,20 @@ function ToolCallBatchCard({ entries }: { entries: ToolBatchEntry[] }) {
           )}
         </span>
         <div className="flex shrink-0 items-center gap-1 self-start sm:self-auto">
-          {inFlight > 0 && (
+          {inFlightCount > 0 && (
             <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-neutral-400">
-              {inFlight} running…
+              {inFlightCount} running…
             </span>
           )}
-          {errored && (
+          {hasChildFailures && (
+            <span
+              className="rounded bg-amber-900/30 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-amber-300 light:bg-amber-100 light:text-amber-800"
+              title="One or more child tool calls failed; expand the batch to see the failed call."
+            >
+              {failedChildLabel}
+            </span>
+          )}
+          {hasAggregateError && (
             <span className="rounded bg-red-900/30 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-red-300 light:bg-red-100 light:text-red-800">
               error
             </span>

--- a/packages/client/src/lib/tool-call-batch-status.ts
+++ b/packages/client/src/lib/tool-call-batch-status.ts
@@ -1,0 +1,36 @@
+export interface ToolBatchStatusInput {
+  result: unknown | undefined;
+}
+
+export interface ToolBatchStatus {
+  inFlightCount: number;
+  failedChildCount: number;
+  hasChildFailures: boolean;
+  /**
+   * True only for failures that belong to the aggregate container itself.
+   * Individual child tool failures must not promote the whole batch to an
+   * errored state; callers should surface them separately with child-oriented
+   * copy and keep each child row responsible for its own error styling.
+   */
+  hasAggregateError: boolean;
+}
+
+export function getToolBatchStatus(
+  entries: ToolBatchStatusInput[],
+  options: { aggregateError?: boolean } = {},
+): ToolBatchStatus {
+  const inFlightCount = entries.filter((entry) => entry.result === undefined).length;
+  const failedChildCount = entries.filter((entry) => isErrorResult(entry.result)).length;
+  return {
+    inFlightCount,
+    failedChildCount,
+    hasChildFailures: failedChildCount > 0,
+    hasAggregateError: options.aggregateError === true,
+  };
+}
+
+function isErrorResult(result: unknown): boolean {
+  return (
+    typeof result === "object" && result !== null && "isError" in result && result.isError === true
+  );
+}

--- a/tests/test-tool-call-batch-status.ts
+++ b/tests/test-tool-call-batch-status.ts
@@ -1,0 +1,54 @@
+import { getToolBatchStatus } from "../packages/client/src/lib/tool-call-batch-status";
+
+let failures = 0;
+function assert(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`PASS ${label}`);
+    return;
+  }
+  failures += 1;
+  console.error(`FAIL ${label}${detail !== undefined ? ` — ${detail}` : ""}`);
+}
+
+async function main(): Promise<void> {
+  console.log("[test-tool-call-batch-status] aggregated tool-call status");
+
+  const mixedStatus = getToolBatchStatus([
+    { result: { isError: true } },
+    { result: { isError: false } },
+    { result: { isError: undefined } },
+  ]);
+  assert("counts failed child calls", mixedStatus.failedChildCount === 1);
+  assert("flags child failures", mixedStatus.hasChildFailures);
+  assert(
+    "does not promote child failure to aggregate error",
+    !mixedStatus.hasAggregateError,
+    JSON.stringify(mixedStatus),
+  );
+  assert("completed siblings are not treated as running", mixedStatus.inFlightCount === 0);
+
+  const runningStatus = getToolBatchStatus([{ result: undefined }, { result: { isError: false } }]);
+  assert("counts only missing results as in-flight", runningStatus.inFlightCount === 1);
+  assert("does not report failures for successful/running batch", !runningStatus.hasChildFailures);
+  assert("running batch is not an aggregate error", !runningStatus.hasAggregateError);
+
+  const successStatus = getToolBatchStatus([
+    { result: { isError: false } },
+    { result: { content: [{ type: "text", text: "ok" }] } },
+  ]);
+  assert("successful batch has no failed children", successStatus.failedChildCount === 0);
+  assert("successful batch has no aggregate error", !successStatus.hasAggregateError);
+
+  const aggregateErrorStatus = getToolBatchStatus([{ result: { isError: false } }], {
+    aggregateError: true,
+  });
+  assert("explicit aggregate-level errors are preserved", aggregateErrorStatus.hasAggregateError);
+
+  if (failures > 0) {
+    console.log(`\n[test-tool-call-batch-status] FAIL — ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log("\n[test-tool-call-batch-status] PASS");
+}
+
+void main();


### PR DESCRIPTION
## Summary

Aggregated tool-call batches were presented with a global red `error` badge whenever any single child tool call failed. That made successful sibling calls look errored too, even though only one invocation had failed.

This PR separates child failure status from aggregate-level error status. A failed child remains visibly identifiable in the expanded batch, while the aggregate summary now uses child-oriented status copy instead of marking the whole batch as globally errored. Explicit aggregate-level errors remain supported by the new status helper.

## Usage

No new user-facing commands or configuration are required. The behavior is exercised automatically in chat when multiple batchable tool calls are aggregated into one `tools ×N` block and one child result has `isError: true`.

## What changed (3 files, +105)

- `packages/client/src/components/ChatView.tsx` — uses a dedicated batch-status helper so child tool failures render as an amber child-failure badge on the aggregate summary, while each failed child keeps its own red/error row styling when expanded.
- `packages/client/src/lib/tool-call-batch-status.ts` — adds a small helper that counts in-flight and failed child calls without promoting child failures to aggregate errors; keeps an explicit aggregate-error option for future genuine container-level failures.
- `tests/test-tool-call-batch-status.ts` — adds regression coverage for mixed success/failure batches, running batches, successful batches, and explicit aggregate-level errors.

## Test plan

- [x] `scripts/run-tests.sh --only tool-call-batch-status` — passed
- [x] `npm run build` — passed
- [x] `npm run check` — passed
- [x] `npm run test:ci` — all 58 tests passed
- [ ] CI green before merge
