### PR TITLE
chore(release): v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ section. See the "Versions" section of the README for the support window policy.
 
 ## [Unreleased]
 
+## [1.5.4] — 2026-09-11
+
+### Added
+
+- **Resizable project sidebar.** The project/session sidebar can now be dragged wider or narrower, with persisted sizing and hardened bounds so the workspace layout remains usable.
+- **MCP result spooling for large tool output.** Oversized MCP text results are written to workspace files and surfaced with a file reference instead of flooding the chat stream, keeping sessions responsive while preserving access to full output.
+
+### Changed
+
+- **Dependency vulnerability remediation for v1.5.4.** Refreshed affected runtime, build, and tooling dependencies and overrides to resolve reported npm vulnerabilities while avoiding unrelated dependency churn.
+
+### Fixed
+
+- **Tool-call aggregate errors reflect failed child calls.** Batched tool-call status now treats child tool errors as failed aggregate results so users see the correct failure state instead of a misleading success.
+- **New sessions pick up refreshed MCP tools.** MCP tool definitions are refreshed when sessions start, so newly created chats can use the latest configured server tools without requiring a server restart.
+- **Auth summary reads are safe in restricted runtimes.** Sandbox and unreadable-auth scenarios now avoid leaking raw auth file access errors into model/runtime paths while still reporting provider presence safely.
+
 ## [1.5.3] — 2026-08-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-forge",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-forge",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "workspaces": [
         "packages/*"
       ],
@@ -17249,7 +17249,7 @@
     },
     "packages/client": {
       "name": "@pi-forge/client",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.2",
         "@codemirror/lang-css": "^6.3.1",
@@ -17321,7 +17321,7 @@
     },
     "packages/server": {
       "name": "@pi-forge/server",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.84.3",
         "@earendil-works/pi-ai": "0.84.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-forge",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/client",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-forge/server",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the v1.5.4 release bump from v1.5.3. This rolls the root/server/client package versions and lockfile metadata to 1.5.4 and publishes release notes generated from changes merged since v1.5.3, including MCP result spooling, refreshed MCP tools for new sessions, tool-call aggregate error handling, auth-summary hardening, dependency vulnerability remediation, and the resizable project sidebar.

## Usage

No runtime usage changes are required for the version bump. After this PR merges, maintainers can tag the merged main commit as `v1.5.4` and let the release workflow publish artifacts.

```bash
git tag v1.5.4
git push origin v1.5.4
```

## What changed (5 files, +24/-7)

- `CHANGELOG.md` — adds the dated `1.5.4` release notes under the established Added/Changed/Fixed sections.
- `package.json` — bumps the root package version to `1.5.4`.
- `packages/server/package.json` — bumps the server workspace version to `1.5.4`.
- `packages/client/package.json` — bumps the client workspace version to `1.5.4`.
- `package-lock.json` — refreshes only root/workspace package version metadata to `1.5.4`.

## Test plan

- [x] `npx npm@latest approve-scripts --allow-scripts-pending`
- [x] `npm install --include=dev` after the first build showed this worktree was missing dev dependencies
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run test:ci`
- [x] `npm audit --include=dev`
- [x] `npm audit --omit=dev`
- [x] Version consistency check for root, server, client, and lockfile package metadata
- [x] Reviewed final diff for accidental lockfile churn
- [ ] CI green before merge
