### PR TITLE
fix: resolve high critical npm vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4989,30 +4989,6 @@
         "mime": "^3"
       }
     },
-    "node_modules/@fastify/static": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
-      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/accept-negotiator": "^2.0.0",
-        "@fastify/send": "^4.0.0",
-        "content-disposition": "^1.0.1",
-        "fastify-plugin": "^5.0.0",
-        "fastq": "^1.17.1",
-        "glob": "^13.0.0"
-      }
-    },
     "node_modules/@fastify/swagger": {
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/@fastify/swagger/-/swagger-9.7.0.tgz",
@@ -5034,29 +5010,6 @@
         "openapi-types": "^12.1.3",
         "rfdc": "^1.3.1",
         "yaml": "^2.4.2"
-      }
-    },
-    "node_modules/@fastify/swagger-ui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-6.0.0.tgz",
-      "integrity": "sha512-L9c4CbXj3FnquqpCmn0IfbEeIqDUNi6QwXd23VhQj/bHEjNzDFIAy2W9I3prvSqM+mJWOElIa6uXROmcMDnfUA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/static": "^9.1.2",
-        "fastify-plugin": "^5.0.0",
-        "openapi-types": "^12.1.3",
-        "rfdc": "^1.3.1",
-        "yaml": "^2.4.1"
       }
     },
     "node_modules/@fastify/websocket": {
@@ -7599,15 +7552,6 @@
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -7805,9 +7749,9 @@
       "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8175,15 +8119,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -9740,9 +9684,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -9897,9 +9841,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9941,9 +9885,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -10846,9 +10790,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -12343,6 +12287,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/@xmldom/xmldom": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/markdown-table": {
@@ -14263,9 +14216,9 @@
       "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -14627,9 +14580,9 @@
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -15546,6 +15499,7 @@
       "version": "7.5.16",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
       "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -15578,6 +15532,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -15996,15 +15951,6 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
-    },
-    "node_modules/undici": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
-      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
     },
     "node_modules/undici-types": {
       "version": "8.3.0",
@@ -17116,9 +17062,9 @@
       "license": "MIT"
     },
     "node_modules/zip-stream/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -17310,9 +17256,9 @@
         "@fastify/cors": "^11.0.1",
         "@fastify/multipart": "^10.0.0",
         "@fastify/rate-limit": "^11.0.0",
-        "@fastify/static": "^9.1.3",
+        "@fastify/static": "^10.1.3",
         "@fastify/swagger": "^9.5.0",
-        "@fastify/swagger-ui": "^6.0.0",
+        "@fastify/swagger-ui": "^6.1.1",
         "@fastify/websocket": "^11.0.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.1",
@@ -17328,8 +17274,8 @@
         "mammoth": "^1.12.0",
         "node-pty": "^1.0.0",
         "pdf-parse": "^2.4.5",
-        "tar": "^7.5.15",
-        "undici": "^8.7.0"
+        "tar": "^7.5.22",
+        "undici": "^8.10.0"
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.9",
@@ -17338,6 +17284,54 @@
         "@types/ws": "^8.18.1",
         "tsx": "^4.22.3",
         "typescript": "^6.0.3"
+      }
+    },
+    "packages/server/node_modules/@fastify/static": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.3.tgz",
+      "integrity": "sha512-W6jqajYS974XjPjB5hQWoxPM8NKM4+p8YmQT6G5IbCa4uhdWSVadZUv75siy1wEA/3ty8RYdpBydfWeu9AqAqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/error": "^4.0.0",
+        "@fastify/send": "^4.0.0",
+        "content-disposition": "^2.0.1",
+        "fastify-plugin": "^6.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^13.0.0"
+      }
+    },
+    "packages/server/node_modules/@fastify/swagger-ui": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-6.1.1.tgz",
+      "integrity": "sha512-RKCLSHASlzS2JZvHWn14NmEpHyl0yNosGvqzhUumm/LGPG6RWQBf4oscTFt83QDvc5O5Tol3Beup8inAl/k4EA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/static": "^10.1.0",
+        "fastify-plugin": "^6.0.0",
+        "openapi-types": "^12.1.3",
+        "rfdc": "^1.3.1",
+        "yaml": "^2.4.1"
       }
     },
     "packages/server/node_modules/@opentelemetry/api": {
@@ -17356,6 +17350,69 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "packages/server/node_modules/content-disposition": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+      "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "packages/server/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "packages/server/node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "packages/server/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,22 @@
     "serialize-javascript": ">=6.0.2",
     "qs": ">=6.15.2",
     "tmp": ">=0.2.6",
-    "uuid": ">=11.1.1"
+    "uuid": ">=11.1.1",
+    "mammoth": {
+      "@xmldom/xmldom": "0.8.15"
+    },
+    "fast-uri": "3.1.6",
+    "find-my-way": "9.7.0",
+    "ip-address": "10.3.1",
+    "minimatch@3.1.5": {
+      "brace-expansion": "1.1.18"
+    },
+    "minimatch@5.1.9": {
+      "brace-expansion": "2.1.4"
+    },
+    "minimatch@10.2.5": {
+      "brace-expansion": "5.0.9"
+    }
   },
   "devDependencies": {
     "@earendil-works/pi-agent-core": "0.84.3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,9 +15,9 @@
     "@fastify/cors": "^11.0.1",
     "@fastify/multipart": "^10.0.0",
     "@fastify/rate-limit": "^11.0.0",
-    "@fastify/static": "^9.1.3",
+    "@fastify/static": "^10.1.3",
     "@fastify/swagger": "^9.5.0",
-    "@fastify/swagger-ui": "^6.0.0",
+    "@fastify/swagger-ui": "^6.1.1",
     "@fastify/websocket": "^11.0.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.1",
@@ -33,8 +33,8 @@
     "mammoth": "^1.12.0",
     "node-pty": "^1.0.0",
     "pdf-parse": "^2.4.5",
-    "tar": "^7.5.15",
-    "undici": "^8.7.0"
+    "tar": "^7.5.22",
+    "undici": "^8.10.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.9",

--- a/packages/server/src/config-export.ts
+++ b/packages/server/src/config-export.ts
@@ -41,12 +41,14 @@
  * the allow-listed names — this is the only validation that matters
  * for safety, since the names map deterministically to disk targets.
  *
- * Atomic writes: each imported file lands in `<dst>.import.tmp` first,
- * then `rename`s into place — same shape config-manager / project-
- * manager already use, so a crash mid-import never produces a half-
- * written config file.
+ * Atomic writes: each imported file is copied/written to a temp file
+ * beside the final destination first, then `rename`s into place — same
+ * shape config-manager / project-manager already use, so a crash
+ * mid-import never produces a half-written config file. The temp file
+ * must live on the destination filesystem because extraction stages
+ * under `tmpdir()`, which can be a different mount.
  */
-import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { Readable } from "node:stream";
@@ -179,7 +181,8 @@ export async function buildExportTar(): Promise<ExportResult> {
  *      entry name that isn't in `ALLOWED_FILES`.
  *   2. Validate each accepted file (JSON.parse). Files that fail
  *      validation never make it to disk.
- *   3. Atomic rename per file from temp into target.
+ *   3. Copy each valid staged file into a destination-local temp file,
+ *      then atomically rename that temp file into target.
  *
  * The "validate before any disk write" ordering matters: a partial
  * import (e.g. `mcp.json` good, `settings.json` corrupt) would leave
@@ -270,16 +273,25 @@ export async function importConfigFromBuffer(buf: Buffer): Promise<ImportSummary
       return { imported: [], skipped, errors };
     }
 
-    // Atomic move. mkdir parent dirs since pi config dir might not
-    // exist on a fresh deploy that's only setting these via import.
+    // Atomic final writes. mkdir parent dirs since pi config dir might
+    // not exist on a fresh deploy that's only setting these via import.
+    // Do NOT rename directly from the extraction stage: `tmpdir()` can
+    // be a different filesystem than PI_CONFIG_DIR / FORGE_DATA_DIR,
+    // which would fail with EXDEV. Copy to a temp file beside the final
+    // destination, then same-directory rename into place.
     const imported: string[] = [];
     for (const name of valid) {
       const src = join(stage, name);
       const dst = TARGETS[name as AllowedFile]();
       await mkdir(dirname(dst), { recursive: true });
       const tmpDst = `${dst}.${Date.now()}.import.tmp`;
-      await rename(src, tmpDst);
-      await rename(tmpDst, dst);
+      try {
+        await copyFile(src, tmpDst);
+        await rename(tmpDst, dst);
+      } catch (err) {
+        await rm(tmpDst, { force: true }).catch(() => undefined);
+        throw err;
+      }
       imported.push(name);
     }
     return { imported, skipped, errors };

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -31,8 +31,13 @@ import {
 import {
   ensureProjectLoaded as mcpEnsureProjectLoaded,
   getStatus as mcpGetStatus,
+  reloadGlobal as mcpReloadGlobal,
 } from "../mcp/manager.js";
-import { BUILTIN_TOOL_NAMES } from "../session-registry.js";
+import {
+  BUILTIN_TOOL_NAMES,
+  listSessions,
+  rebuildAgentSessionForTools,
+} from "../session-registry.js";
 import { discoverExtensionResources } from "../extensions-discovery.js";
 import {
   getAllToolOverrides,
@@ -61,6 +66,24 @@ import {
   type ServerThemeConfig,
 } from "../theme-config.js";
 import { errorSchema } from "./_schemas.js";
+
+const RUNTIME_IMPORT_FILES = new Set([
+  "mcp.json",
+  "settings.json",
+  "models.json",
+  "skills-overrides.json",
+  "tool-overrides.json",
+]);
+
+const MCP_IMPORT_FILES = new Set(["mcp.json"]);
+
+async function refreshRuntimeAfterConfigImport(imported: string[]): Promise<void> {
+  if (imported.some((name) => MCP_IMPORT_FILES.has(name))) {
+    await mcpReloadGlobal();
+  }
+  if (!imported.some((name) => RUNTIME_IMPORT_FILES.has(name))) return;
+  await Promise.all(listSessions().map((live) => rebuildAgentSessionForTools(live.sessionId)));
+}
 
 const modelsJsonSchema = {
   type: "object",
@@ -1226,6 +1249,9 @@ export const configRoutes: FastifyPluginAsync = async (fastify) => {
       }
       try {
         const summary = await importConfigFromBuffer(buf);
+        if (summary.errors.length === 0 && summary.imported.length > 0) {
+          await refreshRuntimeAfterConfigImport(summary.imported);
+        }
         return summary;
       } catch (err) {
         return internalError(reply, err);

--- a/tests/test-attachments.ts
+++ b/tests/test-attachments.ts
@@ -19,6 +19,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import JSZip from "jszip";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -46,6 +47,39 @@ const TINY_PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
   "base64",
 );
+
+async function makeMinimalDocx(text: string): Promise<Buffer> {
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+  );
+  zip.folder("_rels")?.file(
+    ".rels",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  zip.folder("word")?.file(
+    "document.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:r><w:t>${escaped}</w:t></w:r></w:p></w:body>
+</w:document>`,
+  );
+  return zip.generateAsync({ type: "nodebuffer" });
+}
 
 async function main(): Promise<void> {
   const workspacePath = await mkdtemp(join(tmpdir(), "pi-attach-ws-"));
@@ -195,7 +229,40 @@ async function main(): Promise<void> {
       );
     }
 
-    // ---- 3. Oversize file → 400 BEFORE prompt() invoked ----
+    // ---- 3. DOCX file is converted and prepended as text ----
+    {
+      calls.length = 0;
+      const docx = await makeMinimalDocx("Hello from DOCX attachment");
+      const fd = new FormData();
+      fd.append("text", "summarize this");
+      fd.append(
+        "attachments",
+        new Blob([new Uint8Array(docx)], {
+          type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        }),
+        "sample.docx",
+      );
+      const res = await fetch(`${base}/api/v1/sessions/${live.sessionId}/prompt`, {
+        method: "POST",
+        body: fd,
+      });
+      assert("DOCX multipart → 202", res.status === 202, `status=${res.status}`);
+      await new Promise((r) => setTimeout(r, 50));
+      assert("session.prompt was called once for DOCX", calls.length === 1);
+      const call = calls[0];
+      assert(
+        "DOCX text is included in composed prompt",
+        call?.text.includes("Hello from DOCX attachment") === true,
+        `got: ${JSON.stringify(call?.text ?? "")}`,
+      );
+      assert(
+        "DOCX prompt keeps filename in fence header",
+        call?.text.startsWith("``` file: sample.docx\n") === true,
+        `got: ${JSON.stringify(call?.text?.slice(0, 64) ?? "")}`,
+      );
+    }
+
+    // ---- 4. Oversize file → 400 BEFORE prompt() invoked ----
     {
       calls.length = 0;
       // MAX_FILE_BYTES is 20 MB (routes/prompt.ts); send 21 MB to trip
@@ -220,7 +287,7 @@ async function main(): Promise<void> {
       assert("prompt() not called for oversize", calls.length === 0);
     }
 
-    // ---- 4. >4 images → 400 BEFORE prompt() invoked ----
+    // ---- 5. >4 images → 400 BEFORE prompt() invoked ----
     {
       calls.length = 0;
       const fd = new FormData();
@@ -243,7 +310,7 @@ async function main(): Promise<void> {
       assert("prompt() not called for too-many-images", calls.length === 0);
     }
 
-    // ---- 5. JSON path still works (backward compat) ----
+    // ---- 6. JSON path still works (backward compat) ----
     {
       calls.length = 0;
       const res = await fetch(`${base}/api/v1/sessions/${live.sessionId}/prompt`, {

--- a/tests/test-config-export.ts
+++ b/tests/test-config-export.ts
@@ -58,6 +58,16 @@ async function getRaw(
   return { status: res.status, buf: Buffer.from(ab), headers: res.headers };
 }
 
+async function getJson(base: string, path: string): Promise<JsonResponse> {
+  const res = await fetch(`${base}${path}`);
+  const text = await res.text();
+  return {
+    status: res.status,
+    body: text === "" ? undefined : JSON.parse(text),
+    headers: res.headers,
+  };
+}
+
 async function postMultipart(
   base: string,
   path: string,
@@ -384,7 +394,42 @@ async function main(): Promise<void> {
       );
     }
 
-    // ---- 4. Import with malformed JSON → entire import fails atomically ----
+    // ---- 4. Imported runtime MCP settings apply without server restart ----
+    {
+      const before = await getJson(base, "/api/v1/mcp/settings");
+      assert("GET /mcp/settings before disabled import → 200", before.status === 200);
+      assert(
+        "  MCP initially enabled in runtime cache",
+        (before.body as { enabled?: boolean })?.enabled === true,
+        JSON.stringify(before.body),
+      );
+
+      const tar = await makeTarGz({
+        "mcp.json": JSON.stringify({ disabled: true, servers: {} }),
+      });
+      const r = await postMultipart(
+        base,
+        "/api/v1/config/import",
+        "file",
+        "config.tar.gz",
+        "application/gzip",
+        tar,
+      );
+      assert("POST /config/import (mcp disabled) → 200", r.status === 200);
+      const summary = r.body as { imported: string[]; skipped: string[]; errors: unknown[] };
+      assert("  mcp.json imported", summary.imported.includes("mcp.json"), JSON.stringify(summary));
+      assert("  no import errors", summary.errors.length === 0, JSON.stringify(summary.errors));
+
+      const after = await getJson(base, "/api/v1/mcp/settings");
+      assert("GET /mcp/settings after import → 200", after.status === 200);
+      assert(
+        "  imported mcp.json is reflected in runtime cache without restart",
+        (after.body as { enabled?: boolean })?.enabled === false,
+        JSON.stringify(after.body),
+      );
+    }
+
+    // ---- 5. Import with malformed JSON → entire import fails atomically ----
     {
       // Snapshot current state so we can prove the failed import
       // didn't mutate anything.
@@ -437,7 +482,7 @@ async function main(): Promise<void> {
       );
     }
 
-    // ---- 5. Import with no file in the multipart → 400 ----
+    // ---- 6. Import with no file in the multipart → 400 ----
     {
       const fd = new FormData();
       fd.append("notafile", "hi");
@@ -445,7 +490,7 @@ async function main(): Promise<void> {
       assert("POST /config/import (no file) → 400", res.status === 400, `status=${res.status}`);
     }
 
-    // ---- 6. Import a non-gzip body → 400/500 with a parseable error ----
+    // ---- 7. Import a non-gzip body → 400/500 with a parseable error ----
     {
       // Plain (un-gzipped) tar still has a tar header but our buffer
       // here is just gibberish — parse failure should be surfaced as
@@ -472,7 +517,7 @@ async function main(): Promise<void> {
       );
     }
 
-    // ---- 7. Export with one file missing on disk → tar omits it ----
+    // ---- 8. Export with one file missing on disk → tar omits it ----
     {
       await rm(join(dataDir, "mcp.json"));
       const r = await getRaw(base, "/api/v1/config/export");

--- a/tests/test-publish-package.ts
+++ b/tests/test-publish-package.ts
@@ -17,14 +17,14 @@
  * CLIENT_DIST_PATH override, dynamic import of the server entry. A
  * regression in the shim would only surface here.
  *
- * Note: this test runs `node publish/bin/pi-forge.mjs` while still
- * inside the repo, so Node's module resolution finds the server's
- * runtime deps via the hoisted root `node_modules/`. A real `npm i
- * pi-forge` install gets its deps from the synthetic package.json's
- * `dependencies` field — which we assert separately by shape.
+ * Before booting the bin shim, this test runs a production install
+ * inside `publish/`. Workspace installs are free to place server deps
+ * under `packages/server/node_modules/`, which the flat publish artifact
+ * cannot see; installing from the synthetic package.json catches missing
+ * runtime deps the same way a real `npm i pi-forge` consumer would.
  *
- * Builds the workspace + assembles publish/ on every run (~5s warm,
- * ~30s cold). Costly but we want the assertion that "the publish
+ * Builds the workspace + assembles publish/ + installs runtime deps on
+ * every run. Costly but we want the assertion that "the publish
  * artifact is bootable" to be green every CI run, not just on tag.
  */
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
@@ -192,6 +192,15 @@ async function main(): Promise<void> {
       `got ${synth.dependencies[dep] ?? "<missing>"}`,
     );
   }
+
+  console.log("[test-publish-package] installing publish runtime deps…");
+  const install = spawnSync("npm", ["install", "--omit=dev", "--no-audit", "--no-fund"], {
+    cwd: publishDir,
+    stdio: "inherit",
+    env: process.env,
+  });
+  assert("publish npm install exits 0", install.status === 0, `exit=${install.status ?? "null"}`);
+  if (install.status !== 0) process.exit(1);
 
   // --- Boot the bin shim ---------------------------------------------
   // Use isolated dirs so this test doesn't touch the user's real


### PR DESCRIPTION
## Summary

Resolves the current high/critical `npm audit` findings with minimal direct dependency bumps and targeted overrides. Also fixes two config/attachment regressions found during manual validation:

- Config import no longer attempts a cross-device rename from `/tmp` into config dirs, avoiding `EXDEV` failures.
- Successfully imported runtime config is refreshed immediately instead of requiring a server reboot.
- DOCX attachment conversion stays compatible with `mammoth` while using a patched `@xmldom/xmldom` version.

## Usage

No user-facing workflow changes. Operators can continue using Settings → Backup import/export and DOCX attachments normally.

## What changed

- `package.json`, `package-lock.json`, `packages/server/package.json` — bump/override vulnerable dependency chains for `@fastify/static`, `@fastify/swagger-ui`, `tar`, `undici`, `fast-uri`, `find-my-way`, `ip-address`, `brace-expansion`, and `@xmldom/xmldom`.
- `packages/server/src/config-export.ts` — copy validated staged import files to destination-local temp files before atomic final rename, avoiding cross-device `EXDEV`.
- `packages/server/src/routes/config.ts` — refresh MCP runtime state and rebuild live sessions after a fully successful runtime config import.
- `tests/test-config-export.ts` — cover config import round-trip plus immediate runtime application for imported MCP settings.
- `tests/test-attachments.ts` — add DOCX attachment conversion regression coverage.

## Test plan

- [x] `npm audit --audit-level=high`
- [x] `npm audit --omit=dev --audit-level=high`
- [x] `npm run format`
- [x] `npm run build`
- [x] `NODE_OPTIONS=--max-old-space-size=4096 npm run check`
- [x] `npm run test:ci`
- [x] Manual validation over Vite reported working by user
