### PR TITLE
feat: spool large MCP results to workspace files

### DIFF
--- a/docs/agent/mcp.md
+++ b/docs/agent/mcp.md
@@ -26,3 +26,14 @@ MCP result truncation is a global MCP setting persisted in `FORGE_DATA_DIR/mcp.j
 under `truncation`. The bridge defaults to enabled at 30,000 text characters and
 can be disabled or retuned from Settings → MCP; keep this contract in sync with
 `tests/test-mcp-truncation.ts`.
+
+MCP result spooling is a separate global setting under `spooling`, enabled by default.
+Oversized successful MCP results are written through `file-manager.writeFile()` to a
+workspace-relative JSON file before truncation, and the model receives only a
+summary/path/preview. The default destination is `<workspace>/.mcp-results/`. `isError:
+true` results deliberately bypass spooling so errors stay visible inline. If the
+workspace write fails, the bridge falls back to the same inline conversion/truncation
+path with an `MCP_RESULT_SPOOL_FAILED` warning. Because writes go through
+`file-manager.writeFile()`, sandbox mode gets the normal ownership/permission handoff
+for newly created directories/files. Any change here must preserve project-root
+validation and the non-spooled truncation tests.

--- a/docs/agent/mcp.md
+++ b/docs/agent/mcp.md
@@ -30,10 +30,10 @@ can be disabled or retuned from Settings → MCP; keep this contract in sync wit
 MCP result spooling is a separate global setting under `spooling`, enabled by default.
 Oversized successful MCP results are written through `file-manager.writeFile()` to a
 workspace-relative JSON file before truncation, and the model receives only a
-summary/path/preview. The default destination is `<workspace>/.mcp-results/`. `isError:
-true` results deliberately bypass spooling so errors stay visible inline. If the
-workspace write fails, the bridge falls back to the same inline conversion/truncation
-path with an `MCP_RESULT_SPOOL_FAILED` warning. Because writes go through
-`file-manager.writeFile()`, sandbox mode gets the normal ownership/permission handoff
-for newly created directories/files. Any change here must preserve project-root
-validation and the non-spooled truncation tests.
+summary/path/size notice with no payload preview. The default destination is
+`<workspace>/.mcp-results/`. `isError: true` results deliberately bypass spooling so
+errors stay visible inline. If the workspace write fails, the bridge falls back to the
+same inline conversion/truncation path with an `MCP_RESULT_SPOOL_FAILED` warning.
+Because writes go through `file-manager.writeFile()`, sandbox mode gets the normal
+ownership/permission handoff for newly created directories/files. Any change here must
+preserve project-root validation and the non-spooled truncation tests.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -196,9 +196,9 @@ filename containing the MCP server name, tool name, timestamp, and UUID.
 With the default directory, files land at
 `<project workspace>/.mcp-results/<server>__<tool>__<timestamp>__<uuid>.json`.
 The model receives only a concise `MCP_RESULT_SPOOLED` text result with
-the workspace-relative path, approximate character count, byte size, and
-a short preview. The summary instructs the agent to use file-reading
-tools to inspect the saved file incrementally.
+the workspace-relative path, approximate character count, and byte size.
+No payload preview is included inline; the summary instructs the agent to
+use file-reading tools to inspect the saved file incrementally.
 
 Error results (`isError: true`) bypass spooling so failures remain
 visible inline and continue through the existing truncation behavior if

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -54,6 +54,12 @@ to swap a global server for a project-specific one).
     "enabled": true,
     "maxChars": 30000
   },
+  "spooling": {
+    "enabled": true,
+    "thresholdChars": 30000,
+    "directory": ".mcp-results",
+    "format": "json"
+  },
   "servers": {
     "weather": {
       "url": "https://mcp.example.com/sse",
@@ -107,6 +113,10 @@ shape, so existing files don't need rewriting:
 | `disabled` | boolean (top-level) | — | `false` | Master kill-switch. When `true`, NO MCP tools reach the agent regardless of per-server `enabled`. |
 | `truncation.enabled` | boolean (top-level) | — | `true` | When true, text MCP results are capped before they enter agent context. |
 | `truncation.maxChars` | integer (top-level) | — | `30000` | Total text-character cap across all text blocks in one MCP result. Images pass through unchanged. |
+| `spooling.enabled` | boolean (top-level) | — | `true` | When true, oversized non-error MCP results are written as JSON files in the current project workspace instead of being returned inline. Set false to restore truncation-only behavior. |
+| `spooling.thresholdChars` | integer (top-level) | — | `30000` | Total text-character size that triggers spooling before truncation. |
+| `spooling.directory` | string (top-level) | — | `.mcp-results` | Workspace-relative directory for result files. Traversal or symlink escapes fail safely and fall back to inline/truncated output. |
+| `spooling.format` | `"json"` (top-level) | — | `"json"` | Spool files contain the complete raw MCP `CallToolResult` JSON, including structured content and image blocks. |
 
 ## Stdio env passthrough
 
@@ -174,6 +184,39 @@ keeps two servers' `search` tools from colliding.
   dropping it)
 
 `isError: true` prefixes the first text block with `[error]`.
+
+## Large result spooling
+
+MCP result spooling is enabled by default (`spooling.enabled: true`). When enabled,
+pi-forge measures the total text payload of a successful MCP tool
+result before normal truncation. If it exceeds `thresholdChars`, the
+complete raw MCP result is written to a JSON file under
+`spooling.directory` in the current project workspace, using a safe
+filename containing the MCP server name, tool name, timestamp, and UUID.
+With the default directory, files land at
+`<project workspace>/.mcp-results/<server>__<tool>__<timestamp>__<uuid>.json`.
+The model receives only a concise `MCP_RESULT_SPOOLED` text result with
+the workspace-relative path, approximate character count, byte size, and
+a short preview. The summary instructs the agent to use file-reading
+tools to inspect the saved file incrementally.
+
+Error results (`isError: true`) bypass spooling so failures remain
+visible inline and continue through the existing truncation behavior if
+large. If writing the spool file fails (for example because the directory
+tries to escape the workspace), pi-forge falls back to the current safe
+inline conversion/truncation and prepends an `MCP_RESULT_SPOOL_FAILED`
+warning instead of crashing the agent turn.
+
+Images are not expanded into a larger model-context dump by spooling.
+For JSON spools, the raw result JSON preserves image block metadata and
+base64 data in the file; the inline summary notes that images were
+present so the agent can inspect deliberately.
+
+Spool writes use `file-manager.writeFile()`, the same workspace-bounded
+write path used by the Files UI. In agent-tool sandbox mode, newly
+created result directories/files receive the sandbox ownership and group
+permissions handoff, so sandboxed read tools can inspect them while path
+validation still prevents writes outside the project workspace.
 
 ## Lifecycle
 

--- a/packages/client/src/components/SettingsPanel.tsx
+++ b/packages/client/src/components/SettingsPanel.tsx
@@ -3416,6 +3416,7 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
   const refreshProject = useMcpStore((s) => s.refreshProject);
   const setMcpEnabled = useMcpStore((s) => s.setMcpEnabled);
   const setMcpTruncation = useMcpStore((s) => s.setMcpTruncation);
+  const setMcpSpooling = useMcpStore((s) => s.setMcpSpooling);
   const upsertServer = useMcpStore((s) => s.upsertServer);
   const deleteServer = useMcpStore((s) => s.deleteServer);
   const probeServerStore = useMcpStore((s) => s.probeServer);
@@ -3428,6 +3429,12 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
   const [busy, setBusy] = useState(false);
   const [probing, setProbing] = useState<string | undefined>(undefined);
   const [truncationMaxDraft, setTruncationMaxDraft] = useState<string | undefined>(undefined);
+  const [spoolingThresholdDraft, setSpoolingThresholdDraft] = useState<string | undefined>(
+    undefined,
+  );
+  const [spoolingDirectoryDraft, setSpoolingDirectoryDraft] = useState<string | undefined>(
+    undefined,
+  );
 
   // Per-tool listing fetched alongside the server config so each
   // server row can cascade its tools (each tool gets its own
@@ -3498,6 +3505,25 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
       onError(undefined);
     } catch (err) {
       onError(`Failed to update MCP truncation: ${errorCode(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveSpooling = async (next: {
+    enabled: boolean;
+    thresholdChars: number;
+    directory: string;
+    format: "json";
+  }): Promise<void> => {
+    setBusy(true);
+    try {
+      await setMcpSpooling(next);
+      setSpoolingThresholdDraft(undefined);
+      setSpoolingDirectoryDraft(undefined);
+      onError(undefined);
+    } catch (err) {
+      onError(`Failed to update MCP spooling: ${errorCode(err)}`);
     } finally {
       setBusy(false);
     }
@@ -3701,6 +3727,78 @@ function McpTab({ onError }: { onError: (msg: string | undefined) => void }) {
           >
             {enabled ? "Enabled" : "Disabled"}
           </button>
+        </div>
+        <div className="flex flex-wrap items-end justify-between gap-3 border-t border-neutral-800 pt-3">
+          <div className="min-w-[240px] flex-1">
+            <div className="text-sm font-medium text-neutral-100">Result spooling</div>
+            <div className="text-[11px] text-neutral-500">
+              Writes oversized successful MCP results to workspace files before truncation. Default:
+              <code className="ml-1 font-mono">&lt;workspace&gt;/.mcp-results/</code>.
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <label className="text-[11px] text-neutral-500" htmlFor="mcp-spooling-threshold">
+              Threshold chars
+            </label>
+            <input
+              id="mcp-spooling-threshold"
+              type="number"
+              min={1}
+              max={1000000}
+              value={spoolingThresholdDraft ?? String(settings.spooling.thresholdChars)}
+              onChange={(e) => setSpoolingThresholdDraft(e.target.value)}
+              onBlur={() => {
+                const parsed = Number.parseInt(
+                  spoolingThresholdDraft ?? String(settings.spooling.thresholdChars),
+                  10,
+                );
+                if (
+                  Number.isFinite(parsed) &&
+                  parsed >= 1 &&
+                  parsed !== settings.spooling.thresholdChars
+                ) {
+                  void saveSpooling({ ...settings.spooling, thresholdChars: parsed });
+                } else {
+                  setSpoolingThresholdDraft(undefined);
+                }
+              }}
+              disabled={busy || !settings.spooling.enabled}
+              className="w-28 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs text-neutral-100 disabled:opacity-50"
+            />
+            <label className="text-[11px] text-neutral-500" htmlFor="mcp-spooling-directory">
+              Directory
+            </label>
+            <input
+              id="mcp-spooling-directory"
+              type="text"
+              value={spoolingDirectoryDraft ?? settings.spooling.directory}
+              onChange={(e) => setSpoolingDirectoryDraft(e.target.value)}
+              onBlur={() => {
+                const next = (spoolingDirectoryDraft ?? settings.spooling.directory).trim();
+                if (next.length > 0 && next !== settings.spooling.directory) {
+                  void saveSpooling({ ...settings.spooling, directory: next });
+                } else {
+                  setSpoolingDirectoryDraft(undefined);
+                }
+              }}
+              disabled={busy || !settings.spooling.enabled}
+              className="w-40 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 disabled:opacity-50"
+            />
+            <label className="flex items-center gap-2 rounded border border-neutral-700 px-3 py-1 text-xs text-neutral-300">
+              <input
+                type="checkbox"
+                checked={settings.spooling.enabled}
+                disabled={busy}
+                onChange={(e) =>
+                  void saveSpooling({
+                    ...settings.spooling,
+                    enabled: e.target.checked,
+                  })
+                }
+              />
+              <span>{settings.spooling.enabled ? "Spooling" : "Inline only"}</span>
+            </label>
+          </div>
         </div>
         <div className="flex flex-wrap items-end justify-between gap-3 border-t border-neutral-800 pt-3">
           <div className="min-w-[240px] flex-1">

--- a/packages/client/src/lib/api-client/index.ts
+++ b/packages/client/src/lib/api-client/index.ts
@@ -676,9 +676,14 @@ function vMcpSettings(value: unknown, status: number): McpSettingsResponse {
     typeof value.total !== "number" ||
     !isObject(value.truncation) ||
     typeof value.truncation.enabled !== "boolean" ||
-    typeof value.truncation.maxChars !== "number"
+    typeof value.truncation.maxChars !== "number" ||
+    !isObject(value.spooling) ||
+    typeof value.spooling.enabled !== "boolean" ||
+    typeof value.spooling.thresholdChars !== "number" ||
+    typeof value.spooling.directory !== "string" ||
+    value.spooling.format !== "json"
   ) {
-    fail(status, "expected { enabled, connected, total, truncation }");
+    fail(status, "expected { enabled, connected, total, truncation, spooling }");
   }
   return {
     enabled: value.enabled,
@@ -687,6 +692,12 @@ function vMcpSettings(value: unknown, status: number): McpSettingsResponse {
     truncation: {
       enabled: value.truncation.enabled,
       maxChars: value.truncation.maxChars,
+    },
+    spooling: {
+      enabled: value.spooling.enabled,
+      thresholdChars: value.spooling.thresholdChars,
+      directory: value.spooling.directory,
+      format: "json",
     },
   };
 }
@@ -2075,6 +2086,11 @@ export const api = {
     request("/api/v1/mcp/settings", vMcpSettings, {
       method: "PUT",
       body: { truncation },
+    }),
+  setMcpSpooling: (spooling: McpSettingsResponse["spooling"]) =>
+    request("/api/v1/mcp/settings", vMcpSettings, {
+      method: "PUT",
+      body: { spooling },
     }),
   /** GLOBAL servers (config + status). Pass projectId to also include
    *  status entries for the project's `.mcp.json` servers. */

--- a/packages/client/src/lib/api-client/types.ts
+++ b/packages/client/src/lib/api-client/types.ts
@@ -112,6 +112,8 @@ export interface McpSettingsResponse {
   total: number;
   /** MCP text-result truncation applied before MCP results enter agent context. */
   truncation: { enabled: boolean; maxChars: number };
+  /** Optional large-result spooling to workspace files before truncation. */
+  spooling: { enabled: boolean; thresholdChars: number; directory: string; format: "json" };
 }
 
 // ---------------- processes ----------------

--- a/packages/client/src/store/mcp-store.ts
+++ b/packages/client/src/store/mcp-store.ts
@@ -19,7 +19,11 @@ function sameSettings(a: McpSettingsResponse | undefined, b: McpSettingsResponse
     a.connected === b.connected &&
     a.total === b.total &&
     a.truncation.enabled === b.truncation.enabled &&
-    a.truncation.maxChars === b.truncation.maxChars
+    a.truncation.maxChars === b.truncation.maxChars &&
+    a.spooling.enabled === b.spooling.enabled &&
+    a.spooling.thresholdChars === b.spooling.thresholdChars &&
+    a.spooling.directory === b.spooling.directory &&
+    a.spooling.format === b.spooling.format
   );
 }
 
@@ -102,6 +106,7 @@ interface McpState {
   refreshProject: (projectId: string | undefined) => Promise<void>;
   setMcpEnabled: (enabled: boolean) => Promise<void>;
   setMcpTruncation: (truncation: { enabled: boolean; maxChars: number }) => Promise<void>;
+  setMcpSpooling: (spooling: McpSettingsResponse["spooling"]) => Promise<void>;
   upsertServer: (name: string, body: McpServerConfig) => Promise<void>;
   deleteServer: (name: string) => Promise<void>;
   probeServer: (name: string, projectId: string | undefined) => Promise<void>;
@@ -240,6 +245,21 @@ export const useMcpStore = create<McpState>((set, get) => ({
     }
     try {
       const r = await api.setMcpTruncation(truncation);
+      set({ settings: r, error: undefined });
+    } catch (err) {
+      if (prior !== undefined) set({ settings: prior });
+      set({ error: describeError(err) });
+      throw err;
+    }
+  },
+
+  setMcpSpooling: async (spooling) => {
+    const prior = get().settings;
+    if (prior !== undefined) {
+      set({ settings: { ...prior, spooling } });
+    }
+    try {
+      const r = await api.setMcpSpooling(spooling);
       set({ settings: r, error: undefined });
     } catch (err) {
       if (prior !== undefined) set({ settings: prior });

--- a/packages/server/src/mcp/config.ts
+++ b/packages/server/src/mcp/config.ts
@@ -112,6 +112,17 @@ export interface McpTruncationConfig {
   maxChars?: number;
 }
 
+export interface McpSpoolingConfig {
+  /** Default true. When true, oversized non-error MCP results are written to workspace files. */
+  enabled?: boolean;
+  /** Total text-character threshold before spooling. Default 30000. */
+  thresholdChars?: number;
+  /** Workspace-relative directory for result files. Default .mcp-results. */
+  directory?: string;
+  /** Spool file format. Only json is currently supported. */
+  format?: "json";
+}
+
 export interface McpJson {
   /**
    * Master kill-switch surfaced as a toggle in Settings → MCP. When
@@ -123,6 +134,8 @@ export interface McpJson {
   disabled?: boolean;
   /** MCP result truncation settings. Defaults to enabled with a 30k character cap. */
   truncation?: McpTruncationConfig;
+  /** MCP result spooling settings. Defaults to enabled. */
+  spooling?: McpSpoolingConfig;
   servers: Record<string, McpServerConfig>;
 }
 
@@ -139,6 +152,8 @@ export function isStdioConfig(cfg: McpServerConfig): boolean {
 
 const SECRET_PLACEHOLDER = "***REDACTED***";
 export const DEFAULT_MCP_TRUNCATION_MAX_CHARS = 30_000;
+export const DEFAULT_MCP_SPOOLING_THRESHOLD_CHARS = 30_000;
+export const DEFAULT_MCP_SPOOLING_DIRECTORY = ".mcp-results";
 
 export function normalizeMcpTruncationConfig(
   input: McpTruncationConfig | undefined,
@@ -150,6 +165,20 @@ export function normalizeMcpTruncationConfig(
       ? Math.floor(rawMax)
       : DEFAULT_MCP_TRUNCATION_MAX_CHARS;
   return { enabled, maxChars };
+}
+
+export function normalizeMcpSpoolingConfig(
+  input: McpSpoolingConfig | undefined,
+): Required<McpSpoolingConfig> {
+  const enabled = input?.enabled !== false;
+  const rawThreshold = input?.thresholdChars;
+  const thresholdChars =
+    typeof rawThreshold === "number" && Number.isFinite(rawThreshold) && rawThreshold >= 1
+      ? Math.floor(rawThreshold)
+      : DEFAULT_MCP_SPOOLING_THRESHOLD_CHARS;
+  const rawDirectory = typeof input?.directory === "string" ? input.directory.trim() : "";
+  const directory = rawDirectory.length > 0 ? rawDirectory : DEFAULT_MCP_SPOOLING_DIRECTORY;
+  return { enabled, thresholdChars, directory, format: "json" };
 }
 
 async function ensureDir(): Promise<void> {
@@ -193,12 +222,23 @@ export async function readMcpJson(): Promise<McpJson> {
       typeof rawTruncation === "object" && rawTruncation !== null
         ? normalizeMcpTruncationConfig(rawTruncation)
         : undefined;
+    const rawSpooling = (parsed as { spooling?: unknown }).spooling;
+    const spooling =
+      typeof rawSpooling === "object" && rawSpooling !== null
+        ? normalizeMcpSpoolingConfig(rawSpooling)
+        : undefined;
     if (typeof servers !== "object" || servers === null) {
-      return { disabled, ...(truncation !== undefined ? { truncation } : {}), servers: {} };
+      return {
+        disabled,
+        ...(truncation !== undefined ? { truncation } : {}),
+        ...(spooling !== undefined ? { spooling } : {}),
+        servers: {},
+      };
     }
     return {
       disabled,
       ...(truncation !== undefined ? { truncation } : {}),
+      ...(spooling !== undefined ? { spooling } : {}),
       servers: servers as Record<string, McpServerConfig>,
     };
   } catch (err) {
@@ -253,6 +293,7 @@ export async function readMcpJsonRedacted(): Promise<McpJson> {
   return {
     disabled: raw.disabled === true,
     ...(raw.truncation !== undefined ? { truncation: raw.truncation } : {}),
+    ...(raw.spooling !== undefined ? { spooling: raw.spooling } : {}),
     servers: out,
   };
 }
@@ -346,6 +387,15 @@ export async function writeMcpJson(next: McpJson): Promise<void> {
   if (truncation.enabled !== true || truncation.maxChars !== DEFAULT_MCP_TRUNCATION_MAX_CHARS) {
     safe.truncation = truncation;
   }
+  const spooling = normalizeMcpSpoolingConfig(next.spooling);
+  if (
+    spooling.enabled !== true ||
+    spooling.thresholdChars !== DEFAULT_MCP_SPOOLING_THRESHOLD_CHARS ||
+    spooling.directory !== DEFAULT_MCP_SPOOLING_DIRECTORY ||
+    spooling.format !== "json"
+  ) {
+    safe.spooling = spooling;
+  }
   for (const [name, server] of Object.entries(next.servers ?? {})) {
     const merged = copyServerCleaned(server);
     if (server.headers !== undefined) {
@@ -376,6 +426,15 @@ export async function setMcpTruncationConfig(truncation: McpTruncationConfig): P
   cur.truncation = normalizeMcpTruncationConfig({
     ...normalizeMcpTruncationConfig(cur.truncation),
     ...truncation,
+  });
+  await writeMcpJson(cur);
+}
+
+export async function setMcpSpoolingConfig(spooling: McpSpoolingConfig): Promise<void> {
+  const cur = await readMcpJson();
+  cur.spooling = normalizeMcpSpoolingConfig({
+    ...normalizeMcpSpoolingConfig(cur.spooling),
+    ...spooling,
   });
   await writeMcpJson(cur);
 }

--- a/packages/server/src/mcp/manager.ts
+++ b/packages/server/src/mcp/manager.ts
@@ -11,6 +11,7 @@ import {
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import {
   isStdioConfig,
+  normalizeMcpSpoolingConfig,
   normalizeMcpTruncationConfig,
   readMcpJson,
   resolveMcpHeaders,
@@ -19,7 +20,11 @@ import {
   type McpTransport,
 } from "./config.js";
 import { isStdioTrustedForProject } from "./stdio-trust.js";
-import { bridgeMcpTool, setMcpResultTruncationSettings } from "./tool-bridge.js";
+import {
+  bridgeMcpTool,
+  setMcpResultSpoolingSettings,
+  setMcpResultTruncationSettings,
+} from "./tool-bridge.js";
 
 /** Looser-than-the-SDK transport handle — we only need close().
  *  The SDK's `Transport` interface declares `sessionId: string` (not
@@ -75,6 +80,12 @@ export type Scope = "global" | { project: string };
 
 const PROJECT_MCP_FILE = ".mcp.json";
 
+interface McpToolCatalogEntry {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
 interface PoolEntry {
   scope: Scope;
   name: string;
@@ -84,7 +95,7 @@ interface PoolEntry {
   state: ConnectionState;
   lastError?: string;
   /** Cached tool catalogue from the last successful `client.listTools()`. */
-  tools: { name: string; description: string; inputSchema: Record<string, unknown> }[];
+  tools: McpToolCatalogEntry[];
   /** Pre-built ToolDefinitions, rebuilt every reconnect so the closure
    *  captures the latest client instance. */
   bridged: ToolDefinition[];
@@ -136,6 +147,7 @@ async function loadGlobalNow(): Promise<void> {
   const cfg = await readMcpJson();
   globallyEnabled = cfg.disabled !== true;
   setMcpResultTruncationSettings(normalizeMcpTruncationConfig(cfg.truncation));
+  setMcpResultSpoolingSettings(normalizeMcpSpoolingConfig(cfg.spooling));
   await syncScope("global", cfg.servers);
   globalLoaded = true;
 }
@@ -174,7 +186,7 @@ export async function reloadGlobal(): Promise<void> {
  * project entry wins (the session sees the project's bridged tool,
  * not the global one).
  */
-export function customToolsForProject(projectId: string): ToolDefinition[] {
+export function customToolsForProject(projectId: string, workspacePath?: string): ToolDefinition[] {
   // Server-name override: when the project has a server with the
   // same NAME as a global server, the project entry replaces the
   // global one entirely (not just on tool-name collision). Reason:
@@ -196,10 +208,11 @@ export function customToolsForProject(projectId: string): ToolDefinition[] {
     if (e.scope === "global") continue;
     if (e.scope.project !== projectId) continue;
     if (e.state !== "connected") continue;
-    for (const t of e.bridged) {
-      if (seenToolNames.has(t.name)) continue;
-      seenToolNames.add(t.name);
-      out.push(t);
+    for (const t of e.tools) {
+      const bridgedName = `${e.name}__${t.name}`;
+      if (seenToolNames.has(bridgedName)) continue;
+      seenToolNames.add(bridgedName);
+      out.push(bridgeSessionMcpTool(e, t, workspacePath));
     }
   }
   for (const e of pool.values()) {
@@ -208,13 +221,30 @@ export function customToolsForProject(projectId: string): ToolDefinition[] {
     // entry entirely.
     if (projectServerNames.has(e.name)) continue;
     if (e.state !== "connected") continue;
-    for (const t of e.bridged) {
-      if (seenToolNames.has(t.name)) continue;
-      seenToolNames.add(t.name);
-      out.push(t);
+    for (const t of e.tools) {
+      const bridgedName = `${e.name}__${t.name}`;
+      if (seenToolNames.has(bridgedName)) continue;
+      seenToolNames.add(bridgedName);
+      out.push(bridgeSessionMcpTool(e, t, workspacePath));
     }
   }
   return out;
+}
+
+function bridgeSessionMcpTool(
+  entry: PoolEntry,
+  tool: McpToolCatalogEntry,
+  workspacePath: string | undefined,
+): ToolDefinition {
+  return bridgeMcpTool({
+    serverName: entry.name,
+    toolName: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    getClient: () => pool.get(entryKey(entry.scope, entry.name))?.client,
+    recoverStaleSession: () => recoverStaleSession(entry.scope, entry.name),
+    ...(workspacePath !== undefined ? { spoolingContext: { workspacePath } } : {}),
+  });
 }
 
 export interface ServerStatus {

--- a/packages/server/src/mcp/tool-bridge.ts
+++ b/packages/server/src/mcp/tool-bridge.ts
@@ -334,7 +334,7 @@ interface McpCallResult {
   structuredContent?: unknown;
 }
 
-const MCP_SPOOL_PREVIEW_CHARS = 1_000;
+const MCP_SPOOL_PREVIEW_CHARS = 240;
 const MCP_SPOOL_SAFE_NAME_RE = /[^A-Za-z0-9_.-]+/g;
 
 let runtimeSpoolingSettings: McpResultSpoolingSettings = {

--- a/packages/server/src/mcp/tool-bridge.ts
+++ b/packages/server/src/mcp/tool-bridge.ts
@@ -334,7 +334,6 @@ interface McpCallResult {
   structuredContent?: unknown;
 }
 
-const MCP_SPOOL_PREVIEW_CHARS = 240;
 const MCP_SPOOL_SAFE_NAME_RE = /[^A-Za-z0-9_.-]+/g;
 
 let runtimeSpoolingSettings: McpResultSpoolingSettings = {
@@ -416,7 +415,6 @@ async function maybeSpoolMcpResult(opts: {
           relativePath,
           textChars,
           bytes: Buffer.byteLength(serialized, "utf8"),
-          preview: buildMcpPreview(opts.res),
           containsImages: mcpResultContainsImages(opts.res),
         }),
       },
@@ -439,15 +437,6 @@ function safeFilenamePart(value: string): string {
   return cleaned.length > 0 ? cleaned : "mcp";
 }
 
-function buildMcpPreview(res: unknown): string {
-  const agent = mcpResultToAgentResult(res);
-  const text = agent.content
-    .filter((block): block is { type: "text"; text: string } => block.type === "text")
-    .map((block) => block.text)
-    .join("\n\n");
-  return sanitizeDiagnostic(text.length > 0 ? text : "(no text preview)", MCP_SPOOL_PREVIEW_CHARS);
-}
-
 function mcpResultContainsImages(res: unknown): boolean {
   const blocks = Array.isArray((res as McpCallResult | undefined)?.content)
     ? ((res as McpCallResult).content as McpContentBlock[])
@@ -460,7 +449,6 @@ function buildSpooledSummary(opts: {
   relativePath: string;
   textChars: number;
   bytes: number;
-  preview: string;
   containsImages: boolean;
 }): string {
   const imageNote = opts.containsImages
@@ -472,8 +460,8 @@ function buildSpooledSummary(opts: {
     `Approximate text size: ${opts.textChars.toLocaleString()} characters\n` +
     `File size: ${opts.bytes.toLocaleString()} bytes\n` +
     `${imageNote}\n` +
-    `Use file-reading tools to inspect '${opts.relativePath}' incrementally; do not re-run the same broad MCP call just to recover omitted content.\n\n` +
-    `Preview (first ${MCP_SPOOL_PREVIEW_CHARS.toLocaleString()} chars max):\n${opts.preview}`
+    `No result preview is included inline to conserve model context. ` +
+    `Use file-reading tools to inspect '${opts.relativePath}' incrementally; do not re-run the same broad MCP call just to recover omitted content.`
   );
 }
 

--- a/packages/server/src/mcp/tool-bridge.ts
+++ b/packages/server/src/mcp/tool-bridge.ts
@@ -1,11 +1,25 @@
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
 import { Type } from "typebox";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { writeFile } from "../file-manager.js";
 
 export interface McpResultTruncationSettings {
   enabled: boolean;
   maxChars: number;
+}
+
+export interface McpResultSpoolingSettings {
+  enabled: boolean;
+  thresholdChars: number;
+  directory: string;
+  format: "json";
+}
+
+export interface McpSpoolingContext {
+  workspacePath: string;
 }
 
 export const MCP_TOOL_CALL_TIMEOUT_MS = 120_000;
@@ -43,6 +57,8 @@ export function bridgeMcpTool(opts: {
   /** Reconnects the owning MCP server after the remote rejects the
    *  cached session id. Returns true when a fresh client is available. */
   recoverStaleSession?: () => Promise<boolean>;
+  /** Workspace context for optional large-result spooling. Omitted for status-only bridge copies. */
+  spoolingContext?: McpSpoolingContext;
 }): ToolDefinition {
   const prefixedName = `${opts.serverName}__${opts.toolName}`;
   const description =
@@ -63,7 +79,13 @@ export function bridgeMcpTool(opts: {
       }
       try {
         const res = await callMcpTool(client, opts.toolName, params, signal);
-        return safelyConvertMcpResult(prefixedName, opts.serverName, opts.toolName, res);
+        return await safelyConvertMcpResult(
+          prefixedName,
+          opts.serverName,
+          opts.toolName,
+          res,
+          opts.spoolingContext,
+        );
       } catch (err) {
         if (
           !isAbortError(err) &&
@@ -83,7 +105,13 @@ export function bridgeMcpTool(opts: {
           if (recovered && retryClient !== undefined) {
             try {
               const retryRes = await callMcpTool(retryClient, opts.toolName, params, signal);
-              return safelyConvertMcpResult(prefixedName, opts.serverName, opts.toolName, retryRes);
+              return await safelyConvertMcpResult(
+                prefixedName,
+                opts.serverName,
+                opts.toolName,
+                retryRes,
+                opts.spoolingContext,
+              );
             } catch (retryErr) {
               logMcpToolFailure({
                 serverName: opts.serverName,
@@ -131,13 +159,22 @@ async function callMcpTool(
   }
 }
 
-function safelyConvertMcpResult(
+async function safelyConvertMcpResult(
   prefixedName: string,
   serverName: string,
   toolName: string,
   res: unknown,
-): AgentToolResult<unknown> {
+  spoolingContext: McpSpoolingContext | undefined,
+): Promise<AgentToolResult<unknown>> {
   try {
+    const spooled = await maybeSpoolMcpResult({
+      prefixedName,
+      serverName,
+      toolName,
+      res,
+      spoolingContext,
+    });
+    if (spooled !== undefined) return spooled;
     return mcpResultToAgentResult(res);
   } catch (err) {
     logMcpToolFailure({ serverName, toolName, phase: "result_conversion", error: err });
@@ -205,7 +242,7 @@ function isAbortError(err: unknown): boolean {
 function logMcpToolFailure(opts: {
   serverName: string;
   toolName: string;
-  phase: "call" | "abort" | "reconnect" | "retry" | "result_conversion";
+  phase: "call" | "abort" | "reconnect" | "retry" | "result_conversion" | "spooling";
   error: unknown;
 }): void {
   const error = opts.error as { name?: unknown; code?: unknown; cause?: unknown };
@@ -228,8 +265,12 @@ function logMcpToolFailure(opts: {
 }
 
 function safeStringify(value: unknown, maxChars: number): string {
+  return sanitizeDiagnostic(safeStringifyFull(value), maxChars);
+}
+
+function safeStringifyFull(value: unknown): string {
   const seen = new WeakSet<object>();
-  let text: string;
+  let text: string | undefined;
   try {
     text = JSON.stringify(value, (_key, nested) => {
       if (typeof nested === "bigint") return nested.toString();
@@ -242,8 +283,7 @@ function safeStringify(value: unknown, maxChars: number): string {
   } catch (err) {
     text = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
   }
-  if (text === undefined) text = String(value);
-  return sanitizeDiagnostic(text, maxChars);
+  return text === undefined ? String(value) : text;
 }
 
 function safeDetails(value: unknown): unknown {
@@ -292,6 +332,163 @@ interface McpCallResult {
   content?: unknown;
   isError?: unknown;
   structuredContent?: unknown;
+}
+
+const MCP_SPOOL_PREVIEW_CHARS = 1_000;
+const MCP_SPOOL_SAFE_NAME_RE = /[^A-Za-z0-9_.-]+/g;
+
+let runtimeSpoolingSettings: McpResultSpoolingSettings = {
+  enabled: true,
+  thresholdChars: 30_000,
+  directory: ".mcp-results",
+  format: "json",
+};
+
+export function setMcpResultSpoolingSettings(settings: McpResultSpoolingSettings): void {
+  runtimeSpoolingSettings = {
+    enabled: settings.enabled,
+    thresholdChars: Math.max(1, Math.floor(settings.thresholdChars)),
+    directory: settings.directory.trim().length > 0 ? settings.directory.trim() : ".mcp-results",
+    format: "json",
+  };
+}
+
+export function getMcpResultSpoolingSettings(): McpResultSpoolingSettings {
+  return { ...runtimeSpoolingSettings };
+}
+
+export function measureMcpResultTextChars(res: unknown): number {
+  const r = (res ?? {}) as McpCallResult;
+  const blocks = Array.isArray(r.content) ? (r.content as McpContentBlock[]) : [];
+  let total = 0;
+  for (const block of blocks) {
+    if (block.type === "text" && typeof block.text === "string") total += block.text.length;
+    else if (block.type !== "image") total += safeStringifyFull(block).length;
+  }
+  if (total === 0 && r.structuredContent !== undefined) {
+    total += safeStringifyFull(r.structuredContent).length;
+  }
+  return total;
+}
+
+async function maybeSpoolMcpResult(opts: {
+  prefixedName: string;
+  serverName: string;
+  toolName: string;
+  res: unknown;
+  spoolingContext: McpSpoolingContext | undefined;
+}): Promise<AgentToolResult<unknown> | undefined> {
+  const settings = runtimeSpoolingSettings;
+  const r = (opts.res ?? {}) as McpCallResult;
+  if (!settings.enabled || opts.spoolingContext === undefined || r.isError === true)
+    return undefined;
+  const textChars = measureMcpResultTextChars(opts.res);
+  if (textChars <= settings.thresholdChars) return undefined;
+
+  const serialized = `${safeStringifyFull(opts.res)}\n`;
+  const relativePath = buildSpoolRelativePath(settings.directory, opts.serverName, opts.toolName);
+  try {
+    await writeFile(
+      join(opts.spoolingContext.workspacePath, relativePath),
+      opts.spoolingContext.workspacePath,
+      serialized,
+    );
+  } catch (err) {
+    logMcpToolFailure({
+      serverName: opts.serverName,
+      toolName: opts.toolName,
+      phase: "spooling",
+      error: err,
+    });
+    const fallback = mcpResultToAgentResult(opts.res);
+    return prependTextWarning(
+      fallback,
+      `MCP_RESULT_SPOOL_FAILED: pi-forge could not write the oversized MCP result to a workspace file (${errorMessage(err)}). Falling back to inline/truncated result.\n\n`,
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: buildSpooledSummary({
+          prefixedName: opts.prefixedName,
+          relativePath,
+          textChars,
+          bytes: Buffer.byteLength(serialized, "utf8"),
+          preview: buildMcpPreview(opts.res),
+          containsImages: mcpResultContainsImages(opts.res),
+        }),
+      },
+    ],
+    details: JSON.stringify({ spooled: true, path: relativePath, textChars }),
+  };
+}
+
+function buildSpoolRelativePath(directory: string, serverName: string, toolName: string): string {
+  const normalizedDir = directory.replaceAll("\\", "/").replace(/^\/+/, "").replace(/\/+$/, "");
+  const dir = normalizedDir.length > 0 ? normalizedDir : ".mcp-results";
+  const server = safeFilenamePart(serverName);
+  const tool = safeFilenamePart(toolName);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return `${dir}/${server}__${tool}__${timestamp}__${randomUUID()}.json`;
+}
+
+function safeFilenamePart(value: string): string {
+  const cleaned = value.replace(MCP_SPOOL_SAFE_NAME_RE, "_").replace(/^\.+$/, "_").slice(0, 80);
+  return cleaned.length > 0 ? cleaned : "mcp";
+}
+
+function buildMcpPreview(res: unknown): string {
+  const agent = mcpResultToAgentResult(res);
+  const text = agent.content
+    .filter((block): block is { type: "text"; text: string } => block.type === "text")
+    .map((block) => block.text)
+    .join("\n\n");
+  return sanitizeDiagnostic(text.length > 0 ? text : "(no text preview)", MCP_SPOOL_PREVIEW_CHARS);
+}
+
+function mcpResultContainsImages(res: unknown): boolean {
+  const blocks = Array.isArray((res as McpCallResult | undefined)?.content)
+    ? ((res as McpCallResult).content as McpContentBlock[])
+    : [];
+  return blocks.some((block) => block.type === "image");
+}
+
+function buildSpooledSummary(opts: {
+  prefixedName: string;
+  relativePath: string;
+  textChars: number;
+  bytes: number;
+  preview: string;
+  containsImages: boolean;
+}): string {
+  const imageNote = opts.containsImages
+    ? "\nImage content was present. The raw JSON file preserves image block metadata/data; inspect carefully instead of dumping it wholesale into model context."
+    : "";
+  return (
+    `MCP_RESULT_SPOOLED: Tool '${opts.prefixedName}' returned an oversized result and pi-forge wrote the complete raw MCP result to a workspace file.\n` +
+    `Path: ${opts.relativePath}\n` +
+    `Approximate text size: ${opts.textChars.toLocaleString()} characters\n` +
+    `File size: ${opts.bytes.toLocaleString()} bytes\n` +
+    `${imageNote}\n` +
+    `Use file-reading tools to inspect '${opts.relativePath}' incrementally; do not re-run the same broad MCP call just to recover omitted content.\n\n` +
+    `Preview (first ${MCP_SPOOL_PREVIEW_CHARS.toLocaleString()} chars max):\n${opts.preview}`
+  );
+}
+
+function prependTextWarning(
+  result: AgentToolResult<unknown>,
+  warning: string,
+): AgentToolResult<unknown> {
+  const content = [...result.content];
+  const firstText = content.findIndex((block) => block.type === "text");
+  if (firstText >= 0 && content[firstText]?.type === "text") {
+    content[firstText] = { type: "text", text: warning + content[firstText].text };
+  } else {
+    content.unshift({ type: "text", text: warning });
+  }
+  return { ...result, content };
 }
 
 /**

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -3,6 +3,7 @@ import {
   deleteMcpServer,
   readMcpJsonRedacted,
   setMcpDisabled,
+  setMcpSpoolingConfig,
   setMcpTruncationConfig,
   upsertMcpServer,
   type McpHeaderValue,
@@ -20,7 +21,10 @@ import {
   unloadProject,
 } from "../mcp/manager.js";
 import { grantStdioTrust, isStdioTrustedForProject, revokeStdioTrust } from "../mcp/stdio-trust.js";
-import { getMcpResultTruncationSettings } from "../mcp/tool-bridge.js";
+import {
+  getMcpResultSpoolingSettings,
+  getMcpResultTruncationSettings,
+} from "../mcp/tool-bridge.js";
 import { getProject } from "../project-manager.js";
 import { errorSchema } from "./_schemas.js";
 
@@ -71,6 +75,17 @@ const serverConfigSchema = {
       additionalProperties: { type: "string" },
     },
     cwd: { type: "string", minLength: 1 },
+  },
+} as const;
+
+const spoolingSchema = {
+  type: "object",
+  required: ["enabled", "thresholdChars", "directory", "format"],
+  properties: {
+    enabled: { type: "boolean" },
+    thresholdChars: { type: "integer", minimum: 1 },
+    directory: { type: "string" },
+    format: { type: "string", enum: ["json"] },
   },
 } as const;
 
@@ -160,7 +175,7 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
         response: {
           200: {
             type: "object",
-            required: ["enabled", "connected", "total", "truncation"],
+            required: ["enabled", "connected", "total", "truncation", "spooling"],
             properties: {
               enabled: { type: "boolean" },
               connected: { type: "integer", minimum: 0 },
@@ -173,6 +188,7 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
                   maxChars: { type: "integer", minimum: 1 },
                 },
               },
+              spooling: spoolingSchema,
             },
           },
         },
@@ -183,12 +199,27 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
       const enabled = isGloballyEnabled();
       const total = status.length;
       const connected = status.filter((s) => s.state === "connected").length;
-      return { enabled, connected, total, truncation: getMcpResultTruncationSettings() };
+      return {
+        enabled,
+        connected,
+        total,
+        truncation: getMcpResultTruncationSettings(),
+        spooling: getMcpResultSpoolingSettings(),
+      };
     },
   );
 
   fastify.put<{
-    Body: { enabled?: boolean; truncation?: { enabled?: boolean; maxChars?: number } };
+    Body: {
+      enabled?: boolean;
+      truncation?: { enabled?: boolean; maxChars?: number };
+      spooling?: {
+        enabled?: boolean;
+        thresholdChars?: number;
+        directory?: string;
+        format?: "json";
+      };
+    };
   }>(
     "/mcp/settings",
     {
@@ -212,12 +243,22 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
                 maxChars: { type: "integer", minimum: 1, maximum: 1000000 },
               },
             },
+            spooling: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                enabled: { type: "boolean" },
+                thresholdChars: { type: "integer", minimum: 1, maximum: 1000000 },
+                directory: { type: "string", minLength: 1 },
+                format: { type: "string", enum: ["json"] },
+              },
+            },
           },
         },
         response: {
           200: {
             type: "object",
-            required: ["enabled", "connected", "total", "truncation"],
+            required: ["enabled", "connected", "total", "truncation", "spooling"],
             properties: {
               enabled: { type: "boolean" },
               connected: { type: "integer", minimum: 0 },
@@ -230,6 +271,7 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
                   maxChars: { type: "integer", minimum: 1 },
                 },
               },
+              spooling: spoolingSchema,
             },
           },
           400: errorSchema,
@@ -243,6 +285,9 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
       if (req.body.truncation !== undefined) {
         await setMcpTruncationConfig(req.body.truncation);
       }
+      if (req.body.spooling !== undefined) {
+        await setMcpSpoolingConfig(req.body.spooling);
+      }
       await reloadGlobal();
       const status = getStatus();
       return {
@@ -250,6 +295,7 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
         total: status.length,
         connected: status.filter((s) => s.state === "connected").length,
         truncation: getMcpResultTruncationSettings(),
+        spooling: getMcpResultSpoolingSettings(),
       };
     },
   );
@@ -486,7 +532,7 @@ export const mcpRoutes: FastifyPluginAsync = async (fastify) => {
         return reply.code(404).send({ error: "project_not_found" });
       }
       await ensureProjectLoaded(project.id, project.path);
-      const tools = customToolsForProject(project.id).map((t) => ({
+      const tools = customToolsForProject(project.id, project.path).map((t) => ({
         name: t.name,
         description: t.description,
       }));

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -2349,5 +2349,5 @@ async function resolveMcpCustomTools(
   await mcpEnsureGlobalLoaded().catch(() => undefined);
   if (!mcpIsGloballyEnabled()) return [];
   await mcpEnsureProjectLoaded(projectId, workspacePath).catch(() => undefined);
-  return mcpCustomToolsForProject(projectId);
+  return mcpCustomToolsForProject(projectId, workspacePath);
 }

--- a/tests/test-mcp-truncation.ts
+++ b/tests/test-mcp-truncation.ts
@@ -405,6 +405,14 @@ async function main(): Promise<void> {
       );
       assert("spooling above threshold: path included", pathMatch !== null, summary.slice(0, 300));
       assert("spooling above threshold: image data not inline", !summary.includes("base64-image"));
+      assert(
+        "spooling above threshold: no payload preview inline",
+        !summary.includes("L".repeat(24)),
+      );
+      assert(
+        "spooling above threshold: tells model preview is omitted",
+        summary.includes("No result preview is included inline"),
+      );
       if (pathMatch?.[1] !== undefined) {
         const stored = await readFile(join(workspace, pathMatch[1]), "utf8");
         assert("spooling above threshold: writes raw text", stored.includes(fullText));

--- a/tests/test-mcp-truncation.ts
+++ b/tests/test-mcp-truncation.ts
@@ -21,8 +21,10 @@
  *     entry coming from an MCP server gets truncated end-to-end.
  *   - The 60/40 head/tail ratio is honored.
  */
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -59,6 +61,33 @@ interface ToolBridgeModule {
   MCP_TEXT_HEAD_RATIO: number;
   getMcpResultTruncationSettings: () => { enabled: boolean; maxChars: number };
   setMcpResultTruncationSettings: (settings: { enabled: boolean; maxChars: number }) => void;
+  getMcpResultSpoolingSettings: () => {
+    enabled: boolean;
+    thresholdChars: number;
+    directory: string;
+    format: "json";
+  };
+  setMcpResultSpoolingSettings: (settings: {
+    enabled: boolean;
+    thresholdChars: number;
+    directory: string;
+    format: "json";
+  }) => void;
+  measureMcpResultTextChars: (res: unknown) => number;
+  bridgeMcpTool: (opts: {
+    serverName: string;
+    toolName: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    getClient: () => unknown;
+    spoolingContext?: { workspacePath: string };
+  }) => {
+    execute: (
+      toolCallId: string,
+      params: unknown,
+      signal?: AbortSignal,
+    ) => Promise<{ content: ContentBlock[] }>;
+  };
 }
 
 async function main(): Promise<void> {
@@ -72,6 +101,10 @@ async function main(): Promise<void> {
     MCP_TEXT_HEAD_RATIO,
     getMcpResultTruncationSettings,
     setMcpResultTruncationSettings,
+    getMcpResultSpoolingSettings,
+    setMcpResultSpoolingSettings,
+    measureMcpResultTextChars,
+    bridgeMcpTool,
   } = mod;
 
   const headLen = Math.floor(MCP_TEXT_CAP_CHARS * MCP_TEXT_HEAD_RATIO);
@@ -274,6 +307,212 @@ async function main(): Promise<void> {
     }
   }
   setMcpResultTruncationSettings({ enabled: true, maxChars: MCP_TEXT_CAP_CHARS });
+
+  // ---------- spooling: disabled preserves truncation ----------
+  {
+    const workspace = await mkdtemp(join(tmpdir(), "pi-forge-mcp-spool-disabled-"));
+    try {
+      setMcpResultSpoolingSettings({
+        enabled: false,
+        thresholdChars: 100,
+        directory: ".mcp-results",
+        format: "json",
+      });
+      const tool = bridgeMcpTool({
+        serverName: "srv",
+        toolName: "disabled",
+        description: "",
+        inputSchema: { type: "object", properties: {} },
+        getClient: () => ({
+          callTool: async () => ({ content: [{ type: "text", text: "D".repeat(50_000) }] }),
+        }),
+        spoolingContext: { workspacePath: workspace },
+      });
+      const out = await tool.execute("call-disabled", {});
+      const text = out.content[0]?.type === "text" ? out.content[0].text : "";
+      assert(
+        "spooling disabled: truncation still applies",
+        text.startsWith("MCP_RESULT_TRUNCATED:") && !text.includes("MCP_RESULT_SPOOLED"),
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }
+
+  // ---------- spooling: below threshold remains inline ----------
+  {
+    const workspace = await mkdtemp(join(tmpdir(), "pi-forge-mcp-spool-small-"));
+    try {
+      setMcpResultSpoolingSettings({
+        enabled: true,
+        thresholdChars: 100,
+        directory: ".mcp-results",
+        format: "json",
+      });
+      const tool = bridgeMcpTool({
+        serverName: "srv",
+        toolName: "small",
+        description: "",
+        inputSchema: { type: "object", properties: {} },
+        getClient: () => ({
+          callTool: async () => ({ content: [{ type: "text", text: "short result" }] }),
+        }),
+        spoolingContext: { workspacePath: workspace },
+      });
+      const out = await tool.execute("call-1", {});
+      assert(
+        "spooling below threshold: stays inline",
+        out.content[0]?.type === "text" && out.content[0].text === "short result",
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }
+
+  // ---------- spooling: above threshold writes complete raw JSON ----------
+  {
+    const workspace = await mkdtemp(join(tmpdir(), "pi-forge-mcp-spool-large-"));
+    try {
+      const fullText = "L".repeat(240);
+      setMcpResultSpoolingSettings({
+        enabled: true,
+        thresholdChars: 100,
+        directory: ".mcp-results",
+        format: "json",
+      });
+      const tool = bridgeMcpTool({
+        serverName: "server/name",
+        toolName: "tool name",
+        description: "",
+        inputSchema: { type: "object", properties: {} },
+        getClient: () => ({
+          callTool: async () => ({
+            content: [
+              { type: "text", text: fullText },
+              { type: "image", data: "base64-image", mimeType: "image/png" },
+            ],
+            structuredContent: { count: 1 },
+          }),
+        }),
+        spoolingContext: { workspacePath: workspace },
+      });
+      const out = await tool.execute("call-2", {});
+      const summary = out.content[0]?.type === "text" ? out.content[0].text : "";
+      const pathMatch = /^Path: (.+)$/m.exec(summary);
+      assert(
+        "spooling above threshold: summary returned",
+        summary.startsWith("MCP_RESULT_SPOOLED:"),
+      );
+      assert("spooling above threshold: path included", pathMatch !== null, summary.slice(0, 300));
+      assert("spooling above threshold: image data not inline", !summary.includes("base64-image"));
+      if (pathMatch?.[1] !== undefined) {
+        const stored = await readFile(join(workspace, pathMatch[1]), "utf8");
+        assert("spooling above threshold: writes raw text", stored.includes(fullText));
+        assert("spooling above threshold: preserves image JSON", stored.includes("base64-image"));
+        assert(
+          "spooling above threshold: path is in configured dir",
+          pathMatch[1].startsWith(".mcp-results/"),
+        );
+      }
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }
+
+  // ---------- spooling: invalid directory falls back to truncation ----------
+  {
+    const workspace = await mkdtemp(join(tmpdir(), "pi-forge-mcp-spool-invalid-"));
+    try {
+      setMcpResultSpoolingSettings({
+        enabled: true,
+        thresholdChars: 100,
+        directory: "../escape",
+        format: "json",
+      });
+      const tool = bridgeMcpTool({
+        serverName: "srv",
+        toolName: "escape",
+        description: "",
+        inputSchema: { type: "object", properties: {} },
+        getClient: () => ({
+          callTool: async () => ({ content: [{ type: "text", text: "E".repeat(50_000) }] }),
+        }),
+        spoolingContext: { workspacePath: workspace },
+      });
+      const out = await tool.execute("call-3", {});
+      const text = out.content[0]?.type === "text" ? out.content[0].text : "";
+      assert("spooling invalid dir: warning returned", text.startsWith("MCP_RESULT_SPOOL_FAILED:"));
+      assert(
+        "spooling invalid dir: truncation still applies",
+        text.includes("MCP_RESULT_TRUNCATED"),
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }
+
+  // ---------- spooling: isError bypasses spooling ----------
+  {
+    const workspace = await mkdtemp(join(tmpdir(), "pi-forge-mcp-spool-error-"));
+    try {
+      setMcpResultSpoolingSettings({
+        enabled: true,
+        thresholdChars: 100,
+        directory: ".mcp-results",
+        format: "json",
+      });
+      const tool = bridgeMcpTool({
+        serverName: "srv",
+        toolName: "error",
+        description: "",
+        inputSchema: { type: "object", properties: {} },
+        getClient: () => ({
+          callTool: async () => ({
+            content: [{ type: "text", text: "boom " + "B".repeat(500) }],
+            isError: true,
+          }),
+        }),
+        spoolingContext: { workspacePath: workspace },
+      });
+      const out = await tool.execute("call-4", {});
+      const text = out.content[0]?.type === "text" ? out.content[0].text : "";
+      assert(
+        "spooling isError: stays inline",
+        text.includes("[error]") && !text.includes("MCP_RESULT_SPOOLED"),
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }
+
+  // ---------- spooling settings + measurement ----------
+  {
+    const settings = getMcpResultSpoolingSettings();
+    assert(
+      "spooling settings: persisted in runtime",
+      settings.enabled === true && settings.thresholdChars === 100 && settings.format === "json",
+      JSON.stringify(settings),
+    );
+    assert(
+      "measurement: sums text content",
+      measureMcpResultTextChars({
+        content: [
+          { type: "text", text: "abc" },
+          { type: "text", text: "defg" },
+        ],
+      }) === 7,
+    );
+    assert(
+      "measurement: structured-only content is measured untruncated",
+      measureMcpResultTextChars({ structuredContent: { data: "S".repeat(20_000) } }) > 20_000,
+    );
+  }
+  setMcpResultSpoolingSettings({
+    enabled: true,
+    thresholdChars: MCP_TEXT_CAP_CHARS,
+    directory: ".mcp-results",
+    format: "json",
+  });
 
   // ---------- 60/40 head/tail ratio honored ----------
   {

--- a/tests/test-mcp.ts
+++ b/tests/test-mcp.ts
@@ -265,6 +265,17 @@ async function main(): Promise<void> {
         JSON.stringify({ enabled: true, maxChars: 30000 }),
       JSON.stringify(toolBridge.getMcpResultTruncationSettings()),
     );
+    assert(
+      "spooling default: enabled to .mcp-results at 30k chars",
+      JSON.stringify(toolBridge.getMcpResultSpoolingSettings()) ===
+        JSON.stringify({
+          enabled: true,
+          thresholdChars: 30000,
+          directory: ".mcp-results",
+          format: "json",
+        }),
+      JSON.stringify(toolBridge.getMcpResultSpoolingSettings()),
+    );
     const status1 = manager.getStatus();
     assert("global load: 1 server in pool", status1.length === 1);
     assert(


### PR DESCRIPTION
## Summary

Large MCP tool results could only be returned inline to the model, where pi-forge's MCP truncation protected context size but could drop the middle of large result data. This PR adds MCP result spooling: oversized successful MCP results are written to workspace JSON files and the model receives a compact path/size notice instead of the payload.

Spooling is enabled by default, keeps existing truncation as the fallback/non-spooled path, uses workspace-bounded `file-manager.writeFile()` writes for sandbox compatibility, and omits inline previews to conserve model context.

## Usage

MCP spooling can be configured in **Settings → MCP → Result spooling** or in `${FORGE_DATA_DIR}/mcp.json`:

```json
{
  "spooling": {
    "enabled": true,
    "thresholdChars": 30000,
    "directory": ".mcp-results",
    "format": "json"
  }
}
```

When a successful MCP result exceeds `thresholdChars`, pi-forge writes the complete raw MCP `CallToolResult` JSON to:

```text
<project workspace>/.mcp-results/<server>__<tool>__<timestamp>__<uuid>.json
```

The tool result shown to the model includes the relative path, approximate text size, byte size, and instructions to inspect the file incrementally. `isError: true` results bypass spooling so errors remain visible inline. If the spool write fails, pi-forge falls back to current inline conversion/truncation and prepends an `MCP_RESULT_SPOOL_FAILED` warning.

## What changed (13 files, +799/-31)

- `packages/server/src/mcp/tool-bridge.ts` — measures MCP text payloads, writes oversized successful results via `file-manager.writeFile()`, builds no-preview spooled summaries, preserves error/truncation fallback behavior, and keeps image payloads in raw JSON rather than inline context.
- `packages/server/src/mcp/config.ts` — adds top-level `spooling` config with default-enabled normalization, persistence, and update helper.
- `packages/server/src/mcp/manager.ts` — loads runtime spooling settings and threads session workspace context into bridged MCP tools.
- `packages/server/src/session-registry.ts` — passes workspace paths when resolving MCP custom tools for session create/resume/fork/refresh paths.
- `packages/server/src/routes/mcp.ts` — exposes spooling settings through MCP settings GET/PUT schemas and responses.
- `packages/client/src/lib/api-client/index.ts`, `packages/client/src/lib/api-client/types.ts`, `packages/client/src/store/mcp-store.ts` — validates, stores, compares, and updates MCP spooling settings from the browser.
- `packages/client/src/components/SettingsPanel.tsx` — adds Settings → MCP controls for spooling enabled state, threshold, and output directory.
- `tests/test-mcp-truncation.ts` — adds direct coverage for below-threshold inline behavior, above-threshold spooling, no inline preview, image preservation in raw JSON, traversal/fallback, error bypass, disabled-spooling truncation, and structured-content measurement.
- `tests/test-mcp.ts` — verifies default spooling runtime settings are enabled at `.mcp-results` with a 30k threshold.
- `docs/mcp.md`, `docs/agent/mcp.md` — document default-enabled spooling behavior, file location, no-preview summary, error/fallback behavior, and sandbox-safe write path.

## Test plan

- [x] `scripts/run-tests.sh --only mcp-truncation,mcp,mcp-store`
- [x] `npm run build`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npm run check`
- [x] `npm run test:ci`
- [x] Manual Streamable HTTP MCP spooling verification: local MCP server returned `generate_large_result` payload with 55,000 text chars and begin/end sentinels; pi-forge spooled the raw JSON result and returned a compact no-preview path/size summary. Temporary helper was removed before publishing.
